### PR TITLE
fix(core): move project memory dir under tmp directory

### DIFF
--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -147,13 +147,14 @@ describe('Storage – additional helpers', () => {
     expect(storage.getProjectAgentsDir()).toBe(expected);
   });
 
-  it('getProjectMemoryDir returns ~/.gemini/memory/<identifier>', async () => {
+  it('getProjectMemoryDir returns ~/.gemini/tmp/<identifier>/memory', async () => {
     await storage.initialize();
     const expected = path.join(
       os.homedir(),
       GEMINI_DIR,
-      'memory',
+      'tmp',
       PROJECT_SLUG,
+      'memory',
     );
     expect(storage.getProjectMemoryDir()).toBe(expected);
   });

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -267,8 +267,7 @@ export class Storage {
   }
 
   getProjectMemoryDir(): string {
-    const identifier = this.getProjectIdentifier();
-    return path.join(Storage.getGlobalGeminiDir(), 'memory', identifier);
+    return this.getProjectMemoryTempDir();
   }
 
   getProjectMemoryTempDir(): string {


### PR DESCRIPTION
## Summary

Moves the project-scoped memory directory from `~/.gemini/memory/<project>` to `~/.gemini/tmp/<project>/memory`, aligning it with the existing temp directory structure.

## Details

`getProjectMemoryDir()` now delegates to `getProjectMemoryTempDir()`, which already returns the correct path under the tmp directory. This eliminates a redundant top-level `memory/` directory in `~/.gemini/` and keeps project-scoped memory co-located with other project-specific temp data.

## Related Issues

Closes #18007

## How to Validate

1. Run storage tests:
   ```
   npm test -w @google/gemini-cli-core -- src/config/storage.test.ts
   ```
2. Run memory-related tests:
   ```
   npm test -w @google/gemini-cli-core -- src/tools/memoryTool.test.ts src/context/memoryContextManager.test.ts src/services/memoryService.test.ts
   ```
3. All tests should pass (90 tests across 4 files).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
