### PR TITLE
feat(core,cli): prioritize summary for topics (#24608)

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -10,6 +10,7 @@ import { ToolGroupMessage } from './ToolGroupMessage.js';
 import {
   UPDATE_TOPIC_TOOL_NAME,
   TOPIC_PARAM_TITLE,
+  TOPIC_PARAM_SUMMARY,
   TOPIC_PARAM_STRATEGIC_INTENT,
   makeFakeConfig,
   CoreToolCallStatus,
@@ -257,42 +258,15 @@ describe('<ToolGroupMessage />', () => {
       unmount();
     });
 
-    it('renders update_topic tool call using TopicMessage', async () => {
+    it('renders update_topic tool call prioritizing summary over strategic_intent', async () => {
       const toolCalls = [
         createToolCall({
-          callId: 'topic-tool',
+          callId: 'topic-tool-priority',
           name: UPDATE_TOPIC_TOOL_NAME,
           args: {
             [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            [TOPIC_PARAM_STRATEGIC_INTENT]: 'This is the description',
-          },
-        }),
-      ];
-      const item = createItem(toolCalls);
-
-      const { lastFrame, unmount } = await renderWithProviders(
-        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
-        {
-          config: baseMockConfig,
-          settings: fullVerbositySettings,
-        },
-      );
-
-      const output = lastFrame();
-      expect(output).toContain('Testing Topic: ');
-      expect(output).toContain('This is the description');
-      expect(output).toMatchSnapshot('update_topic_tool');
-      unmount();
-    });
-
-    it('renders update_topic tool call with summary instead of strategic_intent', async () => {
-      const toolCalls = [
-        createToolCall({
-          callId: 'topic-tool-summary',
-          name: UPDATE_TOPIC_TOOL_NAME,
-          args: {
-            [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            summary: 'This is the summary',
+            [TOPIC_PARAM_SUMMARY]: 'This is the summary',
+            [TOPIC_PARAM_STRATEGIC_INTENT]: 'This should be ignored',
           },
         }),
       ];
@@ -309,6 +283,34 @@ describe('<ToolGroupMessage />', () => {
       const output = lastFrame();
       expect(output).toContain('Testing Topic: ');
       expect(output).toContain('This is the summary');
+      expect(output).not.toContain('This should be ignored');
+      unmount();
+    });
+
+    it('renders update_topic tool call falling back to strategic_intent', async () => {
+      const toolCalls = [
+        createToolCall({
+          callId: 'topic-tool-fallback',
+          name: UPDATE_TOPIC_TOOL_NAME,
+          args: {
+            [TOPIC_PARAM_TITLE]: 'Testing Topic',
+            [TOPIC_PARAM_STRATEGIC_INTENT]: 'Fallback intent',
+          },
+        }),
+      ];
+      const item = createItem(toolCalls);
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
+        {
+          config: baseMockConfig,
+          settings: fullVerbositySettings,
+        },
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('Testing Topic: ');
+      expect(output).toContain('Fallback intent');
       unmount();
     });
 
@@ -319,7 +321,7 @@ describe('<ToolGroupMessage />', () => {
           name: UPDATE_TOPIC_TOOL_NAME,
           args: {
             [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            [TOPIC_PARAM_STRATEGIC_INTENT]: 'This is the description',
+            [TOPIC_PARAM_SUMMARY]: 'This is the summary',
           },
         }),
         createToolCall({

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -26,19 +26,20 @@ export const isTopicTool = (name: string): boolean =>
 export const TopicMessage: React.FC<TopicMessageProps> = ({ args }) => {
   const rawTitle = args?.[TOPIC_PARAM_TITLE];
   const title = typeof rawTitle === 'string' ? rawTitle : undefined;
-  const rawIntent =
-    args?.[TOPIC_PARAM_STRATEGIC_INTENT] || args?.[TOPIC_PARAM_SUMMARY];
-  const intent = typeof rawIntent === 'string' ? rawIntent : undefined;
+  const rawDescription =
+    args?.[TOPIC_PARAM_SUMMARY] || args?.[TOPIC_PARAM_STRATEGIC_INTENT];
+  const description =
+    typeof rawDescription === 'string' ? rawDescription : undefined;
 
   return (
     <Box flexDirection="row" marginLeft={2} flexWrap="wrap">
       <Text color={theme.text.primary} bold wrap="truncate-end">
         {title || 'Topic'}
-        {intent && <Text>: </Text>}
+        {description && <Text>: </Text>}
       </Text>
-      {intent && (
+      {description && (
         <Text color={theme.text.secondary} wrap="wrap">
-          {intent}
+          {description}
         </Text>
       )}
     </Box>

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including update_topic 1`] = `
 "
-  Testing Topic: This is the description
+  Testing Topic: This is the summary
 
 ╭──────────────────────────────────────────────────────────────────────────╮
 │ ✓  read_file Read a file                                                 │
@@ -139,12 +139,6 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where
 │                                                                          │                       ▄
 │ line1                                                                    │                       █
 ╰──────────────────────────────────────────────────────────────────────────╯                       █
-"
-`;
-
-exports[`<ToolGroupMessage /> > Golden Snapshots > renders update_topic tool call using TopicMessage > update_topic_tool 1`] = `
-"
-  Testing Topic: This is the description
 "
 `;
 


### PR DESCRIPTION
## Summary

Prioritize the topic `summary` over `strategic_intent` in the CLI UI chat history while maintaining the `strategic_intent` as the primary source for the live status line.

## Details

This PR implements a "Prioritize and Fallback" strategy to address both the need for richer topic updates and the constraints of the terminal UI layout:

- **UI (`TopicMessage.tsx`)**: Modified to display the `summary` parameter if provided by the model. If no summary is present, it gracefully falls back to displaying the `strategic_intent`.
- **Backend Tool Declaration**: Restored `strategic_intent` as the **required** parameter and kept `summary` as **optional**. This ensures the model always provides a short intent for the status line while allowing for detailed summaries when appropriate.
- **Backend Tool Implementation**: Reverted `getDescription()` to use the (now required) short intent, preventing terminal line overflow in the "Executing..." status line.
- **Tests**: Updated CLI unit tests and snapshots to verify that the UI correctly prioritizes the summary and falls back to the intent.

## Related Issues

Closes #24608

## How to Validate

- Run `npm test -w @google/gemini-cli -- src/ui/components/messages/ToolGroupMessage.test.tsx`
- Run `npm run build`
- Verify visually that the status line remains concise while the chat history shows the full summary when available.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run

## Example screeshots

### After this update
Shows a detailed  NL summary in the UI
<img width="951" height="895" alt="topics_ui_with_summary" src="https://github.com/user-attachments/assets/9092db75-674d-4cfc-a8b4-8f3dcd79385e" />

### Before this update
Shows only a 1 linear intent. Which is not a great UX
<img width="1003" height="869" alt="topics_ui_with_intent" src="https://github.com/user-attachments/assets/68876730-87e6-4d79-a8e3-fae0d72ccb2e" />


