### PR TITLE
fix(core): inject skill system instructions into subagent prompts if activated

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -30,7 +30,7 @@ import { CompressionStatus } from '../core/turn.js';
 import { type ToolCallRequestInfo } from '../scheduler/types.js';
 import { ChatCompressionService } from '../context/chatCompressionService.js';
 import { getDirectoryContextString } from '../utils/environmentContext.js';
-import { renderUserMemory } from '../prompts/snippets.js';
+import { renderUserMemory, renderAgentSkills } from '../prompts/snippets.js';
 import { promptIdContext } from '../utils/promptIdContext.js';
 import {
   logAgentStart,
@@ -78,7 +78,10 @@ import {
   runWithScopedWorkspaceContext,
 } from '../config/scoped-config.js';
 import { CompleteTaskTool } from '../tools/complete-task.js';
-import { COMPLETE_TASK_TOOL_NAME } from '../tools/definitions/base-declarations.js';
+import {
+  COMPLETE_TASK_TOOL_NAME,
+  ACTIVATE_SKILL_TOOL_NAME,
+} from '../tools/definitions/base-declarations.js';
 
 /** A callback function to report on agent activity. */
 export type ActivityCallback = (activity: SubagentActivityEvent) => void;
@@ -1317,6 +1320,21 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
     // Inject user inputs into the prompt template.
     let finalPrompt = templateString(promptConfig.systemPrompt, inputs);
+
+    // Inject skill SI if ACTIVATE_SKILL_TOOL_NAME is available to this agent.
+    if (this.toolRegistry.getTool(ACTIVATE_SKILL_TOOL_NAME) !== undefined) {
+      const skills = this.context.config.getSkillManager().getSkills();
+      if (skills.length > 0) {
+        const skillsPrompt = renderAgentSkills(
+          skills.map((s) => ({
+            name: s.name,
+            description: s.description,
+            location: s.location,
+          })),
+        );
+        finalPrompt += `\n\n${skillsPrompt}`;
+      }
+    }
 
     // Append memory context if available.
     const systemMemory = this.context.config.getSystemInstructionMemory();


### PR DESCRIPTION
## Summary

Fixes a bug where custom subagents did not receive System Instructions (SI) for the `activate_skill` tool, even if the tool was authorized and present in their registry.

## Details

Previously, the logic to append the agent skills section to the system prompt only lived in `PromptProvider.getCoreSystemPrompt()`, which is used by the main agent but not by specialized subagents or custom subagents. This meant that if a subagent (e.g., loaded from `config.yaml`) was granted access to the `activate_skill` tool, it would not know how to use it because the relevant skill descriptions and formatting instructions were missing from its system prompt.

This PR adds a targeted check inside `LocalAgentExecutor.buildSystemPrompt()` to dynamically inject the output of `renderAgentSkills()` into the subagent's prompt, but *only* if the `ACTIVATE_SKILL_TOOL_NAME` tool is present in its localized tool registry.

## Related Issues

N/A

## How to Validate

1. Run the `core` unit tests: `npm test -w @google/gemini-cli-core`
2. Configure a custom subagent in `.gemini/agents/test_agent.yaml` with `tools: ["activate_skill", "run_shell_command"]`.
3. Invoke the subagent and ask it to use a skill (e.g., `pr-creator`). It should correctly activate and use the skill.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
