### PR TITLE
feat(acp): add support for `/about` command

### DIFF
--- a/packages/cli/src/acp/commandHandler.test.ts
+++ b/packages/cli/src/acp/commandHandler.test.ts
@@ -26,5 +26,8 @@ describe('CommandHandler', () => {
 
     const init = parse('/init');
     expect(init.commandToExecute?.name).toBe('init');
+
+    const about = parse('/about');
+    expect(about.commandToExecute?.name).toBe('about');
   });
 });

--- a/packages/cli/src/acp/commandHandler.ts
+++ b/packages/cli/src/acp/commandHandler.ts
@@ -10,6 +10,7 @@ import { MemoryCommand } from './commands/memory.js';
 import { ExtensionsCommand } from './commands/extensions.js';
 import { InitCommand } from './commands/init.js';
 import { RestoreCommand } from './commands/restore.js';
+import { AboutCommand } from './commands/about.js';
 
 export class CommandHandler {
   private registry: CommandRegistry;
@@ -24,6 +25,7 @@ export class CommandHandler {
     registry.register(new ExtensionsCommand());
     registry.register(new InitCommand());
     registry.register(new RestoreCommand());
+    registry.register(new AboutCommand());
     return registry;
   }
 

--- a/packages/cli/src/acp/commands/about.ts
+++ b/packages/cli/src/acp/commands/about.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  IdeClient,
+  UserAccountManager,
+  getVersion,
+} from '@google/gemini-cli-core';
+import type {
+  Command,
+  CommandContext,
+  CommandExecutionResponse,
+} from './types.js';
+import process from 'node:process';
+
+export class AboutCommand implements Command {
+  readonly name = 'about';
+  readonly description = 'Show version and environment info';
+
+  async execute(
+    context: CommandContext,
+    _args: string[] = [],
+  ): Promise<CommandExecutionResponse> {
+    const osVersion = process.platform;
+    let sandboxEnv = 'no sandbox';
+    if (process.env['SANDBOX'] && process.env['SANDBOX'] !== 'sandbox-exec') {
+      sandboxEnv = process.env['SANDBOX'];
+    } else if (process.env['SANDBOX'] === 'sandbox-exec') {
+      sandboxEnv = `sandbox-exec (${
+        process.env['SEATBELT_PROFILE'] || 'unknown'
+      })`;
+    }
+    const modelVersion = context.agentContext.config.getModel() || 'Unknown';
+    const cliVersion = await getVersion();
+    const selectedAuthType =
+      context.settings.merged?.security?.auth?.selectedType ?? '';
+    const gcpProject = process.env['GOOGLE_CLOUD_PROJECT'] || '';
+    const ideClient = await getIdeClientName(context);
+
+    const userAccountManager = new UserAccountManager();
+    const cachedAccount = userAccountManager.getCachedGoogleAccount();
+    const userEmail = cachedAccount ?? 'Unknown';
+
+    const tier = context.agentContext.config.getUserTierName() || 'Unknown';
+
+    const info = [
+      `- Version: ${cliVersion}`,
+      `- OS: ${osVersion}`,
+      `- Sandbox: ${sandboxEnv}`,
+      `- Model: ${modelVersion}`,
+      `- Auth Type: ${selectedAuthType}`,
+      `- GCP Project: ${gcpProject}`,
+      `- IDE Client: ${ideClient}`,
+      `- User Email: ${userEmail}`,
+      `- Tier: ${tier}`,
+    ].join('\n');
+
+    return {
+      name: this.name,
+      data: `Gemini CLI Info:\n${info}`,
+    };
+  }
+}
+
+async function getIdeClientName(context: CommandContext) {
+  if (!context.agentContext.config.getIdeMode()) {
+    return '';
+  }
+  const ideClient = await IdeClient.getInstance();
+  return ideClient?.getDetectedIdeDisplayName() ?? '';
+}


### PR DESCRIPTION
## Summary

Added support for the `/about` command in the ACP client interface to provide version and environment information, mirroring the functionality in the TUI.

## Details

- **New Command Implementation**: Created `about.ts` in `src/acp/commands/` to collect and format information about the CLI version, OS, active model, auth type, GCP project, and user tier.
- **Handler Integration**: Registered `AboutCommand` in `commandHandler.ts` to make it available represented in the ACP registry.
- **Tests**: Added a test case in `commandHandler.test.ts` to verify correct parsing of the `/about` slash command.
- **Verification**: Verified that the test passes and the package build succeeds.



## How to Validate

Ensure /about works as expected from ACP based IDEs when accessing gemini-cli agent.

<img width="587" height="610" alt="image" src="https://github.com/user-attachments/assets/79e22bdb-41de-4d99-a2e6-3c7c986f815d" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [√] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [√] Validated on required platforms/methods:
  - [√] MacOS
    - [√] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
