### PR TITLE
fix(cli): ensure skills list outputs to stdout in non-interactive environments

### DIFF
--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 import { type Config } from '@google/gemini-cli-core';
 import { handleList, listCommand } from './list.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
@@ -32,8 +40,7 @@ vi.mock('../utils.js', () => ({
 describe('skills list command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockLoadCliConfig = vi.mocked(loadCliConfig);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let stdoutWriteSpy: any;
+  let stdoutWriteSpy: MockInstance<typeof process.stdout.write>;
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -32,7 +32,8 @@ vi.mock('../utils.js', () => ({
 describe('skills list command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockLoadCliConfig = vi.mocked(loadCliConfig);
-  let stdoutWriteSpy: MockInstance;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutWriteSpy: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/packages/cli/src/commands/skills/list.test.ts
+++ b/packages/cli/src/commands/skills/list.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { coreEvents, type Config } from '@google/gemini-cli-core';
+import { type Config } from '@google/gemini-cli-core';
 import { handleList, listCommand } from './list.js';
 import { loadSettings, type LoadedSettings } from '../../config/settings.js';
 import { loadCliConfig } from '../../config/config.js';
@@ -32,12 +32,16 @@ vi.mock('../utils.js', () => ({
 describe('skills list command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockLoadCliConfig = vi.mocked(loadCliConfig);
+  let stdoutWriteSpy: MockInstance;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     mockLoadSettings.mockReturnValue({
       merged: {},
     } as unknown as LoadedSettings);
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -56,10 +60,7 @@ describe('skills list command', () => {
 
       await handleList({});
 
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
-        'No skills discovered.',
-      );
+      expect(stdoutWriteSpy).toHaveBeenCalledWith('No skills discovered.\n');
     });
 
     it('should list all discovered skills', async () => {
@@ -87,24 +88,19 @@ describe('skills list command', () => {
 
       await handleList({});
 
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
-        chalk.bold('Discovered Agent Skills:'),
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        chalk.bold('Discovered Agent Skills:') + '\n\n',
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining('skill1'),
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining(chalk.green('[Enabled]')),
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining('skill2'),
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining(chalk.red('[Disabled]')),
       );
     });
@@ -135,12 +131,10 @@ describe('skills list command', () => {
 
       // Default
       await handleList({ all: false });
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining('regular'),
       );
-      expect(coreEvents.emitConsoleLog).not.toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('builtin'),
       );
 
@@ -148,16 +142,13 @@ describe('skills list command', () => {
 
       // With all: true
       await handleList({ all: true });
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining('regular'),
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining('builtin'),
       );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
         expect.stringContaining(chalk.gray(' [Built-in]')),
       );
     });

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -5,7 +5,6 @@
  */
 
 import type { CommandModule } from 'yargs';
-import { debugLogger } from '@google/gemini-cli-core';
 import { loadSettings } from '../../config/settings.js';
 import { loadCliConfig, type CliArgs } from '../../config/config.js';
 import { exitCli } from '../utils.js';
@@ -42,12 +41,11 @@ export async function handleList(args: { all?: boolean }) {
   });
 
   if (skills.length === 0) {
-    debugLogger.log('No skills discovered.');
+    process.stdout.write('No skills discovered.\n');
     return;
   }
 
-  debugLogger.log(chalk.bold('Discovered Agent Skills:'));
-  debugLogger.log('');
+  process.stdout.write(chalk.bold('Discovered Agent Skills:') + '\n\n');
 
   for (const skill of skills) {
     const status = skill.disabled
@@ -56,10 +54,11 @@ export async function handleList(args: { all?: boolean }) {
 
     const builtinSuffix = skill.isBuiltin ? chalk.gray(' [Built-in]') : '';
 
-    debugLogger.log(`${chalk.bold(skill.name)} ${status}${builtinSuffix}`);
-    debugLogger.log(`  Description: ${skill.description}`);
-    debugLogger.log(`  Location:    ${skill.location}`);
-    debugLogger.log('');
+    process.stdout.write(
+      `${chalk.bold(skill.name)} ${status}${builtinSuffix}\n`,
+    );
+    process.stdout.write(`  Description: ${skill.description}\n`);
+    process.stdout.write(`  Location:    ${skill.location}\n\n`);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes a regression where `gemini skills list` produced no output on stdout when run in non-interactive environments (e.g., via a Python script's `subprocess.run`). This regression was caused by PR #22739, which configured the `ConsolePatcher` to drop `console.log` and `console.info` messages in headless mode to reduce noise. Because `skills list` relied on `debugLogger.log` (which wraps `console.log`), its intended stdout payload was incorrectly suppressed.

This PR modifies the `skills list` command to write its output directly using `process.stdout.write`, bypassing the `ConsolePatcher` and ensuring the list is reliably printed regardless of the TTY state.

## Details
- Replaced `debugLogger.log` calls with `process.stdout.write` in `packages/cli/src/commands/skills/list.ts`.
- Formatted newlines explicitly to match the previous output.
- Removed the unused `debugLogger` import.
- Updated unit tests (`list.test.ts`) to spy on `process.stdout.write` instead of `coreEvents.emitConsoleLog`.

## Related Issues
Caused by #22739
Fixes #24574

## How to Validate
1. Run `gemini skills list` in a standard terminal. It should print the discovered skills as expected.
2. Run `gemini skills list` in a non-interactive environment (e.g., piping to `cat` or using a Python script):
   `python3 -c "import subprocess; print(subprocess.run(['node', 'packages/cli/bin/gemini', 'skills', 'list'], capture_output=True, text=True).stdout)"`
   It should successfully print the list of skills instead of an empty string.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker