### PR TITLE
feat(cli): add bulk extension enable/disable

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -94,8 +94,10 @@ These are convenient shortcuts that map to specific models:
 | `gemini extensions list`                           | List all installed extensions                | `gemini extensions list`                                                       |
 | `gemini extensions update <name>`                  | Update a specific extension                  | `gemini extensions update my-extension`                                        |
 | `gemini extensions update --all`                   | Update all extensions                        | `gemini extensions update --all`                                               |
-| `gemini extensions enable <name>`                  | Enable an extension                          | `gemini extensions enable my-extension`                                        |
-| `gemini extensions disable <name>`                 | Disable an extension                         | `gemini extensions disable my-extension`                                       |
+| `gemini extensions enable <names..>`               | Enable one or more extensions                | `gemini extensions enable ext-a ext-b`                                         |
+| `gemini extensions enable --all`                   | Enable all installed extensions              | `gemini extensions enable --all`                                               |
+| `gemini extensions disable <names..>`              | Disable one or more extensions               | `gemini extensions disable ext-a ext-b`                                        |
+| `gemini extensions disable --all`                  | Disable all installed extensions             | `gemini extensions disable --all`                                              |
 | `gemini extensions link <path>`                    | Link local extension for development         | `gemini extensions link /path/to/extension`                                    |
 | `gemini extensions new <path>`                     | Create new extension from template           | `gemini extensions new ./my-extension`                                         |
 | `gemini extensions validate <path>`                | Validate extension structure                 | `gemini extensions validate ./my-extension`                                    |

--- a/docs/extensions/reference.md
+++ b/docs/extensions/reference.md
@@ -41,27 +41,41 @@ To uninstall one or more extensions, use the `uninstall` command:
 gemini extensions uninstall <name...>
 ```
 
-### Disable an extension
+### Disable extensions
 
-Extensions are enabled globally by default. You can disable an extension
-entirely or for a specific workspace.
+Extensions are enabled globally by default. You can disable one or more
+extensions entirely or for a specific workspace.
 
 ```bash
-gemini extensions disable <name> [--scope <scope>]
+gemini extensions disable <names..> [--scope <scope>]
 ```
 
-- `<name>`: The name of the extension to disable.
+To disable every installed extension at once, use `--all`:
+
+```bash
+gemini extensions disable --all
+```
+
+- `<names..>`: One or more extension names to disable.
+- `--all`: Disable every installed extension.
 - `--scope`: The scope to disable the extension in (`user` or `workspace`).
 
-### Enable an extension
+### Enable extensions
 
-Re-enable a disabled extension using the `enable` command:
+Re-enable one or more disabled extensions using the `enable` command:
 
 ```bash
