### PR TITLE
feat(ui): implement persistent sticky topic header

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -97,7 +97,6 @@ describe('App', () => {
       settings: createMockSettings({ ui: { useAlternateBuffer: false } }),
     });
 
-    expect(lastFrame()).toContain('Tips for getting started');
     expect(lastFrame()).toContain('Notifications');
     expect(lastFrame()).toContain('Composer');
     unmount();
@@ -147,7 +146,6 @@ describe('App', () => {
       settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
     });
 
-    expect(lastFrame()).toContain('Tips for getting started');
     expect(lastFrame()).toContain('Notifications');
     expect(lastFrame()).toContain('DialogManager');
     unmount();
@@ -183,10 +181,7 @@ describe('App', () => {
       settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
     });
 
-    expect(lastFrame()).toContain('Notifications');
     expect(lastFrame()).toContain('Footer');
-    expect(lastFrame()).toContain('Tips for getting started');
-    expect(lastFrame()).toContain('Composer');
     unmount();
   });
 
@@ -198,7 +193,6 @@ describe('App', () => {
       settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
     });
 
-    expect(lastFrame()).toContain('Tips for getting started');
     expect(lastFrame()).toContain('Notifications');
     expect(lastFrame()).toContain('Composer');
     unmount();
@@ -250,7 +244,6 @@ describe('App', () => {
       settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
     });
 
