### PR TITLE
fix(core): prevent PTY resource leak by terminating active executions on process exit

### DIFF
--- a/packages/core/src/services/executionLifecycleService.ts
+++ b/packages/core/src/services/executionLifecycleService.ts
@@ -628,4 +628,34 @@ export class ExecutionLifecycleService {
       execution.writeInput?.(input);
     }
   }
+
+  static cleanupAll(): void {
+    for (const executionId of this.activeExecutions.keys()) {
+      try {
+        this.kill(executionId);
+      } catch {
+        // Ignore errors during global cleanup
+      }
+    }
+  }
 }
+
+// --- Global Cleanup Hooks ---
+// Ensures that if the gemini-cli process exits or is killed,
+// any spawned subprocesses (like node-pty shells) are terminated.
+let hasCleanedUp = false;
+const handleProcessExit = () => {
+  if (hasCleanedUp) return;
+  hasCleanedUp = true;
+  ExecutionLifecycleService.cleanupAll();
+};
+
+process.on('exit', handleProcessExit);
+process.on('SIGINT', () => {
+  handleProcessExit();
+  process.exit(130);
+});
+process.on('SIGTERM', () => {
+  handleProcessExit();
+  process.exit(143);
+});


### PR DESCRIPTION
### Issue
When running `gemini-cli`, any spawned subprocesses (like `node-pty` shells) managed by `ExecutionLifecycleService` are left orphaned if the CLI process is forcefully exited (e.g., via `SIGINT`/`Ctrl+C`). This creates background zombies that hoard terminal slots (PTYs) on macOS and Linux, eventually leading to a Denial of Service (e.g., "no more PTYs" or "503 open terminals").

### Fix
This patch adds a static `cleanupAll()` method to `ExecutionLifecycleService` and registers global process exit/signal hooks. This ensures that whenever `gemini-cli` exits, it explicitly destroys all remaining PTY instances by invoking the `kill()` lifecycle method for each active execution.