### PR TITLE
fix: prevent crash when message contains image from clipboard on Windows

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -714,6 +714,31 @@ describe('handleAtCommand', () => {
         await fsPromises.rm(tempImageDir, { recursive: true, force: true });
       }
     });
+
+    it('should handle cross-drive absolute paths on Windows without crashing', async () => {
+      // On Windows, path.relative() between different drives (e.g., C: vs D:)
+      // returns an absolute path instead of a `..`-prefixed one. The ignore
+      // check must handle this case without throwing.
+      const fakeCrossDrivePath =
+        process.platform === 'win32'
+          ? 'Z:\\temp\\clipboard-cross-drive.png'
+          : '/mnt/other-drive/clipboard-cross-drive.png';
+
+      const query = `explain this image @${fakeCrossDrivePath}`;
+
+      const result = await handleAtCommand({
+        query,
+        config: mockConfig,
+        addItem: mockAddItem,
+        onDebugMessage: mockOnDebugMessage,
+        messageId: 251,
+        signal: abortController.signal,
+      });
+
+      // Should not throw RangeError — cross-drive paths are treated as
+      // outside the project and skip the ignore check entirely.
+      expect(result.error).toBeUndefined();
+    });
   });
 
   describe('when recursive file search is disabled', () => {

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -682,6 +682,40 @@ describe('handleAtCommand', () => {
     });
   });
 
