### PR TITLE
Fix issue where topic headers can be posted back to back

### DIFF
--- a/evals/update_topic.eval.ts
+++ b/evals/update_topic.eval.ts
@@ -215,4 +215,44 @@ export default app;
       expect(fs.existsSync(path.join(rig.testDir, 'src/routes.ts'))).toBe(true);
     },
   });
+
+  /**
+   * Regression test for a bug where update_topic was called multiple times in a
+   * row.
+   */
+  evalTest('USUALLY_PASSES', {
+    name: 'update_topic should be called just once',
+    prompt:
+      'What is 2+2. Post your answer with update_topic tool. Do not talk.',
+    files: {
+      '.gemini/settings.json': JSON.stringify({
+        experimental: {
+          topicUpdateNarration: true,
+        },
+      }),
+    },
+    assert: async (rig, result) => {
+      const toolLogs = rig.readToolLogs();
+      const topicCalls = toolLogs.filter(
+        (l) => l.toolRequest.name === UPDATE_TOPIC_TOOL_NAME,
+      );
+
+      expect(
+        topicCalls.length,
+        'Expected at least one update_topic call',
+      ).toStrictEqual(1);
+
+      expect(
+        topicCalls.some((l) => {
+          const params = JSON.parse(l.toolRequest.args);
+          return (
+            params.title?.includes('4') ||
+            params.summary?.includes('4') ||
+            params.strategic_intent?.includes('4')
+          );
+        }),
+        'Expected update_topic to contain the answer "4"',
+      ).toBe(true);
+    },
+  });
 });

--- a/evals/update_topic.eval.ts
+++ b/evals/update_topic.eval.ts
@@ -218,41 +218,44 @@ export default app;
 
   /**
    * Regression test for a bug where update_topic was called multiple times in a
-   * row.
+   * row. We have seen cases of this occurring in earlier versions of the update_topic
+   * system instruction, prior to https://github.com/google-gemini/gemini-cli/pull/24640.
+   * This test demonstrated that there are cases where it can still occur and validates
+   * the prompt change that improves the behavior.
    */
