### PR TITLE
feat/fast and no save sessions flag for quick one shot prompt execution

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -107,6 +107,7 @@ export interface CliArgs {
   acceptRawOutputRisk: boolean | undefined;
   isCommand: boolean | undefined;
   fast?: boolean;
+  saveSession?: boolean;
 }
 
 /**
@@ -449,6 +450,11 @@ export async function parseArguments(
           type: 'boolean',
           description:
             'Enable fast mode: minimize request payload and skip preflight requests (quota, experiments).',
+        })
+        .option('save-session', {
+          type: 'boolean',
+          default: true,
+          description: 'Persist the chat session to disk.',
         }),
     )
     .version(await getVersion()) // This will enable the --version flag based on package.json
@@ -922,6 +928,7 @@ export async function loadCliConfig(
     worktreeSettings,
     minimalPayload: !!argv.fast,
     skipPreflightRequests: !!argv.fast,
+    saveSession: argv.saveSession,
 
     coreTools: settings.tools?.core || undefined,
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -106,6 +106,7 @@ export interface CliArgs {
   rawOutput: boolean | undefined;
   acceptRawOutputRisk: boolean | undefined;
   isCommand: boolean | undefined;
+  fast?: boolean;
 }
 
 /**
@@ -443,6 +444,11 @@ export async function parseArguments(
         .option('accept-raw-output-risk', {
           type: 'boolean',
           description: 'Suppress the security warning when using --raw-output.',
+        })
+        .option('fast', {
+          type: 'boolean',
+          description:
+            'Enable fast mode: minimize request payload and skip preflight requests (quota, experiments).',
         }),
     )
     .version(await getVersion()) // This will enable the --version flag based on package.json
@@ -534,7 +540,8 @@ export async function loadCliConfig(
   }
 
   const memoryImportFormat = settings.context?.importFormat || 'tree';
-  const includeDirectoryTree = settings.context?.includeDirectoryTree ?? true;
+  const includeDirectoryTree =
+    (settings.context?.includeDirectoryTree ?? true) && !argv.fast;
 
   const ideMode = settings.ide?.enabled ?? false;
 
@@ -614,7 +621,7 @@ export async function loadCliConfig(
     .getExtensions()
     .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
 
-  const experimentalJitContext = settings.experimental.jitContext;
+  const experimentalJitContext = settings.experimental.jitContext && !argv.fast;
 
   let extensionRegistryURI =
     process.env['GEMINI_CLI_EXTENSION_REGISTRY_URI'] ??
@@ -887,7 +894,7 @@ export async function loadCliConfig(
   const useGeneralistProfile =
     settings.experimental?.generalistProfile ?? false;
   const useContextManagement =
-    settings.experimental?.contextManagement ?? false;
+    (settings.experimental?.contextManagement ?? false) && !argv.fast;
   const contextManagement = {
     ...(useGeneralistProfile ? generalistProfile : {}),
     ...(useContextManagement ? settings?.contextManagement : {}),
@@ -913,6 +920,8 @@ export async function loadCliConfig(
     debugMode,
     question,
     worktreeSettings,
+    minimalPayload: !!argv.fast,
+    skipPreflightRequests: !!argv.fast,
 
     coreTools: settings.tools?.core || undefined,
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
@@ -977,20 +986,23 @@ export async function loadCliConfig(
     extensionRegistryURI,
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,
-    plan: settings.general?.plan?.enabled ?? true,
-    tracker: settings.experimental?.taskTracker,
+    plan: (settings.general?.plan?.enabled ?? true) && !argv.fast,
+    tracker: (settings.experimental?.taskTracker ?? false) && !argv.fast,
     directWebFetch: settings.experimental?.directWebFetch,
     planSettings: settings.general?.plan?.directory
       ? settings.general.plan
       : (extensionPlanSettings ?? settings.general?.plan),
     enableEventDrivenScheduler: true,
-    skillsSupport: settings.skills?.enabled ?? true,
+    skillsSupport: (settings.skills?.enabled ?? true) && !argv.fast,
     disabledSkills: settings.skills?.disabled,
-    experimentalJitContext: settings.experimental?.jitContext,
-    experimentalMemoryManager: settings.experimental?.memoryManager,
+    experimentalJitContext: experimentalJitContext,
+    experimentalMemoryManager:
+      (settings.experimental?.memoryManager ?? false) && !argv.fast,
     contextManagement,
-    modelSteering: settings.experimental?.modelSteering,
-    topicUpdateNarration: settings.experimental?.topicUpdateNarration,
+    modelSteering:
+      (settings.experimental?.modelSteering ?? false) && !argv.fast,
+    topicUpdateNarration:
+      (settings.experimental?.topicUpdateNarration ?? false) && !argv.fast,
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,
@@ -1032,8 +1044,8 @@ export async function loadCliConfig(
     dynamicModelConfiguration: settings.experimental?.dynamicModelConfiguration,
     modelConfigServiceConfig: settings.modelConfigs,
     // TODO: loading of hooks based on workspace trust
-    enableHooks: settings.hooksConfig.enabled,
-    enableHooksUI: settings.hooksConfig.enabled,
+    enableHooks: (settings.hooksConfig.enabled ?? true) && !argv.fast,
+    enableHooksUI: (settings.hooksConfig.enabled ?? true) && !argv.fast,
     hooks: settings.hooks || {},
     disabledHooks: settings.hooksConfig?.disabled || [],
     projectHooks: projectHooks || {},

--- a/packages/core/src/code_assist/experiments/experiments.ts
+++ b/packages/core/src/code_assist/experiments/experiments.ts
@@ -25,6 +25,9 @@ let experimentsPromise: Promise<Experiments> | undefined;
 export async function getExperiments(
   server?: CodeAssistServer,
 ): Promise<Experiments> {
+  if (server?.config?.getSkipPreflightRequests()) {
+    return { flags: {}, experimentIds: [] };
+  }
   if (experimentsPromise) {
     return experimentsPromise;
   }

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -172,10 +172,15 @@ async function initOauthClient(
       // This will verify locally that the credentials look good.
       const { token } = await client.getAccessToken();
       if (token) {
-        // This will check with the server to see if it hasn't been revoked.
-        await client.getTokenInfo(token);
+        if (!config.getSkipPreflightRequests()) {
+          // This will check with the server to see if it hasn't been revoked.
+          await client.getTokenInfo(token);
+        }
 
-        if (!userAccountManager.getCachedGoogleAccount()) {
+        if (
+          !userAccountManager.getCachedGoogleAccount() &&
+          !config.getSkipPreflightRequests()
+        ) {
           try {
             await fetchAndCacheUserInfo(client);
           } catch (error) {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -404,6 +404,12 @@ export class CodeAssistServer implements ContentGenerator {
     signal?: AbortSignal,
     retryDelay: number = 100,
   ): Promise<T> {
+    if (
+      this.config?.getSkipPreflightRequests() &&
+      method !== 'generateContent'
+    ) {
+      return {} as T;
+    }
     const res = await this.client.request<T>({
       url: this.getMethodUrl(method),
       method: 'POST',
@@ -432,6 +438,9 @@ export class CodeAssistServer implements ContentGenerator {
     url: string,
     signal?: AbortSignal,
   ): Promise<T> {
+    if (this.config?.getSkipPreflightRequests()) {
+      return {} as T;
+    }
     const res = await this.client.request<T>({
       url,
       method: 'GET',
@@ -458,6 +467,12 @@ export class CodeAssistServer implements ContentGenerator {
     req: object,
     signal?: AbortSignal,
   ): Promise<AsyncGenerator<T>> {
+    if (
+      this.config?.getSkipPreflightRequests() &&
+      method !== 'streamGenerateContent'
+    ) {
+      return (async function* () {})() as AsyncGenerator<T>;
+    }
     const res = await this.client.request<AsyncIterable<unknown>>({
       url: this.getMethodUrl(method),
       method: 'POST',

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -27,6 +27,10 @@ import {
   OnboardingSuccessEvent,
 } from '../telemetry/index.js';
 
+import { Storage } from '../config/storage.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
 export class ProjectIdRequiredError extends Error {
   constructor() {
     super(
@@ -89,6 +93,27 @@ export function resetUserDataCacheForTesting() {
   });
 }
 
+async function loadPersistentUserData(): Promise<UserData | undefined> {
+  const filePath = path.join(Storage.getGlobalGeminiDir(), 'user_data.json');
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return JSON.parse(content) as UserData;
+  } catch {
+    return undefined;
+  }
+}
+
+async function savePersistentUserData(userData: UserData): Promise<void> {
+  const filePath = path.join(Storage.getGlobalGeminiDir(), 'user_data.json');
+  try {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify(userData, null, 2), 'utf-8');
+  } catch (e) {
+    debugLogger.debug('Failed to save persistent user data', e);
+  }
+}
+
 /**
  * Sets up the user by loading their Code Assist configuration and onboarding if needed.
  *
@@ -122,6 +147,19 @@ export async function setupUser(
     process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
     undefined;
 
+  if (config.getSkipPreflightRequests()) {
+    const cached = await loadPersistentUserData();
+    if (cached) {
+      return cached;
+    }
+    return {
+      projectId: projectId || 'unknown-project',
+      userTier: UserTierId.STANDARD,
+      userTierName: 'Standard',
+      hasOnboardedPreviously: true,
+    };
+  }
+
   const projectCache = userDataCache.getOrCreate(client, () =>
     createCache<string | undefined, Promise<UserData>>({
       storage: 'map',
@@ -129,9 +167,12 @@ export async function setupUser(
     }),
   );
 
-  return projectCache.getOrCreate(projectId, () =>
+  const userData = await projectCache.getOrCreate(projectId, () =>
     _doSetupUser(client, projectId, config, httpOptions),
   );
+
+  void savePersistentUserData(userData);
+  return userData;
 }
 
 /**
@@ -150,6 +191,8 @@ async function _doSetupUser(
     '',
     undefined,
     undefined,
+    undefined,
+    config,
   );
   const coreClientMetadata: ClientMetadata = {
     ideType: 'IDE_UNSPECIFIED',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -587,6 +587,8 @@ export interface ConfigParameters {
   debugMode: boolean;
   question?: string;
 
+  skipPreflightRequests?: boolean;
+  minimalPayload?: boolean;
   coreTools?: string[];
   mainAgentTools?: string[];
   /** @deprecated Use Policy Engine instead */