+  describe('absolute and out-of-project paths', () => {
+    it('should not crash on absolute paths outside the project (e.g., clipboard images)', async () => {
+      // Clipboard images are saved to a temp directory outside the project.
+      // The `ignore` library throws RangeError on absolute paths, so we must
+      // skip the ignore check for them.
+      const tempImageDir = path.join(os.tmpdir(), 'gemini-test-images');
+      await fsPromises.mkdir(tempImageDir, { recursive: true });
+      const tempImagePath = path.join(tempImageDir, 'clipboard-test.png');
+      // Create a minimal valid PNG file (1x1 pixel)
+      const pngHeader = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+      await fsPromises.writeFile(tempImagePath, pngHeader);
+
+      try {
+        const query = `explain this image @${tempImagePath}`;
+
+        const result = await handleAtCommand({
+          query,
+          config: mockConfig,
+          addItem: mockAddItem,
+          onDebugMessage: mockOnDebugMessage,
+          messageId: 250,
+          signal: abortController.signal,
+        });
+
+        // Should not throw RangeError — the path is resolved, not crashed
+        expect(result.error).toBeUndefined();
+      } finally {
+        await fsPromises.rm(tempImageDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('when recursive file search is disabled', () => {
     beforeEach(() => {
       vi.mocked(mockConfig.getEnableRecursiveFileSearch).mockReturnValue(false);

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -289,9 +289,15 @@ async function resolveFilePaths(
         const absolutePath = path.resolve(dir, pathName);
         const stats = await fs.stat(absolutePath);
 
-        const relativePath = path.isAbsolute(pathName)
+        const rawRelative = path.isAbsolute(pathName)
           ? path.relative(dir, absolutePath)
           : pathName;
+        // On Windows, path.relative() between different drives (e.g., C: vs D:)
+        // returns the source path unchanged (still absolute). Fall back to the
+        // absolute path so downstream tools handle cross-drive paths correctly.
+        const relativePath = path.isAbsolute(rawRelative)
+          ? absolutePath
+          : rawRelative;
 
         if (stats.isDirectory()) {
           const pathSpec = path.join(relativePath, '**');
@@ -339,7 +345,12 @@ async function resolveFilePaths(
                 const lines = globResult.llmContent.split('\n');
                 if (lines.length > 1 && lines[1]) {
                   const firstMatchAbsolute = lines[1].trim();
-                  const pathSpec = path.relative(dir, firstMatchAbsolute);
+                  const rawPathSpec = path.relative(dir, firstMatchAbsolute);
+                  // On Windows, path.relative() between different drives returns
+                  // the source path unchanged (absolute). Fall back to absolute.
+                  const pathSpec = path.isAbsolute(rawPathSpec)
+                    ? firstMatchAbsolute
+                    : rawPathSpec;
                   resolvedFiles.push({
                     part,
                     pathSpec,

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -238,15 +238,28 @@ async function resolveFilePaths(
       continue;
     }
 
+    // Convert absolute paths to relative for the ignore check. The `ignore`
+    // library throws RangeError on absolute or `..`-prefixed paths, which
+    // happens for clipboard images saved to a temp directory outside the project.
+    let ignoreCheckPath = pathName;
+    if (path.isAbsolute(pathName)) {
+      const targetDir = config.getWorkspaceContext().getDirectories()[0];
+      if (targetDir) {
+        ignoreCheckPath = path.relative(targetDir, pathName);
+      }
+    }
+    const isOutsideProject = ignoreCheckPath.startsWith('..');
     const gitIgnored =
+      !isOutsideProject &&
       respectFileIgnore.respectGitIgnore &&
-      fileDiscovery.shouldIgnoreFile(pathName, {
+      fileDiscovery.shouldIgnoreFile(ignoreCheckPath, {
         respectGitIgnore: true,
         respectGeminiIgnore: false,
       });
     const geminiIgnored =
+      !isOutsideProject &&
       respectFileIgnore.respectGeminiIgnore &&
-      fileDiscovery.shouldIgnoreFile(pathName, {
+      fileDiscovery.shouldIgnoreFile(ignoreCheckPath, {
         respectGitIgnore: false,
         respectGeminiIgnore: true,
       });

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -245,10 +245,16 @@ async function resolveFilePaths(
     if (path.isAbsolute(pathName)) {
       const targetDir = config.getWorkspaceContext().getDirectories()[0];
       if (targetDir) {
-        ignoreCheckPath = path.relative(targetDir, pathName);
+        ignoreCheckPath = path.relative(
+          resolveToRealPath(targetDir),
+          resolveToRealPath(pathName),
+        );
       }
     }
-    const isOutsideProject = ignoreCheckPath.startsWith('..');
+    // On Windows, path.relative() between different drives (e.g., C: vs D:)
+    // returns an absolute path instead of a `..`-prefixed one, so check both.
+    const isOutsideProject =
+      ignoreCheckPath.startsWith('..') || path.isAbsolute(ignoreCheckPath);
     const gitIgnored =
       !isOutsideProject &&
       respectFileIgnore.respectGitIgnore &&


### PR DESCRIPTION
## Summary

Fixes #24817 — On Windows, pasting a clipboard image into the CLI causes a `RangeError: path should be a path.relative()'d string` crash.

**Root cause:** Clipboard images are saved to a temp directory **outside** the project (e.g., `C:/Users/.../.gemini/tmp/editor/images/clipboard-xxx.png`). When `resolveFilePaths()` in `atCommandProcessor.ts` passes this absolute path to `FileDiscoveryService.shouldIgnoreFile()`, the `ignore` library's `checkPath()` throws a `RangeError` because it only accepts relative paths within the project root.

**Fix:** Convert absolute `@path` references to relative paths (relative to the workspace root) before calling the ignore check. If the resulting relative path starts with `..` (meaning it's outside the project), skip the ignore check entirely — files outside the project can't be gitignored/geminiignored anyway.

## Changes
- `packages/cli/src/ui/hooks/atCommandProcessor.ts`: Convert absolute paths to relative before ignore checks, skip check for out-of-project paths
- `packages/cli/src/ui/hooks/atCommandProcessor.test.ts`: Add test for absolute clipboard image paths outside the project

## Test plan
- [x] All 60 `atCommandProcessor.test.ts` tests pass (59 existing + 1 new)
- [x] New test verifies: absolute temp path for clipboard image does not throw `RangeError`
- [x] Existing git-ignore and gemini-ignore tests still pass (no regression)
- [x] ESLint + Prettier pass via pre-commit hooks