### PR TITLE
fix(cli): resolve bunx execution -S not found error on Windows

### DIFF
--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -6,6 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Suppress DEP0040 (Punycode deprecation warning) safely, as Windows limits shebang flags.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = ((...args: unknown[]) => {
+  const [warning, type, code] = args;
+  if (type === 'DEP0040' || code === 'DEP0040' || (type === 'DeprecationWarning' && String(warning).includes('punycode'))) {
+    return;
+  }
+  return Reflect.apply(originalEmitWarning, process, args);
+}) as typeof process.emitWarning;
+
 import * as url from 'node:url';
 import * as path from 'node:path';
 

--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -6,16 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Suppress DEP0040 (Punycode deprecation warning) safely, as Windows limits shebang flags.
-const originalEmitWarning = process.emitWarning;
-process.emitWarning = ((...args: unknown[]) => {
-  const [warning, type, code] = args;
-  if (type === 'DEP0040' || code === 'DEP0040' || (type === 'DeprecationWarning' && String(warning).includes('punycode'))) {
-    return;
-  }
-  return Reflect.apply(originalEmitWarning, process, args);
-}) as typeof process.emitWarning;
-
+import './suppress-warnings.js';
 import * as url from 'node:url';
 import * as path from 'node:path';
 

--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import './suppress-warnings.js';
+import '../suppress-warnings.js';
 import * as url from 'node:url';
 import * as path from 'node:path';
 

--- a/packages/a2a-server/src/suppress-warnings.ts
+++ b/packages/a2a-server/src/suppress-warnings.ts
@@ -12,9 +12,21 @@
 //
 // Suppresses DEP0040 (punycode deprecation) — the -S flag required to pass
 // --no-warnings=DEP0040 via shebang is not supported on Windows.
-const originalEmitWarning = process.emitWarning;
-process.emitWarning = ((...args: unknown[]) => {
-  const [, , code] = args;
+const originalEmitWarning = process.emitWarning.bind(process);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+process.emitWarning = ((
+  warning: string | Error,
+  options?: string | NodeJS.EmitWarningOptions,
+) => {
+  const code =
+    typeof options === 'object' && options !== null
+      ? options.code
+      : typeof options === 'string'
+        ? options
+        : undefined;
   if (code === 'DEP0040') return;
-  return Reflect.apply(originalEmitWarning, process, args);
+  if (typeof options === 'string') {
+    return originalEmitWarning(warning, { code: options });
+  }
+  return originalEmitWarning(warning, options);
 }) as typeof process.emitWarning;

--- a/packages/a2a-server/src/suppress-warnings.ts
+++ b/packages/a2a-server/src/suppress-warnings.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file must be imported first in the entry point to ensure the
+// process.emitWarning override is in place before any other module is evaluated.
+// In ESM, static imports are hoisted, so suppression logic placed inline in an
+// entry file runs too late to catch warnings emitted during module loading.
+//
+// Suppresses DEP0040 (punycode deprecation) — the -S flag required to pass
+// --no-warnings=DEP0040 via shebang is not supported on Windows.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = ((...args: unknown[]) => {
+  const [, , code] = args;
+  if (code === 'DEP0040') return;
+  return Reflect.apply(originalEmitWarning, process, args);
+}) as typeof process.emitWarning;

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,16 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Suppress DEP0040 (Punycode deprecation warning) safely, as Windows limits shebang flags.
-const originalEmitWarning = process.emitWarning;
-process.emitWarning = ((...args: unknown[]) => {
-  const [warning, type, code] = args;
-  if (type === 'DEP0040' || code === 'DEP0040' || (type === 'DeprecationWarning' && String(warning).includes('punycode'))) {
-    return;
-  }
-  return Reflect.apply(originalEmitWarning, process, args);
-}) as typeof process.emitWarning;
-
+import './src/suppress-warnings.js';
 import { main } from './src/gemini.js';
 import { FatalError, writeToStderr } from '@google/gemini-cli-core';
 import { runExitCleanup } from './src/utils/cleanup.js';

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,6 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Suppress DEP0040 (Punycode deprecation warning) safely, as Windows limits shebang flags.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = ((...args: unknown[]) => {
+  const [warning, type, code] = args;
+  if (type === 'DEP0040' || code === 'DEP0040' || (type === 'DeprecationWarning' && String(warning).includes('punycode'))) {
+    return;
+  }
+  return Reflect.apply(originalEmitWarning, process, args);
+}) as typeof process.emitWarning;
+
 import { main } from './src/gemini.js';
 import { FatalError, writeToStderr } from '@google/gemini-cli-core';
 import { runExitCleanup } from './src/utils/cleanup.js';

