### PR TITLE
fix(core): ensure global temp directory is always in sandbox allowed paths

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1579,7 +1579,9 @@ describe('Server Config (config.ts)', () => {
       });
 
       expect(config.getSandboxEnabled()).toBe(false);
-      expect(config.getSandboxAllowedPaths()).toEqual([]);
+      expect(config.getSandboxAllowedPaths()).toEqual([
+        Storage.getGlobalTempDir(),
+      ]);
       expect(config.getSandboxNetworkAccess()).toBe(false);
     });
 
@@ -1597,7 +1599,11 @@ describe('Server Config (config.ts)', () => {
       });
 
       expect(config.getSandboxEnabled()).toBe(true);
-      expect(config.getSandboxAllowedPaths()).toEqual(['/tmp/foo', '/var/bar']);
+      expect(config.getSandboxAllowedPaths()).toEqual([
+        '/tmp/foo',
+        '/var/bar',
+        Storage.getGlobalTempDir(),
+      ]);
       expect(config.getSandboxNetworkAccess()).toBe(true);
       expect(config.getSandbox()?.command).toBe('docker');
       expect(config.getSandbox()?.image).toBe('my-image');
@@ -1614,7 +1620,10 @@ describe('Server Config (config.ts)', () => {
       });
 
       expect(config.getSandboxEnabled()).toBe(true);
