### PR TITLE
fix(policy): allow complete_task in plan mode

### DIFF
--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -107,7 +107,8 @@ toolName = [
   "activate_skill",
   "codebase_investigator",
   "cli_help",
-  "get_internal_docs"
+  "get_internal_docs",
+  "complete_task"
 ]
 decision = "allow"
 priority = 70


### PR DESCRIPTION
## Summary

Allow the `complete_task` tool to be executed when the agent is in plan mode.

## Details

Subagents operating in plan mode were failing with `ERROR_NO_COMPLETE_TASK_CALL` because they were not allowed to call the `complete_task` tool, even though it is injected dynamically by the execution loop. This change adds `"complete_task"` to the allowlist of tools for plan mode in `packages/core/src/policy/policies/plan.toml`.

## Related Issues

Related to the user report that subagents fail with `ERROR_NO_COMPLETE_TASK_CALL` in plan mode.

## How to Validate

Run the policy tests:
- `npm test -w @google/gemini-cli-core -- src/policy/toml-loader.test.ts`
- `npm test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts`

Both should pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