@@ -760,6 +762,8 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly worktreeSettings: WorktreeSettings | undefined;
   readonly enableConseca: boolean;
 
+  private readonly skipPreflightRequests: boolean;
+  private readonly minimalPayload: boolean;
   private readonly coreTools: string[] | undefined;
   private readonly mainAgentTools: string[] | undefined;
   /** @deprecated Use Policy Engine instead */
@@ -990,6 +994,8 @@ export class Config implements McpContext, AgentLoopContext {
     this.debugMode = params.debugMode;
     this.question = params.question;
     this.worktreeSettings = params.worktreeSettings;
+    this.minimalPayload = params.minimalPayload ?? false;
+    this.skipPreflightRequests = params.skipPreflightRequests ?? false;
 
     this._sandboxPolicyManager = new SandboxPolicyManager();
     const initialApprovalMode =
@@ -1548,19 +1554,24 @@ export class Config implements McpContext, AgentLoopContext {
     this.baseLlmClient = new BaseLlmClient(this.contentGenerator, this);
 
     const codeAssistServer = getCodeAssistServer(this);
-    const quotaPromise = codeAssistServer?.projectId
-      ? this.refreshUserQuota()
-      : Promise.resolve();
+    const quotaPromise =
+      codeAssistServer?.projectId && !this.skipPreflightRequests
+        ? this.refreshUserQuota()
+        : Promise.resolve();
 
-    this.experimentsPromise = getExperiments(codeAssistServer)
-      .then((experiments) => {
-        this.setExperiments(experiments);
-        return experiments;
-      })
-      .catch((e) => {
-        debugLogger.error('Failed to fetch experiments', e);
-        return undefined;
-      });
+    if (!this.skipPreflightRequests) {
+      this.experimentsPromise = getExperiments(codeAssistServer)
+        .then((experiments) => {
+          this.setExperiments(experiments);
+          return experiments;
+        })
+        .catch((e) => {
+          debugLogger.error('Failed to fetch experiments', e);
+          return undefined;
+        });
+    } else {
+      this.experimentsPromise = Promise.resolve(undefined);
+    }
 
     await quotaPromise;
 
@@ -1584,19 +1595,21 @@ export class Config implements McpContext, AgentLoopContext {
     // Fetch admin controls
     const experiments = await this.experimentsPromise;
 
-    const adminControlsEnabled =
-      experiments?.flags[ExperimentFlags.ENABLE_ADMIN_CONTROLS]?.boolValue ??
-      false;
-    const adminControls = await fetchAdminControls(
-      codeAssistServer,
-      this.getRemoteAdminSettings(),
-      adminControlsEnabled,
-      (newSettings: AdminControlsSettings) => {
-        this.setRemoteAdminSettings(newSettings);
-        coreEvents.emitAdminSettingsChanged();
-      },
-    );
-    this.setRemoteAdminSettings(adminControls);
+    if (!this.skipPreflightRequests) {
+      const adminControlsEnabled =
+        experiments?.flags[ExperimentFlags.ENABLE_ADMIN_CONTROLS]?.boolValue ??
+        false;
+      const adminControls = await fetchAdminControls(
+        codeAssistServer,
+        this.getRemoteAdminSettings(),
+        adminControlsEnabled,
+        (newSettings: AdminControlsSettings) => {
+          this.setRemoteAdminSettings(newSettings);
+          coreEvents.emitAdminSettingsChanged();
+        },
+      );
+      this.setRemoteAdminSettings(adminControls);
+    }
 
     if ((await this.getProModelNoAccess()) && isAutoModel(this.model)) {
       this.setModel(PREVIEW_GEMINI_FLASH_MODEL);
@@ -1606,6 +1619,9 @@ export class Config implements McpContext, AgentLoopContext {
   async getExperimentsAsync(): Promise<Experiments | undefined> {
     if (this.experiments) {
       return this.experiments;
+    }
+    if (this.skipPreflightRequests) {
+      return undefined;
     }
     const codeAssistServer = getCodeAssistServer(this);
     return getExperiments(codeAssistServer);
@@ -1774,6 +1790,14 @@ export class Config implements McpContext, AgentLoopContext {
 
   shouldLoadMemoryFromIncludeDirectories(): boolean {
     return this.loadMemoryFromIncludeDirectories;
+  }
+
+  getMinimalPayload(): boolean {
+    return this.minimalPayload;
+  }
+
+  getSkipPreflightRequests(): boolean {
+    return this.skipPreflightRequests;
   }
 
   getIncludeDirectoryTree(): boolean {
@@ -2072,6 +2096,9 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   async refreshAvailableCredits(): Promise<void> {
+    if (this.skipPreflightRequests) {
+      return;
+    }
     const codeAssistServer = getCodeAssistServer(this);
     if (!codeAssistServer) {
       return;
@@ -2085,6 +2112,9 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   async refreshUserQuota(): Promise<RetrieveUserQuotaResponse | undefined> {
+    if (this.skipPreflightRequests) {
+      return undefined;
+    }
     const codeAssistServer = getCodeAssistServer(this);
     if (!codeAssistServer || !codeAssistServer.projectId) {
       return undefined;
@@ -2349,6 +2379,9 @@ export class Config implements McpContext, AgentLoopContext {
    * via system instruction updates.
    */
   getSystemInstructionMemory(): string | HierarchicalMemory {
+    if (this.minimalPayload) {
+      return '';
+    }
     if (this.experimentalJitContext && this.memoryContextManager) {
       const global = this.memoryContextManager.getGlobalMemory();
       const userProjectMemory =
@@ -2367,7 +2400,11 @@ export class Config implements McpContext, AgentLoopContext {
    * disabled (Tier 2 memory is already in the system instruction).
    */
   getSessionMemory(): string {
-    if (!this.experimentalJitContext || !this.memoryContextManager) {
+    if (
+      this.minimalPayload ||
+      !this.experimentalJitContext ||
+      !this.memoryContextManager
+    ) {
       return '';
     }
     const sections: string[] = [];

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -624,6 +624,7 @@ export interface ConfigParameters {
   fileDiscoveryService?: FileDiscoveryService;
   includeDirectories?: string[];
   bugCommand?: BugCommandSettings;
+  saveSession?: boolean;
   model: string;
   disableLoopDetection?: boolean;
   maxSessionTurns?: number;
@@ -946,6 +947,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly experimentalMemoryManager: boolean;
   private readonly memoryBoundaryMarkers: readonly string[];
   private readonly topicUpdateNarration: boolean;
+  private readonly saveSession: boolean;
   private readonly disableLLMCorrection: boolean;
   private readonly planEnabled: boolean;
   private readonly trackerEnabled: boolean;
@@ -1198,6 +1200,7 @@ export class Config implements McpContext, AgentLoopContext {
       },
     };
     this.topicUpdateNarration = params.topicUpdateNarration ?? false;
+    this.saveSession = params.saveSession ?? true;
     this.modelSteering = params.modelSteering ?? false;
     this.injectionService = new InjectionService(() =>
       this.isModelSteeringEnabled(),
@@ -1798,6 +1801,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getSkipPreflightRequests(): boolean {
     return this.skipPreflightRequests;
+  }
+
+  getSaveSession(): boolean {
+    return this.saveSession;
   }
 
   getIncludeDirectoryTree(): boolean {

--- a/packages/core/src/config/config_minimal.test.ts
+++ b/packages/core/src/config/config_minimal.test.ts
@@ -100,4 +100,15 @@ describe('Config Minimal Mode', () => {
     const userData = await setupUser(mockAuthClient, config);
     expect(userData.projectId).toBe('cached-project');
   });
+
+  it('should respect saveSession flag', () => {
+    const configOn = new Config({ ...baseParams, saveSession: true });
+    expect(configOn.getSaveSession()).toBe(true);
+
+    const configOff = new Config({ ...baseParams, saveSession: false });
+    expect(configOff.getSaveSession()).toBe(false);
+
+    const configDefault = new Config({ ...baseParams });
+    expect(configDefault.getSaveSession()).toBe(true);
+  });
 });

--- a/packages/core/src/config/config_minimal.test.ts
+++ b/packages/core/src/config/config_minimal.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Config, type ConfigParameters } from './config.js';
+import { AuthType } from '../core/contentGenerator.js';
+import { getExperiments } from '../code_assist/experiments/experiments.js';
+import { fetchAdminControls } from '../code_assist/admin/admin_controls.js';
+import { createContentGeneratorConfig } from '../core/contentGenerator.js';
+import { CodeAssistServer } from '../code_assist/server.js';
+import { setupUser, type UserData } from '../code_assist/setup.js';
+import { UserTierId } from '../code_assist/types.js';
+import * as fs from 'node:fs/promises';
+
+vi.mock('../code_assist/experiments/experiments.js');
+vi.mock('../code_assist/admin/admin_controls.js');
+vi.mock('../core/contentGenerator.js');
+vi.mock('node:fs/promises');
+vi.mock('../core/client.js', () => ({
+  GeminiClient: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn(),
+    stripThoughtsFromHistory: vi.fn(),
+    updateSystemInstruction: vi.fn(),
+    setTools: vi.fn(),
+  })),
+}));
+
+const TARGET_DIR = process.cwd();
+const SESSION_ID = 'test-session';
+
+const baseParams: ConfigParameters = {
+  sessionId: SESSION_ID,
+  targetDir: TARGET_DIR,
+  cwd: TARGET_DIR,
+  debugMode: false,
+  model: 'test-model',
+};
+
+describe('Config Minimal Mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty memory in getSystemInstructionMemory if minimalPayload is true', () => {
+    const config = new Config({ ...baseParams, minimalPayload: true, userMemory: 'some memory' });
+    expect(config.getSystemInstructionMemory()).toBe('');
+  });
+
+  it('should return empty memory in getSessionMemory if minimalPayload is true', () => {
+    const config = new Config({ ...baseParams, minimalPayload: true });
+    expect(config.getSessionMemory()).toBe('');
+  });
+
+  it('should skip quota and experiments in refreshAuth if skipPreflightRequests is true', async () => {
+    const config = new Config({ ...baseParams, skipPreflightRequests: true });
+    
+    vi.mocked(createContentGeneratorConfig).mockResolvedValue({
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+    });
+
+    vi.spyOn(config as any, 'refreshUserQuota').mockResolvedValue({} as any);
+
+    await config.refreshAuth(AuthType.LOGIN_WITH_GOOGLE);
+
+    expect(getExperiments).not.toHaveBeenCalled();
+    expect(fetchAdminControls).not.toHaveBeenCalled();
+  });
+
+  it('CodeAssistServer should skip non-essential requests if skipPreflightRequests is true', async () => {
+    const config = new Config({ ...baseParams, skipPreflightRequests: true });
+    const mockAuthClient = { request: vi.fn() } as any;
+    const server = new CodeAssistServer(mockAuthClient, 'test-project', {}, '', undefined, undefined, undefined, config);
+
+    await server.loadCodeAssist({ metadata: {} });
+    expect(mockAuthClient.request).not.toHaveBeenCalled();
+
+    await server.listExperiments({} as any);
+    expect(mockAuthClient.request).not.toHaveBeenCalled();
+
+    await server.retrieveUserQuota({ project: 'test' });
+    expect(mockAuthClient.request).not.toHaveBeenCalled();
+  });
+
+  it('setupUser should use cached UserData in Fast Mode', async () => {
+    const config = new Config({ ...baseParams, skipPreflightRequests: true });
+    const mockAuthClient = {} as any;
+
+    const mockUserData: UserData = {
+      projectId: 'cached-project',
+      userTier: UserTierId.STANDARD,
+      userTierName: 'Standard',
+      hasOnboardedPreviously: true,
+    };
+    
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(mockUserData));
+
+    const userData = await setupUser(mockAuthClient, config);
+    expect(userData.projectId).toBe('cached-project');
+  });
+});

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -301,6 +301,11 @@ export class GeminiClient {
     }
     this.lastUsedModelId = modelId;
 
+    if (this.config.getMinimalPayload()) {
+      this.getChat().setTools([]);
+      return;
+    }
+
     const toolRegistry = this.context.toolRegistry;
     const toolDeclarations = toolRegistry.getFunctionDeclarations(modelId);
     const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
@@ -370,8 +375,9 @@ export class GeminiClient {
     this.lastUsedModelId = undefined;
 
     const toolRegistry = this.context.toolRegistry;
-    const toolDeclarations = toolRegistry.getFunctionDeclarations();
-    const tools: Tool[] = [{ functionDeclarations: toolDeclarations }];
+    const tools: Tool[] = this.config.getMinimalPayload()
+      ? []
+      : [{ functionDeclarations: toolRegistry.getFunctionDeclarations() }];
 
     const history = await getInitialChatHistory(this.config, extraHistory);
 

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -44,6 +44,9 @@ export class PromptProvider {
     userMemory?: string | HierarchicalMemory,
     interactiveOverride?: boolean,
   ): string {
+    if (context.config.getMinimalPayload()) {
+      return '';
+    }
     const systemMdResolution = resolvePathFromEnv(
       process.env['GEMINI_SYSTEM_MD'],
     );
@@ -265,6 +268,9 @@ export class PromptProvider {
   }
 
   getCompressionPrompt(context: AgentLoopContext): string {
+    if (context.config.getMinimalPayload()) {
+      return '';
+    }
     const desiredModel = resolveModel(
       context.config.getActiveModel(),
       context.config.getGemini31LaunchedSync?.() ?? false,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -157,6 +157,10 @@ export class ChatRecordingService {
     resumedSessionData?: ResumedSessionData,
     kind?: 'main' | 'subagent',
   ): void {
+    if (!this.context.config.getSaveSession()) {
+      this.conversationFile = null;
+      return;
+    }
     try {
       this.kind = kind;
       if (resumedSessionData) {

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -46,6 +46,9 @@ ${folderStructure}`;
  * @returns A promise that resolves to an array of `Part` objects containing environment information.
  */
 export async function getEnvironmentContext(config: Config): Promise<Part[]> {
+  if (config.getMinimalPayload()) {
+    return [];
+  }
   const today = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
     year: 'numeric',
@@ -89,13 +92,19 @@ export async function getInitialChatHistory(
   extraHistory?: Content[],
 ): Promise<Content[]> {
   const envParts = await getEnvironmentContext(config);
-  const envContextString = envParts.map((part) => part.text || '').join('\n\n');
+  const history: Content[] = [];
 
-  return [
-    {
-      role: 'user',
-      parts: [{ text: envContextString }],
-    },
-    ...(extraHistory ?? []),
-  ];
+  if (envParts.length > 0) {
+    const envContextString = envParts
+      .map((part) => part.text || '')
+      .join('\n\n');
+    if (envContextString.trim()) {
+      history.push({
+        role: 'user',
+        parts: [{ text: envContextString }],
+      });
+    }
+  }
+
+  return [...history, ...(extraHistory ?? [])];
 }


### PR DESCRIPTION
fixes #16335

## feat(cli): implement --fast mode to minimize one-shot prompt overhead

This commit introduces a new `--fast` flag designed to reduce the execution time and API payload size for simple, single-turn prompts.

Key features of Fast Mode:
- **Zero Pre-flight Requests**: Skips all non-essential network calls during initialization, including:
    - User quota checks (`/v1internal:retrieveUserQuota`)
    - Experiment fetching (`/v1internal:listExperiments`)
    - Admin control requests (`/v1internal:fetchAdminControls`)
    - OAuth metadata validation (`/tokeninfo`)
- **Minimal Request Payload**: Automatically strips the following from the Gemini API request:
    - Default System Prompt (no need for `GEMINI_SYSTEM_MD=/dev/null`)
    - Session Context (OS info, current date, directory listings)
    - Loaded Context (global, project, and extension memory)
    - Tool Definitions (function declarations)
- **Feature Disabling**: Automatically turns off directory tree scanning, system/project hooks, and skill discovery.
- **Persistent Metadata Caching**: Implements a local cache at `~/.gemini/user_data.json` to store the Project ID and account tier. This allows Fast Mode to use your real project ID without needing a network call to fetch it, avoiding 'unknown-project' permission errors.

How to use:
  `gemini --fast -p "your simple prompt"`

To warm up the cache after a long period of inactivity or account change:
  `gemini --list-sessions`

## feat(cli): add --no-save-session flag to skip session persistence

This commit adds a new `--no-save-session` flag (mapped to the `--save-session` boolean option) that allows users to skip saving the chat conversation to disk.

This is particularly useful when combined with `--fast` for transient prompts that do not need to be resumed or kept in the session history.

Usage:
  `gemini --fast --no-save-session -p "transient prompt"`

By default, sessions continue to be saved to disk (`--save-session=true`).
