### PR TITLE
fix(cli): prevent history item suppression during tool confirmation

### DIFF
--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../hooks/useAlternateBuffer.js', () => ({
 }));
 
 vi.mock('../hooks/useConfirmingTool.js', () => ({
-  useConfirmingTool: vi.fn(),
+  useConfirmingTool: vi.fn(() => null),
 }));
 
 vi.mock('./AppHeader.js', () => ({

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -882,6 +882,82 @@ describe('MainContent', () => {
       expect(output).toContain('Here is your answer.');
       unmount();
     });
+
+    it('bypasses suppression for the current turn during confirmation, but keeps old turns suppressed', async () => {
+      const { useConfirmingTool } = await import(
+        '../hooks/useConfirmingTool.js'
+      );
+      vi.mocked(useConfirmingTool).mockReturnValue({
+        tool: {
+          callId: 'call-1',
+          name: 'some_tool',
+          status: CoreToolCallStatus.AwaitingApproval,
+          confirmationDetails: {
+            type: 'confirm_shell_command' as const,
+            command: 'echo "hello"',
+          },
+        },
+        index: 0,
+        total: 1,
+      } as unknown as ConfirmingToolState);
+
+      mockUseSettings.mockReturnValue(settingsWithNarration);
+      const uiState = {
+        ...defaultMockUiState,
+        history: [
+          // Previous turn: should remain suppressed
+          { id: 10, type: 'user' as const, text: 'Old Turn' },
+          { id: 11, type: 'gemini' as const, text: 'Old narration' },
+          {
+            id: 12,
+            type: 'tool_group' as const,
+            tools: [
+              {
+                callId: 'old',
+                name: 'ls',
+                status: CoreToolCallStatus.Success,
+                description: '',
+                resultDisplay: '',
+                confirmationDetails: undefined,
+              } as IndividualToolCallDisplay,
+            ],
+          },
+          // Current turn: should be bypassed (shown)
+          { id: 20, type: 'user' as const, text: 'Current Turn' },
+          { id: 21, type: 'gemini' as const, text: 'Current narration' },
+        ],
+        pendingHistoryItems: [
+          {
+            type: 'tool_group' as const,
+            tools: [
+              {
+                callId: 'call-1',
+                name: 'some_tool',
+                status: CoreToolCallStatus.AwaitingApproval,
+                description: '',
+                resultDisplay: '',
+                confirmationDetails: undefined,
+              } as IndividualToolCallDisplay,
+            ],
+          },
+        ],
+      };
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <MainContent />,
+        {
+          uiState: uiState as Partial<UIState>,
+          settings: settingsWithNarration,
+        },
+      );
+
+      const output = lastFrame();
+      // Old narration should STILL be suppressed
+      expect(output).not.toContain('Old narration');
+      // Current narration should be VISIBLE because of the bypass
+      expect(output).toContain('Current narration');
+      unmount();
+    });
   });
 
   it('renders multiple thinking messages sequentially correctly', async () => {

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -123,13 +123,19 @@ export const MainContent = () => {
 
           // Rule 2: Suppress text in intermediate turns (turns containing non-topic
           // tools) to hide mechanical narration.
-          if (turnIsIntermediate && !showConfirmationQueue) {
+
+          const isCurrentTurn = i > lastUserPromptIndex;
+          // Scoping the bypass to the current turn prevents old narration from reappearing.
+          // This logic affects the rendered height of the history list by conditionally hiding turns.
+          const bypassSuppression = isCurrentTurn && showConfirmationQueue;
+
+          if (turnIsIntermediate && !bypassSuppression) {
             flags[i] = true;
           }
 
           // Rule 3: Suppress text that precedes a topic tool in the same turn,
           // as the topic tool "replaces" it.
-          if (hasTopicToolInTurn && !showConfirmationQueue) {
+          if (hasTopicToolInTurn && !bypassSuppression) {
             flags[i] = true;
           }
         }
@@ -141,6 +147,7 @@ export const MainContent = () => {
     pendingHistoryItems,
     topicUpdateNarrationEnabled,
     showConfirmationQueue,
+    lastUserPromptIndex,
   ]);
 
   const augmentedHistory = useMemo(

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -123,20 +123,25 @@ export const MainContent = () => {
 
           // Rule 2: Suppress text in intermediate turns (turns containing non-topic
           // tools) to hide mechanical narration.
-          if (turnIsIntermediate) {
+          if (turnIsIntermediate && !showConfirmationQueue) {
             flags[i] = true;
           }
 
           // Rule 3: Suppress text that precedes a topic tool in the same turn,
           // as the topic tool "replaces" it.
-          if (hasTopicToolInTurn) {
+          if (hasTopicToolInTurn && !showConfirmationQueue) {
             flags[i] = true;
           }
         }
       }
     }
     return flags;
-  }, [uiState.history, pendingHistoryItems, topicUpdateNarrationEnabled]);
+  }, [
+    uiState.history,
+    pendingHistoryItems,
+    topicUpdateNarrationEnabled,
+    showConfirmationQueue,
+  ]);
 
   const augmentedHistory = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Fixes an issue where history items would disappear from the CLI UI while an interactive tool confirmation (like `ask_user`) was active.

## Details

The suppression logic in `MainContent` was hiding turns that preceded a topic tool, even if the session was currently paused waiting for user input. This led to the context of the user's prompt (the "narrative" or "reasoning") vanishing from the users view.

This PR bypasses the suppression rules when `showConfirmationQueue` is active.

## Related Issues

Fixes #24850

## How to Validate

1. Run the CLI: `npm run start`
2. Perform a task that triggers an `ask_user` prompt after some narration (e.g., "Write an essay about X and then ask if I liked it").
3. Observe that the essay/narration remains visible while the `ask_user` prompt is displayed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