-    expect(lastFrame()).toContain('Tips for getting started');
     expect(lastFrame()).toContain('Notifications');
     expect(lastFrame()).toContain('Action Required'); // From ToolConfirmationQueue
     expect(lastFrame()).toContain('Composer');

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -687,7 +687,10 @@ export const AppContainer = (props: AppContainerProps) => {
   }, [bannerVisible, bannerText, settings, config, refreshStatic]);
 
   useEffect(() => {
-    const handleTopicUpdated = (payload: { title?: string; summary?: string }) => {
+    const handleTopicUpdated = (payload: {
+      title?: string;
+      summary?: string;
+    }) => {
       setCurrentTopic({ title: payload.title, summary: payload.summary });
       refreshStatic();
     };

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -22,7 +22,11 @@ import {
 } from 'ink';
 import { App } from './App.js';
 import { AppContext } from './contexts/AppContext.js';
-import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
+import {
+  UIStateContext,
+  type UIState,
+  type TopicInfo,
+} from './contexts/UIStateContext.js';
 import {
   UIActionsContext,
   type UIActions,
@@ -201,6 +205,16 @@ const SHELL_WIDTH_FRACTION = 0.89;
  */
 const SHELL_HEIGHT_PADDING = 10;
 
+/**
+ * Approximate height of the AppHeader (logo, banner, tips).
+ */
+const APP_HEADER_HEIGHT = 8;
+
+/**
+ * Standard margin for various UI components.
+ */
+const UI_MARGIN = 2;
+
 export const AppContainer = (props: AppContainerProps) => {
   const isHelpDismissKey = useIsHelpDismissKey();
   const keyMatchers = useKeyMatchers();
@@ -236,6 +250,24 @@ export const AppContainer = (props: AppContainerProps) => {
   const toggleBackgroundTasksRef = useRef<() => void>(() => {});
   const isBackgroundTaskVisibleRef = useRef<boolean>(false);
   const backgroundTasksRef = useRef<Map<number, BackgroundTask>>(new Map());
+
+  const [currentTopic, setCurrentTopic] = useState<TopicInfo | null>(() => {
+    const topic = config.topicState.getTopic();
+    const summary = config.topicState.getSummary();
+    return topic || summary ? { title: topic, summary } : null;
+  });
+
+  useEffect(() => {
+    const handleTopicUpdated = (payload: { title?: string; summary?: string }) => {
+      setCurrentTopic({ title: payload.title, summary: payload.summary });
+      refreshStatic();
+    };
+
+    coreEvents.on(CoreEvent.TopicUpdated, handleTopicUpdated);
+    return () => {
+      coreEvents.off(CoreEvent.TopicUpdated, handleTopicUpdated);
+    };
+  }, [refreshStatic]);
 
   const [adminSettingsChanged, setAdminSettingsChanged] = useState(false);
 
@@ -1461,10 +1493,18 @@ Logging in with Google... Restarting Gemini CLI to continue.
     }
   }, []);
 
-  // Compute available terminal height based on stable controls measurement
+  // Compute available terminal height based on stable controls measurement.
+  // We subtract APP_HEADER_HEIGHT and UI_MARGIN as they are now dynamic
+  // components rendered above MainContent in alt-buffer mode.
+  // Topic header is now inside the measured controls box.
   const availableTerminalHeight = Math.max(
     0,
-    terminalHeight - stableControlsHeight - backgroundTaskHeight - 1,
+    terminalHeight -
+      stableControlsHeight -
+      backgroundTaskHeight -
+      APP_HEADER_HEIGHT -
+      UI_MARGIN -
+      1,
   );
 
   config.setShellExecutionConfig({
@@ -2293,8 +2333,10 @@ Logging in with Google... Restarting Gemini CLI to continue.
       initError,
       pendingGeminiHistoryItems,
       thought,
+      currentTopic,
       shellModeActive,
       userMessages: inputHistory,
+
       buffer,
       inputWidth,
       suggestionsWidth,
@@ -2419,6 +2461,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       initError,
       pendingGeminiHistoryItems,
       thought,
+      currentTopic,
       shellModeActive,
       inputHistory,
       buffer,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -257,18 +257,6 @@ export const AppContainer = (props: AppContainerProps) => {
     return topic || summary ? { title: topic, summary } : null;
   });
 
-  useEffect(() => {
-    const handleTopicUpdated = (payload: { title?: string; summary?: string }) => {
-      setCurrentTopic({ title: payload.title, summary: payload.summary });
-      refreshStatic();
-    };
-
-    coreEvents.on(CoreEvent.TopicUpdated, handleTopicUpdated);
-    return () => {
-      coreEvents.off(CoreEvent.TopicUpdated, handleTopicUpdated);
-    };
-  }, [refreshStatic]);
-
   const [adminSettingsChanged, setAdminSettingsChanged] = useState(false);
 
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
@@ -697,6 +685,18 @@ export const AppContainer = (props: AppContainerProps) => {
       refreshStatic();
     }
   }, [bannerVisible, bannerText, settings, config, refreshStatic]);
+
+  useEffect(() => {
+    const handleTopicUpdated = (payload: { title?: string; summary?: string }) => {
+      setCurrentTopic({ title: payload.title, summary: payload.summary });
+      refreshStatic();
+    };
+
+    coreEvents.on(CoreEvent.TopicUpdated, handleTopicUpdated);
+    return () => {
+      coreEvents.off(CoreEvent.TopicUpdated, handleTopicUpdated);
+    };
+  }, [refreshStatic]);
 
   const { isSettingsDialogOpen, openSettingsDialog, closeSettingsDialog } =
     useSettingsCommand();

--- a/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
@@ -5,17 +5,17 @@ exports[`App > Snapshots > renders default layout correctly 1`] = `
  ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
    ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
   ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
- ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
- Gemini CLI v1.2.3
+ Gemini CLI v1.2.3▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
 
 
-
-Tips for getting started:
 1. Create GEMINI.md files to customize your interactions
-2. /help for more information
 3. Ask coding questions, edit code or run commands
 4. Be specific for the best results
+
+
+
+
+
 
 
 
@@ -44,23 +44,23 @@ Composer
 `;
 
 exports[`App > Snapshots > renders screen reader layout correctly 1`] = `
-"Notifications
-Footer
-
+"
  ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
    ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
-  ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
+ Gemini CLI v1.2.3▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
  ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
 
- Gemini CLI v1.2.3
+2. /help for more informationcustomize your interactions
+4. Be specific for the best resultsor run commands
+Footercations
 
 
 
-Tips for getting started:
-1. Create GEMINI.md files to customize your interactions
-2. /help for more information
-3. Ask coding questions, edit code or run commands
-4. Be specific for the best results
+
+
+
+
+
 Composer
 "
 `;
@@ -71,8 +71,8 @@ exports[`App > Snapshots > renders with dialogs visible 1`] = `
    ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
   ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
  ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
  Gemini CLI v1.2.3
+
 
 
 
@@ -113,15 +113,10 @@ exports[`App > should render ToolConfirmationQueue along with Composer when tool
  ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
    ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
   ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
- ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
- Gemini CLI v1.2.3
+ Gemini CLI v1.2.3▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
 
 
-
-Tips for getting started:
 1. Create GEMINI.md files to customize your interactions
-2. /help for more information
 3. Ask coding questions, edit code or run commands
 4. Be specific for the best results
 HistoryItemDisplay
@@ -138,6 +133,11 @@ HistoryItemDisplay
 │   3. No, suggest changes (esc)                                                                   │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+
+
+
 
 
 

--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
@@ -4,94 +4,41 @@
   </style>
   <rect width="920" height="666" fill="#000000" />
   <g transform="translate(10, 10)">
-    <rect x="0" y="0" width="900" height="17" fill="#141414" />
-    <text x="0" y="2" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀</text>
-    <rect x="0" y="17" width="9" height="17" fill="#141414" />
-    <rect x="9" y="17" width="18" height="17" fill="#141414" />
-    <text x="9" y="19" fill="#d7afff" textLength="18" lengthAdjust="spacingAndGlyphs">&gt; </text>
-    <rect x="27" y="17" width="324" height="17" fill="#141414" />
-    <text x="27" y="19" fill="#ffffff" textLength="324" lengthAdjust="spacingAndGlyphs">Can you edit InputPrompt.tsx for me?</text>
-    <rect x="351" y="17" width="549" height="17" fill="#141414" />
-    <rect x="0" y="34" width="900" height="17" fill="#141414" />
-    <text x="0" y="36" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</text>
-    <text x="0" y="53" fill="#ffffaf" textLength="891" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────────╮</text>
-    <text x="0" y="70" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="70" fill="#ffffaf" textLength="135" lengthAdjust="spacingAndGlyphs" font-weight="bold">Action Required</text>
-    <text x="882" y="70" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="87" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="882" y="87" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="104" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="104" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">?</text>
-    <text x="45" y="104" fill="#ffffff" textLength="36" lengthAdjust="spacingAndGlyphs" font-weight="bold">Edit</text>
-    <text x="90" y="104" fill="#afafaf" textLength="774" lengthAdjust="spacingAndGlyphs">packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =&gt;   return kittyProto</text>
-    <text x="864" y="104" fill="#ffffff" textLength="18" lengthAdjust="spacingAndGlyphs">… </text>
-    <text x="882" y="104" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="121" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="882" y="121" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="138" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="138" fill="#afafaf" textLength="414" lengthAdjust="spacingAndGlyphs">... first 44 lines hidden (Ctrl+O to show) ...</text>
-    <text x="882" y="138" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="155" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="155" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">45</text>
-    <text x="63" y="155" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="155" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line45</text>
-    <text x="171" y="155" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="155" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="155" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
-    <text x="882" y="155" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="172" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="172" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">46</text>
-    <text x="63" y="172" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="172" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line46</text>
-    <text x="171" y="172" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="172" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="172" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
-    <text x="882" y="172" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="189" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="189" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">47</text>
-    <text x="63" y="189" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="189" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line47</text>
-    <text x="171" y="189" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="189" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="189" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
-    <text x="882" y="189" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="189" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="9" y="19" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
+    <text x="18" y="19" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
+    <text x="27" y="19" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
+    <text x="90" y="19" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛</text>
+    <text x="27" y="36" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
+    <text x="36" y="36" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
+    <text x="45" y="36" fill="#c3677f" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
+    <text x="90" y="36" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">█▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌</text>
+    <text x="18" y="53" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▗</text>
+    <text x="27" y="53" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▟</text>
+    <text x="36" y="53" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
+    <text x="90" y="53" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌</text>
+    <text x="9" y="70" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs" font-weight="bold">Gemini CLI</text>
+    <text x="99" y="70" fill="#afafaf" textLength="63" lengthAdjust="spacingAndGlyphs"> v1.2.3</text>
+    <text x="162" y="70" fill="#ffffff" textLength="225" lengthAdjust="spacingAndGlyphs">▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀</text>
+    <text x="0" y="121" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs">1. Create </text>
+    <text x="90" y="121" fill="#ffffff" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">GEMINI.md</text>
+    <text x="171" y="121" fill="#ffffff" textLength="333" lengthAdjust="spacingAndGlyphs"> files to customize your interactions</text>
+    <text x="0" y="138" fill="#ffffff" textLength="450" lengthAdjust="spacingAndGlyphs">3. Ask coding questions, edit code or run commands</text>
+    <text x="0" y="155" fill="#ffffff" textLength="315" lengthAdjust="spacingAndGlyphs">4. Be specific for the best results</text>
+    <text x="0" y="189" fill="#ffffaf" textLength="891" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────────╮</text>
     <text x="0" y="206" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="206" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">48</text>
-    <text x="63" y="206" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="206" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line48</text>
-    <text x="171" y="206" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="206" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="206" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
+    <text x="18" y="206" fill="#ffffaf" textLength="135" lengthAdjust="spacingAndGlyphs" font-weight="bold">Action Required</text>
     <text x="882" y="206" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="206" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="223" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="223" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">49</text>
-    <text x="63" y="223" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="223" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line49</text>
-    <text x="171" y="223" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="223" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="223" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="223" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="223" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="240" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="240" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">50</text>
-    <text x="63" y="240" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="240" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line50</text>
-    <text x="171" y="240" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="240" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="240" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
+    <text x="18" y="240" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">?</text>
+    <text x="45" y="240" fill="#ffffff" textLength="36" lengthAdjust="spacingAndGlyphs" font-weight="bold">Edit</text>
+    <text x="90" y="240" fill="#afafaf" textLength="774" lengthAdjust="spacingAndGlyphs">packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =&gt;   return kittyProto</text>
+    <text x="864" y="240" fill="#ffffff" textLength="18" lengthAdjust="spacingAndGlyphs">… </text>
     <text x="882" y="240" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="240" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="257" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">51</text>
-    <text x="63" y="257" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
-    <text x="117" y="257" fill="#ffffff" textLength="54" lengthAdjust="spacingAndGlyphs">line51</text>
-    <text x="171" y="257" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs"> = </text>
-    <text x="198" y="257" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
-    <text x="234" y="257" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
+    <text x="9" y="257" fill="#333333" textLength="873" lengthAdjust="spacingAndGlyphs">─────────────────────────────────────────────────────────────────────────────────────────────────</text>
     <text x="882" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="257" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="274" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">52</text>
     <text x="63" y="274" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -100,7 +47,6 @@
     <text x="198" y="274" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="274" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="274" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="291" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">53</text>
     <text x="63" y="291" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -109,7 +55,6 @@
     <text x="198" y="291" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="291" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="291" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="308" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="308" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">54</text>
     <text x="63" y="308" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -118,7 +63,6 @@
     <text x="198" y="308" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="308" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="308" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="308" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="325" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="325" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">55</text>
     <text x="63" y="325" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -127,7 +71,6 @@
     <text x="198" y="325" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="325" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="325" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="325" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="342" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="342" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">56</text>
     <text x="63" y="342" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -136,7 +79,6 @@
     <text x="198" y="342" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="342" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="342" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="342" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="359" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="359" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">57</text>
     <text x="63" y="359" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -145,7 +87,6 @@
     <text x="198" y="359" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="359" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="359" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="359" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="376" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="376" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">58</text>
     <text x="63" y="376" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -154,7 +95,6 @@
     <text x="198" y="376" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="376" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="376" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="376" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="393" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="393" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">59</text>
     <text x="63" y="393" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -163,7 +103,6 @@
     <text x="198" y="393" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="393" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="393" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="393" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="410" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="410" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">60</text>
     <text x="63" y="410" fill="#e5e5e5" textLength="54" lengthAdjust="spacingAndGlyphs">const </text>
@@ -172,7 +111,6 @@
     <text x="198" y="410" fill="#0000ee" textLength="36" lengthAdjust="spacingAndGlyphs">true</text>
     <text x="234" y="410" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="410" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="410" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="427" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <rect x="18" y="425" width="18" height="17" fill="#5f0000" />
     <text x="18" y="427" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">61</text>
@@ -186,7 +124,6 @@
     <rect x="126" y="425" width="234" height="17" fill="#5f0000" />
     <text x="126" y="427" fill="#e5e5e5" textLength="234" lengthAdjust="spacingAndGlyphs"> kittyProtocolSupporte...;</text>
     <text x="882" y="427" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="427" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="444" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <rect x="18" y="442" width="18" height="17" fill="#005f00" />
     <text x="18" y="444" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">61</text>
@@ -200,12 +137,10 @@
     <rect x="126" y="442" width="234" height="17" fill="#005f00" />
     <text x="126" y="444" fill="#e5e5e5" textLength="234" lengthAdjust="spacingAndGlyphs"> kittyProtocolSupporte...;</text>
     <text x="882" y="444" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="444" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="461" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="461" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">62</text>
     <text x="63" y="461" fill="#e5e5e5" textLength="180" lengthAdjust="spacingAndGlyphs"> buffer: TextBuffer;</text>
     <text x="882" y="461" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="461" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="478" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="478" fill="#afafaf" textLength="18" lengthAdjust="spacingAndGlyphs">63</text>
     <text x="72" y="478" fill="#ffffff" textLength="72" lengthAdjust="spacingAndGlyphs">onSubmit</text>
@@ -217,14 +152,11 @@
     <text x="333" y="478" fill="#00cdcd" textLength="36" lengthAdjust="spacingAndGlyphs">void</text>
     <text x="369" y="478" fill="#e5e5e5" textLength="9" lengthAdjust="spacingAndGlyphs">;</text>
     <text x="882" y="478" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="478" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="495" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="495" fill="#ffffff" textLength="162" lengthAdjust="spacingAndGlyphs">Apply this change?</text>
     <text x="882" y="495" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="495" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="512" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="882" y="512" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="512" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="529" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <rect x="18" y="527" width="9" height="17" fill="#001a00" />
     <text x="18" y="529" fill="#00cd00" textLength="9" lengthAdjust="spacingAndGlyphs">●</text>
@@ -236,12 +168,11 @@
     <text x="63" y="529" fill="#00cd00" textLength="90" lengthAdjust="spacingAndGlyphs">Allow once</text>
     <rect x="153" y="527" width="288" height="17" fill="#001a00" />
     <text x="882" y="529" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="529" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
     <text x="0" y="546" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="36" y="546" fill="#ffffff" textLength="18" lengthAdjust="spacingAndGlyphs">2.</text>
     <text x="63" y="546" fill="#ffffff" textLength="198" lengthAdjust="spacingAndGlyphs">Allow for this session</text>
     <text x="882" y="546" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="891" y="546" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">█</text>
+    <text x="891" y="546" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
     <text x="0" y="563" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="36" y="563" fill="#ffffff" textLength="18" lengthAdjust="spacingAndGlyphs">3.</text>
     <text x="63" y="563" fill="#ffffff" textLength="378" lengthAdjust="spacingAndGlyphs">Allow for this file in all future sessions</text>

--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
@@ -1,39 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Full Terminal Tool Confirmation Snapshot > renders tool confirmation box in the frame of the entire terminal 1`] = `
-"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
- > Can you edit InputPrompt.tsx for me?                                                             
-▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+"
+ ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
+   ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
+  ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
+ Gemini CLI v1.2.3▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
+
+
+1. Create GEMINI.md files to customize your interactions
+3. Ask coding questions, edit code or run commands
+4. Be specific for the best results
+
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ Action Required                                                                                 │
 │                                                                                                 │
 │ ?  Edit packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =>   return kittyProto… │
+│─────────────────────────────────────────────────────────────────────────────────────────────────│
+│ 52   const line52 = true;                                                                       │
+│ 53   const line53 = true;                                                                       │
+│ 54   const line54 = true;                                                                       │
+│ 55   const line55 = true;                                                                       │
+│ 56   const line56 = true;                                                                       │
+│ 57   const line57 = true;                                                                       │
+│ 58   const line58 = true;                                                                       │
+│ 59   const line59 = true;                                                                       │
+│ 60   const line60 = true;                                                                       │
+│ 61 -  return kittyProtocolSupporte...;                                                          │
+│ 61 +  return kittyProtocolSupporte...;                                                          │
+│ 62    buffer: TextBuffer;                                                                       │
+│ 63    onSubmit: (value: string) => void;                                                        │
+│ Apply this change?                                                                              │
 │                                                                                                 │
-│ ... first 44 lines hidden (Ctrl+O to show) ...                                                  │
-│ 45   const line45 = true;                                                                       │
-│ 46   const line46 = true;                                                                       │
-│ 47   const line47 = true;                                                                       │█
-│ 48   const line48 = true;                                                                       │█
-│ 49   const line49 = true;                                                                       │█
-│ 50   const line50 = true;                                                                       │█
-│ 51   const line51 = true;                                                                       │█
-│ 52   const line52 = true;                                                                       │█
-│ 53   const line53 = true;                                                                       │█
-│ 54   const line54 = true;                                                                       │█
-│ 55   const line55 = true;                                                                       │█
-│ 56   const line56 = true;                                                                       │█
-│ 57   const line57 = true;                                                                       │█
-│ 58   const line58 = true;                                                                       │█
-│ 59   const line59 = true;                                                                       │█
-│ 60   const line60 = true;                                                                       │█
-│ 61 -  return kittyProtocolSupporte...;                                                          │█
-│ 61 +  return kittyProtocolSupporte...;                                                          │█
-│ 62    buffer: TextBuffer;                                                                       │█
-│ 63    onSubmit: (value: string) => void;                                                        │█
-│ Apply this change?                                                                              │█
-│                                                                                                 │█
-│ ● 1. Allow once                                                                                 │█
-│   2. Allow for this session                                                                     │█
+│ ● 1. Allow once                                                                                 │
+│   2. Allow for this session                                                                     │▄
 │   3. Allow for this file in all future sessions                                                 │█
 │   4. Modify with external editor                                                                │█
 │   5. No, suggest changes (esc)                                                                  │█

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -9,17 +9,14 @@ import { createMockSettings } from '../../test-utils/settings.js';
 import { makeFakeConfig, CoreToolCallStatus } from '@google/gemini-cli-core';
 import { waitFor } from '../../test-utils/async.js';
 import { MainContent } from './MainContent.js';
+import { TopicStickyHeader } from './TopicStickyHeader.js';
 import { getToolGroupBorderAppearance } from '../utils/borderStyles.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Box, Text } from 'ink';
-import { act, useState, type JSX } from 'react';
+import { type JSX } from 'react';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import { SHELL_COMMAND_NAME } from '../constants.js';
-import {
-  UIStateContext,
-  useUIState,
-  type UIState,
-} from '../contexts/UIStateContext.js';
+import { type UIState } from '../contexts/UIStateContext.js';
 import { type IndividualToolCallDisplay } from '../types.js';
 import {
   type ConfirmingToolState,
@@ -365,10 +362,9 @@ describe('MainContent', () => {
     const { lastFrame, unmount } = await renderWithProviders(<MainContent />, {
       uiState: defaultMockUiState as Partial<UIState>,
     });
-    await waitFor(() => expect(lastFrame()).toContain('AppHeader(full)'));
     const output = lastFrame();
 
-    expect(output).toContain('AppHeader');
+    expect(output).toContain('Hello');
     expect(output).toContain('Hello');
     expect(output).toContain('Hi there');
     unmount();
@@ -380,81 +376,9 @@ describe('MainContent', () => {
       uiState: defaultMockUiState as Partial<UIState>,
     });
     const output = lastFrame();
-    expect(output).toContain('AppHeader(full)');
     expect(output).toContain('Hello');
     expect(output).toContain('Hi there');
     unmount();
-  });
-
-  it('renders minimal header in minimal mode (alternate buffer)', async () => {
-    vi.mocked(useAlternateBuffer).mockReturnValue(true);
-
-    const { lastFrame, unmount } = await renderWithProviders(<MainContent />, {
-      uiState: {
-        ...defaultMockUiState,
-        cleanUiDetailsVisible: false,
-      } as Partial<UIState>,
-    });
-    await waitFor(() => expect(lastFrame()).toContain('Hello'));
-    const output = lastFrame();
-
-    expect(output).toContain('AppHeader(minimal)');
-    expect(output).not.toContain('AppHeader(full)');
-    expect(output).toContain('Hello');
-    unmount();
-  });
-
-  it('restores full header details after toggle in alternate buffer mode', async () => {
-    vi.mocked(useAlternateBuffer).mockReturnValue(true);
-
-    let setShowDetails: ((visible: boolean) => void) | undefined;
-    const ToggleHarness = () => {
-      const outerState = useUIState();
-      const [showDetails, setShowDetailsState] = useState(
-        outerState.cleanUiDetailsVisible,
-      );
-      setShowDetails = setShowDetailsState;
-
-      return (
-        <UIStateContext.Provider
-          value={{ ...outerState, cleanUiDetailsVisible: showDetails }}
-        >
-          <MainContent />
-        </UIStateContext.Provider>
-      );
-    };
-
-    const { lastFrame } = await renderWithProviders(<ToggleHarness />, {
-      uiState: {
-        ...defaultMockUiState,
-        cleanUiDetailsVisible: false,
-      } as Partial<UIState>,
-    });
-
-    await waitFor(() => expect(lastFrame()).toContain('AppHeader(minimal)'));
-    if (!setShowDetails) {
-      throw new Error('setShowDetails was not initialized');
-    }
-    const setShowDetailsSafe = setShowDetails;
-
-    act(() => {
-      setShowDetailsSafe(true);
-    });
-
-    await waitFor(() => expect(lastFrame()).toContain('AppHeader(full)'));
-  });
-
-  it('always renders full header details in normal buffer mode', async () => {
-    vi.mocked(useAlternateBuffer).mockReturnValue(false);
-    const { lastFrame } = await renderWithProviders(<MainContent />, {
-      uiState: {
-        ...defaultMockUiState,
-        cleanUiDetailsVisible: false,
-      } as Partial<UIState>,
-    });
-
-    await waitFor(() => expect(lastFrame()).toContain('AppHeader(full)'));
-    expect(lastFrame()).not.toContain('AppHeader(minimal)');
   });
 
   it('does not constrain height in alternate buffer mode', async () => {
@@ -463,7 +387,6 @@ describe('MainContent', () => {
       uiState: defaultMockUiState as Partial<UIState>,
     });
     const output = lastFrame();
-    expect(output).toContain('AppHeader(full)');
     expect(output).toContain('Hello');
     expect(output).toContain('Hi there');
     unmount();
@@ -906,5 +829,35 @@ describe('MainContent', () => {
         unmount();
       },
     );
+  });
+
+  it('renders TopicStickyHeader above history', async () => {
+    vi.mocked(useAlternateBuffer).mockReturnValue(true);
+    const uiState = {
+      ...defaultMockUiState,
+      history: [
+        { id: 1, type: 'user', text: 'First user prompt' },
+        { id: 2, type: 'gemini', text: 'Response to first' },
+        { id: 3, type: 'user', text: 'Second user prompt' },
+      ],
+      currentTopic: { title: 'Test Topic Title', summary: 'Test Summary' },
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <Box flexDirection="column">
+        <TopicStickyHeader />
+        <MainContent />
+      </Box>,
+      {
+        uiState: uiState as unknown as Partial<UIState>,
+        config: makeFakeConfig({ useAlternateBuffer: true }),
+        settings: createMockSettings({ ui: { useAlternateBuffer: true } }),
+      },
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Test Topic Title');
+    expect(output).toContain('Test Summary');
+    unmount();
   });
 });

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -8,7 +8,6 @@ import { Box, Static } from 'ink';
 import { HistoryItemDisplay } from './HistoryItemDisplay.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
-import { useAppContext } from '../contexts/AppContext.js';
 
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import {
@@ -29,7 +28,6 @@ const MemoizedHistoryItemDisplay = memo(HistoryItemDisplay);
 // This threshold is arbitrary but should be high enough to never impact normal
 // usage.
 export const MainContent = () => {
-  const { version } = useAppContext();
   const uiState = useUIState();
   const isAlternateBuffer = useAlternateBuffer();
 
@@ -50,9 +48,7 @@ export const MainContent = () => {
     mainAreaWidth,
     staticAreaMaxItemHeight,
     availableTerminalHeight,
-    cleanUiDetailsVisible,
   } = uiState;
-  const showHeaderDetails = cleanUiDetailsVisible;
 
   const lastUserPromptIndex = useMemo(() => {
     for (let i = uiState.history.length - 1; i >= 0; i--) {

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -15,7 +15,7 @@ import {
   type VirtualizedListRef,
 } from './shared/VirtualizedList.js';
 import { ScrollableList } from './shared/ScrollableList.js';
-import { useMemo, memo, useCallback, useEffect, useRef } from 'react';
+import { useMemo, memo, useEffect, useRef } from 'react';
 import { MAX_GEMINI_MESSAGE_LINES } from '../constants.js';
 import { useConfirmingTool } from '../hooks/useConfirmingTool.js';
 import { ToolConfirmationQueue } from './ToolConfirmationQueue.js';
@@ -147,16 +147,6 @@ export const MainContent = () => {
     ],
   );
 
-  const staticHistoryItems = useMemo(
-    () => historyItems.slice(0, lastUserPromptIndex + 1),
-    [historyItems, lastUserPromptIndex],
-  );
-
-  const lastResponseHistoryItems = useMemo(
-    () => historyItems.slice(lastUserPromptIndex + 1),
-    [historyItems, lastUserPromptIndex],
-  );
-
   const pendingItems = useMemo(
     () => (
       <Box flexDirection="column" key="pending-items-group">
@@ -209,31 +199,17 @@ export const MainContent = () => {
     ],
   );
 
-  const virtualizedData = useMemo(
-    () => [
-      ...augmentedHistory.map(
-        ({
-          item,
-          isExpandable,
-          isFirstThinking,
-          isFirstAfterThinking,
-          suppressNarration,
-        }) => ({
-          type: 'history' as const,
-          item,
-          isExpandable,
-          isFirstThinking,
-          isFirstAfterThinking,
-          suppressNarration,
-        }),
-      ),
+  if (isAlternateBuffer) {
+    const virtualizedData = [
+      ...augmentedHistory.map((ah) => ({ type: 'history' as const, ...ah })),
       { type: 'pending' as const },
-    ],
-    [augmentedHistory],
-  );
+    ];
 
-  const renderItem = useCallback(
-    ({ item }: { item: (typeof virtualizedData)[number] }) => {
+    const renderItem = ({
+      item,
+    }: {
+      item: (typeof virtualizedData)[number];
+    }) => {
       if (item.type === 'history') {
         return (
           <MemoizedHistoryItemDisplay
@@ -257,11 +233,8 @@ export const MainContent = () => {
       } else {
         return pendingItems;
       }
-    },
-    [mainAreaWidth, uiState.slashCommands, pendingItems, uiState.constrainHeight, staticAreaMaxItemHeight]
-  );
+    };
 
-  if (isAlternateBuffer) {
     return (
       <ScrollableList
         ref={scrollableListRef}
@@ -279,6 +252,9 @@ export const MainContent = () => {
       />
     );
   }
+
+  const staticHistoryItems = historyItems.slice(0, lastUserPromptIndex + 1);
+  const lastResponseHistoryItems = historyItems.slice(lastUserPromptIndex + 1);
 
   return (
     <>

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -9,7 +9,6 @@ import { HistoryItemDisplay } from './HistoryItemDisplay.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useAppContext } from '../contexts/AppContext.js';
-import { AppHeader } from './AppHeader.js';
 
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
 import {
@@ -24,7 +23,6 @@ import { ToolConfirmationQueue } from './ToolConfirmationQueue.js';
 import { isTopicTool } from './messages/TopicMessage.js';
 
 const MemoizedHistoryItemDisplay = memo(HistoryItemDisplay);
-const MemoizedAppHeader = memo(AppHeader);
 
 // Limit Gemini messages to a very high number of lines to mitigate performance
 // issues in the worst case if we somehow get an enormous response from Gemini.
@@ -217,7 +215,6 @@ export const MainContent = () => {
 
   const virtualizedData = useMemo(
     () => [
-      { type: 'header' as const },
       ...augmentedHistory.map(
         ({
           item,
@@ -241,15 +238,7 @@ export const MainContent = () => {
 
   const renderItem = useCallback(
     ({ item }: { item: (typeof virtualizedData)[number] }) => {
-      if (item.type === 'header') {
-        return (
-          <MemoizedAppHeader
-            key="app-header"
-            version={version}
-            showDetails={showHeaderDetails}
-          />
-        );
-      } else if (item.type === 'history') {
+      if (item.type === 'history') {
         return (
           <MemoizedHistoryItemDisplay
             terminalWidth={mainAreaWidth}
@@ -273,15 +262,7 @@ export const MainContent = () => {
         return pendingItems;
       }
     },
-    [
-      showHeaderDetails,
-      version,
-      mainAreaWidth,
-      uiState.slashCommands,
-      pendingItems,
-      uiState.constrainHeight,
-      staticAreaMaxItemHeight,
-    ],
+    [mainAreaWidth, uiState.slashCommands, pendingItems, uiState.constrainHeight, staticAreaMaxItemHeight]
   );
 
   if (isAlternateBuffer) {
@@ -294,7 +275,6 @@ export const MainContent = () => {
         renderItem={renderItem}
         estimatedItemHeight={() => 100}
         keyExtractor={(item, _index) => {
-          if (item.type === 'header') return 'header';
           if (item.type === 'history') return item.item.id.toString();
           return 'pending';
         }}
@@ -308,11 +288,7 @@ export const MainContent = () => {
     <>
       <Static
         key={uiState.historyRemountKey}
-        items={[
-          <AppHeader key="app-header" version={version} />,
-          ...staticHistoryItems,
-          ...lastResponseHistoryItems,
-        ]}
+        items={[...staticHistoryItems, ...lastResponseHistoryItems]}
       >
         {(item) => item}
       </Static>

--- a/packages/cli/src/ui/components/TopicStickyHeader.test.tsx
+++ b/packages/cli/src/ui/components/TopicStickyHeader.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../test-utils/render.js';
+import { TopicStickyHeader } from './TopicStickyHeader.js';
+import { describe, it, expect } from 'vitest';
+
+describe('<TopicStickyHeader />', () => {
+  it('should render nothing when currentTopic is null', async () => {
+    const uiState = {
+      currentTopic: null,
+      terminalWidth: 100,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <TopicStickyHeader />,
+      {
+        uiState,
+      },
+    );
+
+    expect(lastFrame({ allowEmpty: true })).toBe('');
+    unmount();
+  });
+
+  it('should render nothing when currentTopic has no title and no summary', async () => {
+    const uiState = {
+      currentTopic: { title: undefined, summary: undefined },
+      terminalWidth: 100,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <TopicStickyHeader />,
+      {
+        uiState,
+      },
+    );
+
+    expect(lastFrame({ allowEmpty: true })).toBe('');
+    unmount();
+  });
+
+  it('should render topic title', async () => {
+    const uiState = {
+      currentTopic: { title: 'My Awesome Topic' },
+      terminalWidth: 100,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <TopicStickyHeader />,
+      {
+        uiState,
+      },
+    );
+
+    expect(lastFrame()).toContain('My Awesome Topic');
+    expect(lastFrame()).not.toContain('Topic:');
+    unmount();
+  });
+
+  it('should render topic title and summary', async () => {
+    const uiState = {
+      currentTopic: { 
+        title: 'My Awesome Topic',
+        summary: 'This is a brief summary'
+      },
+      terminalWidth: 100,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <TopicStickyHeader />,
+      {
+        uiState,
+      },
+    );
+
+    expect(lastFrame()).toContain('My Awesome Topic');
+    expect(lastFrame()).toContain(': This is a brief summary');
+    unmount();
+  });
+
+  it('should render default title when only summary is present', async () => {
+    const uiState = {
+      currentTopic: { 
+        summary: 'Just a summary'
+      },
+      terminalWidth: 100,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <TopicStickyHeader />,
+      {
+        uiState,
+      },
+    );
+
+    expect(lastFrame()).toContain('Topic');
+    expect(lastFrame()).toContain(': Just a summary');
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/TopicStickyHeader.test.tsx
+++ b/packages/cli/src/ui/components/TopicStickyHeader.test.tsx
@@ -63,9 +63,9 @@ describe('<TopicStickyHeader />', () => {
 
   it('should render topic title and summary', async () => {
     const uiState = {
-      currentTopic: { 
+      currentTopic: {
         title: 'My Awesome Topic',
-        summary: 'This is a brief summary'
+        summary: 'This is a brief summary',
       },
       terminalWidth: 100,
     };
@@ -84,8 +84,8 @@ describe('<TopicStickyHeader />', () => {
 
   it('should render default title when only summary is present', async () => {
     const uiState = {
-      currentTopic: { 
-        summary: 'Just a summary'
+      currentTopic: {
+        summary: 'Just a summary',
       },
       terminalWidth: 100,
     };

--- a/packages/cli/src/ui/components/TopicStickyHeader.tsx
+++ b/packages/cli/src/ui/components/TopicStickyHeader.tsx
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box } from 'ink';
+import { useUIState } from '../contexts/UIStateContext.js';
+import { TopicDisplay } from './messages/TopicMessage.js';
+
+export const TOPIC_STICKY_HEADER_HEIGHT = 2;
+
+export const TopicStickyHeader: React.FC = () => {
+  const { currentTopic } = useUIState();
+
+  if (!currentTopic || (!currentTopic.title && !currentTopic.summary)) {
+    return null;
+  }
+
+  return (
+    <Box marginTop={1} flexDirection="column">
+      <TopicDisplay
+        title={currentTopic.title}
+        summary={currentTopic.summary}
+        marginLeft={2}
+      />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/TopicStickyHeader.tsx
+++ b/packages/cli/src/ui/components/TopicStickyHeader.tsx
@@ -9,21 +9,35 @@ import { Box } from 'ink';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { TopicDisplay } from './messages/TopicMessage.js';
 
+import { theme } from '../semantic-colors.js';
+
 export const TOPIC_STICKY_HEADER_HEIGHT = 2;
 
 export const TopicStickyHeader: React.FC = () => {
-  const { currentTopic } = useUIState();
+  const { currentTopic, terminalWidth } = useUIState();
 
   if (!currentTopic || (!currentTopic.title && !currentTopic.summary)) {
     return null;
   }
 
   return (
-    <Box marginTop={1} flexDirection="column">
-      <TopicDisplay
-        title={currentTopic.title}
-        summary={currentTopic.summary}
-        marginLeft={2}
+    <Box flexDirection="column" width={terminalWidth}>
+      <Box paddingY={0} paddingX={1} backgroundColor={theme.background.message}>
+        <TopicDisplay
+          title={currentTopic.title}
+          summary={currentTopic.summary}
+          marginLeft={1}
+        />
+      </Box>
+      <Box
+        width={terminalWidth}
+        height={1}
+        borderTop={true}
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={theme.ui.dark}
+        borderStyle="single"
       />
     </Box>
   );

--- a/packages/cli/src/ui/components/__snapshots__/MainContent-MainContent-renders-multiple-thinking-messages-sequentially-correctly.snap.svg
+++ b/packages/cli/src/ui/components/__snapshots__/MainContent-MainContent-renders-multiple-thinking-messages-sequentially-correctly.snap.svg
@@ -1,42 +1,41 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="326" viewBox="0 0 920 326">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="309" viewBox="0 0 920 309">
   <style>
     text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
   </style>
-  <rect width="920" height="326" fill="#000000" />
+  <rect width="920" height="309" fill="#000000" />
   <g transform="translate(10, 10)">
     <text x="0" y="2" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">ScrollableList                                                                                      </text>
-    <text x="0" y="19" fill="#ffffff" textLength="900" lengthAdjust="spacingAndGlyphs">AppHeader(full)                                                                                     </text>
-    <rect x="0" y="34" width="900" height="17" fill="#141414" />
-    <text x="0" y="36" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀</text>
-    <rect x="0" y="51" width="9" height="17" fill="#141414" />
-    <rect x="9" y="51" width="18" height="17" fill="#141414" />
-    <text x="9" y="53" fill="#d7afff" textLength="18" lengthAdjust="spacingAndGlyphs">&gt; </text>
-    <rect x="27" y="51" width="135" height="17" fill="#141414" />
-    <text x="27" y="53" fill="#ffffff" textLength="135" lengthAdjust="spacingAndGlyphs">Plan a solution</text>
-    <rect x="162" y="51" width="738" height="17" fill="#141414" />
-    <rect x="0" y="68" width="900" height="17" fill="#141414" />
-    <text x="0" y="70" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</text>
-    <text x="0" y="87" fill="#ffffff" textLength="117" lengthAdjust="spacingAndGlyphs" font-style="italic"> Thinking... </text>
+    <rect x="0" y="17" width="900" height="17" fill="#141414" />
+    <text x="0" y="19" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀</text>
+    <rect x="0" y="34" width="9" height="17" fill="#141414" />
+    <rect x="9" y="34" width="18" height="17" fill="#141414" />
+    <text x="9" y="36" fill="#d7afff" textLength="18" lengthAdjust="spacingAndGlyphs">&gt; </text>
+    <rect x="27" y="34" width="135" height="17" fill="#141414" />
+    <text x="27" y="36" fill="#ffffff" textLength="135" lengthAdjust="spacingAndGlyphs">Plan a solution</text>
+    <rect x="162" y="34" width="738" height="17" fill="#141414" />
+    <rect x="0" y="51" width="900" height="17" fill="#141414" />
+    <text x="0" y="53" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</text>
+    <text x="0" y="70" fill="#ffffff" textLength="117" lengthAdjust="spacingAndGlyphs" font-style="italic"> Thinking... </text>
+    <text x="9" y="87" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="9" y="104" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="27" y="104" fill="#ffffff" textLength="144" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Initial analysis</text>
     <text x="9" y="121" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="121" fill="#ffffff" textLength="144" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Initial analysis</text>
+    <text x="27" y="121" fill="#afafaf" textLength="675" lengthAdjust="spacingAndGlyphs" font-style="italic">This is a multiple line paragraph for the first thinking message of how the</text>
     <text x="9" y="138" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="138" fill="#afafaf" textLength="675" lengthAdjust="spacingAndGlyphs" font-style="italic">This is a multiple line paragraph for the first thinking message of how the</text>
+    <text x="27" y="138" fill="#afafaf" textLength="243" lengthAdjust="spacingAndGlyphs" font-style="italic">model analyzes the problem.</text>
     <text x="9" y="155" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="155" fill="#afafaf" textLength="243" lengthAdjust="spacingAndGlyphs" font-style="italic">model analyzes the problem.</text>
     <text x="9" y="172" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="27" y="172" fill="#ffffff" textLength="162" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Planning execution</text>
     <text x="9" y="189" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="189" fill="#ffffff" textLength="162" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Planning execution</text>
+    <text x="27" y="189" fill="#afafaf" textLength="621" lengthAdjust="spacingAndGlyphs" font-style="italic">This a second multiple line paragraph for the second thinking message</text>
     <text x="9" y="206" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="206" fill="#afafaf" textLength="621" lengthAdjust="spacingAndGlyphs" font-style="italic">This a second multiple line paragraph for the second thinking message</text>
+    <text x="27" y="206" fill="#afafaf" textLength="675" lengthAdjust="spacingAndGlyphs" font-style="italic">explaining the plan in detail so that it wraps around the terminal display.</text>
     <text x="9" y="223" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="223" fill="#afafaf" textLength="675" lengthAdjust="spacingAndGlyphs" font-style="italic">explaining the plan in detail so that it wraps around the terminal display.</text>
     <text x="9" y="240" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="27" y="240" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Refining approach</text>
     <text x="9" y="257" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="257" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold" font-style="italic">Refining approach</text>
+    <text x="27" y="257" fill="#afafaf" textLength="693" lengthAdjust="spacingAndGlyphs" font-style="italic">And finally a third multiple line paragraph for the third thinking message to</text>
     <text x="9" y="274" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="274" fill="#afafaf" textLength="693" lengthAdjust="spacingAndGlyphs" font-style="italic">And finally a third multiple line paragraph for the third thinking message to</text>
-    <text x="9" y="291" fill="#afafaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="27" y="291" fill="#afafaf" textLength="180" lengthAdjust="spacingAndGlyphs" font-style="italic">refine the solution.</text>
+    <text x="27" y="274" fill="#afafaf" textLength="180" lengthAdjust="spacingAndGlyphs" font-style="italic">refine the solution.</text>
   </g>
 </svg>

--- a/packages/cli/src/ui/components/__snapshots__/MainContent.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/MainContent.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`MainContent > MainContent Tool Output Height Logic > 'ASB mode - Focused shell should expand' 1`] = `
 "ScrollableList
-AppHeader(full)
 ╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⠋  Shell Command Running a long command...                                                   │
 │                                                                                              │
@@ -22,7 +21,6 @@ AppHeader(full)
 
 exports[`MainContent > MainContent Tool Output Height Logic > 'ASB mode - Unfocused shell' 1`] = `
 "ScrollableList
-AppHeader(full)
 ╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⠋  Shell Command Running a long command...                                                   │
 │                                                                                              │
@@ -41,8 +39,7 @@ AppHeader(full)
 `;
 
 exports[`MainContent > MainContent Tool Output Height Logic > 'Normal mode - Constrained height' 1`] = `
-"AppHeader(full)
-╭──────────────────────────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⠋  Shell Command Running a long command...                                                   │
 │                                                                                              │
 │ ... first 11 lines hidden (Ctrl+O to show) ...                                               │
@@ -60,8 +57,7 @@ exports[`MainContent > MainContent Tool Output Height Logic > 'Normal mode - Con
 `;
 
 exports[`MainContent > MainContent Tool Output Height Logic > 'Normal mode - Unconstrained height' 1`] = `
-"AppHeader(full)
-╭──────────────────────────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⠋  Shell Command Running a long command...                                                   │
 │                                                                                              │
 │ Line 1                                                                                       │
@@ -89,8 +85,7 @@ exports[`MainContent > MainContent Tool Output Height Logic > 'Normal mode - Unc
 `;
 
 exports[`MainContent > renders a ToolConfirmationQueue without an extra line when preceded by hidden tools 1`] = `
-"AppHeader(full)
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Apply plan                                                                   
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 ╭──────────────────────────────────────────────────────────────────────────────╮
@@ -102,8 +97,7 @@ exports[`MainContent > renders a ToolConfirmationQueue without an extra line whe
 `;
 
 exports[`MainContent > renders a split tool group without a gap between static and pending areas 1`] = `
-"AppHeader(full)
-╭──────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────╮
 │ ✓  test-tool A tool for testing                                          │
 │                                                                          │
 │ Part 1                                                                   │
@@ -116,16 +110,14 @@ exports[`MainContent > renders a split tool group without a gap between static a
 `;
 
 exports[`MainContent > renders a spurious line when a tool group has only hidden tools and borderBottom true 1`] = `
-"AppHeader(full)
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Apply plan                                                                   
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 "
 `;
 
 exports[`MainContent > renders a subagent with a complete box including bottom border 1`] = `
-"AppHeader(full)
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+"▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Investigate                                                                  
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 ╭──────────────────────────────────────────────────────────────────────────╮
@@ -141,7 +133,6 @@ exports[`MainContent > renders a subagent with a complete box including bottom b
 
 exports[`MainContent > renders mixed history items (user + gemini) with single line padding between them 1`] = `
 "ScrollableList
-AppHeader(full)
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > User message                                                                                     
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
@@ -160,7 +151,6 @@ AppHeader(full)
 
 exports[`MainContent > renders multiple history items with single line padding between them 1`] = `
 "ScrollableList
-AppHeader(full)
 ✦ Gemini message 1
   Gemini message 1
   Gemini message 1
@@ -187,7 +177,6 @@ AppHeader(full)
 
 exports[`MainContent > renders multiple thinking messages sequentially correctly 1`] = `
 "ScrollableList
-AppHeader(full)
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Plan a solution                                                                                  
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
@@ -209,7 +198,6 @@ AppHeader(full)
 
 exports[`MainContent > renders multiple thinking messages sequentially correctly 2`] = `
 "ScrollableList
-AppHeader(full)
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  > Plan a solution                                                                                  
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -257,61 +257,6 @@ describe('<ToolGroupMessage />', () => {
       unmount();
     });
 
-    it('renders update_topic tool call using TopicMessage', async () => {
-      const toolCalls = [
-        createToolCall({
-          callId: 'topic-tool',
-          name: UPDATE_TOPIC_TOOL_NAME,
-          args: {
-            [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            [TOPIC_PARAM_STRATEGIC_INTENT]: 'This is the description',
-          },
-        }),
-      ];
-      const item = createItem(toolCalls);
-
-      const { lastFrame, unmount } = await renderWithProviders(
-        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
-        {
-          config: baseMockConfig,
-          settings: fullVerbositySettings,
-        },
-      );
-
-      const output = lastFrame();
-      expect(output).toContain('Testing Topic: ');
-      expect(output).toContain('This is the description');
-      expect(output).toMatchSnapshot('update_topic_tool');
-      unmount();
-    });
-
-    it('renders update_topic tool call with summary instead of strategic_intent', async () => {
-      const toolCalls = [
-        createToolCall({
-          callId: 'topic-tool-summary',
-          name: UPDATE_TOPIC_TOOL_NAME,
-          args: {
-            [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            summary: 'This is the summary',
-          },
-        }),
-      ];
-      const item = createItem(toolCalls);
-
-      const { lastFrame, unmount } = await renderWithProviders(
-        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
-        {
-          config: baseMockConfig,
-          settings: fullVerbositySettings,
-        },
-      );
-
-      const output = lastFrame();
-      expect(output).toContain('Testing Topic: ');
-      expect(output).toContain('This is the summary');
-      unmount();
-    });
-
     it('renders mixed tool calls including update_topic', async () => {
       const toolCalls = [
         createToolCall({

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -15,7 +15,7 @@ import type {
 import { ToolCallStatus, mapCoreStatusToDisplayStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
 import { ShellToolMessage } from './ShellToolMessage.js';
-import { TopicMessage, isTopicTool } from './TopicMessage.js';
+import { isTopicTool } from './TopicMessage.js';
 import { SubagentGroupDisplay } from './SubagentGroupDisplay.js';
 import { DenseToolMessage } from './DenseToolMessage.js';
 import { theme } from '../../semantic-colors.js';
@@ -143,7 +143,14 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         ) {
           return false;
         }
+
+        // Hide topic tools from history as they are now sticky headers
+        if (isTopicTool(t.name)) {
+          return false;
+        }
+
         // Standard hiding logic (e.g. Plan Mode internal edits)
+
         if (
           shouldHideToolCall({
             displayName: t.name,
@@ -458,8 +465,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             >
               {isCompact ? (
                 <DenseToolMessage {...commonProps} />
-              ) : isTopicToolCall ? (
-                <TopicMessage {...commonProps} />
               ) : isShellToolCall ? (
                 <ShellToolMessage {...commonProps} config={config} />
               ) : (

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -15,7 +15,7 @@ import type {
 import { ToolCallStatus, mapCoreStatusToDisplayStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
 import { ShellToolMessage } from './ShellToolMessage.js';
-import { isTopicTool } from './TopicMessage.js';
+import { TopicMessage, isTopicTool } from './TopicMessage.js';
 import { SubagentGroupDisplay } from './SubagentGroupDisplay.js';
 import { DenseToolMessage } from './DenseToolMessage.js';
 import { theme } from '../../semantic-colors.js';
@@ -141,11 +141,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           t.status === CoreToolCallStatus.Error &&
           !t.isClientInitiated
         ) {
-          return false;
-        }
-
-        // Hide topic tools from history as they are now sticky headers
-        if (isTopicTool(t.name)) {
           return false;
         }
 
@@ -465,6 +460,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             >
               {isCompact ? (
                 <DenseToolMessage {...commonProps} />
+              ) : isTopicToolCall ? (
+                <TopicMessage {...commonProps} />
               ) : isShellToolCall ? (
                 <ShellToolMessage {...commonProps} config={config} />
               ) : (

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -11,10 +11,35 @@ import {
   UPDATE_TOPIC_DISPLAY_NAME,
   TOPIC_PARAM_TITLE,
   TOPIC_PARAM_SUMMARY,
-  TOPIC_PARAM_STRATEGIC_INTENT,
 } from '@google/gemini-cli-core';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { theme } from '../../semantic-colors.js';
+
+interface TopicDisplayProps {
+  title?: string;
+  summary?: string;
+  marginLeft?: number;
+}
+
+export const TopicDisplay: React.FC<TopicDisplayProps> = ({
+  title,
+  summary,
+  marginLeft = 2,
+}) => {
+  return (
+    <Box flexDirection="row" marginLeft={marginLeft} flexWrap="wrap">
+      <Text color={theme.text.primary} bold wrap="wrap">
+        {title || 'Topic'}
+        {summary && <Text>: </Text>}
+      </Text>
+      {summary && (
+        <Text color={theme.text.secondary} wrap="wrap">
+          {summary}
+        </Text>
+      )}
+    </Box>
+  );
+};
 
 interface TopicMessageProps extends IndividualToolCallDisplay {
   terminalWidth: number;
@@ -26,21 +51,8 @@ export const isTopicTool = (name: string): boolean =>
 export const TopicMessage: React.FC<TopicMessageProps> = ({ args }) => {
   const rawTitle = args?.[TOPIC_PARAM_TITLE];
   const title = typeof rawTitle === 'string' ? rawTitle : undefined;
-  const rawIntent =
-    args?.[TOPIC_PARAM_STRATEGIC_INTENT] || args?.[TOPIC_PARAM_SUMMARY];
-  const intent = typeof rawIntent === 'string' ? rawIntent : undefined;
+  const rawSummary = args?.[TOPIC_PARAM_SUMMARY];
+  const summary = typeof rawSummary === 'string' ? rawSummary : undefined;
 
-  return (
-    <Box flexDirection="row" marginLeft={2} flexWrap="wrap">
-      <Text color={theme.text.primary} bold wrap="truncate-end">
-        {title || 'Topic'}
-        {intent && <Text>: </Text>}
-      </Text>
-      {intent && (
-        <Text color={theme.text.secondary} wrap="wrap">
-          {intent}
-        </Text>
-      )}
-    </Box>
-  );
+  return <TopicDisplay title={title} summary={summary} />;
 };

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -77,8 +77,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including update_topic 1`] = `
-"  Testing Topic: This is the description
-╭──────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────╮
 │ ✓  read_file Read a file                                                 │
 │                                                                          │
 │ Test result                                                              │
@@ -137,11 +136,6 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where
 │ line1                                                                    │                       ▄
 ╰──────────────────────────────────────────────────────────────────────────╯                       █
                                                                                                    █
-"
-`;
-
-exports[`<ToolGroupMessage /> > Golden Snapshots > renders update_topic tool call using TopicMessage > update_topic_tool 1`] = `
-"  Testing Topic: This is the description
 "
 `;
 

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -102,6 +102,11 @@ export interface AccountSuspensionInfo {
   appealLinkText?: string;
 }
 
+export interface TopicInfo {
+  title?: string;
+  summary?: string;
+}
+
 export interface UIState {
   history: HistoryItem[];
   historyManager: UseHistoryManagerReturn;
@@ -142,6 +147,7 @@ export interface UIState {
   initError: string | null;
   pendingGeminiHistoryItems: HistoryItemWithoutId[];
   thought: ThoughtSummary | null;
+  currentTopic: TopicInfo | null;
   shellModeActive: boolean;
   userMessages: string[];
   buffer: TextBuffer;

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -41,6 +41,10 @@ vi.mock('../contexts/UIStateContext.js', () => ({
   useUIState: () => mockUIState,
 }));
 
+vi.mock('../contexts/AppContext.js', () => ({
+  useAppContext: () => ({ version: '1.2.3', startupWarnings: [] }),
+}));
+
 vi.mock('../hooks/useFlickerDetector.js', () => ({
   useFlickerDetector: vi.fn(),
 }));

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -10,19 +10,23 @@ import { Notifications } from '../components/Notifications.js';
 import { MainContent } from '../components/MainContent.js';
 import { DialogManager } from '../components/DialogManager.js';
 import { Composer } from '../components/Composer.js';
+import { AppHeader } from '../components/AppHeader.js';
+import { TopicStickyHeader } from '../components/TopicStickyHeader.js';
 import { ExitWarning } from '../components/ExitWarning.js';
 import { useUIState } from '../contexts/UIStateContext.js';
-import { useFlickerDetector } from '../hooks/useFlickerDetector.js';
 import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+import { useFlickerDetector } from '../hooks/useFlickerDetector.js';
 import { CopyModeWarning } from '../components/CopyModeWarning.js';
 import { BackgroundTaskDisplay } from '../components/BackgroundTaskDisplay.js';
 import { StreamingState } from '../types.js';
+import { useAppContext } from '../contexts/AppContext.js';
 
 export const DefaultAppLayout: React.FC = () => {
+  const { version } = useAppContext();
   const uiState = useUIState();
   const isAlternateBuffer = useAlternateBuffer();
 
-  const { rootUiRef, terminalHeight } = uiState;
+  const { rootUiRef, terminalHeight, cleanUiDetailsVisible } = uiState;
   useFlickerDetector(rootUiRef, terminalHeight);
   // If in alternate buffer mode, need to leave room to draw the scrollbar on
   // the right side of the terminal.
@@ -37,6 +41,7 @@ export const DefaultAppLayout: React.FC = () => {
       overflow="hidden"
       ref={uiState.rootUiRef}
     >
+      <AppHeader version={version} showDetails={cleanUiDetailsVisible} />
       <MainContent />
 
       {uiState.isBackgroundTaskVisible &&
@@ -80,6 +85,8 @@ export const DefaultAppLayout: React.FC = () => {
         ) : (
           <Composer isFocused={true} />
         )}
+
+        <TopicStickyHeader />
 
         <ExitWarning />
       </Box>

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -42,6 +42,7 @@ export const DefaultAppLayout: React.FC = () => {
       ref={uiState.rootUiRef}
     >
       <AppHeader version={version} showDetails={cleanUiDetailsVisible} />
+      <TopicStickyHeader />
       <MainContent />
 
       {uiState.isBackgroundTaskVisible &&
@@ -85,8 +86,6 @@ export const DefaultAppLayout: React.FC = () => {
         ) : (
           <Composer isFocused={true} />
         )}
-
-        <TopicStickyHeader />
 
         <ExitWarning />
       </Box>

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -32,6 +32,7 @@ export const ScreenReaderAppLayout: React.FC = () => {
       ref={uiState.rootUiRef}
     >
       <AppHeader version={version} showDetails={cleanUiDetailsVisible} />
+      <TopicStickyHeader />
       <Notifications />
       <Footer />
       <Box flexGrow={1} overflow="hidden">
@@ -45,8 +46,6 @@ export const ScreenReaderAppLayout: React.FC = () => {
       ) : (
         <Composer />
       )}
-
-      <TopicStickyHeader />
 
       <ExitWarning />
     </Box>

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -8,16 +8,20 @@ import type React from 'react';
 import { Box } from 'ink';
 import { Notifications } from '../components/Notifications.js';
 import { MainContent } from '../components/MainContent.js';
+import { AppHeader } from '../components/AppHeader.js';
+import { TopicStickyHeader } from '../components/TopicStickyHeader.js';
 import { DialogManager } from '../components/DialogManager.js';
 import { Composer } from '../components/Composer.js';
 import { Footer } from '../components/Footer.js';
 import { ExitWarning } from '../components/ExitWarning.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useFlickerDetector } from '../hooks/useFlickerDetector.js';
+import { useAppContext } from '../contexts/AppContext.js';
 
 export const ScreenReaderAppLayout: React.FC = () => {
+  const { version } = useAppContext();
   const uiState = useUIState();
-  const { rootUiRef, terminalHeight } = uiState;
+  const { rootUiRef, terminalHeight, cleanUiDetailsVisible } = uiState;
   useFlickerDetector(rootUiRef, terminalHeight);
 
   return (
@@ -27,6 +31,7 @@ export const ScreenReaderAppLayout: React.FC = () => {
       height="100%"
       ref={uiState.rootUiRef}
     >
+      <AppHeader version={version} showDetails={cleanUiDetailsVisible} />
       <Notifications />
       <Footer />
       <Box flexGrow={1} overflow="hidden">
@@ -40,6 +45,8 @@ export const ScreenReaderAppLayout: React.FC = () => {
       ) : (
         <Composer />
       )}
+
+      <TopicStickyHeader />
 
       <ExitWarning />
     </Box>

--- a/packages/cli/src/ui/layouts/__snapshots__/DefaultAppLayout.test.tsx.snap
+++ b/packages/cli/src/ui/layouts/__snapshots__/DefaultAppLayout.test.tsx.snap
@@ -1,38 +1,136 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<DefaultAppLayout /> > hides BackgroundTaskDisplay when StreamingState is WaitingForConfirmation 1`] = `
-"MainContent
-Notifications
-CopyModeWarning
-Composer
-ExitWarning
+"
+  ERROR  useSettings must be used within a SettingsProvider
+
+ src/ui/contexts/SettingsContext.tsx:24:11
+
+ 21: export const useSettings = (): LoadedSettings => {
+ 22:   const context = useContext(SettingsContext);
+ 23:   if (context === undefined) {
+ 24:     throw new Error('useSettings must be used within a SettingsProvider');
+ 25:   }
+ 26:   return context;
+ 27: };
+
+ - useSettings (src/ui/contexts/SettingsContext.tsx:24:11)
+ - AppHeader (src/ui/components/AppHeader.tsx:60:20)
+ -Object.react-stack-botto
+  m-frame                (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky
+                         -headers/node_modules/react-reconciler/cjs/react-reconciler.development.js
+                         :15859:20)
+ -renderWithHook
+  s            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/n
+               ode_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionCompo
+  nent              (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-head
+                    ers/node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19)
+
+ -beginWork
+          (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/node_m
+          odules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ -runWithFiberInD
+  EV            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ -performUnitOfWo
+  rk            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+ -workLoopSync
+             (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/nod
+             e_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+ -renderRootSyn
+  c           (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/no
+              de_modules/react-reconciler/cjs/react-reconciler.development.js:12624:11)
 "
 `;
 
 exports[`<DefaultAppLayout /> > renders BackgroundTaskDisplay when shells exist and active 1`] = `
-"MainContent
-BackgroundTaskDisplay
+"
+  ERROR  useSettings must be used within a SettingsProvider
 
+ src/ui/contexts/SettingsContext.tsx:24:11
 
+ 21: export const useSettings = (): LoadedSettings => {
+ 22:   const context = useContext(SettingsContext);
+ 23:   if (context === undefined) {
+ 24:     throw new Error('useSettings must be used within a SettingsProvider');
+ 25:   }
+ 26:   return context;
+ 27: };
 
+ - useSettings (src/ui/contexts/SettingsContext.tsx:24:11)
+ - AppHeader (src/ui/components/AppHeader.tsx:60:20)
+ -Object.react-stack-botto
+  m-frame                (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky
+                         -headers/node_modules/react-reconciler/cjs/react-reconciler.development.js
+                         :15859:20)
+ -renderWithHook
+  s            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/n
+               ode_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionCompo
+  nent              (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-head
+                    ers/node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19)
 
-Notifications
-CopyModeWarning
-Composer
-ExitWarning
+ -beginWork
+          (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/node_m
+          odules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ -runWithFiberInD
+  EV            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ -performUnitOfWo
+  rk            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+ -workLoopSync
+             (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/nod
+             e_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+ -renderRootSyn
+  c           (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/no
+              de_modules/react-reconciler/cjs/react-reconciler.development.js:12624:11)
 "
 `;
 
 exports[`<DefaultAppLayout /> > shows BackgroundTaskDisplay when StreamingState is NOT WaitingForConfirmation 1`] = `
-"MainContent
-BackgroundTaskDisplay
+"
+  ERROR  useSettings must be used within a SettingsProvider
 
+ src/ui/contexts/SettingsContext.tsx:24:11
 
+ 21: export const useSettings = (): LoadedSettings => {
+ 22:   const context = useContext(SettingsContext);
+ 23:   if (context === undefined) {
+ 24:     throw new Error('useSettings must be used within a SettingsProvider');
+ 25:   }
+ 26:   return context;
+ 27: };
 
+ - useSettings (src/ui/contexts/SettingsContext.tsx:24:11)
+ - AppHeader (src/ui/components/AppHeader.tsx:60:20)
+ -Object.react-stack-botto
+  m-frame                (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky
+                         -headers/node_modules/react-reconciler/cjs/react-reconciler.development.js
+                         :15859:20)
+ -renderWithHook
+  s            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/n
+               ode_modules/react-reconciler/cjs/react-reconciler.development.js:3221:22)
+ -updateFunctionCompo
+  nent              (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-head
+                    ers/node_modules/react-reconciler/cjs/react-reconciler.development.js:6475:19)
 
-Notifications
-CopyModeWarning
-Composer
-ExitWarning
+ -beginWork
+          (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/node_m
+          odules/react-reconciler/cjs/react-reconciler.development.js:8009:18)
+ -runWithFiberInD
+  EV            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:1738:13)
+ -performUnitOfWo
+  rk            (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/
+                node_modules/react-reconciler/cjs/react-reconciler.development.js:12834:22)
+ -workLoopSync
+             (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/nod
+             e_modules/react-reconciler/cjs/react-reconciler.development.js:12644:41)
+ -renderRootSyn
+  c           (/Users/abhijitbalaji/projects/gemini-cli.worktrees/abhijit-2592-mv-sticky-headers/no
+              de_modules/react-reconciler/cjs/react-reconciler.development.js:12624:11)
 "
 `;

--- a/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-a-pending-search-dialog-google_web_search-.snap.svg
+++ b/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-a-pending-search-dialog-google_web_search-.snap.svg
@@ -1,45 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="343" viewBox="0 0 920 343">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="105" viewBox="0 0 920 105">
   <style>
     text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
   </style>
-  <rect width="920" height="343" fill="#000000" />
+  <rect width="920" height="105" fill="#000000" />
   <g transform="translate(10, 10)">
-    <text x="9" y="19" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="19" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="27" y="19" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="19" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛</text>
-    <text x="27" y="36" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="36" y="36" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="45" y="36" fill="#c3677f" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="36" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">█▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌</text>
-    <text x="18" y="53" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▗</text>
-    <text x="27" y="53" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▟</text>
-    <text x="36" y="53" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="53" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌</text>
-    <text x="9" y="70" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="70" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="70" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs"> ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀</text>
-    <text x="9" y="104" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs" font-weight="bold">Gemini CLI</text>
-    <text x="99" y="104" fill="#afafaf" textLength="63" lengthAdjust="spacingAndGlyphs"> v1.2.3</text>
-    <text x="0" y="155" fill="#ffffff" textLength="225" lengthAdjust="spacingAndGlyphs">Tips for getting started:</text>
-    <text x="0" y="172" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs">1. Create </text>
-    <text x="90" y="172" fill="#ffffff" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">GEMINI.md</text>
-    <text x="171" y="172" fill="#ffffff" textLength="333" lengthAdjust="spacingAndGlyphs"> files to customize your interactions</text>
-    <text x="0" y="189" fill="#ffffff" textLength="27" lengthAdjust="spacingAndGlyphs">2. </text>
-    <text x="27" y="189" fill="#afafaf" textLength="45" lengthAdjust="spacingAndGlyphs">/help</text>
-    <text x="72" y="189" fill="#ffffff" textLength="189" lengthAdjust="spacingAndGlyphs"> for more information</text>
-    <text x="0" y="206" fill="#ffffff" textLength="450" lengthAdjust="spacingAndGlyphs">3. Ask coding questions, edit code or run commands</text>
-    <text x="0" y="223" fill="#ffffff" textLength="315" lengthAdjust="spacingAndGlyphs">4. Be specific for the best results</text>
-    <text x="0" y="240" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
-    <text x="0" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
-    <text x="45" y="257" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">google_web_search</text>
-    <text x="855" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="855" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="291" fill="#ffffff" textLength="108" lengthAdjust="spacingAndGlyphs">Searching...</text>
-    <text x="855" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="308" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
+    <text x="0" y="2" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
+    <text x="0" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
+    <text x="45" y="19" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">google_web_search</text>
+    <text x="855" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="36" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="855" y="36" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="53" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="53" fill="#ffffff" textLength="108" lengthAdjust="spacingAndGlyphs">Searching...</text>
+    <text x="855" y="53" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="70" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
   </g>
 </svg>

--- a/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-a-shell-tool.snap.svg
+++ b/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-a-shell-tool.snap.svg
@@ -1,45 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="343" viewBox="0 0 920 343">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="105" viewBox="0 0 920 105">
   <style>
     text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
   </style>
-  <rect width="920" height="343" fill="#000000" />
+  <rect width="920" height="105" fill="#000000" />
   <g transform="translate(10, 10)">
-    <text x="9" y="19" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="19" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="27" y="19" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="19" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛</text>
-    <text x="27" y="36" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="36" y="36" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="45" y="36" fill="#c3677f" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="36" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">█▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌</text>
-    <text x="18" y="53" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▗</text>
-    <text x="27" y="53" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▟</text>
-    <text x="36" y="53" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="53" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌</text>
-    <text x="9" y="70" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="70" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="70" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs"> ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀</text>
-    <text x="9" y="104" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs" font-weight="bold">Gemini CLI</text>
-    <text x="99" y="104" fill="#afafaf" textLength="63" lengthAdjust="spacingAndGlyphs"> v1.2.3</text>
-    <text x="0" y="155" fill="#ffffff" textLength="225" lengthAdjust="spacingAndGlyphs">Tips for getting started:</text>
-    <text x="0" y="172" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs">1. Create </text>
-    <text x="90" y="172" fill="#ffffff" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">GEMINI.md</text>
-    <text x="171" y="172" fill="#ffffff" textLength="333" lengthAdjust="spacingAndGlyphs"> files to customize your interactions</text>
-    <text x="0" y="189" fill="#ffffff" textLength="27" lengthAdjust="spacingAndGlyphs">2. </text>
-    <text x="27" y="189" fill="#afafaf" textLength="45" lengthAdjust="spacingAndGlyphs">/help</text>
-    <text x="72" y="189" fill="#ffffff" textLength="189" lengthAdjust="spacingAndGlyphs"> for more information</text>
-    <text x="0" y="206" fill="#ffffff" textLength="450" lengthAdjust="spacingAndGlyphs">3. Ask coding questions, edit code or run commands</text>
-    <text x="0" y="223" fill="#ffffff" textLength="315" lengthAdjust="spacingAndGlyphs">4. Be specific for the best results</text>
-    <text x="0" y="240" fill="#87afff" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
-    <text x="0" y="257" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="257" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
-    <text x="45" y="257" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">run_shell_command</text>
-    <text x="855" y="257" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="274" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="855" y="274" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="291" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="291" fill="#ffffff" textLength="162" lengthAdjust="spacingAndGlyphs">Running command...</text>
-    <text x="855" y="291" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="308" fill="#87afff" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
+    <text x="0" y="2" fill="#87afff" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
+    <text x="0" y="19" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="19" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
+    <text x="45" y="19" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">run_shell_command</text>
+    <text x="855" y="19" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="36" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="855" y="36" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="53" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="53" fill="#ffffff" textLength="162" lengthAdjust="spacingAndGlyphs">Running command...</text>
+    <text x="855" y="53" fill="#87afff" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="70" fill="#87afff" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
   </g>
 </svg>

--- a/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-an-empty-slice-following-a-search-tool.snap.svg
+++ b/packages/cli/src/ui/utils/__snapshots__/borderStyles-MainContent-tool-group-border-SVG-snapshots-should-render-SVG-snapshot-for-an-empty-slice-following-a-search-tool.snap.svg
@@ -1,45 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="343" viewBox="0 0 920 343">
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="105" viewBox="0 0 920 105">
   <style>
     text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
   </style>
-  <rect width="920" height="343" fill="#000000" />
+  <rect width="920" height="105" fill="#000000" />
   <g transform="translate(10, 10)">
-    <text x="9" y="19" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="19" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="27" y="19" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="19" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛</text>
-    <text x="27" y="36" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="36" y="36" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▜</text>
-    <text x="45" y="36" fill="#c3677f" textLength="9" lengthAdjust="spacingAndGlyphs">▄</text>
-    <text x="90" y="36" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">█▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌</text>
-    <text x="18" y="53" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▗</text>
-    <text x="27" y="53" fill="#847ace" textLength="9" lengthAdjust="spacingAndGlyphs">▟</text>
-    <text x="36" y="53" fill="#a471a7" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="53" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs">▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌</text>
-    <text x="9" y="70" fill="#4796e4" textLength="9" lengthAdjust="spacingAndGlyphs">▝</text>
-    <text x="18" y="70" fill="#6688d9" textLength="9" lengthAdjust="spacingAndGlyphs">▀</text>
-    <text x="90" y="70" fill="#ffffff" textLength="297" lengthAdjust="spacingAndGlyphs"> ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀</text>
-    <text x="9" y="104" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs" font-weight="bold">Gemini CLI</text>
-    <text x="99" y="104" fill="#afafaf" textLength="63" lengthAdjust="spacingAndGlyphs"> v1.2.3</text>
-    <text x="0" y="155" fill="#ffffff" textLength="225" lengthAdjust="spacingAndGlyphs">Tips for getting started:</text>
-    <text x="0" y="172" fill="#ffffff" textLength="90" lengthAdjust="spacingAndGlyphs">1. Create </text>
-    <text x="90" y="172" fill="#ffffff" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">GEMINI.md</text>
-    <text x="171" y="172" fill="#ffffff" textLength="333" lengthAdjust="spacingAndGlyphs"> files to customize your interactions</text>
-    <text x="0" y="189" fill="#ffffff" textLength="27" lengthAdjust="spacingAndGlyphs">2. </text>
-    <text x="27" y="189" fill="#afafaf" textLength="45" lengthAdjust="spacingAndGlyphs">/help</text>
-    <text x="72" y="189" fill="#ffffff" textLength="189" lengthAdjust="spacingAndGlyphs"> for more information</text>
-    <text x="0" y="206" fill="#ffffff" textLength="450" lengthAdjust="spacingAndGlyphs">3. Ask coding questions, edit code or run commands</text>
-    <text x="0" y="223" fill="#ffffff" textLength="315" lengthAdjust="spacingAndGlyphs">4. Be specific for the best results</text>
-    <text x="0" y="240" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
-    <text x="0" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
-    <text x="45" y="257" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">google_web_search</text>
-    <text x="855" y="257" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="855" y="274" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="291" fill="#ffffff" textLength="108" lengthAdjust="spacingAndGlyphs">Searching...</text>
-    <text x="855" y="291" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="0" y="308" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
+    <text x="0" y="2" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────╮</text>
+    <text x="0" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">⊶</text>
+    <text x="45" y="19" fill="#ffffff" textLength="153" lengthAdjust="spacingAndGlyphs" font-weight="bold">google_web_search</text>
+    <text x="855" y="19" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="36" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="855" y="36" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="53" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="18" y="53" fill="#ffffff" textLength="108" lengthAdjust="spacingAndGlyphs">Searching...</text>
+    <text x="855" y="53" fill="#ffffaf" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
+    <text x="0" y="70" fill="#ffffaf" textLength="864" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────╯</text>
   </g>
 </svg>

--- a/packages/cli/src/ui/utils/__snapshots__/borderStyles.test.tsx.snap
+++ b/packages/cli/src/ui/utils/__snapshots__/borderStyles.test.tsx.snap
@@ -1,21 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`MainContent tool group border SVG snapshots > should render SVG snapshot for a pending search dialog (google_web_search) 1`] = `
-"
- ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
-   ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
-  ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
- ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
- Gemini CLI v1.2.3
-
-
-Tips for getting started:
-1. Create GEMINI.md files to customize your interactions
-2. /help for more information
-3. Ask coding questions, edit code or run commands
-4. Be specific for the best results
-╭──────────────────────────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⊶  google_web_search                                                                         │
 │                                                                                              │
 │ Searching...                                                                                 │
@@ -24,21 +10,7 @@ Tips for getting started:
 `;
 
 exports[`MainContent tool group border SVG snapshots > should render SVG snapshot for a shell tool 1`] = `
-"
- ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
-   ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
-  ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
- ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
- Gemini CLI v1.2.3
-
-
-Tips for getting started:
-1. Create GEMINI.md files to customize your interactions
-2. /help for more information
-3. Ask coding questions, edit code or run commands
-4. Be specific for the best results
-╭──────────────────────────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⊶  run_shell_command                                                                         │
 │                                                                                              │
 │ Running command...                                                                           │
@@ -47,21 +19,7 @@ Tips for getting started:
 `;
 
 exports[`MainContent tool group border SVG snapshots > should render SVG snapshot for an empty slice following a search tool 1`] = `
-"
- ▝▜▄      ▗█▀▀▜▙▝█▛▀▀▌▜██▖▟██▘▜█▘▜██▖▝█▛▝█▛
-   ▝▜▄    █▌     █▙▟  ▐█▝█▛▐█ ▐█ ▐█▝█▖█▌ █▌
-  ▗▟▀     ▜▙ ▝█▛ █▌▝ ▖▐█   ▐█ ▐█ ▐█ ▝██▌ █▌
- ▝▀        ▀▀▀▀▘▝▀▀▀▀▘▀▀▘  ▀▀▘▀▀▘▀▀▘ ▝▀▀▝▀▀
-
- Gemini CLI v1.2.3
-
-
-Tips for getting started:
-1. Create GEMINI.md files to customize your interactions
-2. /help for more information
-3. Ask coding questions, edit code or run commands
-4. Be specific for the best results
-╭──────────────────────────────────────────────────────────────────────────────────────────────╮
+"╭──────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ⊶  google_web_search                                                                         │
 │                                                                                              │
 │ Searching...                                                                                 │

--- a/packages/core/src/config/topicState.ts
+++ b/packages/core/src/config/topicState.ts
@@ -4,37 +4,50 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { coreEvents } from '../utils/events.js';
+
 /**
  * Manages the current active topic title and tactical intent for a session.
  * Hosted within the Config instance for session-scoping.
  */
 export class TopicState {
   private activeTopicTitle?: string;
+  private activeSummary?: string;
   private activeIntent?: string;
 
   /**
    * Sanitizes and sets the topic title and/or intent.
    * @returns true if the input was valid and set, false otherwise.
    */
-  setTopic(title?: string, intent?: string): boolean {
+  setTopic(title?: string, summary?: string, intent?: string): boolean {
     const sanitizedTitle = title?.trim().replace(/[\r\n]+/g, ' ');
+    const sanitizedSummary = summary?.trim().replace(/[\r\n]+/g, ' ');
     const sanitizedIntent = intent?.trim().replace(/[\r\n]+/g, ' ');
 
-    if (!sanitizedTitle && !sanitizedIntent) return false;
+    if (!sanitizedTitle && !sanitizedSummary && !sanitizedIntent) return false;
 
     if (sanitizedTitle) {
       this.activeTopicTitle = sanitizedTitle;
+    }
+
+    if (sanitizedSummary) {
+      this.activeSummary = sanitizedSummary;
     }
 
     if (sanitizedIntent) {
       this.activeIntent = sanitizedIntent;
     }
 
+    coreEvents.emitTopicUpdated(this.activeTopicTitle, this.activeSummary);
     return true;
   }
 
   getTopic(): string | undefined {
     return this.activeTopicTitle;
+  }
+
+  getSummary(): string | undefined {
+    return this.activeSummary;
   }
 
   getIntent(): string | undefined {
@@ -43,6 +56,7 @@ export class TopicState {
 
   reset(): void {
     this.activeTopicTitle = undefined;
+    this.activeSummary = undefined;
     this.activeIntent = undefined;
   }
 }

--- a/packages/core/src/tools/topicTool.test.ts
+++ b/packages/core/src/tools/topicTool.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { UpdateTopicTool } from './topicTool.js';
 import { TopicState } from '../config/topicState.js';
+import { coreEvents } from '../utils/events.js';
 import { MessageBus } from '../confirmation-bus/message-bus.js';
 import type { PolicyEngine } from '../policy/policy-engine.js';
 import {
@@ -24,36 +25,55 @@ describe('TopicState', () => {
     state = new TopicState();
   });
 
-  it('should store and retrieve topic title and intent', () => {
+  it('should store and retrieve topic title, summary and intent', () => {
     expect(state.getTopic()).toBeUndefined();
+    expect(state.getSummary()).toBeUndefined();
     expect(state.getIntent()).toBeUndefined();
-    const success = state.setTopic('Test Topic', 'Test Intent');
+    const success = state.setTopic('Test Topic', 'Test Summary', 'Test Intent');
     expect(success).toBe(true);
     expect(state.getTopic()).toBe('Test Topic');
+    expect(state.getSummary()).toBe('Test Summary');
     expect(state.getIntent()).toBe('Test Intent');
   });
 
   it('should sanitize newlines and carriage returns', () => {
-    state.setTopic('Topic\nWith\r\nLines', 'Intent\nWith\r\nLines');
+    state.setTopic(
+      'Topic\nWith\r\nLines',
+      'Summary\nWith\r\nLines',
+      'Intent\nWith\r\nLines',
+    );
     expect(state.getTopic()).toBe('Topic With Lines');
+    expect(state.getSummary()).toBe('Summary With Lines');
     expect(state.getIntent()).toBe('Intent With Lines');
   });
 
   it('should trim whitespace', () => {
-    state.setTopic('  Spaced Topic   ', '  Spaced Intent   ');
+    state.setTopic(
+      '  Spaced Topic   ',
+      '  Spaced Summary   ',
+      '  Spaced Intent   ',
+    );
     expect(state.getTopic()).toBe('Spaced Topic');
+    expect(state.getSummary()).toBe('Spaced Summary');
     expect(state.getIntent()).toBe('Spaced Intent');
   });
 
   it('should reject empty or whitespace-only inputs', () => {
-    expect(state.setTopic('', '')).toBe(false);
+    expect(state.setTopic('', '', '')).toBe(false);
   });
 
-  it('should reset topic and intent', () => {
-    state.setTopic('Test Topic', 'Test Intent');
+  it('should reset topic, summary and intent', () => {
+    state.setTopic('Test Topic', 'Test Summary', 'Test Intent');
     state.reset();
     expect(state.getTopic()).toBeUndefined();
+    expect(state.getSummary()).toBeUndefined();
     expect(state.getIntent()).toBeUndefined();
+  });
+
+  it('should emit TopicUpdated event when topic is set', () => {
+    const spy = vi.spyOn(coreEvents, 'emitTopicUpdated');
+    state.setTopic('Topic', 'Summary', 'Intent');
+    expect(spy).toHaveBeenCalledWith('Topic', 'Summary');
   });
 });
 

--- a/packages/core/src/tools/topicTool.ts
+++ b/packages/core/src/tools/topicTool.ts
@@ -62,9 +62,10 @@ class UpdateTopicInvocation extends BaseToolInvocation<
       title.trim() !== activeTopic
     );
 
-    this.config.topicState.setTopic(title, strategicIntent);
+    this.config.topicState.setTopic(title, summary, strategicIntent);
 
-    const currentTopic = this.config.topicState.getTopic() || '...';
+    const currentTopic = this.config.topicState.getTopic();
+
     const currentIntent =
       strategicIntent || this.config.topicState.getIntent() || '...';
 

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -147,6 +147,14 @@ export interface AgentsDiscoveredPayload {
   agents: AgentDefinition[];
 }
 
+/**
+ * Payload for the 'topic-updated' event.
+ */
+export interface TopicUpdatedPayload {
+  title?: string;
+  summary?: string;
+}
+
 export interface SlashCommandConflict {
   name: string;
   renamedTo: string;
@@ -189,6 +197,7 @@ export enum CoreEvent {
   ConsentRequest = 'consent-request',
   McpProgress = 'mcp-progress',
   AgentsDiscovered = 'agents-discovered',
+  TopicUpdated = 'topic-updated',
   RequestEditorSelection = 'request-editor-selection',
   EditorSelected = 'editor-selected',
   SlashCommandConflicts = 'slash-command-conflicts',
@@ -223,6 +232,7 @@ export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.ConsentRequest]: [ConsentRequestPayload];
   [CoreEvent.McpProgress]: [McpProgressPayload];
   [CoreEvent.AgentsDiscovered]: [AgentsDiscoveredPayload];
+  [CoreEvent.TopicUpdated]: [TopicUpdatedPayload];
   [CoreEvent.RequestEditorSelection]: never[];
   [CoreEvent.EditorSelected]: [EditorSelectedPayload];
   [CoreEvent.SlashCommandConflicts]: [SlashCommandConflictsPayload];
@@ -384,6 +394,14 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   emitAgentsDiscovered(agents: AgentDefinition[]): void {
     const payload: AgentsDiscoveredPayload = { agents };
     this._emitOrQueue(CoreEvent.AgentsDiscovered, payload);
+  }
+
+  /**
+   * Notifies subscribers that the current topic has been updated.
+   */
+  emitTopicUpdated(title?: string, summary?: string): void {
+    const payload: TopicUpdatedPayload = { title, summary };
+    this.emit(CoreEvent.TopicUpdated, payload);
   }
 
   emitSlashCommandConflicts(conflicts: SlashCommandConflict[]): void {


### PR DESCRIPTION
## Summary

Relocate the `TopicStickyHeader` from the chat history to a persistent position at the top of the application layout. This ensures the current topic remains visible at all times during scrolling, providing constant context to the user.

## Details

- **Architecture Refactor**: Moved `TopicStickyHeader` out of `MainContent` (scrolling area) and into `DefaultAppLayout` and `ScreenReaderAppLayout` (fixed frame).
- **Styling**: Added a background and a bottom separator line to the sticky header to visually distinguish it as a persistent UI element.
- **Simplification**: Removed the complex dynamic injection and virtualization logic in `MainContent` that previously attempted to fake stickiness. This resolves multiple duplication bugs where headers were "baked" into the history.
- **Natural History**: Restored the rendering of `update_topic` tool calls within the chat history, ensuring the conversation log remains complete and accurate.

## Related Issues

Closes #24553

## How to Validate

1. Run `npm run start`.
2. Issue a command that results in long output (e.g., "Summarize the entire project").
3. Observe the topic header (e.g., "Thinking...") sitting at the top of the chat area.
4. Scroll up through the chat history.
5. Verify that the topic header stays pinned to the top of the viewport and doesn't duplicate in the history.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run