-gemini extensions enable <name> [--scope <scope>]
+gemini extensions enable <names..> [--scope <scope>]
 ```
 
-- `<name>`: The name of the extension to enable.
+To enable every installed extension at once, use `--all`:
+
+```bash
+gemini extensions enable --all
+```
+
+- `<names..>`: One or more extension names to enable.
+- `--all`: Enable every installed extension.
 - `--scope`: The scope to enable the extension in (`user` or `workspace`).
 
 ### Update an extension

--- a/packages/cli/src/commands/extensions/disable.test.ts
+++ b/packages/cli/src/commands/extensions/disable.test.ts
@@ -23,6 +23,7 @@ import {
   type LoadedSettings,
 } from '../../config/settings.js';
 import { getErrorMessage } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
 
 // Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
@@ -64,6 +65,7 @@ describe('extensions disable command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockGetErrorMessage = vi.mocked(getErrorMessage);
   const mockExtensionManager = vi.mocked(ExtensionManager);
+  const mockExitCli = vi.mocked(exitCli);
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -76,6 +78,7 @@ describe('extensions disable command', () => {
     mockExtensionManager.prototype.disableExtension = vi
       .fn()
       .mockResolvedValue(undefined);
+    mockExtensionManager.prototype.getExtensions = vi.fn().mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -85,21 +88,18 @@ describe('extensions disable command', () => {
   describe('handleDisable', () => {
     it.each([
       {
-        name: 'my-extension',
         scope: undefined,
         expectedScope: SettingScope.User,
         expectedLog:
           'Extension "my-extension" successfully disabled for scope "undefined".',
       },
       {
-        name: 'my-extension',
         scope: 'user',
         expectedScope: SettingScope.User,
         expectedLog:
           'Extension "my-extension" successfully disabled for scope "user".',
       },
       {
-        name: 'my-extension',
         scope: 'workspace',
         expectedScope: SettingScope.Workspace,
         expectedLog:
@@ -107,9 +107,9 @@ describe('extensions disable command', () => {
       },
     ])(
       'should disable an extension in the $expectedScope scope when scope is $scope',
-      async ({ name, scope, expectedScope, expectedLog }) => {
+      async ({ scope, expectedScope, expectedLog }) => {
         const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
-        await handleDisable({ name, scope });
+        await handleDisable({ names: ['my-extension'], scope });
         expect(mockExtensionManager).toHaveBeenCalledWith(
           expect.objectContaining({
             workspaceDir: '/test/dir',
@@ -120,30 +120,86 @@ describe('extensions disable command', () => {
         ).toHaveBeenCalled();
         expect(
           mockExtensionManager.prototype.disableExtension,
-        ).toHaveBeenCalledWith(name, expectedScope);
+        ).toHaveBeenCalledWith('my-extension', expectedScope);
         expect(emitConsoleLog).toHaveBeenCalledWith('log', expectedLog);
         mockCwd.mockRestore();
       },
     );
 
-    it('should log an error message and exit with code 1 when extension disabling fails', async () => {
-      const mockProcessExit = vi
-        .spyOn(process, 'exit')
-        .mockImplementation((() => {}) as (
-          code?: string | number | null | undefined,
-        ) => never);
+    it('should disable multiple extensions when given a list of names', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      await handleDisable({ names: ['ext-a', 'ext-b'] });
+
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledWith('ext-a', SettingScope.User);
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledWith('ext-b', SettingScope.User);
+      mockCwd.mockRestore();
+    });
+
+    it('should dedupe duplicate names', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      await handleDisable({ names: ['ext-a', 'ext-a'] });
+
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledTimes(1);
+      mockCwd.mockRestore();
+    });
+
+    it('should disable every installed extension when --all is set', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      mockExtensionManager.prototype.getExtensions = vi
+        .fn()
+        .mockReturnValue([{ name: 'ext-a' }, { name: 'ext-b' }]);
+
+      await handleDisable({ all: true });
+
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledWith('ext-a', SettingScope.User);
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledWith('ext-b', SettingScope.User);
+      mockCwd.mockRestore();
+    });
+
+    it('should log a message and return when --all is set with no installed extensions', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      mockExtensionManager.prototype.getExtensions = vi
+        .fn()
+        .mockReturnValue([]);
+
+      await handleDisable({ all: true });
+
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'No extensions currently installed.',
+      );
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).not.toHaveBeenCalled();
+      mockCwd.mockRestore();
+    });
+
+    it('should log each error and call exitCli(1) when disabling fails', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
       const error = new Error('Disable failed');
       (
         mockExtensionManager.prototype.disableExtension as Mock
       ).mockRejectedValue(error);
       mockGetErrorMessage.mockReturnValue('Disable failed message');
-      await handleDisable({ name: 'my-extension' });
+
+      await handleDisable({ names: ['my-extension'] });
+
       expect(emitConsoleLog).toHaveBeenCalledWith(
         'error',
-        'Disable failed message',
+        'Failed to disable "my-extension": Disable failed message',
       );
-      expect(mockProcessExit).toHaveBeenCalledWith(1);
-      mockProcessExit.mockRestore();
+      expect(mockExitCli).toHaveBeenCalledWith(1);
+      mockCwd.mockRestore();
     });
   });
 
@@ -151,8 +207,8 @@ describe('extensions disable command', () => {
     const command = disableCommand;
 
     it('should have correct command and describe', () => {
-      expect(command.command).toBe('disable [--scope] <name>');
-      expect(command.describe).toBe('Disables an extension.');
+      expect(command.command).toBe('disable [names..]');
+      expect(command.describe).toBe('Disables one or more extensions.');
     });
 
     describe('builder', () => {
@@ -176,16 +232,33 @@ describe('extensions disable command', () => {
         (command.builder as (yargs: Argv) => Argv)(
           yargsMock as unknown as Argv,
         );
-        expect(yargsMock.positional).toHaveBeenCalledWith('name', {
-          describe: 'The name of the extension to disable.',
-          type: 'string',
-        });
+        expect(yargsMock.positional).toHaveBeenCalledWith(
+          'names',
+          expect.objectContaining({
+            type: 'string',
+            array: true,
+          }),
+        );
+        expect(yargsMock.option).toHaveBeenCalledWith(
+          'all',
+          expect.objectContaining({ type: 'boolean' }),
+        );
         expect(yargsMock.option).toHaveBeenCalledWith('scope', {
           describe: 'The scope to disable the extension in.',
           type: 'string',
           default: SettingScope.User,
         });
         expect(yargsMock.check).toHaveBeenCalled();
+      });
+
+      it('check function should throw when neither names nor --all is provided', () => {
+        (command.builder as (yargs: Argv) => Argv)(
+          yargsMock as unknown as Argv,
+        );
+        const checkCallback = yargsMock.check.mock.calls[0][0];
+        expect(() => checkCallback({})).toThrow(
+          /at least one extension name to disable/,
+        );
       });
 
       it('check function should throw for invalid scope', () => {
@@ -198,7 +271,7 @@ describe('extensions disable command', () => {
         )
           .map((s) => s.toLowerCase())
           .join(', ')}.`;
