### PR TITLE
feat(cli): support selective topic expansion and click-to-expand

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -10,6 +10,7 @@ import { ToolGroupMessage } from './ToolGroupMessage.js';
 import {
   UPDATE_TOPIC_TOOL_NAME,
   TOPIC_PARAM_TITLE,
+  TOPIC_PARAM_SUMMARY,
   TOPIC_PARAM_STRATEGIC_INTENT,
   makeFakeConfig,
   CoreToolCallStatus,
@@ -292,7 +293,7 @@ describe('<ToolGroupMessage />', () => {
           name: UPDATE_TOPIC_TOOL_NAME,
           args: {
             [TOPIC_PARAM_TITLE]: 'Testing Topic',
-            summary: 'This is the summary',
+            [TOPIC_PARAM_SUMMARY]: 'This is the summary',
           },
         }),
       ];

--- a/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
@@ -12,6 +12,7 @@ import {
   TOPIC_PARAM_SUMMARY,
   TOPIC_PARAM_STRATEGIC_INTENT,
   CoreToolCallStatus,
+  UPDATE_TOPIC_TOOL_NAME,
 } from '@google/gemini-cli-core';
 
 describe('<TopicMessage />', () => {
@@ -36,7 +37,7 @@ describe('<TopicMessage />', () => {
         terminalWidth={80}
         availableTerminalHeight={height}
         callId="test-topic"
-        name="update_topic"
+        name={UPDATE_TOPIC_TOOL_NAME}
         description="Updating topic"
         status={CoreToolCallStatus.Success}
         confirmationDetails={undefined}

--- a/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { TopicMessage } from './TopicMessage.js';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import {
@@ -22,7 +22,14 @@ describe('<TopicMessage />', () => {
       'This is the detailed summary that should be expandable.',
   };
 
-  const renderTopic = async (args: Record<string, unknown>, height?: number) =>
+  const renderTopic = async (
+    args: Record<string, unknown>,
+    height?: number,
+    toolActions?: {
+      isExpanded?: (callId: string) => boolean;
+      toggleExpansion?: (callId: string) => void;
+    },
+  ) =>
     renderWithProviders(
       <TopicMessage
         args={args}
@@ -35,6 +42,7 @@ describe('<TopicMessage />', () => {
         confirmationDetails={undefined}
         resultDisplay={undefined}
       />,
+      { toolActions, mouseEventsEnabled: true },
     );
 
   it('renders title and intent by default (collapsed)', async () => {
@@ -46,13 +54,37 @@ describe('<TopicMessage />', () => {
     expect(frame).toContain('(ctrl+o to expand)');
   });
 
-  it('renders summary when expanded', async () => {
+  it('renders summary when globally expanded (Ctrl+O)', async () => {
     const { lastFrame } = await renderTopic(baseArgs, undefined);
     const frame = lastFrame();
     expect(frame).toContain('Test Topic:');
     expect(frame).toContain('This is the strategic intent.');
     expect(frame).toContain('This is the detailed summary');
     expect(frame).toContain('(ctrl+o to collapse)');
+  });
+
+  it('renders summary when selectively expanded via context', async () => {
+    const isExpanded = vi.fn((id) => id === 'test-topic');
+    const { lastFrame } = await renderTopic(baseArgs, 40, { isExpanded });
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic:');
+    expect(frame).toContain('This is the detailed summary');
+    expect(frame).toContain('(ctrl+o to collapse)');
+  });
+
+  it('calls toggleExpansion when clicked', async () => {
+    const toggleExpansion = vi.fn();
+    const { simulateClick } = await renderTopic(baseArgs, 40, {
+      toggleExpansion,
+    });
+
+    // In renderWithProviders, the component is wrapped in a Box with terminalWidth.
+    // The TopicMessage has marginLeft={2}.
+    // So col 5 should definitely hit the text content.
+    // row 1 is the first line of the TopicMessage.
+    await simulateClick(5, 1);
+
+    expect(toggleExpansion).toHaveBeenCalledWith('test-topic');
   });
 
   it('falls back to summary if strategic_intent is missing', async () => {
@@ -76,17 +108,6 @@ describe('<TopicMessage />', () => {
     const frame = lastFrame();
     expect(frame).toContain('Test Topic:');
     expect(frame).toContain('Only intent is present.');
-    expect(frame).not.toContain('(ctrl+o to expand)');
-  });
-
-  it('renders title only if both intent and summary are missing', async () => {
-    const args = {
-      [TOPIC_PARAM_TITLE]: 'Test Topic',
-    };
-    const { lastFrame } = await renderTopic(args, 40);
-    const frame = lastFrame();
-    expect(frame).toContain('Test Topic');
-    expect(frame).not.toContain(':');
     expect(frame).not.toContain('(ctrl+o to expand)');
   });
 });

--- a/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
@@ -51,7 +51,7 @@ describe('<TopicMessage />', () => {
     expect(frame).toContain('Test Topic:');
     expect(frame).toContain('This is the strategic intent.');
     expect(frame).not.toContain('This is the detailed summary');
-    expect(frame).toContain('(ctrl+o to expand)');
+    expect(frame).not.toContain('(ctrl+o to expand)');
   });
 
   it('renders summary when globally expanded (Ctrl+O)', async () => {
@@ -60,7 +60,7 @@ describe('<TopicMessage />', () => {
     expect(frame).toContain('Test Topic:');
     expect(frame).toContain('This is the strategic intent.');
     expect(frame).toContain('This is the detailed summary');
-    expect(frame).toContain('(ctrl+o to collapse)');
+    expect(frame).not.toContain('(ctrl+o to collapse)');
   });
 
   it('renders summary when selectively expanded via context', async () => {
@@ -69,7 +69,7 @@ describe('<TopicMessage />', () => {
     const frame = lastFrame();
     expect(frame).toContain('Test Topic:');
     expect(frame).toContain('This is the detailed summary');
-    expect(frame).toContain('(ctrl+o to collapse)');
+    expect(frame).not.toContain('(ctrl+o to collapse)');
   });
 
   it('calls toggleExpansion when clicked', async () => {

--- a/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TopicMessage } from './TopicMessage.js';
+import { renderWithProviders } from '../../../test-utils/render.js';
+import {
+  TOPIC_PARAM_TITLE,
+  TOPIC_PARAM_SUMMARY,
+  TOPIC_PARAM_STRATEGIC_INTENT,
+  CoreToolCallStatus,
+} from '@google/gemini-cli-core';
+
+describe('<TopicMessage />', () => {
+  const baseArgs = {
+    [TOPIC_PARAM_TITLE]: 'Test Topic',
+    [TOPIC_PARAM_STRATEGIC_INTENT]: 'This is the strategic intent.',
+    [TOPIC_PARAM_SUMMARY]:
+      'This is the detailed summary that should be expandable.',
+  };
+
+  const renderTopic = async (args: Record<string, unknown>, height?: number) =>
+    renderWithProviders(
+      <TopicMessage
+        args={args}
+        terminalWidth={80}
+        availableTerminalHeight={height}
+        callId="test-topic"
+        name="update_topic"
+        description="Updating topic"
+        status={CoreToolCallStatus.Success}
+        confirmationDetails={undefined}
+        resultDisplay={undefined}
+      />,
+    );
+
+  it('renders title and intent by default (collapsed)', async () => {
+    const { lastFrame } = await renderTopic(baseArgs, 40);
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic:');
+    expect(frame).toContain('This is the strategic intent.');
+    expect(frame).not.toContain('This is the detailed summary');
+    expect(frame).toContain('(ctrl+o to expand)');
+  });
+
+  it('renders summary when expanded', async () => {
+    const { lastFrame } = await renderTopic(baseArgs, undefined);
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic:');
+    expect(frame).toContain('This is the strategic intent.');
+    expect(frame).toContain('This is the detailed summary');
+    expect(frame).toContain('(ctrl+o to collapse)');
+  });
+
+  it('falls back to summary if strategic_intent is missing', async () => {
+    const args = {
+      [TOPIC_PARAM_TITLE]: 'Test Topic',
+      [TOPIC_PARAM_SUMMARY]: 'Only summary is present.',
+    };
+    const { lastFrame } = await renderTopic(args, 40);
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic:');
+    expect(frame).toContain('Only summary is present.');
+    expect(frame).not.toContain('(ctrl+o to expand)');
+  });
+
+  it('renders only strategic_intent if summary is missing', async () => {
+    const args = {
+      [TOPIC_PARAM_TITLE]: 'Test Topic',
+      [TOPIC_PARAM_STRATEGIC_INTENT]: 'Only intent is present.',
+    };
+    const { lastFrame } = await renderTopic(args, 40);
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic:');
+    expect(frame).toContain('Only intent is present.');
+    expect(frame).not.toContain('(ctrl+o to expand)');
+  });
+
+  it('renders title only if both intent and summary are missing', async () => {
+    const args = {
+      [TOPIC_PARAM_TITLE]: 'Test Topic',
+    };
+    const { lastFrame } = await renderTopic(args, 40);
+    const frame = lastFrame();
+    expect(frame).toContain('Test Topic');
+    expect(frame).not.toContain(':');
+    expect(frame).not.toContain('(ctrl+o to expand)');
+  });
+});

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useEffect, useId, useRef } from 'react';
+import { useEffect, useId, useRef, useCallback } from 'react';
 import { Box, Text, type DOMElement } from 'ink';
 import {
   UPDATE_TOPIC_TOOL_NAME,
@@ -63,33 +63,34 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
   const intent = strategicIntent || summary;
 
   // Extra summary: only if both exist and are different (or just summary if we want to show it below)
-  // According to requirements: "show intent and we need to make it optionally expandable ... to show the summary"
   const hasExtraSummary = !!(
     strategicIntent &&
     summary &&
     strategicIntent !== summary
   );
 
-  const handleToggle = () => {
+  const handleToggle = useCallback(() => {
     if (toggleExpansion && hasExtraSummary) {
       toggleExpansion(callId);
     }
-  };
+  }, [toggleExpansion, hasExtraSummary, callId]);
 
   useMouseClick(containerRef, handleToggle, {
     isActive: isExpandable && hasExtraSummary,
   });
 
   useEffect(() => {
-    if (isExpandable && hasExtraSummary && !isExpanded && overflowActions) {
+    // Only register if there is more content (summary) and it's currently hidden
+    const hasHiddenContent = isExpandable && hasExtraSummary && !isExpanded;
+
+    if (hasHiddenContent && overflowActions) {
       overflowActions.addOverflowingId(overflowId);
     } else if (overflowActions) {
       overflowActions.removeOverflowingId(overflowId);
     }
+
     return () => {
-      if (overflowActions) {
-        overflowActions.removeOverflowingId(overflowId);
-      }
+      overflowActions?.removeOverflowingId(overflowId);
     };
   }, [isExpandable, hasExtraSummary, isExpanded, overflowActions, overflowId]);
 

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -91,8 +91,6 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
     };
   }, [isExpandable, hasExtraSummary, overflowActions, overflowId]);
 
-  const toggleText = `(ctrl+o to ${isExpanded ? 'collapse' : 'expand'})`;
-
   return (
     <Box ref={containerRef} flexDirection="column" marginLeft={2}>
       <Box flexDirection="row" flexWrap="wrap">
@@ -104,11 +102,6 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
           <Text color={theme.text.secondary} wrap="wrap">
             {intent}
           </Text>
-        )}
-        {isExpandable && hasExtraSummary && (
-          <Box marginLeft={1}>
-            <Text color={theme.text.secondary}>{toggleText}</Text>
-          </Box>
         )}
       </Box>
       {isExpanded && hasExtraSummary && summary && (

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useEffect, useId } from 'react';
 import { Box, Text } from 'ink';
 import {
   UPDATE_TOPIC_TOOL_NAME,
@@ -15,31 +16,85 @@ import {
 } from '@google/gemini-cli-core';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { theme } from '../../semantic-colors.js';
+import { useOverflowActions } from '../../contexts/OverflowContext.js';
 
 interface TopicMessageProps extends IndividualToolCallDisplay {
   terminalWidth: number;
+  availableTerminalHeight?: number;
+  isExpandable?: boolean;
 }
 
 export const isTopicTool = (name: string): boolean =>
   name === UPDATE_TOPIC_TOOL_NAME || name === UPDATE_TOPIC_DISPLAY_NAME;
 
-export const TopicMessage: React.FC<TopicMessageProps> = ({ args }) => {
+export const TopicMessage: React.FC<TopicMessageProps> = ({
+  args,
+  availableTerminalHeight,
+  isExpandable = true,
+}) => {
+  const isExpanded = availableTerminalHeight === undefined;
+  const overflowActions = useOverflowActions();
+  const uniqueId = useId();
+  const overflowId = `topic-${uniqueId}`;
+
   const rawTitle = args?.[TOPIC_PARAM_TITLE];
   const title = typeof rawTitle === 'string' ? rawTitle : undefined;
-  const rawIntent =
-    args?.[TOPIC_PARAM_STRATEGIC_INTENT] || args?.[TOPIC_PARAM_SUMMARY];
-  const intent = typeof rawIntent === 'string' ? rawIntent : undefined;
+
+  const rawStrategicIntent = args?.[TOPIC_PARAM_STRATEGIC_INTENT];
+  const strategicIntent =
+    typeof rawStrategicIntent === 'string' ? rawStrategicIntent : undefined;
+
+  const rawSummary = args?.[TOPIC_PARAM_SUMMARY];
+  const summary = typeof rawSummary === 'string' ? rawSummary : undefined;
+
+  // Top line intent: prefer strategic_intent, fallback to summary
+  const intent = strategicIntent || summary;
+
+  // Extra summary: only if both exist and are different (or just summary if we want to show it below)
+  // According to requirements: "show intent and we need to make it optionally expandable ... to show the summary"
+  const hasExtraSummary = !!(
+    strategicIntent &&
+    summary &&
+    strategicIntent !== summary
+  );
+
+  useEffect(() => {
+    if (isExpandable && hasExtraSummary && overflowActions) {
+      overflowActions.addOverflowingId(overflowId);
+    }
+    return () => {
+      if (overflowActions) {
+        overflowActions.removeOverflowingId(overflowId);
+      }
+    };
+  }, [isExpandable, hasExtraSummary, overflowActions, overflowId]);
+
+  const toggleText = `(ctrl+o to ${isExpanded ? 'collapse' : 'expand'})`;
 
   return (
-    <Box flexDirection="row" marginLeft={2} flexWrap="wrap">
-      <Text color={theme.text.primary} bold wrap="truncate-end">
-        {title || 'Topic'}
-        {intent && <Text>: </Text>}
-      </Text>
-      {intent && (
-        <Text color={theme.text.secondary} wrap="wrap">
-          {intent}
+    <Box flexDirection="column" marginLeft={2}>
+      <Box flexDirection="row" flexWrap="wrap">
+        <Text color={theme.text.primary} bold wrap="truncate-end">
+          {title || 'Topic'}
+          {intent && <Text>: </Text>}
         </Text>
+        {intent && (
+          <Text color={theme.text.secondary} wrap="wrap">
+            {intent}
+          </Text>
+        )}
+        {isExpandable && hasExtraSummary && (
+          <Box marginLeft={1}>
+            <Text color={theme.text.secondary}>{toggleText}</Text>
+          </Box>
+        )}
+      </Box>
+      {isExpanded && hasExtraSummary && summary && (
+        <Box marginTop={1} marginLeft={0}>
+          <Text color={theme.text.secondary} wrap="wrap">
+            {summary}
+          </Text>
+        </Box>
       )}
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -81,15 +81,17 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
   });
 
   useEffect(() => {
-    if (isExpandable && hasExtraSummary && overflowActions) {
+    if (isExpandable && hasExtraSummary && !isExpanded && overflowActions) {
       overflowActions.addOverflowingId(overflowId);
+    } else if (overflowActions) {
+      overflowActions.removeOverflowingId(overflowId);
     }
     return () => {
       if (overflowActions) {
         overflowActions.removeOverflowingId(overflowId);
       }
     };
-  }, [isExpandable, hasExtraSummary, overflowActions, overflowId]);
+  }, [isExpandable, hasExtraSummary, isExpanded, overflowActions, overflowId]);
 
   return (
     <Box ref={containerRef} flexDirection="column" marginLeft={2}>

--- a/packages/cli/src/ui/components/messages/TopicMessage.tsx
+++ b/packages/cli/src/ui/components/messages/TopicMessage.tsx
@@ -5,8 +5,8 @@
  */
 
 import type React from 'react';
-import { useEffect, useId } from 'react';
-import { Box, Text } from 'ink';
+import { useEffect, useId, useRef } from 'react';
+import { Box, Text, type DOMElement } from 'ink';
 import {
   UPDATE_TOPIC_TOOL_NAME,
   UPDATE_TOPIC_DISPLAY_NAME,
@@ -17,6 +17,8 @@ import {
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { theme } from '../../semantic-colors.js';
 import { useOverflowActions } from '../../contexts/OverflowContext.js';
+import { useToolActions } from '../../contexts/ToolActionsContext.js';
+import { useMouseClick } from '../../hooks/useMouseClick.js';
 
 interface TopicMessageProps extends IndividualToolCallDisplay {
   terminalWidth: number;
@@ -28,14 +30,24 @@ export const isTopicTool = (name: string): boolean =>
   name === UPDATE_TOPIC_TOOL_NAME || name === UPDATE_TOPIC_DISPLAY_NAME;
 
 export const TopicMessage: React.FC<TopicMessageProps> = ({
+  callId,
   args,
   availableTerminalHeight,
   isExpandable = true,
 }) => {
-  const isExpanded = availableTerminalHeight === undefined;
+  const { isExpanded: isExpandedInContext, toggleExpansion } = useToolActions();
+
+  // Expansion is active if either:
+  // 1. The individual callId is expanded in the ToolActionsContext
+  // 2. The entire turn is expanded (Ctrl+O) which sets availableTerminalHeight to undefined
+  const isExpanded =
+    (isExpandedInContext ? isExpandedInContext(callId) : false) ||
+    availableTerminalHeight === undefined;
+
   const overflowActions = useOverflowActions();
   const uniqueId = useId();
   const overflowId = `topic-${uniqueId}`;
+  const containerRef = useRef<DOMElement>(null);
 
   const rawTitle = args?.[TOPIC_PARAM_TITLE];
   const title = typeof rawTitle === 'string' ? rawTitle : undefined;
@@ -58,6 +70,16 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
     strategicIntent !== summary
   );
 
+  const handleToggle = () => {
+    if (toggleExpansion && hasExtraSummary) {
+      toggleExpansion(callId);
+    }
+  };
+
+  useMouseClick(containerRef, handleToggle, {
+    isActive: isExpandable && hasExtraSummary,
+  });
+
   useEffect(() => {
     if (isExpandable && hasExtraSummary && overflowActions) {
       overflowActions.addOverflowingId(overflowId);
@@ -72,7 +94,7 @@ export const TopicMessage: React.FC<TopicMessageProps> = ({
   const toggleText = `(ctrl+o to ${isExpanded ? 'collapse' : 'expand'})`;
 
   return (
-    <Box flexDirection="column" marginLeft={2}>
+    <Box ref={containerRef} flexDirection="column" marginLeft={2}>
       <Box flexDirection="row" flexWrap="wrap">
         <Text color={theme.text.primary} bold wrap="truncate-end">
           {title || 'Topic'}


### PR DESCRIPTION
## Summary

Implement selective topic expansion and click-to-expand support in the Gemini CLI history. This allows users to toggle individual topic summaries via mouse clicks while maintaining the global `Ctrl+O` functionality.

## Details

- **Selective Expansion**: Integrated `TopicMessage` with `ToolActionsContext` to track expansion state per `callId`.
- **Click-to-Expand**: Added `useMouseClick` hook to the topic container, allowing users to toggle summaries by clicking the topic line.
- **Hybrid Logic**: Combined individual expansion state with the global expansion state (`Ctrl+O`), ensuring both interaction models work seamlessly together.
- **UI Cleanup**: Removed the `(ctrl+o to expand/collapse)` hint text to reduce visual clutter, as functionality is discoverable via click or the global shortcut.
- **Note**: Mouse reporting (and thus clicking) is active by default in **Alternate Buffer** mode. In Standard Mode, users may need to toggle mouse support via `Ctrl+S` depending on their terminal configuration.

## Related Issues

Closes #24791

## How to Validate

1. **Unit Tests**: Run `npm test -w @google/gemini-cli -- src/ui/components/messages/TopicMessage.test.tsx` to verify all rendering states and click simulation.
2. **Manual (AB Mode)**: Enter a shell or subagent session (Alternate Buffer mode). Emitted topics with summaries should be selectively toggleable by clicking.
3. **Manual (Global)**: Verify that `Ctrl+O` still toggles all topics in the current turn simultaneously.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
