### PR TITLE
Add instructions for how to start react in prod and force react to prod mode

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -122,6 +122,13 @@ code.
   # From the root of the repository
   npm run start
   ```
+- **Production mode (React optimizations):** This method runs the CLI with React
+  production mode enabled, which is useful for testing performance without
+  development overhead.
+  ```bash
+  # From the root of the repository
+  npm run start:prod
+  ```
 - **Production-like mode (linked package):** This method simulates a global
   installation by linking your local package. It's useful for testing a local
   build in a production workflow.

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -94,6 +94,10 @@ const cliConfig = {
     'process.env.GEMINI_SANDBOX_IMAGE_DEFAULT': JSON.stringify(
       pkg.config?.sandboxImageUri,
     ),
+    'process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || 'production',
+    ),
+    'process.env.DEV': JSON.stringify(process.env.DEV || 'false'),
   },
   plugins: createWasmPlugins(),
   alias: {
@@ -114,6 +118,10 @@ const a2aServerConfig = {
     __filename: '__chunk_filename',
     __dirname: '__chunk_dirname',
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
+    'process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || 'production',
+    ),
+    'process.env.DEV': JSON.stringify(process.env.DEV || 'false'),
   },
   plugins: createWasmPlugins(),
   alias: commonAliases,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development node scripts/start.js",
+    "start:prod": "cross-env NODE_ENV=production node scripts/start.js",
     "start:a2a-server": "CODER_AGENT_PORT=41242 npm run start --workspace @google/gemini-cli-a2a-server",
     "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "deflake": "node scripts/deflake.js",

--- a/packages/devtools/esbuild.client.js
+++ b/packages/devtools/esbuild.client.js
@@ -17,6 +17,9 @@ await esbuild.build({
   target: 'es2020',
   jsx: 'automatic',
   outfile: 'dist/client/main.js',
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
 });
 
 // Embed client assets as string constants so the devtools server can be

--- a/packages/vscode-ide-companion/esbuild.js
+++ b/packages/vscode-ide-companion/esbuild.js
@@ -48,6 +48,9 @@ async function main() {
     },
     define: {
       'import.meta.url': 'import_meta.url',
+      'process.env.NODE_ENV': JSON.stringify(
+        production ? 'production' : 'development',
+      ),
     },
     alias: {
       punycode: 'punycode/',


### PR DESCRIPTION
## Summary

When debugging performance and memory issues it is helpful to not get distracted by React dev only issues

Run
` npm run start:prod`
to run with prod react.