### PR TITLE
fix(core): remove tmux alternate buffer warning

### DIFF
--- a/packages/core/src/utils/compatibility.test.ts
+++ b/packages/core/src/utils/compatibility.test.ts
@@ -289,19 +289,6 @@ describe('compatibility', () => {
       );
     });
 
-    it('should return tmux warning when detected and in alternate buffer', () => {
-      vi.stubEnv('TMUX', '/tmp/tmux-1001/default,1,0');
-
-      const warnings = getCompatibilityWarnings({ isAlternateBuffer: true });
-      expect(warnings).toContainEqual(
-        expect.objectContaining({
-          id: 'tmux-alternate-buffer',
-          message: expect.stringContaining('tmux detected'),
-          priority: WarningPriority.High,
-        }),
-      );
-    });
-
     it('should return low-color tmux warning when detected', () => {
       vi.stubEnv('TERM', 'screen');
       vi.stubEnv('TMUX', '1');

--- a/packages/core/src/utils/compatibility.ts
+++ b/packages/core/src/utils/compatibility.ts
@@ -145,15 +145,6 @@ export function getCompatibilityWarnings(options?: {
     });
   }
 
-  if (isTmux() && options?.isAlternateBuffer) {
-    warnings.push({
-      id: 'tmux-alternate-buffer',
-      message:
-        'Warning: tmux detected — alternate buffer mode may cause unexpected scrollback loss and flickering. If you experience issues, disable it in /settings → "Use Alternate Screen Buffer".\n    Tip: Use Ctrl-b [ to access tmux copy mode for scrolling history.',
-      priority: WarningPriority.High,
-    });
-  }
-
   if (isLowColorTmux()) {
     warnings.push({
       id: 'low-color-tmux',


### PR DESCRIPTION
## Summary

This PR removes the `tmux detected` warning that was triggered when using the
alternate screen buffer. This warning was reported to cause frequent false
positives and unnecessary noise for users who have their terminal/tmux correctly
configured.

## Details

- Removed the `tmux-alternate-buffer` warning from `getCompatibilityWarnings` in
  `packages/core/src/utils/compatibility.ts`.
- Removed the corresponding unit test in
  `packages/core/src/utils/compatibility.test.ts`.
- Kept the `low-color-tmux` warning as it provides objective guidance for `TERM`
  misconfigurations (e.g., `TERM=screen` without `COLORTERM`).

## Related Issues

N/A

## How to Validate

1. Run the compatibility unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/compatibility.test.ts
   ```
2. Verify that all tests pass and the tmux alternate buffer test is no longer
   present.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
