### PR TITLE
fix: respect RetryInfo delay for 503 MODEL_CAPACITY_EXHAUSTED errors

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -81,6 +81,34 @@ describe('classifyGoogleError', () => {
     }
   });
 
+  it('should return RetryableQuotaError with retryDelayMs for 503 MODEL_CAPACITY_EXHAUSTED with RetryInfo', () => {
+    const apiError: GoogleApiError = {
+      code: 503,
+      message:
+        'No capacity available for model gemini-3.1-pro-high on the server',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+          domain: 'cloudcode-pa.googleapis.com',
+          metadata: { model: 'gemini-3.1-pro-high' },
+          reason: 'MODEL_CAPACITY_EXHAUSTED',
+        },
+        {
+          '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+          retryDelay: '9s',
+        },
+      ],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const originalError = new Error(apiError.message);
+    const result = classifyGoogleError(originalError);
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+    if (result instanceof RetryableQuotaError) {
+      expect(result.cause).toBe(apiError);
+      expect(result.retryDelayMs).toBe(9000);
+    }
+  });
+
   it('should return original error if code is not 429, 499 or 503', () => {
     const apiError: GoogleApiError = {
       code: 500,

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -106,6 +106,36 @@ describe('classifyGoogleError', () => {
     if (result instanceof RetryableQuotaError) {
       expect(result.cause).toBe(apiError);
       expect(result.retryDelayMs).toBe(9000);
+      expect(result.message).toContain('Suggested retry after 9s.');
+    }
+  });
+
+  it('should return TerminalQuotaError for 503 with RetryInfo exceeding MAX_RETRYABLE_DELAY_SECONDS', () => {
+    const apiError: GoogleApiError = {
+      code: 503,
+      message:
+        'No capacity available for model gemini-3.1-pro-high on the server',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+          domain: 'cloudcode-pa.googleapis.com',
+          metadata: { model: 'gemini-3.1-pro-high' },
+          reason: 'MODEL_CAPACITY_EXHAUSTED',
+        },
+        {
+          '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+          retryDelay: '600s',
+        },
+      ],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const originalError = new Error(apiError.message);
+    const result = classifyGoogleError(originalError);
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+    if (result instanceof TerminalQuotaError) {
+      expect(result.cause).toBe(apiError);
+      expect(result.retryDelayMs).toBe(600000);
+      expect(result.message).toContain('Suggested retry after 600s.');
     }
   });
 

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -232,6 +232,22 @@ export function classifyGoogleError(error: unknown): unknown {
     const errorMessage =
       googleApiError?.message ||
       (error instanceof Error ? error.message : String(error));
+
+    // Extract RetryInfo from error details if available (e.g., MODEL_CAPACITY_EXHAUSTED)
+    let retryDelaySeconds: number | undefined;
+    if (googleApiError?.details) {
+      const retryInfo = googleApiError.details.find(
+        (d): d is RetryInfo =>
+          d['@type'] === 'type.googleapis.com/google.rpc.RetryInfo',
+      );
+      if (retryInfo?.retryDelay) {
+        const parsedDelay = parseDurationInSeconds(retryInfo.retryDelay);
+        if (parsedDelay !== null) {
+          retryDelaySeconds = parsedDelay;
+        }
+      }
+    }
+
     return new RetryableQuotaError(
       errorMessage,
       googleApiError ?? {
@@ -239,6 +255,7 @@ export function classifyGoogleError(error: unknown): unknown {
         message: errorMessage,
         details: [],
       },
+      retryDelaySeconds,
     );
   }
 

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -234,29 +234,41 @@ export function classifyGoogleError(error: unknown): unknown {
       (error instanceof Error ? error.message : String(error));
 
     // Extract RetryInfo from error details if available (e.g., MODEL_CAPACITY_EXHAUSTED)
+    const retryInfo = googleApiError?.details?.find(
+      (d): d is RetryInfo =>
+        d['@type'] === 'type.googleapis.com/google.rpc.RetryInfo',
+    );
+
     let retryDelaySeconds: number | undefined;
-    if (googleApiError?.details) {
-      const retryInfo = googleApiError.details.find(
-        (d): d is RetryInfo =>
-          d['@type'] === 'type.googleapis.com/google.rpc.RetryInfo',
-      );
-      if (retryInfo?.retryDelay) {
-        const parsedDelay = parseDurationInSeconds(retryInfo.retryDelay);
-        if (parsedDelay !== null) {
-          retryDelaySeconds = parsedDelay;
-        }
+    if (retryInfo?.retryDelay) {
+      const parsedDelay = parseDurationInSeconds(retryInfo.retryDelay);
+      if (parsedDelay !== null) {
+        retryDelaySeconds = parsedDelay;
       }
     }
 
-    return new RetryableQuotaError(
-      errorMessage,
-      googleApiError ?? {
-        code: 503,
-        message: errorMessage,
-        details: [],
-      },
-      retryDelaySeconds,
-    );
+    const cause = googleApiError ?? {
+      code: 503,
+      message: errorMessage,
+      details: [],
+    };
+
+    const finalMessage = retryInfo?.retryDelay
+      ? `${errorMessage}\nSuggested retry after ${retryInfo.retryDelay}.`
+      : errorMessage;
+
+    // Respect the MAX_RETRYABLE_DELAY_SECONDS threshold, matching the 429/499
+    // handler logic. If the server suggests waiting longer than 5 minutes, treat
+    // it as terminal so the CLI triggers the fallback/credits flow instead of
+    // silently waiting.
+    if (
+      retryDelaySeconds !== undefined &&
+      retryDelaySeconds > MAX_RETRYABLE_DELAY_SECONDS
+    ) {
+      return new TerminalQuotaError(finalMessage, cause, retryDelaySeconds);
+    }
+
+    return new RetryableQuotaError(finalMessage, cause, retryDelaySeconds);
   }
 
   if (


### PR DESCRIPTION
## Summary

Fixes #24815 — When the Gemini API returns a 503 `MODEL_CAPACITY_EXHAUSTED` error with `RetryInfo` containing a `retryDelay`, the CLI ignores the server-suggested delay and falls back to default exponential backoff.

**Root cause:** The 503 handler in `classifyGoogleError()` creates a `RetryableQuotaError` but never extracts `RetryInfo` from the error details. The 429/499 handler already does this correctly.

**Fix:** Extract `RetryInfo` from the 503 error details and pass the parsed `retryDelay` to `RetryableQuotaError`, matching the existing pattern used for 429/499 errors.

## Changes
- `packages/core/src/utils/googleQuotaErrors.ts`: Parse `RetryInfo` from 503 error details and pass delay to `RetryableQuotaError`
- `packages/core/src/utils/googleQuotaErrors.test.ts`: Add test for 503 with `RetryInfo` containing `retryDelay`

## Test plan
- [x] All 34 `googleQuotaErrors.test.ts` tests pass (including new test)
- [x] New test verifies: 503 + `RetryInfo` with `retryDelay: "9s"` → `RetryableQuotaError` with `retryDelayMs: 9000`
- [x] Existing 503 test (without RetryInfo) still passes — no regression
- [x] ESLint + Prettier pass via pre-commit hooks