### PR TITLE
fix(core): pass includeDirectories to sandbox configuration

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1696,6 +1696,7 @@ export class Config implements McpContext, AgentLoopContext {
       {
         workspace: this.targetDir,
         forbiddenPaths: this.getSandboxForbiddenPaths.bind(this),
+        includeDirectories: this.pendingIncludeDirectories,
         policyManager: this._sandboxPolicyManager,
       },
       this.getApprovalMode(),


### PR DESCRIPTION
## Summary

This PR ensures that `includeDirectories` are correctly passed to the sandbox configuration in the `Config` class.

## Details

The `Config` class was initializing the sandbox configuration but missing the `includeDirectories` property, which is populated from `pendingIncludeDirectories`. This change ensures that any directories marked for inclusion (e.g., when a user trusts a directory or specifies additional context) are properly recognized by the sandbox policy manager.

## Related Issues

N/A

## How to Validate

1. Run the CLI with a configuration that includes specific directories (e.g., via `pendingIncludeDirectories`).
2. Verify that the sandbox correctly allows access to these directories.
3. Unit tests in `packages/core/src/config/config.test.ts` pass and cover basic initialization logic.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
