### PR TITLE
relax tool sandboxing overrides for plan mode to match defaults.

### DIFF
--- a/packages/core/src/policy/policies/sandbox-default.toml
+++ b/packages/core/src/policy/policies/sandbox-default.toml
@@ -2,7 +2,7 @@
 network = false
 readonly = true
 approvedTools = []
-allowOverrides = false
+allowOverrides = true
 
 [modes.default]
 network = false
@@ -17,4 +17,3 @@ approvedTools = ['sed', 'grep', 'awk', 'perl', 'cat', 'echo', 'Add-Content', 'Se
 allowOverrides = true
 
 [commands]
-

--- a/packages/core/src/policy/sandboxPolicyManager.ts
+++ b/packages/core/src/policy/sandboxPolicyManager.ts
@@ -64,7 +64,7 @@ export class SandboxPolicyManager {
                 network: false,
                 readonly: true,
                 approvedTools: [],
-                allowOverrides: false,
+                allowOverrides: true,
               },
               default: {
                 network: false,


### PR DESCRIPTION
## Summary

This PR enables tool sandboxing to function correctly when writing plan files to the temporary session directory. It changes `allowOverrides` from `false` to `true` for `modes.plan` in the `sandbox-default.toml` policy.

## Details

Previously, when tool sandboxing was enabled, `modes.plan` strictly prohibited any sandbox overrides. This unintentionally blocked the internal `SandboxedFileSystemService` from requesting the necessary write permissions to create and save `.md` plan files to the `tmp` session directory, causing operations in Plan Mode to fail with "Sandbox request rejected" errors.

By setting `allowOverrides = true` for plan mode, we allow internal tools that are already permitted by the Policy Engine (like `write_file` for plan files) to request the specific write overrides they need to function. The workspace itself remains read-only as defined by the policy, preserving the security posture.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/24750

## How to Validate

1. Enable tool sandboxing in your settings or via environment variable (`GEMINI_SANDBOX=docker`).
2. Enter plan mode (`/plan`).
3. Ask the agent to plan a change.
4. Verify that the plan file is successfully written to the temporary session directory without any "Sandbox request rejected" errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
