### PR TITLE
fix(cli): remove -S from shebang to fix Windows and BSD execution

### DIFF
--- a/packages/a2a-server/src/http/server.ts
+++ b/packages/a2a-server/src/http/server.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings=DEP0040
+#!/usr/bin/env node
 
 /**
  * @license

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings=DEP0040
+#!/usr/bin/env node
 
 /**
  * @license


### PR DESCRIPTION
## Summary

Reverts the `-S` flag in the shebang of `packages/cli/index.ts` and `packages/a2a-server/src/http/server.ts` to fix execution on Windows, BSD, and BusyBox systems.

## Details

The use of `#!/usr/bin/env -S node --no-warnings=DEP0040` introduced in PR #20154 causes several cross-platform issues:

1. **Windows:** Npm's `cmd-shim` parser doesn't understand the `-S` flag. When generating wrappers, it incorrectly identifies `"-S"` as the target executable, leading to a `" -S " is not recognized as an internal or external command` error.
2. **BSD/BusyBox:** Many non-GNU `env` implementations (like those in OpenBSD, FreeBSD, and Alpine Linux) do not support the `-S` flag, causing direct execution to fail.

The warning suppression flag `--no-warnings=DEP0040` remains in `scripts/start.js`, so local development workflows are unaffected. A future PR should re-add programmatic warning suppression in the CLI itself if needed, using a more portable method than the shebang.

## Related Issues

Fixes #20697

## How to Validate

1. Run `npm run build`
2. Check the first line of `packages/cli/dist/index.js` and `packages/a2a-server/dist/a2a-server.mjs`. It should be `#!/usr/bin/env node`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
