### PR TITLE
feat(acp): add /help command

### DIFF
--- a/packages/cli/src/acp/commandHandler.test.ts
+++ b/packages/cli/src/acp/commandHandler.test.ts
@@ -29,5 +29,8 @@ describe('CommandHandler', () => {
 
     const about = parse('/about');
     expect(about.commandToExecute?.name).toBe('about');
+
+    const help = parse('/help');
+    expect(help.commandToExecute?.name).toBe('help');
   });
 });

--- a/packages/cli/src/acp/commandHandler.ts
+++ b/packages/cli/src/acp/commandHandler.ts
@@ -11,6 +11,7 @@ import { ExtensionsCommand } from './commands/extensions.js';
 import { InitCommand } from './commands/init.js';
 import { RestoreCommand } from './commands/restore.js';
 import { AboutCommand } from './commands/about.js';
+import { HelpCommand } from './commands/help.js';
 
 export class CommandHandler {
   private registry: CommandRegistry;
@@ -26,6 +27,7 @@ export class CommandHandler {
     registry.register(new InitCommand());
     registry.register(new RestoreCommand());
     registry.register(new AboutCommand());
+    registry.register(new HelpCommand(registry));
     return registry;
   }
 

--- a/packages/cli/src/acp/commands/help.test.ts
+++ b/packages/cli/src/acp/commands/help.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HelpCommand } from './help.js';
+import { CommandRegistry } from './commandRegistry.js';
+import type { Command, CommandContext } from './types.js';
+
+describe('HelpCommand', () => {
+  it('returns formatted help text with sorted commands', async () => {
+    const registry = new CommandRegistry();
+
+    const cmdB: Command = {
+      name: 'bravo',
+      description: 'Bravo command',
+      execute: async () => ({ name: 'bravo', data: '' }),
+    };
+
+    const cmdA: Command = {
+      name: 'alpha',
+      description: 'Alpha command',
+      execute: async () => ({ name: 'alpha', data: '' }),
+    };
+
+    registry.register(cmdB);
+    registry.register(cmdA);
+
+    const helpCommand = new HelpCommand(registry);
+
+    const context = {} as CommandContext;
+
+    const response = await helpCommand.execute(context, []);
+
+    expect(response.name).toBe('help');
+
+    const data = response.data as string;
+
+    expect(data).toContain('Gemini CLI Help:');
+    expect(data).toContain('### Basics');
+    expect(data).toContain('### Commands');
+
+    const lines = data.split('\n');
+    const alphaIndex = lines.findIndex((l) => l.includes('/alpha'));
+    const bravoIndex = lines.findIndex((l) => l.includes('/bravo'));
+
+    expect(alphaIndex).toBeLessThan(bravoIndex);
+    expect(alphaIndex).not.toBe(-1);
+    expect(bravoIndex).not.toBe(-1);
+  });
+});

--- a/packages/cli/src/acp/commands/help.ts
+++ b/packages/cli/src/acp/commands/help.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  Command,
+  CommandContext,
+  CommandExecutionResponse,
+} from './types.js';
+import type { CommandRegistry } from './commandRegistry.js';
+
+export class HelpCommand implements Command {
+  readonly name = 'help';
+  readonly description = 'Show available commands';
+
+  constructor(private registry: CommandRegistry) {}
+
+  async execute(
+    _context: CommandContext,
+    _args: string[] = [],
+  ): Promise<CommandExecutionResponse> {
+    const commands = this.registry
+      .getAllCommands()
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const lines: string[] = [];
+
+    lines.push('Gemini CLI Help:');
+    lines.push('');
+    lines.push('### Basics');
+    lines.push(
+      '- **Add context**: Use `@` to specify files for context (e.g., `@src/myFile.ts`) to target specific files or folders.',
+    );
+    lines.push('');
+
+    lines.push('### Commands');
+    for (const cmd of commands) {
+      if (cmd.description) {
+        lines.push(`- **/${cmd.name}** - ${cmd.description}`);
+      }
+    }
+
+    return {
+      name: this.name,
+      data: lines.join('\n'),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Add a /help command to the Agent Client Protocol (ACP) interface to list available commands and basic usage instructions, matching the TUI functionality.

## Details

- Implement HelpCommand in packages/cli/src/acp/commands/help.ts.
- Register the command in commandHandler.ts and pass the CommandRegistry to it.
- Format the output using Markdown headers and bullet points for better rendering in chat interfaces.
- Exclude the "shell mode" instruction from the help output as it is not yet fully supported in the ACP context.
- Add unit tests for command parsing in commandHandler.test.ts.

## Related Issues

Part of request from Jetbrains.

## How to Validate

**Should appear in / completion on ACP mode in IDE**

<img width="503" height="781" alt="image" src="https://github.com/user-attachments/assets/7aaa1ae1-1721-4c86-8065-927b77515474" />

**Should list the help commands appropriate for the ACP**

<img width="503" height="931" alt="image" src="https://github.com/user-attachments/assets/38b3fc50-7cef-43bc-b5db-658709abe731" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
