### PR TITLE
feat(cli): minimalist sandbox status labels

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -81,6 +81,7 @@ const mockConfigPlain = {
   isTrustedFolder: () => true,
   getExtensionRegistryURI: () => undefined,
   getContentGeneratorConfig: () => ({ authType: undefined }),
+  getSandboxEnabled: () => false,
 };
 
 const mockConfig = mockConfigPlain as unknown as Config;
@@ -364,7 +365,7 @@ describe('<Footer />', () => {
       unmount();
     });
 
-    it('should display custom sandbox info when SANDBOX env is set', async () => {
+    it('should display "current process" for custom sandbox when SANDBOX env is set', async () => {
       vi.stubEnv('SANDBOX', 'gemini-cli-test-sandbox');
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
         config: mockConfig,
@@ -374,12 +375,12 @@ describe('<Footer />', () => {
           sessionStats: mockSessionStats,
         },
       });
-      expect(lastFrame()).toContain('test');
+      expect(lastFrame()).toContain('current process');
       vi.unstubAllEnvs();
       unmount();
     });
 
-    it('should display macOS Seatbelt info when SANDBOX is sandbox-exec', async () => {
+    it('should display "current process" for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
       vi.stubEnv('SANDBOX', 'sandbox-exec');
       vi.stubEnv('SEATBELT_PROFILE', 'test-profile');
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
@@ -387,7 +388,7 @@ describe('<Footer />', () => {
         width: 120,
         uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
       });
-      expect(lastFrame()).toMatch(/macOS Seatbelt.*\(test-profile\)/s);
+      expect(lastFrame()).toContain('current process');
       vi.unstubAllEnvs();
       unmount();
     });
@@ -401,6 +402,24 @@ describe('<Footer />', () => {
         uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
       });
       expect(lastFrame()).toContain('no sandbox');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should display "all tools" when tool sandboxing is enabled and agent is local', async () => {
+      vi.stubEnv('SANDBOX', '');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: Object.assign(
+          Object.create(Object.getPrototypeOf(mockConfig)),
+          mockConfig,
+          {
+            getSandboxEnabled: () => true,
+          },
+        ),
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
+      expect(lastFrame()).toContain('all tools');
       vi.unstubAllEnvs();
       unmount();
     });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -67,26 +67,19 @@ interface SandboxIndicatorProps {
 const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
   isTrustedFolder,
 }) => {
+  const config = useConfig();
+  const sandboxEnabled = config.getSandboxEnabled();
   if (isTrustedFolder === false) {
     return <Text color={theme.status.warning}>untrusted</Text>;
   }
 
   const sandbox = process.env['SANDBOX'];
-  if (sandbox && sandbox !== 'sandbox-exec') {
-    return (
-      <Text color="green">{sandbox.replace(/^gemini-(?:cli-)?/, '')}</Text>
-    );
+  if (sandbox) {
+    return <Text color={theme.status.warning}>current process</Text>;
   }
 
-  if (sandbox === 'sandbox-exec') {
-    return (
-      <Text color={theme.status.warning}>
-        macOS Seatbelt{' '}
-        <Text color={theme.ui.comment}>
-          ({process.env['SEATBELT_PROFILE']})
-        </Text>
-      </Text>
-    );
+  if (sandboxEnabled) {
+    return <Text color={theme.status.warning}>all tools</Text>;
   }
 
   return <Text color={theme.status.error}>no sandbox</Text>;
@@ -311,9 +304,8 @@ export const Footer: React.FC = () => {
         let str = 'no sandbox';
         const sandbox = process.env['SANDBOX'];
         if (isTrustedFolder === false) str = 'untrusted';
-        else if (sandbox === 'sandbox-exec')
-          str = `macOS Seatbelt (${process.env['SEATBELT_PROFILE']})`;
-        else if (sandbox) str = sandbox.replace(/^gemini-(?:cli-)?/, '');
+        else if (sandbox) str = 'current process';
+        else if (config.getSandboxEnabled()) str = 'all tools';
 
         addCol(
           id,


### PR DESCRIPTION
## Summary

This PR updates the CLI footer to provide a minimalist sandbox status. It groups all agent-level sandboxing (Docker, Podman, macOS Seatbelt) under a single "current process" label and changes the tool-level sandboxing status to "all tools".

## Details

- Updated `SandboxIndicator` in `Footer.tsx` to use:
    - `"current process"` (Yellow) for all agent-level sandboxing (detected via `SANDBOX` env).
    - `"all tools"` (Yellow) for tool-level sandboxing (detected via config).
    - `"no sandbox"` (Red) for unsandboxed state.
- Aligned all sandboxed states to use yellow (`theme.status.warning`) for consistent visual feedback.
- Updated `Footer.test.tsx` and added unit tests for the new labeling.
- Fixed an ESLint spread operator error on class instances in tests.

## Related Issues


## How to Validate

1. Run the CLI with `security.toolSandboxing` enabled in settings.
2. Observe "all tools" in yellow in the footer.
3. Run the CLI in Docker/Podman or with `sandbox-exec` and observe "current process" in yellow.
4. Run `npm test -w @google/gemini-cli -- src/ui/components/Footer.test.tsx`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