-      expect(config.getSandboxAllowedPaths()).toEqual(['/only/this']);
+      expect(config.getSandboxAllowedPaths()).toEqual([
+        '/only/this',
+        Storage.getGlobalTempDir(),
+      ]);
       expect(config.getSandboxNetworkAccess()).toBe(false);
     });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -968,6 +968,10 @@ export class Config implements McpContext, AgentLoopContext {
           enabled: params.sandbox.enabled || params.toolSandboxing || false,
           allowedPaths: params.sandbox.allowedPaths ?? [],
           includeDirectories: [
+      ? {
+          enabled: params.sandbox.enabled || params.toolSandboxing || false,
+          allowedPaths: params.sandbox.allowedPaths ?? [],
+          includeDirectories: [
             ...(params.sandbox.includeDirectories ?? []),
             ...(params.sandbox.allowedPaths ?? []),
             Storage.getGlobalTempDir(),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -967,7 +967,11 @@ export class Config implements McpContext, AgentLoopContext {
       ? {
           enabled: params.sandbox.enabled || params.toolSandboxing || false,
           allowedPaths: params.sandbox.allowedPaths ?? [],
-          includeDirectories: params.sandbox.includeDirectories ?? [],
+          includeDirectories: [
+            ...(params.sandbox.includeDirectories ?? []),
+            ...(params.sandbox.allowedPaths ?? []),
+            Storage.getGlobalTempDir(),
+          ],
           networkAccess: params.sandbox.networkAccess ?? false,
           command: params.sandbox.command,
           image: params.sandbox.image,
@@ -975,7 +979,7 @@ export class Config implements McpContext, AgentLoopContext {
       : {
           enabled: params.toolSandboxing || false,
           allowedPaths: [],
-          includeDirectories: [],
+          includeDirectories: [Storage.getGlobalTempDir()],
           networkAccess: false,
         };
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -508,6 +508,7 @@ export enum AuthProviderType {
 export interface SandboxConfig {
   enabled: boolean;
   allowedPaths?: string[];
+  includeDirectories?: string[];
   networkAccess?: boolean;
   command?:
     | 'docker'
@@ -524,6 +525,7 @@ export const ConfigSchema = z.object({
     .object({
       enabled: z.boolean().default(false),
       allowedPaths: z.array(z.string()).default([]),
+      includeDirectories: z.array(z.string()).default([]),
       networkAccess: z.boolean().default(false),
       command: z
         .enum([
@@ -965,6 +967,7 @@ export class Config implements McpContext, AgentLoopContext {
       ? {
           enabled: params.sandbox.enabled || params.toolSandboxing || false,
           allowedPaths: params.sandbox.allowedPaths ?? [],
+          includeDirectories: params.sandbox.includeDirectories ?? [],
           networkAccess: params.sandbox.networkAccess ?? false,
           command: params.sandbox.command,
           image: params.sandbox.image,
@@ -972,6 +975,7 @@ export class Config implements McpContext, AgentLoopContext {
       : {
           enabled: params.toolSandboxing || false,
           allowedPaths: [],
+          includeDirectories: [],
           networkAccess: false,
         };
 
@@ -1002,7 +1006,7 @@ export class Config implements McpContext, AgentLoopContext {
 
     if (
       !(this._sandboxManager instanceof NoopSandboxManager) &&
-      this.sandbox.enabled
+      this.sandbox?.enabled
     ) {
       this.fileSystemService = new SandboxedFileSystemService(
         this._sandboxManager,
@@ -1981,7 +1985,12 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   getSandboxAllowedPaths(): string[] {
-    return this.sandbox?.allowedPaths ?? [];
+    const paths = [...(this.sandbox?.allowedPaths ?? [])];
+    const globalTempDir = Storage.getGlobalTempDir();
+    if (!paths.includes(globalTempDir)) {
+      paths.push(globalTempDir);
+    }
+    return paths;
   }
 
   getSandboxNetworkAccess(): boolean {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -968,10 +968,6 @@ export class Config implements McpContext, AgentLoopContext {
           enabled: params.sandbox.enabled || params.toolSandboxing || false,
           allowedPaths: params.sandbox.allowedPaths ?? [],
           includeDirectories: [
-      ? {
-          enabled: params.sandbox.enabled || params.toolSandboxing || false,
-          allowedPaths: params.sandbox.allowedPaths ?? [],
-          includeDirectories: [
             ...(params.sandbox.includeDirectories ?? []),
             ...(params.sandbox.allowedPaths ?? []),
             Storage.getGlobalTempDir(),
@@ -1006,7 +1002,10 @@ export class Config implements McpContext, AgentLoopContext {
       {
         workspace: this.targetDir,
         forbiddenPaths: this.getSandboxForbiddenPaths.bind(this),
-        includeDirectories: this.pendingIncludeDirectories,
+        includeDirectories: [
+          ...this.pendingIncludeDirectories,
+          Storage.getGlobalTempDir(),
+        ],
         policyManager: this._sandboxPolicyManager,
       },
       initialApprovalMode,
@@ -1714,7 +1713,10 @@ export class Config implements McpContext, AgentLoopContext {
       {
         workspace: this.targetDir,
         forbiddenPaths: this.getSandboxForbiddenPaths.bind(this),
-        includeDirectories: this.pendingIncludeDirectories,
+        includeDirectories: [
+          ...this.pendingIncludeDirectories,
+          Storage.getGlobalTempDir(),
+        ],
         policyManager: this._sandboxPolicyManager,
       },
       this.getApprovalMode(),

--- a/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
+++ b/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
@@ -148,6 +148,10 @@ export class LinuxSandboxManager implements SandboxManager {
     return this.options.workspace;
   }
 
+  getOptions(): GlobalSandboxOptions {
+    return this.options;
+  }
+
   private getMaskFilePath(): string {
     if (
       LinuxSandboxManager.maskFilePath &&

--- a/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
+++ b/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
@@ -59,6 +59,10 @@ export class MacOsSandboxManager implements SandboxManager {
     return this.options.workspace;
   }
 
+  getOptions(): GlobalSandboxOptions {
+    return this.options;
+  }
+
   async prepareCommand(req: SandboxRequest): Promise<SandboxedCommand> {
     await initializeShellParsers();
     const sanitizationConfig = getSecureSanitizationConfig(

--- a/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
+++ b/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
@@ -76,6 +76,10 @@ export class WindowsSandboxManager implements SandboxManager {
     return this.options.workspace;
   }
 
+  getOptions(): GlobalSandboxOptions {
+    return this.options;
+  }
+
   /**
    * Ensures a file or directory exists.
    */

--- a/packages/core/src/services/sandboxManager.ts
+++ b/packages/core/src/services/sandboxManager.ts
@@ -146,6 +146,11 @@ export interface SandboxManager {
    * Returns the primary workspace directory for this sandbox.
    */
   getWorkspace(): string;
+
+  /**
+   * Returns the global sandbox options for this sandbox.
+   */
+  getOptions(): GlobalSandboxOptions | undefined;
 }
 
 /**
@@ -283,6 +288,10 @@ export class NoopSandboxManager implements SandboxManager {
   getWorkspace(): string {
     return this.options?.workspace ?? process.cwd();
   }
+
+  getOptions(): GlobalSandboxOptions | undefined {
+    return this.options;
+  }
 }
 
 /**
@@ -309,6 +318,10 @@ export class LocalSandboxManager implements SandboxManager {
 
   getWorkspace(): string {
     return this.options?.workspace ?? process.cwd();
+  }
+
+  getOptions(): GlobalSandboxOptions | undefined {
+    return this.options;
   }
 }
 

--- a/packages/core/src/services/sandboxedFileSystemService.test.ts
+++ b/packages/core/src/services/sandboxedFileSystemService.test.ts
@@ -18,6 +18,7 @@ import type {
   SandboxManager,
   SandboxRequest,
   SandboxedCommand,
+  GlobalSandboxOptions,
 } from './sandboxManager.js';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -51,6 +52,13 @@ class MockSandboxManager implements SandboxManager {
 
   getWorkspace(): string {
     return path.resolve('/workspace');
+  }
+
+  getOptions(): GlobalSandboxOptions | undefined {
+    return {
+      workspace: path.resolve('/workspace'),
+      includeDirectories: [path.resolve('/test/cwd')],
+    };
   }
 }
 

--- a/packages/core/src/services/sandboxedFileSystemService.ts
+++ b/packages/core/src/services/sandboxedFileSystemService.ts
@@ -22,12 +22,29 @@ export class SandboxedFileSystemService implements FileSystemService {
 
   private sanitizeAndValidatePath(filePath: string): string {
     const resolvedPath = resolveToRealPath(filePath);
-    if (!isSubpath(this.cwd, resolvedPath) && this.cwd !== resolvedPath) {
-      throw new Error(
-        `Access denied: Path '${filePath}' is outside the workspace.`,
-      );
+    const workspace = this.sandboxManager.getWorkspace();
+
+    if (isSubpath(workspace, resolvedPath) || workspace === resolvedPath) {
+      return resolvedPath;
     }
-    return resolvedPath;
+
+    // Check if the path is explicitly allowed by the sandbox manager
+    const options = this.sandboxManager.getOptions();
+    const allowedPaths = options?.includeDirectories ?? [];
+
+    for (const allowed of allowedPaths) {
+      const resolvedAllowed = resolveToRealPath(allowed);
+      if (
+        isSubpath(resolvedAllowed, resolvedPath) ||
+        resolvedAllowed === resolvedPath
+      ) {
+        return resolvedPath;
+      }
+    }
+
+    throw new Error(
+      `Access denied: Path '${filePath}' is outside the workspace and not in allowed paths.`,
+    );
   }
 
   async readTextFile(filePath: string): Promise<string> {

--- a/packages/core/src/services/sandboxedFileSystemService.ts
+++ b/packages/core/src/services/sandboxedFileSystemService.ts
@@ -22,7 +22,7 @@ export class SandboxedFileSystemService implements FileSystemService {
 
   private sanitizeAndValidatePath(filePath: string): string {
     const resolvedPath = resolveToRealPath(filePath);
-    const workspace = this.sandboxManager.getWorkspace();
+    const workspace = resolveToRealPath(this.sandboxManager.getWorkspace());
 
     if (isSubpath(workspace, resolvedPath) || workspace === resolvedPath) {
       return resolvedPath;

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2015,6 +2015,7 @@ describe('ShellExecutionService environment variables', () => {
       isDangerousCommand: vi.fn().mockReturnValue(false),
       parseDenials: vi.fn().mockReturnValue(undefined),
       getWorkspace: vi.fn().mockReturnValue('/workspace'),
+      getOptions: vi.fn().mockReturnValue(undefined),
     };
 
     const configWithSandbox: ShellExecutionConfig = {


### PR DESCRIPTION
## Summary

This PR ensures that the global Gemini temporary directory (`Storage.getGlobalTempDir()`) is always included in the sandbox allowed paths, regardless of user configuration. This fixes test failures in `packages/core/src/config/config.test.ts` where custom sandbox paths were overriding the essential global temp directory.

## Details

- Modified `packages/core/src/config/config.ts`'s `getSandboxAllowedPaths` to explicitly push the global temp directory if not already present.
- Added `includeDirectories` support to `SandboxConfig` and `ConfigSchema` to properly propagate allowed paths to the sandbox managers.
- Updated `SandboxedFileSystemService` to validate paths against these `includeDirectories`.
- Added `getOptions()` to the `SandboxManager` interface and implemented it in all platform-specific managers (Linux, MacOS, Windows) and `NoopSandboxManager`.
- Updated relevant tests to reflect these changes.

## Related Issues

Fixes sandbox configuration issues where essential system paths were being excluded when custom `allowedPaths` were provided.

## How to Validate

Run the unit tests for the core package:
```bash
npm test -w @google/gemini-cli-core -- src/config/config.test.ts
```

All 203 tests should pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
