### PR TITLE
docs: update MCP server OAuth redirect port documentation

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -290,7 +290,7 @@ When connecting to an OAuth-enabled server:
 > OAuth authentication requires that your local machine can:
 >
 > - Open a web browser for authentication
-> - Receive redirects on `http://localhost:7777/oauth/callback`
+> - Receive redirects on `http://localhost:<random-port>/oauth/callback` (or a specific port if configured via `redirectUri`)
 
 This feature will not work in:
 
@@ -323,8 +323,8 @@ Use the `/mcp auth` command to manage OAuth authentication:
   if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
-- **`redirectUri`** (string): Custom redirect URI (defaults to
-  `http://localhost:7777/oauth/callback`)
+- **`redirectUri`** (string): Custom redirect URI (defaults to an OS-assigned
+  random port, e.g., `http://localhost:<random-port>/oauth/callback`)
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
 - **`audiences`** (string[]): Audiences the token is valid for
 


### PR DESCRIPTION
## Summary

Update the MCP server documentation to accurately reflect the OAuth redirect port behavior. Following the refactor in #20895, the CLI now uses a random OS-assigned port for the OAuth callback by default instead of hardcoding port `7777`. This prevents port collisions.

## Details

- Modified `docs/tools/mcp-server.md` to specify that `<random-port>` is used by default.
- Clarified that a custom `redirectUri` can still be provided to force a specific callback URL/port.

## Related Issues

N/A

## How to Validate

1. Read the updated documentation in `docs/tools/mcp-server.md`.
2. Observe that the OAuth section now mentions `<random-port>`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
