### PR TITLE
feat(cli): prompt to resume session when first prompt matches history

### DIFF
--- a/conductor/feature-session-resume-prompt.md
+++ b/conductor/feature-session-resume-prompt.md
@@ -1,0 +1,72 @@
+# Session Resume Prompt
+
+## Objective
+
+Prompt the user with an interactive dialog when they submit their very first
+prompt in a new session if that prompt exactly matches the first user message of
+an existing `/chat` session. The dialog will ask whether to resume the matched
+session or start a fresh request. This applies regardless of whether the prompt
+was typed manually or navigated to via `Ctrl+R` or `Up`/`Down` arrows.
+
+## Key Files & Context
+
+- `packages/cli/src/ui/AppContainer.tsx`: Handles `handleFinalSubmit`. We will
+  intercept the very first prompt submission here.
+- `packages/cli/src/ui/contexts/UIStateContext.tsx`: Manages UI state. We need
+  to add state for the new dialog request.
+- `packages/cli/src/ui/contexts/UIActionsContext.tsx`: Contains `UIActions`. We
+  will add a handler for the dialog choices.
+- `packages/cli/src/ui/components/DialogManager.tsx`: Renders dialogs based on
+  UI state.
+- `packages/cli/src/ui/components/SessionResumePromptDialog.tsx` (new): The UI
+  component for the confirmation dialog.
+
+## Implementation Steps
+
+1. **Update State Interfaces (`UIStateContext.tsx`, `UIActionsContext.tsx`)**:
+   - Add `sessionResumePromptRequest` to `UIState`, which holds
+     `{ matchedSession: SessionInfo, submittedValue: string }`.
+   - Add `handleSessionResumePromptChoice(resume: boolean)` to `UIActions`.
+
+2. **Intercept First Prompt (`AppContainer.tsx`)**:
+   - In `handleFinalSubmit(submittedValue: string, bypassSessionCheck = false)`:
+     - If `bypassSessionCheck` is false and this is the very first user prompt
+       (`historyManager.history` has no user messages):
+       - Asynchronously read all previous sessions via
+         `getSessionFiles(chatsDir)`.
+       - If a session is found where
+         `firstUserMessage === submittedValue.trim()`:
+         - Trigger the `sessionResumePromptRequest` with the matched session and
+           the `submittedValue`.
+         - Return early, stopping the current execution.
+
+3. **Handle Dialog Choice (`AppContainer.tsx`)**:
+   - Implement `handleSessionResumePromptChoice`:
+     - Clear the `sessionResumePromptRequest`.
+     - If `resume` is true: Call `handleResumeSession(matchedSession)`.
+     - If `resume` is false: Call `handleFinalSubmit(submittedValue, true)` to
+       execute normally.
+
+4. **Create Dialog Component (`SessionResumePromptDialog.tsx`)**:
+   - Create a generic full-frame dialog using `ink` and `@inkjs/ui` or custom
+     select menus.
+   - Display a message: "A previous session exactly matches your first prompt.
+     Would you like to resume it?"
+   - Provide two options: "Resume previous session" and "Send as new request".
+
+5. **Register Dialog (`DialogManager.tsx`)**:
+   - Render `SessionResumePromptDialog` when
+     `uiState.sessionResumePromptRequest` is not null.
+
+## Verification & Testing
+
+- Start a fresh session, type a prompt that exactly matches a previous session's
+  first prompt (e.g. from history using `Ctrl+R` or typed out), and verify the
+  dialog appears.
+- Select "Resume previous session" and verify the old session loads correctly.
+- Select "Send as new request" and verify the prompt executes as a normal new
+  session.
+- Type a completely novel prompt as the first message and verify it executes
+  immediately without a dialog.
+- Enter a matching prompt as the _second_ message of a session and verify it
+  does NOT trigger the dialog.

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -572,6 +572,7 @@ const mockUIActions: UIActions = {
   handleValidationChoice: vi.fn(),
   handleOverageMenuChoice: vi.fn(),
   handleEmptyWalletChoice: vi.fn(),
+  handleSessionResumePromptChoice: vi.fn(),
   setQueueErrorMessage: vi.fn(),
   addMessage: vi.fn(),
   popAllMessages: vi.fn(),

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -16,15 +16,20 @@ import {
 import {
   type DOMElement,
   ResizeObserver,
-  useApp,
   useStdout,
   useStdin,
+  useApp,
   type AppProps,
   AppContext as InkAppContext,
 } from 'ink';
+import path, { basename } from 'node:path';
 import { App } from './App.js';
 import { AppContext } from './contexts/AppContext.js';
-import { UIStateContext, type UIState } from './contexts/UIStateContext.js';
+import {
+  UIStateContext,
+  type UIState,
+  type SessionResumePromptRequest,
+} from './contexts/UIStateContext.js';
 import {
   UIActionsContext,
   type UIActions,
@@ -110,7 +115,6 @@ import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { calculatePromptWidths } from './components/InputPrompt.js';
 import { calculateMainAreaWidth } from './utils/ui-sizing.js';
 import ansiEscapes from 'ansi-escapes';
-import { basename } from 'node:path';
 import { computeTerminalTitle } from '../utils/windowTitle.js';
 import { useTextBuffer } from './components/shared/text-buffer.js';
 import { useLogger } from './hooks/useLogger.js';
@@ -133,7 +137,7 @@ import { type UpdateObject } from './utils/updateCheck.js';
 import { setUpdateHandler } from '../utils/handleAutoUpdate.js';
 import { registerCleanup, runExitCleanup } from '../utils/cleanup.js';
 import { relaunchApp } from '../utils/processUtils.js';
-import type { SessionInfo } from '../utils/sessionUtils.js';
+import { type SessionInfo, getSessionFiles } from '../utils/sessionUtils.js';
 import { useMessageQueue } from './hooks/useMessageQueue.js';
 import { useMcpStatus } from './hooks/useMcpStatus.js';
 import { useApprovalModeIndicator } from './hooks/useApprovalModeIndicator.js';
@@ -438,6 +442,8 @@ export const AppContainer = (props: AppContainerProps) => {
   );
 
   const [isConfigInitialized, setConfigInitialized] = useState(false);
+  const [sessionResumePromptRequest, setSessionResumePromptRequest] =
+    useState<SessionResumePromptRequest | null>(null);
 
   const logger = useLogger(config.storage);
   const { inputHistory, addInput, initializeFromLogger } =
@@ -1327,7 +1333,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
   );
 
   const handleFinalSubmit = useCallback(
-    async (submittedValue: string) => {
+    async (submittedValue: string, bypassSessionCheck = false) => {
       reset();
       // Explicitly hide the expansion hint and clear its x-second timer when a new turn begins.
       triggerExpandHint(null);
@@ -1338,7 +1344,41 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
       }
 
-      const isSlash = isSlashCommand(submittedValue.trim());
+      const trimmed = submittedValue.trim();
+
+      // Intercept the very first prompt to check for session resume matches
+      if (!bypassSessionCheck && trimmed) {
+        const userMessagesCount = historyManager.history.filter(
+          (h) => h.type === 'user',
+        ).length;
+
+        if (userMessagesCount === 0) {
+          try {
+            const chatsDir = path.join(
+              config.storage.getProjectTempDir(),
+              'chats',
+            );
+            const sessions = await getSessionFiles(
+              chatsDir,
+              config.getSessionId(),
+            );
+            const matchingSession = sessions.find(
+              (s) => s.firstUserMessage === trimmed && !s.isCurrentSession,
+            );
+            if (matchingSession) {
+              setSessionResumePromptRequest({
+                matchedSession: matchingSession,
+                submittedValue,
+              });
+              return;
+            }
+          } catch (e) {
+            debugLogger.error('Failed to check for matching sessions:', e);
+          }
+        }
+      }
+
+      const isSlash = isSlashCommand(trimmed);
       const isIdle = streamingState === StreamingState.Idle;
       const isAgentRunning =
         streamingState === StreamingState.Responding ||
@@ -1417,7 +1457,25 @@ Logging in with Google... Restarting Gemini CLI to continue.
       handleHintSubmit,
       isConfigInitialized,
       triggerExpandHint,
+      historyManager,
     ],
+  );
+
+  const handleSessionResumePromptChoice = useCallback(
+    (resume: boolean) => {
+      const request = sessionResumePromptRequest;
+      setSessionResumePromptRequest(null);
+      if (!request) {
+        return;
+      }
+
+      if (resume) {
+        void handleResumeSession(request.matchedSession);
+      } else {
+        void handleFinalSubmit(request.submittedValue, true);
+      }
+    },
+    [handleFinalSubmit, handleResumeSession, sessionResumePromptRequest],
   );
 
   const handleClearScreen = useCallback(() => {
@@ -2149,6 +2207,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     !!overageMenuRequest ||
     !!emptyWalletRequest ||
     isSessionBrowserOpen ||
+    !!sessionResumePromptRequest ||
     authState === AuthState.AwaitingApiKeyInput ||
     !!newAgents;
 
@@ -2456,6 +2515,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       adminSettingsChanged,
       newAgents,
       showIsExpandableHint,
+      sessionResumePromptRequest,
       hintMode:
         config.isModelSteeringEnabled() && isToolExecuting(pendingHistoryItems),
       hintBuffer: '',
@@ -2583,6 +2643,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       adminSettingsChanged,
       newAgents,
       showIsExpandableHint,
+      sessionResumePromptRequest,
     ],
   );
 
@@ -2623,6 +2684,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       // G1 AI Credits handlers
       handleOverageMenuChoice,
       handleEmptyWalletChoice,
+      handleSessionResumePromptChoice,
       openSessionBrowser,
       closeSessionBrowser,
       handleResumeSession,
@@ -2715,6 +2777,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       handleValidationChoice,
       handleOverageMenuChoice,
       handleEmptyWalletChoice,
+      handleSessionResumePromptChoice,
       openSessionBrowser,
       closeSessionBrowser,
       handleResumeSession,

--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -37,6 +37,7 @@ import { IdeTrustChangeDialog } from './IdeTrustChangeDialog.js';
 import { NewAgentsNotification } from './NewAgentsNotification.js';
 import { AgentConfigDialog } from './AgentConfigDialog.js';
 import { PolicyUpdateDialog } from './PolicyUpdateDialog.js';
+import { SessionResumePromptDialog } from './SessionResumePromptDialog.js';
 
 interface DialogManagerProps {
   addItem: UseHistoryManagerReturn['addItem'];
@@ -349,6 +350,15 @@ export const DialogManager = ({
         onResumeSession={uiActions.handleResumeSession}
         onDeleteSession={uiActions.handleDeleteSession}
         onExit={uiActions.closeSessionBrowser}
+      />
+    );
+  }
+
+  if (uiState.sessionResumePromptRequest) {
+    return (
+      <SessionResumePromptDialog
+        request={uiState.sessionResumePromptRequest}
+        onSelect={uiActions.handleSessionResumePromptChoice}
       />
     );
   }

--- a/packages/cli/src/ui/components/SessionResumePromptDialog.tsx
+++ b/packages/cli/src/ui/components/SessionResumePromptDialog.tsx
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Box, Text } from 'ink';
+import type React from 'react';
+import { useCallback } from 'react';
+import { theme } from '../semantic-colors.js';
+import {
+  RadioButtonSelect,
+  type RadioSelectItem,
+} from './shared/RadioButtonSelect.js';
+import { Colors } from '../colors.js';
+import { formatRelativeTime } from '../../utils/sessionUtils.js';
+import type { SessionResumePromptRequest } from '../contexts/UIStateContext.js';
+
+interface SessionResumePromptDialogProps {
+  request: SessionResumePromptRequest;
+  onSelect: (resume: boolean) => void;
+}
+
+export const SessionResumePromptDialog: React.FC<
+  SessionResumePromptDialogProps
+> = ({ request, onSelect }) => {
+  const { matchedSession } = request;
+
+  const options: Array<RadioSelectItem<boolean>> = [
+    {
+      label: 'Resume previous session',
+      value: true,
+      key: 'resume',
+    },
+    {
+      label: 'Send as new request',
+      value: false,
+      key: 'new',
+    },
+  ];
+
+  const handleSelect = useCallback(
+    (value: boolean) => {
+      onSelect(value);
+    },
+    [onSelect],
+  );
+
+  return (
+    <Box
+      borderStyle="double"
+      borderColor={theme.ui.active}
+      flexDirection="column"
+      paddingX={1}
+      paddingY={1}
+    >
+      <Box marginBottom={1}>
+        <Text bold color={theme.ui.active}>
+          Session Match Found
+        </Text>
+      </Box>
+      <Box marginBottom={1}>
+        <Text>
+          A previous session exactly matches your first prompt. Would you like
+          to resume it?
+        </Text>
+      </Box>
+      <Box
+        flexDirection="column"
+        paddingX={1}
+        paddingY={0.5}
+        borderStyle="round"
+        borderColor={Colors.Gray}
+        marginBottom={1}
+      >
+        <Text color={Colors.Gray}>Previous Session:</Text>
+        <Text italic color={theme.text.link}>
+          {`"${matchedSession.firstUserMessage}"`}
+        </Text>
+        <Box marginTop={0.5}>
+          <Text dimColor>
+            {matchedSession.messageCount} messages · Last updated{' '}
+            {formatRelativeTime(matchedSession.lastUpdated)}
+          </Text>
+        </Box>
+      </Box>
+      <RadioButtonSelect
+        items={options}
+        onSelect={handleSelect}
+        showNumbers={true}
+      />
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -65,6 +65,7 @@ export interface UIActions {
   handleValidationChoice: (choice: 'verify' | 'change_auth' | 'cancel') => void;
   handleOverageMenuChoice: (choice: OverageMenuIntent) => void;
   handleEmptyWalletChoice: (choice: EmptyWalletIntent) => void;
+  handleSessionResumePromptChoice: (resume: boolean) => void;
   openSessionBrowser: () => void;
   closeSessionBrowser: () => void;
   handleResumeSession: (session: SessionInfo) => Promise<void>;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -35,6 +35,7 @@ import type { DOMElement } from 'ink';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 import type { ExtensionUpdateState } from '../state/extensions.js';
 import type { UpdateObject } from '../utils/updateCheck.js';
+import type { SessionInfo } from '../../utils/sessionUtils.js';
 
 export interface ProQuotaDialogRequest {
   failedModel: string;
@@ -79,6 +80,12 @@ export interface EmptyWalletDialogRequest {
   userEmail?: string;
   onGetCredits: () => void;
   resolve: (intent: EmptyWalletIntent) => void;
+}
+
+/** Request for session resume confirmation dialog */
+export interface SessionResumePromptRequest {
+  matchedSession: SessionInfo;
+  submittedValue: string;
 }
 
 import { type UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
@@ -225,6 +232,7 @@ export interface UIState {
   showIsExpandableHint: boolean;
   hintMode: boolean;
   hintBuffer: string;
+  sessionResumePromptRequest: SessionResumePromptRequest | null;
   transientMessage: {
     text: string;
     type: TransientMessageType;


### PR DESCRIPTION

<img width="1913" height="449" alt="Screenshot from 2026-04-06 01-24-29" src="https://github.com/user-attachments/assets/49c2dea1-878d-4c3e-80b8-2d44f924312b" />

## Summary
This PR adds a session resume prompt when the user's first prompt in a new session matches the first prompt of a previous historical session. This improves the user experience by proactively offering to resume ongoing conversations.

## Details
- Intercepts the very first prompt in `AppContainer.tsx`.
- Scans `~/.gemini/tmp/chats` for sessions where the first user message exactly matches the current input.
- Displays a new interactive dialog `SessionResumePromptDialog` allowing the user to choose between resuming the old session or starting a new one.
- Updated `dialogsVisible` to correctly manage UI state during the prompt.

## Related Issues
Closes #24719



## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] Linux
    - [x] npm run
