### PR TITLE
fix(cli): ensure subcommands are visible by adding space and preventing auto-execute

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1409,6 +1409,57 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should NOT auto-execute commands with subcommands even if autoExecute: true on Enter', async () => {
+    const chatCommand: SlashCommand = {
+      name: 'chat',
+      kind: CommandKind.BUILT_IN,
+      description: 'Chat command',
+      action: vi.fn(),
+      autoExecute: true,
+      subCommands: [
+        { name: 'list', description: 'List', kind: CommandKind.BUILT_IN },
+      ],
+    };
+
+    const suggestion = { label: 'chat', value: 'chat' };
+
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [suggestion],
+      activeSuggestionIndex: 0,
+      getCommandFromSuggestion: vi.fn().mockReturnValue(chatCommand),
+      getCompletedText: vi.fn().mockReturnValue('/chat '), // Added space due to subcommands
+      slashCompletionRange: {
+        completionStart: 1,
+        completionEnd: 3, // "/ch" -> start at 1, end at 3
+        getCommandFromSuggestion: vi.fn(),
+        isArgumentCompletion: false,
+        leafCommand: null,
+      },
+    });
+
+    // User typed partial command
+    props.buffer.setText('/ch');
+    props.buffer.lines = ['/ch'];
+    props.buffer.cursor = [0, 3];
+
+    const { stdin, unmount } = await renderWithProviders(
+      <InputPrompt {...props} />,
+      {
+        uiActions,
+      },
+    );
+
+    await act(async () => {
+      stdin.write('\r'); // Enter
+    });
+
+    // Should NOT auto-execute, should just autocomplete (which InputPrompt handles by replacing buffer)
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it('should autocomplete commands with autoExecute: false on Enter', async () => {
     const shareCommand: SlashCommand = {
       name: 'share',

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1086,12 +1086,19 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                   const command =
                     completion.getCommandFromSuggestion(suggestion);
 
+                  const hasSubCommands = !!(
+                    command &&
+                    command.subCommands &&
+                    command.subCommands.length > 0
+                  );
+
                   // Only auto-execute if the command has no completion function
-                  // (i.e., it doesn't require an argument to be selected)
+                  // and no subcommands (so we don't skip showing subcommands)
                   if (
                     command &&
                     isAutoExecutableCommand(command) &&
-                    !command.completion
+                    !command.completion &&
+                    !hasSubCommands
                   ) {
                     const completedText =
                       completion.getCompletedText(suggestion);

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -481,7 +481,34 @@ describe('useCommandCompletion', () => {
   });
 
   describe('handleAutocomplete', () => {
-    it('should complete a partial command and NOT add a space if it has an action', async () => {
+    it('should complete a partial command and ADD a space if it has subcommands even if it has an action', async () => {
+      setupMocks({
+        slashSuggestions: [{ label: 'mcp', value: 'mcp' }],
+        slashCompletionRange: {
+          completionStart: 1,
+          completionEnd: 4,
+          getCommandFromSuggestion: () =>
+            ({
+              action: vi.fn(),
+              subCommands: [{ name: 'list' }],
+            }) as unknown as SlashCommand,
+        },
+      });
+
+      const { result } = await renderCommandCompletionHook('/mcp');
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBe(1);
+      });
+
+      act(() => {
+        result.current.handleAutocomplete(0);
+      });
+
+      expect(result.current.textBuffer.text).toBe('/mcp ');
+    });
+
+    it('should complete a partial command and NOT add a space if it has an action and NO subcommands', async () => {
       setupMocks({
         slashSuggestions: [{ label: 'memory', value: 'memory' }],
         slashCompletionRange: {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -443,10 +443,16 @@ export function useCommandCompletion({
         const command =
           slashCompletionRange.getCommandFromSuggestion(suggestion);
         // Don't add a space if the command has an action (can be executed)
-        // and doesn't have a completion function (doesn't REQUIRE more arguments)
+        // and doesn't have a completion function or subcommands
         const isExecutableCommand = !!(command && command.action);
         const requiresArguments = !!(command && command.completion);
-        shouldAddSpace = !isExecutableCommand || requiresArguments;
+        const hasSubCommands = !!(
+          command &&
+          command.subCommands &&
+          command.subCommands.length > 0
+        );
+        shouldAddSpace =
+          !isExecutableCommand || requiresArguments || hasSubCommands;
       }
 
       if (


### PR DESCRIPTION
## Summary
Fixes a UX issue where slash commands with subcommands (e.g., `/mcp`, `/chat`) prematurely auto-execute or autocomplete without a trailing space, which hides their available subcommands from the user.

## Details
- Modified `useCommandCompletion.tsx` to ensure a trailing space is always added when autocompleting a command that has subcommands.
- Updated `InputPrompt.tsx` to prevent immediate auto-execution of commands with subcommands when selected from the suggestions dropdown.
- This ensures that users always see the available subcommand options immediately after autocompleting a parent command.

## Related Issues
Fixes #24605

## How to Validate
1. Start the CLI in interactive mode (`npm run start`).
2. Type `/mc` and press `Tab` or `Enter`. 
3. Verify that it autocompletes to `/mcp ` (with a trailing space) and immediately displays subcommands like `list`, `auth`, `enable`, etc., instead of executing `listAction` immediately.
4. Type `/ch` and press `Tab` or `Enter`. 
5. Verify that it autocompletes to `/chat ` (with a trailing space) and immediately displays subcommands like `list`, `save`, `resume`, etc.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