-        expect(() => checkCallback({ scope: 'invalid' })).toThrow(
+        expect(() => checkCallback({ all: true, scope: 'invalid' })).toThrow(
           expectedError,
         );
       });
@@ -210,7 +283,7 @@ describe('extensions disable command', () => {
             yargsMock as unknown as Argv,
           );
           const checkCallback = yargsMock.check.mock.calls[0][0];
-          expect(checkCallback({ scope })).toBe(true);
+          expect(checkCallback({ all: true, scope })).toBe(true);
         },
       );
     });
@@ -218,12 +291,14 @@ describe('extensions disable command', () => {
     it('handler should trigger extension disabling', async () => {
       const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
       interface TestArgv {
-        name: string;
+        names: string[];
+        all: boolean;
         scope: string;
         [key: string]: unknown;
       }
       const argv: TestArgv = {
-        name: 'test-ext',
+        names: ['test-ext'],
+        all: false,
         scope: 'workspace',
         _: [],
         $0: '',
@@ -244,6 +319,37 @@ describe('extensions disable command', () => {
         'log',
         'Extension "test-ext" successfully disabled for scope "workspace".',
       );
+      mockCwd.mockRestore();
+    });
+
+    it('handler should normalize a scalar string positional to a single-element array', async () => {
+      // Regression: yargs may pass `names` as a bare string when only one
+      // positional is provided. The handler must wrap it in an array, not let
+      // it be iterated character-by-character.
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      interface TestArgv {
+        names: string;
+        all: boolean;
+        scope: string;
+        [key: string]: unknown;
+      }
+      const argv: TestArgv = {
+        names: 'conductor',
+        all: false,
+        scope: 'user',
+        _: [],
+        $0: '',
+      };
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
+
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockExtensionManager.prototype.disableExtension,
+      ).toHaveBeenCalledWith('conductor', SettingScope.User);
       mockCwd.mockRestore();
     });
   });

--- a/packages/cli/src/commands/extensions/disable.ts
+++ b/packages/cli/src/commands/extensions/disable.ts
@@ -13,7 +13,8 @@ import { promptForSetting } from '../../config/extensions/extensionSettings.js';
 import { exitCli } from '../utils.js';
 
 interface DisableArgs {
-  name: string;
+  names?: string[];
+  all?: boolean;
   scope?: string;
 }
 
@@ -27,32 +28,60 @@ export async function handleDisable(args: DisableArgs) {
   });
   await extensionManager.loadExtensions();
 
