### PR TITLE
docs: move agent disabling instructions and update remote agent status

### DIFF
--- a/docs/core/remote-agents.md
+++ b/docs/core/remote-agents.md
@@ -1,4 +1,4 @@
-# Remote Subagents (experimental)
+# Remote Subagents
 
 Gemini CLI supports connecting to remote subagents using the Agent-to-Agent
 (A2A) protocol. This allows Gemini CLI to interact with other agents, expanding
@@ -9,23 +9,6 @@ agents in the following repositories:
 
 - [ADK Samples (Python)](https://github.com/google/adk-samples/tree/main/python)
 - [ADK Python Contributing Samples](https://github.com/google/adk-python/tree/main/contributing/samples)
-
-<!-- prettier-ignore -->
-> [!NOTE]
-> Remote subagents are currently an experimental feature.
-
-## Configuration
-
-To use remote subagents, you must explicitly enable them in your
-`settings.json`:
-
-```json
-{
-  "experimental": {
-    "enableAgents": true
-  }
-}
-```
 
 ## Proxy support
 
@@ -459,3 +442,16 @@ Users can manage subagents using the following commands within the Gemini CLI:
 > [!TIP]
 > You can use the `@cli_help` agent within Gemini CLI for assistance
 > with configuring subagents.
+
+## Disabling remote agents
+
+Remote subagents are enabled by default. To disable them, set `enableAgents` to
+`false` in your `settings.json`:
+
+```json
+{
+  "experimental": {
+    "enableAgents": false
+  }
+}
+```

--- a/docs/core/subagents.md
+++ b/docs/core/subagents.md
@@ -5,15 +5,6 @@ session. They are designed to handle specific, complex tasks—like deep codebas
 analysis, documentation lookup, or domain-specific reasoning—without cluttering
 the main agent's context or toolset.
 
-Subagents are enabled by default. To disable them, set `enableAgents` to `false`
-in your `settings.json`:
-
-```json
-{
-  "experimental": { "enableAgents": false }
-}
-```
-
 ## What are subagents?
 
 Subagents are "specialists" that the main Gemini agent can hire for a specific
@@ -568,3 +559,14 @@ configuration, authentication, and usage instructions.
 Extensions can bundle and distribute subagents. See the
 [Extensions documentation](../extensions/index.md#subagents) for details on how
 to package agents within an extension.
+
+## Disabling subagents
+
+Subagents are enabled by default. To disable them, set `enableAgents` to `false`
+in your `settings.json`:
+
+```json
+{
+  "experimental": { "enableAgents": false }
+}
+```


### PR DESCRIPTION
## Summary

This PR improves the documentation for subagents and remote subagents by prioritizing feature discovery over disabling instructions. It also marks remote subagents as released.

## Details

- **Subagents Documentation**: Moved the "Disabling subagents" section from the top to the bottom of `docs/core/subagents.md`.
- **Remote Subagents Documentation**: 
    - Removed "experimental" labels and notes from `docs/core/remote-agents.md`.
    - Removed the "Configuration" (enabling) section from the top of the page.
    - Added a "Disabling remote agents" section at the bottom.
    - Preserved the `experimental.enableAgents` flag in configuration examples as the flag itself remains experimental.

## Related Issues

N/A

## How to Validate

1. Review `docs/core/subagents.md` to ensure disabling instructions are at the bottom.
2. Review `docs/core/remote-agents.md` to ensure experimental labels are removed and disabling instructions are at the bottom.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