--- a/packages/cli/src/suppress-warnings.ts
+++ b/packages/cli/src/suppress-warnings.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * @license
  * Copyright 2025 Google LLC
@@ -12,9 +11,21 @@
 //
 // Suppresses DEP0040 (punycode deprecation) — the -S flag required to pass
 // --no-warnings=DEP0040 via shebang is not supported on Windows.
-const originalEmitWarning = process.emitWarning;
-process.emitWarning = ((...args: unknown[]) => {
-  const [, , code] = args;
+const originalEmitWarning = process.emitWarning.bind(process);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+process.emitWarning = ((
+  warning: string | Error,
+  options?: string | NodeJS.EmitWarningOptions,
+) => {
+  const code =
+    typeof options === 'object' && options !== null
+      ? options.code
+      : typeof options === 'string'
+        ? options
+        : undefined;
   if (code === 'DEP0040') return;
-  return Reflect.apply(originalEmitWarning, process, args);
+  if (typeof options === 'string' || options === undefined) {
+    return originalEmitWarning(warning, options);
+  }
+  return originalEmitWarning(warning, options);
 }) as typeof process.emitWarning;

--- a/packages/cli/src/suppress-warnings.ts
+++ b/packages/cli/src/suppress-warnings.ts
@@ -24,8 +24,8 @@ process.emitWarning = ((
         ? options
         : undefined;
   if (code === 'DEP0040') return;
-  if (typeof options === 'string' || options === undefined) {
-    return originalEmitWarning(warning, options);
+  if (typeof options === 'string') {
+    return originalEmitWarning(warning, { code: options });
   }
   return originalEmitWarning(warning, options);
 }) as typeof process.emitWarning;

--- a/packages/cli/src/suppress-warnings.ts
+++ b/packages/cli/src/suppress-warnings.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file must be imported first in the entry point to ensure the
+// process.emitWarning override is in place before any other module is evaluated.
+// In ESM, static imports are hoisted, so suppression logic placed inline in an
+// entry file runs too late to catch warnings emitted during module loading.
+//
+// Suppresses DEP0040 (punycode deprecation) — the -S flag required to pass
+// --no-warnings=DEP0040 via shebang is not supported on Windows.
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = ((...args: unknown[]) => {
+  const [, , code] = args;
+  if (code === 'DEP0040') return;
+  return Reflect.apply(originalEmitWarning, process, args);
+}) as typeof process.emitWarning;


### PR DESCRIPTION
﻿## Problem

When running `gemini` via `bunx` on **Windows**, the CLI fails immediately with:

```
error: interpreter executable '-S' not found
```

This is caused by the `#!/usr/bin/env -S` shebang in `packages/cli/index.ts`. The `-S` flag (split-string) is a GNU coreutils extension not available on Windows.

## Solution

1. **`packages/cli/index.ts`**: Replaced the incompatible `#!/usr/bin/env -S node --experimental-vm-modules --no-warnings` shebang with a plain `#!/usr/bin/env node`. Node flags are now handled via the launcher script.

2. **`packages/cli/src/suppress-warnings.ts`** (new file): Moved the `DEP0040` Punycode deprecation warning suppression into a dedicated first-imported module. This avoids the ESM hoisting issue where `process.env.NODE_NO_WARNINGS` set in the same file as top-level imports was applied too late.

3. **`packages/a2a-server/src/http/server.ts`**: Fixed a relative import path for the `suppress-warnings` module.

## Testing

Tested on Windows 11 with `bun v1.2.x`:
- `bunx gemini` now launches successfully
- DEP0040 warning is correctly suppressed
- No regressions on Linux/macOS (shebang remains valid)
