### PR TITLE
fix: detect newly created files in @ recommendations with core optimizations

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { act, useState } from 'react';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { renderHook } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { useAtCompletion } from './useAtCompletion.js';
@@ -184,6 +185,50 @@ describe('useAtCompletion', () => {
         expect(result.current.suggestions.map((s) => s.value)).toEqual([
           'cRaZycAsE.txt',
         ]);
+      });
+    });
+
+    it('should pick up newly created files when re-triggered (@ menu re-opened)', async () => {
+      const structure: FileSystemStructure = { 'initial.txt': '' };
+      testRootDir = await createTmpDir(structure);
+
+      const { result, rerender } = await renderHook(
+        ({ enabled }) =>
+          useTestHarnessForAtCompletion(enabled, '', mockConfig, testRootDir),
+        { initialProps: { enabled: true } },
+      );
+
+      // Wait for initial suggestions
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toContain(
+          'initial.txt',
+        );
+      });
+
+      // Add a new file to the disk
+      const newFile = path.join(testRootDir, 'newfile.txt');
+      await fs.promises.writeFile(newFile, '');
+
+      // Advance time to expire the 1s cache
+      vi.useFakeTimers();
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+      vi.useRealTimers();
+
+      // Toggle enabled to re-trigger initialize (close and open @ menu)
+      act(() => {
+        rerender({ enabled: false });
+      });
+      act(() => {
+        rerender({ enabled: true });
+      });
+
+      // Wait for the new file to appear in suggestions
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toContain(
+          'newfile.txt',
+        );
       });
     });
   });

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -284,23 +284,24 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
         const initPromises: Array<Promise<void>> = [];
 
         for (const dir of directories) {
-          if (fileSearchMap.current.has(dir)) continue;
-
-          const searcher = FileSearchFactory.create({
-            projectRoot: dir,
-            ignoreDirs: [],
-            fileDiscoveryService: new FileDiscoveryService(
-              dir,
-              config?.getFileFilteringOptions(),
-            ),
-            cache: true,
-            cacheTtl: 30,
-            enableRecursiveFileSearch:
-              config?.getEnableRecursiveFileSearch() ?? true,
-            enableFuzzySearch:
-              config?.getFileFilteringEnableFuzzySearch() ?? true,
-            maxFiles: config?.getFileFilteringOptions()?.maxFileCount,
-          });
+          let searcher = fileSearchMap.current.get(dir);
+          if (!searcher) {
+            searcher = FileSearchFactory.create({
+              projectRoot: dir,
+              ignoreDirs: [],
+              fileDiscoveryService: new FileDiscoveryService(
+                dir,
+                config?.getFileFilteringOptions(),
+              ),
+              cache: true,
+              cacheTtl: 1,
+              enableRecursiveFileSearch:
+                config?.getEnableRecursiveFileSearch() ?? true,
+              enableFuzzySearch:
+                config?.getFileFilteringEnableFuzzySearch() ?? true,
+              maxFiles: config?.getFileFilteringOptions()?.maxFileCount,
+            });
+          }
 
           initPromises.push(
             searcher.initialize().then(() => {

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -799,6 +799,45 @@ describe('FileSearch', () => {
     ]);
   });
 
+  it('should skip re-building the Fzf index if files have not changed (referential equality)', async () => {
+    tmpDir = await createTmpDir({
+      'file1.js': '',
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 10000,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    await fileSearch.initialize();
+    const firstFzf = fileSearch.fzf;
+    const firstResultCache = fileSearch.resultCache;
+
+    expect(firstFzf).toBeDefined();
+    expect(firstResultCache).toBeDefined();
+
+    // Mock crawl to return the exact same array instance
+    const crawlSpy = vi
+      .spyOn(crawler, 'crawl')
+      .mockResolvedValue(fileSearch.allFiles);
+
+    await fileSearch.initialize();
+
+    // Verify that the internal state objects were NOT recreated
+    expect(fileSearch.fzf).toBe(firstFzf);
+    expect(fileSearch.resultCache).toBe(firstResultCache);
+    expect(crawlSpy).toHaveBeenCalled();
+  });
+
   describe('DirectoryFileSearch', () => {
     it('should search for files in the current directory', async () => {
       tmpDir = await createTmpDir({

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -137,21 +137,29 @@ class RecursiveFileSearch implements FileSearch {
   constructor(private readonly options: FileSearchOptions) {}
 
   async initialize(): Promise<void> {
-    this.ignore = loadIgnoreRules(
+    const nextIgnore = loadIgnoreRules(
       this.options.fileDiscoveryService,
       this.options.ignoreDirs,
     );
 
-    this.allFiles = await crawl({
+    const nextFiles = await crawl({
       crawlDirectory: this.options.projectRoot,
       cwd: this.options.projectRoot,
-      ignore: this.ignore,
+      ignore: nextIgnore,
       cache: this.options.cache,
       cacheTtl: this.options.cacheTtl,
       maxDepth: this.options.maxDepth,
       maxFiles: this.options.maxFiles ?? 20000,
     });
 
+    if (nextFiles === this.allFiles && this.ignore) {
+      // optimization: if the file list is referentially equal (from crawl cache)
+      // and we already have ignore rules, skip rebuilding the FZF index.
+      return;
+    }
+
+    this.ignore = nextIgnore;
+    this.allFiles = nextFiles;
     this.buildResultCache();
   }
 


### PR DESCRIPTION
### fix: detect newly created files in @ recommendations with core optimizations

This PR addresses issue #24729, where the Gemini CLI was unable to detect new files created during a session in the `@` file recommendation menu.

#### **The Problem**
The useAtCompletion hook initialized the file searcher only once per session/root-change. Combined with an aggressive 30-second crawler cache, newly created files were not surfaced to the user without a full CLI restart.

#### **The Solution**
- **CLI Refresh**: Updated `useAtCompletion` to re-initialize searchers every time the `@` menu is activated.
- **Improved Latency**: Lowered the crawler cache TTL to **1 second** specifically for the `@` menu, ensuring near-instant discovery of new files while maintaining performance.
- **Core Optimization**: Added a referential equality check in `RecursiveFileSearch.initialize()` to skip expensive FZF re-indexing if the file list is cached and hasn't changed. This keeps the menu fast even in projects with 100k+ files.
- **Verification**: 
  - Added an integration test in `useAtCompletion.test.ts`(CLI).
  - Added a unit test in `fileSearch.test.ts` (Core).

**Fixes #24729**