-  try {
-    if (args.scope?.toLowerCase() === 'workspace') {
-      await extensionManager.disableExtension(
-        args.name,
-        SettingScope.Workspace,
-      );
-    } else {
-      await extensionManager.disableExtension(args.name, SettingScope.User);
+  const scope =
+    args.scope?.toLowerCase() === 'workspace'
+      ? SettingScope.Workspace
+      : SettingScope.User;
+
+  let namesToDisable: string[] = [];
+  if (args.all) {
+    namesToDisable = extensionManager.getExtensions().map((ext) => ext.name);
+  } else if (args.names) {
+    namesToDisable = [...new Set(args.names)];
+  }
+
+  if (namesToDisable.length === 0) {
+    if (args.all) {
+      debugLogger.log('No extensions currently installed.');
     }
-    debugLogger.log(
-      `Extension "${args.name}" successfully disabled for scope "${args.scope}".`,
-    );
-  } catch (error) {
-    debugLogger.error(getErrorMessage(error));
-    process.exit(1);
+    return;
+  }
+
+  const errors: Array<{ name: string; error: string }> = [];
+
+  for (const name of namesToDisable) {
+    try {
+      await extensionManager.disableExtension(name, scope);
+      debugLogger.log(
+        `Extension "${name}" successfully disabled for scope "${args.scope}".`,
+      );
+    } catch (error) {
+      errors.push({ name, error: getErrorMessage(error) });
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const { name, error } of errors) {
+      debugLogger.error(`Failed to disable "${name}": ${error}`);
+    }
+    await exitCli(1);
   }
 }
 
 export const disableCommand: CommandModule = {
-  command: 'disable [--scope] <name>',
-  describe: 'Disables an extension.',
+  command: 'disable [names..]',
+  describe: 'Disables one or more extensions.',
   builder: (yargs) =>
     yargs
-      .positional('name', {
-        describe: 'The name of the extension to disable.',
+      .positional('names', {
+        describe: 'The name(s) of the extension(s) to disable.',
         type: 'string',
+        array: true,
+      })
+      .option('all', {
+        type: 'boolean',
+        describe: 'Disable all installed extensions.',
+        default: false,
       })
       .option('scope', {
         describe: 'The scope to disable the extension in.',
@@ -60,6 +89,11 @@ export const disableCommand: CommandModule = {
         default: SettingScope.User,
       })
       .check((argv) => {
+        if (!argv.all && (!argv.names || argv.names.length === 0)) {
+          throw new Error(
+            'Please include at least one extension name to disable as a positional argument, or use the --all flag.',
+          );
+        }
         if (
           argv.scope &&
           !Object.values(SettingScope)
@@ -77,9 +111,18 @@ export const disableCommand: CommandModule = {
         return true;
       }),
   handler: async (argv) => {
+    const rawNames = argv['names'];
+    const names =
+      rawNames === undefined
+        ? undefined
+        : Array.isArray(rawNames)
+          ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            (rawNames as string[])
+          : [String(rawNames)];
     await handleDisable({
+      names,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: argv['name'] as string,
+      all: argv['all'] as boolean,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       scope: argv['scope'] as string,
     });

--- a/packages/cli/src/commands/extensions/enable.test.ts
+++ b/packages/cli/src/commands/extensions/enable.test.ts
@@ -22,7 +22,7 @@ import {
   SettingScope,
   type LoadedSettings,
 } from '../../config/settings.js';
-import { FatalConfigError } from '@google/gemini-cli-core';
+import { exitCli } from '../utils.js';
 
 // Mock dependencies
 const emitConsoleLog = vi.hoisted(() => vi.fn());
@@ -45,12 +45,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     },
     debugLogger,
     getErrorMessage: vi.fn((error: { message: string }) => error.message),
-    FatalConfigError: class extends Error {
-      constructor(message: string) {
-        super(message);
-        this.name = 'FatalConfigError';
-      }
-    },
   };
 });
 
@@ -77,6 +71,7 @@ vi.mock('../../config/mcp/mcpServerEnablement.js', () => ({
 describe('extensions enable command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockExtensionManager = vi.mocked(ExtensionManager);
+  const mockExitCli = vi.mocked(exitCli);
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -102,14 +97,12 @@ describe('extensions enable command', () => {
   describe('handleEnable', () => {
     it.each([
       {
-        name: 'my-extension',
         scope: undefined,
         expectedScope: SettingScope.User,
         expectedLog:
           'Extension "my-extension" successfully enabled in all scopes.',
       },
       {
-        name: 'my-extension',
         scope: 'workspace',
         expectedScope: SettingScope.Workspace,
         expectedLog:
@@ -117,9 +110,9 @@ describe('extensions enable command', () => {
       },
     ])(
       'should enable an extension in the $expectedScope scope when scope is $scope',
-      async ({ name, scope, expectedScope, expectedLog }) => {
+      async ({ scope, expectedScope, expectedLog }) => {
         const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
-        await handleEnable({ name, scope });
+        await handleEnable({ names: ['my-extension'], scope });
 
         expect(mockExtensionManager).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -131,25 +124,88 @@ describe('extensions enable command', () => {
         ).toHaveBeenCalled();
         expect(
           mockExtensionManager.prototype.enableExtension,
-        ).toHaveBeenCalledWith(name, expectedScope);
+        ).toHaveBeenCalledWith('my-extension', expectedScope);
         expect(emitConsoleLog).toHaveBeenCalledWith('log', expectedLog);
         mockCwd.mockRestore();
       },
     );
 
-    it('should throw FatalConfigError when extension enabling fails', async () => {
+    it('should enable multiple extensions when given a list of names', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      await handleEnable({ names: ['ext-a', 'ext-b'] });
+
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('ext-a', SettingScope.User);
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('ext-b', SettingScope.User);
+      mockCwd.mockRestore();
+    });
+
+    it('should dedupe duplicate names', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      await handleEnable({ names: ['ext-a', 'ext-a'] });
+
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('ext-a', SettingScope.User);
+      mockCwd.mockRestore();
+    });
+
+    it('should enable every installed extension when --all is set', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      mockExtensionManager.prototype.getExtensions = vi.fn().mockReturnValue([
+        { name: 'ext-a', mcpServers: undefined },
+        { name: 'ext-b', mcpServers: undefined },
+      ]);
+
+      await handleEnable({ all: true });
+
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('ext-a', SettingScope.User);
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('ext-b', SettingScope.User);
+      mockCwd.mockRestore();
+    });
+
+    it('should log a message and return when --all is set with no installed extensions', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      mockExtensionManager.prototype.getExtensions = vi
+        .fn()
+        .mockReturnValue([]);
+
+      await handleEnable({ all: true });
+
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'No extensions currently installed.',
+      );
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).not.toHaveBeenCalled();
+      mockCwd.mockRestore();
+    });
+
+    it('should log each error and call exitCli(1) when enabling fails', async () => {
       const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
       const error = new Error('Enable failed');
       (
         mockExtensionManager.prototype.enableExtension as Mock
-      ).mockImplementation(() => {
-        throw error;
-      });
+      ).mockRejectedValue(error);
 
-      const promise = handleEnable({ name: 'my-extension' });
-      await expect(promise).rejects.toThrow(FatalConfigError);
-      await expect(promise).rejects.toThrow('Enable failed');
+      await handleEnable({ names: ['my-extension'] });
 
+      expect(emitConsoleLog).toHaveBeenCalledWith(
+        'error',
+        'Failed to enable "my-extension": Enable failed',
+      );
+      expect(mockExitCli).toHaveBeenCalledWith(1);
       mockCwd.mockRestore();
     });
 
@@ -164,7 +220,7 @@ describe('extensions enable command', () => {
           { name: 'my-extension', mcpServers: { 'test-server': {} } },
         ]);
 
-      await handleEnable({ name: 'my-extension' });
+      await handleEnable({ names: ['my-extension'] });
 
       expect(mockEnablementInstance.autoEnableServers).toHaveBeenCalledWith([
         'test-server',
@@ -173,6 +229,24 @@ describe('extensions enable command', () => {
         'log',
         expect.stringContaining("MCP server 'test-server' was disabled"),
       );
+      mockCwd.mockRestore();
+    });
+
+    it('should batch MCP servers across multiple enabled extensions into one call', async () => {
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      mockEnablementInstance.autoEnableServers.mockResolvedValue([]);
+      mockExtensionManager.prototype.getExtensions = vi.fn().mockReturnValue([
+        { name: 'ext-a', mcpServers: { 'server-a': {} } },
+        { name: 'ext-b', mcpServers: { 'server-b': {} } },
+      ]);
+
+      await handleEnable({ names: ['ext-a', 'ext-b'] });
+
+      expect(mockEnablementInstance.autoEnableServers).toHaveBeenCalledTimes(1);
+      expect(mockEnablementInstance.autoEnableServers).toHaveBeenCalledWith([
+        'server-a',
+        'server-b',
+      ]);
       mockCwd.mockRestore();
     });
 
@@ -185,7 +259,7 @@ describe('extensions enable command', () => {
           { name: 'my-extension', mcpServers: { 'test-server': {} } },
         ]);
 
-      await handleEnable({ name: 'my-extension' });
+      await handleEnable({ names: ['my-extension'] });
 
       expect(mockEnablementInstance.autoEnableServers).toHaveBeenCalledWith([
         'test-server',
@@ -202,8 +276,8 @@ describe('extensions enable command', () => {
     const command = enableCommand;
 
     it('should have correct command and describe', () => {
-      expect(command.command).toBe('enable [--scope] <name>');
-      expect(command.describe).toBe('Enables an extension.');
+      expect(command.command).toBe('enable [names..]');
+      expect(command.describe).toBe('Enables one or more extensions.');
     });
 
     describe('builder', () => {
@@ -226,16 +300,32 @@ describe('extensions enable command', () => {
         (command.builder as (yargs: Argv) => Argv)(
           yargsMock as unknown as Argv,
         );
-        expect(yargsMock.positional).toHaveBeenCalledWith('name', {
-          describe: 'The name of the extension to enable.',
-          type: 'string',
-        });
-        expect(yargsMock.option).toHaveBeenCalledWith('scope', {
-          describe:
-            'The scope to enable the extension in. If not set, will be enabled in all scopes.',
-          type: 'string',
-        });
+        expect(yargsMock.positional).toHaveBeenCalledWith(
+          'names',
+          expect.objectContaining({
+            type: 'string',
+            array: true,
+          }),
+        );
+        expect(yargsMock.option).toHaveBeenCalledWith(
+          'all',
+          expect.objectContaining({ type: 'boolean' }),
+        );
+        expect(yargsMock.option).toHaveBeenCalledWith(
+          'scope',
+          expect.objectContaining({ type: 'string' }),
+        );
         expect(yargsMock.check).toHaveBeenCalled();
+      });
+
+      it('check function should throw when neither names nor --all is provided', () => {
+        (command.builder as (yargs: Argv) => Argv)(
+          yargsMock as unknown as Argv,
+        );
+        const checkCallback = yargsMock.check.mock.calls[0][0];
+        expect(() => checkCallback({})).toThrow(
+          /at least one extension name to enable/,
+        );
       });
 
       it('check function should throw for invalid scope', () => {
@@ -248,7 +338,7 @@ describe('extensions enable command', () => {
         )
           .map((s) => s.toLowerCase())
           .join(', ')}.`;
-        expect(() => checkCallback({ scope: 'invalid' })).toThrow(
+        expect(() => checkCallback({ all: true, scope: 'invalid' })).toThrow(
           expectedError,
         );
       });
@@ -257,12 +347,14 @@ describe('extensions enable command', () => {
     it('handler should call handleEnable', async () => {
       const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
       interface TestArgv {
-        name: string;
+        names: string[];
+        all: boolean;
         scope: string;
         [key: string]: unknown;
       }
       const argv: TestArgv = {
-        name: 'test-ext',
+        names: ['test-ext'],
+        all: false,
         scope: 'workspace',
         _: [],
         $0: '',
@@ -274,6 +366,37 @@ describe('extensions enable command', () => {
       expect(
         mockExtensionManager.prototype.enableExtension,
       ).toHaveBeenCalledWith('test-ext', SettingScope.Workspace);
+      mockCwd.mockRestore();
+    });
+
+    it('handler should normalize a scalar string positional to a single-element array', async () => {
+      // Regression: yargs may pass `names` as a bare string when only one
+      // positional is provided. The handler must wrap it in an array, not let
+      // it be iterated character-by-character.
+      const mockCwd = vi.spyOn(process, 'cwd').mockReturnValue('/test/dir');
+      interface TestArgv {
+        names: string;
+        all: boolean;
+        scope: string;
+        [key: string]: unknown;
+      }
+      const argv: TestArgv = {
+        names: 'conductor',
+        all: false,
+        scope: 'user',
+        _: [],
+        $0: '',
+      };
+      await (command.handler as unknown as (args: TestArgv) => Promise<void>)(
+        argv,
+      );
+
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockExtensionManager.prototype.enableExtension,
+      ).toHaveBeenCalledWith('conductor', SettingScope.User);
       mockCwd.mockRestore();
     });
   });

--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -8,17 +8,14 @@ import { type CommandModule } from 'yargs';
 import { loadSettings, SettingScope } from '../../config/settings.js';
 import { requestConsentNonInteractive } from '../../config/extensions/consent.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
-import {
-  debugLogger,
-  FatalConfigError,
-  getErrorMessage,
-} from '@google/gemini-cli-core';
+import { debugLogger, getErrorMessage } from '@google/gemini-cli-core';
 import { promptForSetting } from '../../config/extensions/extensionSettings.js';
 import { exitCli } from '../utils.js';
 import { McpServerEnablementManager } from '../../config/mcp/mcpServerEnablement.js';
 
 interface EnableArgs {
-  name: string;
+  names?: string[];
+  all?: boolean;
   scope?: string;
 }
 
@@ -32,54 +29,86 @@ export async function handleEnable(args: EnableArgs) {
   });
   await extensionManager.loadExtensions();
 
-  try {
-    if (args.scope?.toLowerCase() === 'workspace') {
-      await extensionManager.enableExtension(args.name, SettingScope.Workspace);
-    } else {
-      await extensionManager.enableExtension(args.name, SettingScope.User);
+  const scope =
+    args.scope?.toLowerCase() === 'workspace'
+      ? SettingScope.Workspace
+      : SettingScope.User;
+
+  let namesToEnable: string[] = [];
+  if (args.all) {
+    namesToEnable = extensionManager.getExtensions().map((ext) => ext.name);
+  } else if (args.names) {
+    namesToEnable = [...new Set(args.names)];
+  }
+
+  if (namesToEnable.length === 0) {
+    if (args.all) {
+      debugLogger.log('No extensions currently installed.');
     }
+    return;
+  }
 
-    // Auto-enable any disabled MCP servers for this extension
-    const extension = extensionManager
-      .getExtensions()
-      .find((e) => e.name === args.name);
+  const errors: Array<{ name: string; error: string }> = [];
+  const mcpServersToEnable: string[] = [];
 
-    if (extension?.mcpServers) {
-      const mcpEnablementManager = McpServerEnablementManager.getInstance();
-      const enabledServers = await mcpEnablementManager.autoEnableServers(
-        Object.keys(extension.mcpServers ?? {}),
-      );
+  for (const name of namesToEnable) {
+    try {
+      await extensionManager.enableExtension(name, scope);
 
-      for (const serverName of enabledServers) {
+      const extension = extensionManager
+        .getExtensions()
+        .find((e) => e.name === name);
+      if (extension?.mcpServers) {
+        mcpServersToEnable.push(...Object.keys(extension.mcpServers));
+      }
+
+      if (args.scope) {
         debugLogger.log(
-          `MCP server '${serverName}' was disabled - now enabled.`,
+          `Extension "${name}" successfully enabled for scope "${args.scope}".`,
+        );
+      } else {
+        debugLogger.log(
+          `Extension "${name}" successfully enabled in all scopes.`,
         );
       }
-      // Note: No restartServer() - CLI exits immediately, servers load on next session
+    } catch (error) {
+      errors.push({ name, error: getErrorMessage(error) });
     }
+  }
 
-    if (args.scope) {
-      debugLogger.log(
-        `Extension "${args.name}" successfully enabled for scope "${args.scope}".`,
-      );
-    } else {
-      debugLogger.log(
-        `Extension "${args.name}" successfully enabled in all scopes.`,
-      );
+  // Auto-enable any disabled MCP servers for newly enabled extensions.
+  if (mcpServersToEnable.length > 0) {
+    const mcpEnablementManager = McpServerEnablementManager.getInstance();
+    const enabledServers =
+      await mcpEnablementManager.autoEnableServers(mcpServersToEnable);
+    for (const serverName of enabledServers) {
+      debugLogger.log(`MCP server '${serverName}' was disabled - now enabled.`);
     }
-  } catch (error) {
-    throw new FatalConfigError(getErrorMessage(error));
+    // Note: No restartServer() - CLI exits immediately, servers load on next session
+  }
+
+  if (errors.length > 0) {
+    for (const { name, error } of errors) {
+      debugLogger.error(`Failed to enable "${name}": ${error}`);
+    }
+    await exitCli(1);
   }
 }
 
 export const enableCommand: CommandModule = {
-  command: 'enable [--scope] <name>',
-  describe: 'Enables an extension.',
+  command: 'enable [names..]',
+  describe: 'Enables one or more extensions.',
   builder: (yargs) =>
     yargs
-      .positional('name', {
-        describe: 'The name of the extension to enable.',
+      .positional('names', {
+        describe: 'The name(s) of the extension(s) to enable.',
         type: 'string',
+        array: true,
+      })
+      .option('all', {
+        type: 'boolean',
+        describe: 'Enable all installed extensions.',
+        default: false,
       })
       .option('scope', {
         describe:
@@ -87,6 +116,11 @@ export const enableCommand: CommandModule = {
         type: 'string',
       })
       .check((argv) => {
+        if (!argv.all && (!argv.names || argv.names.length === 0)) {
+          throw new Error(
+            'Please include at least one extension name to enable as a positional argument, or use the --all flag.',
+          );
+        }
         if (
           argv.scope &&
           !Object.values(SettingScope)
@@ -104,9 +138,18 @@ export const enableCommand: CommandModule = {
         return true;
       }),
   handler: async (argv) => {
+    const rawNames = argv['names'];
+    const names =
+      rawNames === undefined
+        ? undefined
+        : Array.isArray(rawNames)
+          ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            (rawNames as string[])
+          : [String(rawNames)];
     await handleEnable({
+      names,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: argv['name'] as string,
+      all: argv['all'] as boolean,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       scope: argv['scope'] as string,
     });


### PR DESCRIPTION
## Summary

I would like to have the ability to select the extensions that are used in one command rather than run numerous commands to enable / disable multiple extensions at once. This is because I frequently have subsets of commands in my user setup that differ (changing as many as 2-3 per time).

I propose updating the `enable` and `disable` commands to accept bulk operations (and in a subsequent PR provide a select dialog option):
```
gemini extensions enable [names..] [--all]
gemini extensions disable [names..] [--all]
```

## Details

Why is this needed?
This makes it far easier to instantly swap between sets of extensions in the same environment.

For larger code bases, such as large operating system projects (think something like Android), it's easier to have specialized extension packs per area or large subsystem such that you do not context flood the system. While plenty of tools exist to create these extensions, they're a bit of a pain to turn on and off. This command accelerates that process significantly.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/24658

## How to Validate

1. Run `gemini extensions` to see the new command.
2. Run `gemini extensions enable ext-a ext-b` (with extensions available to select) to enable multiple extensions.
3. Run `gemini extensions disable ext-a ext-b` (with extensions available to select) to disable multiple extensions.
4. Run variants of the `enable` and `disable` command with `--all`, or by naming specific extensions to enable or disable subsets.
5. Run the new unit tests.
6. Run variants when in workspace scope.
7. Validate things are selected appropriately when in CLI.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
