### PR TITLE
feat(cli): add JSON output support for list-sessions

### DIFF
--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -9,6 +9,7 @@ import {
   generateSummary,
   writeToStderr,
   writeToStdout,
+  OutputFormat,
   type Config,
 } from '@google/gemini-cli-core';
 import {
@@ -18,37 +19,43 @@ import {
 } from './sessionUtils.js';
 
 export async function listSessions(config: Config): Promise<void> {
-  // Generate summary for most recent session if needed
-  await generateSummary(config);
+  // Only generate summaries for interactive display to keep JSON output clean
+  if (config.getOutputFormat() !== OutputFormat.JSON) {
+    await generateSummary(config);
+  }
 
   const sessionSelector = new SessionSelector(config);
   const sessions = await sessionSelector.listSessions();
 
-  if (sessions.length === 0) {
+  const sortedSessions = sessions.sort(
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+  );
+
+  if (config.getOutputFormat() === OutputFormat.JSON) {
+    writeToStdout(JSON.stringify(sortedSessions, null, 2) + '\n');
+    return;
+  }
+
+  if (sortedSessions.length === 0) {
     writeToStdout('No previous sessions found for this project.');
     return;
   }
 
   writeToStdout(
-    `\nAvailable sessions for this project (${sessions.length}):\n`,
+    `\nAvailable sessions for this project (${sortedSessions.length}):\n`,
   );
 
-  sessions
-    .sort(
-      (a, b) =>
-        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-    )
-    .forEach((session, index) => {
-      const current = session.isCurrentSession ? ', current' : '';
-      const time = formatRelativeTime(session.lastUpdated);
-      const title =
-        session.displayName.length > 100
-          ? session.displayName.slice(0, 97) + '...'
-          : session.displayName;
-      writeToStdout(
-        `  ${index + 1}. ${title} (${time}${current}) [${session.id}]\n`,
-      );
-    });
+  sortedSessions.forEach((session, index) => {
+    const current = session.isCurrentSession ? ', current' : '';
+    const time = formatRelativeTime(session.lastUpdated);
+    const title =
+      session.displayName.length > 100
+        ? session.displayName.slice(0, 97) + '...'
+        : session.displayName;
+    writeToStdout(
+      `  ${index + 1}. ${title} (${time}${current}) [${session.id}]\n`,
+    );
+  });
 }
 
 export async function deleteSession(

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -27,31 +27,30 @@ export async function listSessions(config: Config): Promise<void> {
   const sessionSelector = new SessionSelector(config);
   const sessions = await sessionSelector.listSessions();
 
-  const sortedSessions = sessions.sort(
-    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-  );
-
   if (config.getOutputFormat() === OutputFormat.JSON) {
-    writeToStdout(JSON.stringify(sortedSessions, null, 2) + '\n');
+    writeToStdout(JSON.stringify(sessions, null, 2) + '\n');
     return;
   }
 
-  if (sortedSessions.length === 0) {
+  if (sessions.length === 0) {
     writeToStdout('No previous sessions found for this project.');
     return;
   }
 
   writeToStdout(
-    `\nAvailable sessions for this project (${sortedSessions.length}):\n`,
+    `\nAvailable sessions for this project (${sessions.length}):\n`,
   );
 
-  sortedSessions.forEach((session, index) => {
+  sessions.forEach((session, index) => {
     const current = session.isCurrentSession ? ', current' : '';
     const time = formatRelativeTime(session.lastUpdated);
+
+    const titleChars = Array.from(session.displayName);
     const title =
-      session.displayName.length > 100
-        ? session.displayName.slice(0, 97) + '...'
+      titleChars.length > 100
+        ? titleChars.slice(0, 97).join('') + '...'
         : session.displayName;
+
     writeToStdout(
       `  ${index + 1}. ${title} (${time}${current}) [${session.id}]\n`,
     );
@@ -70,17 +69,10 @@ export async function deleteSession(
     return;
   }
 
-  // Sort sessions by start time to match list-sessions ordering
-  const sortedSessions = sessions.sort(
-    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-  );
-
   let sessionToDelete: SessionInfo;
 
   // Try to find by UUID first
-  const sessionByUuid = sortedSessions.find(
-    (session) => session.id === sessionIndex,
-  );
+  const sessionByUuid = sessions.find((session) => session.id === sessionIndex);
   if (sessionByUuid) {
     sessionToDelete = sessionByUuid;
   } else {
@@ -92,7 +84,7 @@ export async function deleteSession(
       );
       return;
     }
-    sessionToDelete = sortedSessions[index - 1];
+    sessionToDelete = sessions[index - 1];
   }
 
   // Prevent deleting the current session


### PR DESCRIPTION
## Summary
This PR resolves #24690 by adding support for the `--output-format json` flag to the `list-sessions` command. Previously, the command would only output human-readable text, regardless of the format flag, making it difficult to use session data in automated scripts or third-party integrations.

## Problem
The `listSessions` function was previously hardcoded for string-based terminal output only. Additionally, the `generateSummary` function was called unconditionally, which often produced background logs (e.g., "Generating summary...") that would corrupt the JSON output if a user tried to pipe the data to another tool like `jq`.

## Details
- **JSON Support:** Modified `packages/cli/src/utils/sessions.ts` to detect `OutputFormat.JSON` from the config.
- **Output Cleanliness:** Wrapped the `generateSummary` call in a conditional check. It is now skipped when JSON is requested, ensuring a clean data stream to `stdout`.
- **Refactoring:** Extracted the sorting logic into a `sortedSessions` constant. This ensures that the order of sessions (sorted by `startTime`) is identical in both text and JSON modes.
- **Formatting:** Used `JSON.stringify(sortedSessions, null, 2)` for standardized, pretty-printed JSON.

## Related Issues
Fixes #24690

## How to Validate
1. **Build the bundle:**
   ```powershell
   npm run bundle
2. **Test command:**
   ```powershell
   node .\bundle\gemini.js --list-sessions --output-format json
### See attached Image for validation
<img width="1377" height="407" alt="Screenshot 2026-04-05 171405" src="https://github.com/user-attachments/assets/4979c71e-3a06-4870-93b4-ce17ca45c903" />