-  evalTest('USUALLY_PASSES', {
-    name: 'update_topic should be called just once',
-    prompt:
-      'What is 2+2. Post your answer with update_topic tool. Do not talk.',
+  evalTest('ALWAYS_PASSES', {
+    name: 'update_topic should not be called twice in a row',
+    prompt: `
+      We need to build a C compiler.
+
+      Before you write any code, you must formally declare your strategy.
+      First, declare that you will build a Lexer.
+      Then, immediately realize that is wrong and declare that you will actually build a Parser instead.
+
+      Finally, create 'parser.c'.
+    `,
     files: {
+      'package.json': JSON.stringify({ name: 'test-project' }),
       '.gemini/settings.json': JSON.stringify({
         experimental: {
           topicUpdateNarration: true,
         },
       }),
     },
-    assert: async (rig, result) => {
+    assert: async (rig) => {
       const toolLogs = rig.readToolLogs();
-      const topicCalls = toolLogs.filter(
-        (l) => l.toolRequest.name === UPDATE_TOPIC_TOOL_NAME,
-      );
 
-      expect(
-        topicCalls.length,
-        'Expected at least one update_topic call',
-      ).toStrictEqual(1);
-
-      expect(
-        topicCalls.some((l) => {
-          const params = JSON.parse(l.toolRequest.args);
-          return (
-            params.title?.includes('4') ||
-            params.summary?.includes('4') ||
-            params.strategic_intent?.includes('4')
+      // Check for back-to-back update_topic calls
+      for (let i = 1; i < toolLogs.length; i++) {
+        if (
+          toolLogs[i - 1].toolRequest.name === UPDATE_TOPIC_TOOL_NAME &&
+          toolLogs[i].toolRequest.name === UPDATE_TOPIC_TOOL_NAME
+        ) {
+          throw new Error(
+            `Detected back-to-back ${UPDATE_TOPIC_TOOL_NAME} calls at index ${i - 1} and ${i}`,
           );
-        }),
-        'Expected update_topic to contain the answer "4"',
-      ).toBe(true);
+        }
+      }
     },
   });
 });

--- a/evals/update_topic.eval.ts
+++ b/evals/update_topic.eval.ts
@@ -223,7 +223,7 @@ export default app;
    * This test demonstrated that there are cases where it can still occur and validates
    * the prompt change that improves the behavior.
    */
-  evalTest('ALWAYS_PASSES', {
+  evalTest('USUALLY_PASSES', {
     name: 'update_topic should not be called twice in a row',
     prompt: `
       We need to build a C compiler.

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -518,7 +518,8 @@ function mandateTopicUpdateModel(): string {
 ## Topic Updates
 As you work, the user follows along by reading topic updates that you publish with ${UPDATE_TOPIC_TOOL_NAME}. Keep them informed by doing the following:
 
-- Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.\n- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
+- Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.
+- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
 - Each topic update should give a concise description of what you are doing for the next few turns in the \`${TOPIC_PARAM_SUMMARY}\` parameter.
 - Provide topic updates whenever you change "topics". A topic is typically a discrete subgoal and will be every 3 to 10 turns. Do not use ${UPDATE_TOPIC_TOOL_NAME} on every turn.
 - The typical complex user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
@@ -527,7 +528,7 @@ As you work, the user follows along by reading topic updates that you publish wi
   - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")
   - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")
 
-`;
+\`;
 }
 
 function mandateSkillGuidance(hasSkills: boolean): string {

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -519,7 +519,8 @@ function mandateTopicUpdateModel(): string {
 As you work, the user follows along by reading topic updates that you publish with ${UPDATE_TOPIC_TOOL_NAME}. Keep them informed by doing the following:
 
 - Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.
-- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
+- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first turn.
+- For tasks taking multiple turns, also call ${UPDATE_TOPIC_TOOL_NAME} in your last turn to recap what was done.
 - Each topic update should give a concise description of what you are doing for the next few turns in the \`${TOPIC_PARAM_SUMMARY}\` parameter.
 - Provide topic updates whenever you change "topics". A topic is typically a discrete subgoal and will be every 3 to 10 turns. Do not use ${UPDATE_TOPIC_TOOL_NAME} on every turn.
 - The typical complex user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
@@ -528,7 +529,7 @@ As you work, the user follows along by reading topic updates that you publish wi
   - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")
   - ${UPDATE_TOPIC_TOOL_NAME}(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")
 
-\`;
+`;
 }
 
 function mandateSkillGuidance(hasSkills: boolean): string {

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -630,7 +630,8 @@ function mandateTopicUpdateModel(): string {
 As you work, the user follows along by reading topic updates that you publish with ${UPDATE_TOPIC_TOOL_NAME}. Keep them informed by doing the following:
 
 - Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.
-- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
+- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first turn.
+- For tasks taking multiple turns, also call ${UPDATE_TOPIC_TOOL_NAME} in your last turn to recap what was done.
 - Each topic update should give a concise description of what you are doing for the next few turns in the \`${TOPIC_PARAM_SUMMARY}\` parameter.
 - Provide topic updates whenever you change "topics". A topic is typically a discrete subgoal and will be every 3 to 10 turns. Do not use ${UPDATE_TOPIC_TOOL_NAME} on every turn.
 - The typical complex user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
@@ -639,7 +640,7 @@ As you work, the user follows along by reading topic updates that you publish wi
   - \`update_topic(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")\`
   - \`update_topic(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")\`
 
-\`;
+`;
 }
 
 function mandateExplainBeforeActing(): string {

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -629,7 +629,8 @@ function mandateTopicUpdateModel(): string {
 ## Topic Updates
 As you work, the user follows along by reading topic updates that you publish with ${UPDATE_TOPIC_TOOL_NAME}. Keep them informed by doing the following:
 
-- Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.\n- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
+- Usage Exception: NEVER use ${UPDATE_TOPIC_TOOL_NAME} for answering questions, providing explanations, or performing isolated lookup tasks (e.g. reading a single file, running a quick search, or checking a version). It is STRICTLY for orchestrating multi-step codebase modifications or complex investigations involving 3 or more tool calls.
+- Always call ${UPDATE_TOPIC_TOOL_NAME} in your first and last turn for tasks that require 3 or more tool calls. The final turn should always recap what was done.
 - Each topic update should give a concise description of what you are doing for the next few turns in the \`${TOPIC_PARAM_SUMMARY}\` parameter.
 - Provide topic updates whenever you change "topics". A topic is typically a discrete subgoal and will be every 3 to 10 turns. Do not use ${UPDATE_TOPIC_TOOL_NAME} on every turn.
 - The typical complex user message should call ${UPDATE_TOPIC_TOOL_NAME} 3 or more times. Each corresponds to a distinct phase of the task, such as "Researching X", "Researching Y", "Implementing Z with X", and "Testing Z".
@@ -638,7 +639,7 @@ As you work, the user follows along by reading topic updates that you publish wi
   - \`update_topic(${TOPIC_PARAM_TITLE}="Researching Parser", ${TOPIC_PARAM_SUMMARY}="I am starting an investigation into the parser timeout bug. My goal is to first understand the current test coverage and then attempt to reproduce the failure. This phase will focus on identifying the bottleneck in the main loop before we move to implementation.")\`
   - \`update_topic(${TOPIC_PARAM_TITLE}="Implementing Buffer Fix", ${TOPIC_PARAM_SUMMARY}="I have completed the research phase and identified a race condition in the tokenizer's buffer management. I am now transitioning to implementation. This new chapter will focus on refactoring the buffer logic to handle async chunks safely, followed by unit testing the fix.")\`
 
-`;
+\`;
 }
 
 function mandateExplainBeforeActing(): string {


### PR DESCRIPTION
## Summary

Fixes an issue where topic headers, posted with update_topic, can be placed back to back and adds a behavioral eval test that was tested to reproduce the issue, and then has been confirmed to be fixed by a system instruction change.

Ran an eval that shows reasonable results for Gemini 3+: https://github.com/google-gemini/gemini-cli/actions/runs/24042543020

There's some intermittent failures for older models but I'm going to take this as is to avoid making the guidance too prescriptive. We can always strengthen it later.