### PR TITLE
docs: clarify release coordination

### DIFF
--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -22,12 +22,6 @@ nightly) or the release branch (for preview/stable).
 
 - **Platforms:** Tests must pass on **Linux and macOS**.
 
-<!-- prettier-ignore -->
-> [!NOTE]
-> Windows tests currently run with `continue-on-error: true`. While a
-> failure here doesn't block the release technically, it should be
-> investigated.
-
 - **Checks:**
   - **Linting:** No linting errors (ESLint, Prettier, etc.).
   - **Typechecking:** No TypeScript errors.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,9 @@
 # Gemini CLI releases
 
+<!-- prettier-ignore -->
+> [!IMPORTANT]
+> **Coordinate with the Release Manager:** The release manager is responsible for coordinating patches and releases. Please update them before performing any of the release actions described in this document.
+
 ## `dev` vs `prod` environment
 
 Our release flows support both `dev` and `prod` environments.


### PR DESCRIPTION
## Summary

Clarify that releases are coordinated with the release manager in the release documentation.

## Details

Also: remove no-longer-true warning about windows test.