### PR TITLE
fix(ui): fixed auth race condition causing logo to flicker

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -504,6 +504,8 @@ const baseMockUiState = {
   history: [],
   renderMarkdown: true,
   streamingState: StreamingState.Idle,
+  isConfigInitialized: true,
+  isAuthenticating: false,
   terminalWidth: 100,
   terminalHeight: 40,
   currentModel: 'gemini-pro',

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -59,13 +59,20 @@ const NARROW_TERMINAL_BREAKPOINT = 60;
 export const AppHeader = ({ version, showDetails = true }: AppHeaderProps) => {
   const settings = useSettings();
   const config = useConfig();
-  const { terminalWidth, bannerData, bannerVisible, updateInfo } = useUIState();
+  const {
+    terminalWidth,
+    bannerData,
+    bannerVisible,
+    updateInfo,
+    isConfigInitialized,
+    isAuthenticating,
+  } = useUIState();
 
   const { bannerText } = useBanner(bannerData);
   const { showTips } = useTips();
 
   const authType = config.getContentGeneratorConfig()?.authType;
-  const loggedOut = !authType;
+  const loggedOut = isConfigInitialized && !isAuthenticating && !authType;
 
   const showHeader = !(
     settings.merged.ui.hideBanner || config.getScreenReader()

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -336,6 +336,10 @@ export const MainContent = () => {
     isAlternateBuffer,
   ]);
 
+  if (!uiState.isConfigInitialized) {
+    return null;
+  }
+
   if (isAlternateBufferOrTerminalBuffer) {
     return scrollableList;
   }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Fixed race condition related to auth which caused logo mismatches. 

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
- Improved the boolean for whether a user is logged out
- Only render the static `MainContent` when the config is initialized

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #24651

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
- Start the application. The large GEMINI text should not show.
- Logout and start the app. This time, it should show. Also, picking the auth options should not flicker the logo.

Resizing the terminal should not change the UI in either case.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
