### PR TITLE
fix(cli): respect global environment variable allowlist

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -938,6 +938,8 @@ export async function loadCliConfig(
       : undefined,
     blockedEnvironmentVariables:
       settings.security?.environmentVariableRedaction?.blocked,
+    allowedEnvironmentVariables:
+      settings.security?.environmentVariableRedaction?.allowed,
     enableEnvironmentVariableRedaction:
       settings.security?.environmentVariableRedaction?.enabled,
     userMemory: memoryContent,


### PR DESCRIPTION
## Summary

This PR fixes a bug where the global allowlist for environment variable redaction was completely ignored during configuration loading.

## Details

The `settings.security.environmentVariableRedaction.allowed` array is defined in the `settingsSchema.ts` file, and the core `Config` object accepts an `allowedEnvironmentVariables` parameter. However, `loadCliConfig` in `packages/cli/src/config/config.ts` was not mapping the setting from `settings.json` into the `Config` constructor. This one-line fix maps the parsed setting so the global allowlist is respected.

## Related Issues

Fixes #18302

## How to Validate

1. Add a sensitive key name (like `MY_SECRET_TOKEN`) to the `security.environmentVariableRedaction.allowed` array in your `settings.json`.
2. Configure an MCP server in `settings.json`.
3. Set the `MY_SECRET_TOKEN` environment variable on your system.
4. Launch the CLI and verify that the unredacted token is successfully passed to the MCP server during discovery.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
