### PR TITLE
fix: preserve OAuth URLs in terminal auth flows

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -13,6 +13,7 @@ import {
   type OutputPayload,
   type ConsoleLogPayload,
   type UserFeedbackPayload,
+  type OauthDisplayMessagePayload,
   sessionId,
   logUserPrompt,
   AuthType,
@@ -57,6 +58,7 @@ import { getStartupWarnings } from './utils/startupWarnings.js';
 import { getUserStartupWarnings } from './utils/userStartupWarnings.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
+import { formatOauthDisplayMessage } from './utils/oauthDisplay.js';
 import {
   cleanupCheckpoints,
   registerCleanup,
@@ -748,6 +750,15 @@ export function initializeOutputListenersAndFlush() {
           writeToStdout(payload.message);
         }
       });
+    }
+
+    if (coreEvents.listenerCount(CoreEvent.OauthDisplayMessage) === 0) {
+      coreEvents.on(
+        CoreEvent.OauthDisplayMessage,
+        (payload: OauthDisplayMessagePayload) => {
+          writeToStdout(formatOauthDisplayMessage(payload));
+        },
+      );
     }
   }
   coreEvents.drainBacklogs();

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -9,6 +9,7 @@ import type {
   ToolCallRequestInfo,
   ResumedSessionData,
   UserFeedbackPayload,
+  OauthDisplayMessagePayload,
 } from '@google/gemini-cli-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import type { LoadedSettings } from './config/settings.js';
@@ -47,6 +48,7 @@ import {
 } from './utils/errors.js';
 import { TextOutput } from './ui/utils/textOutput.js';
 import { runNonInteractive as runNonInteractiveAgentSession } from './nonInteractiveCliAgentSession.js';
+import { formatOauthDisplayMessage } from './utils/oauthDisplay.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -96,6 +98,10 @@ export async function runNonInteractive(
             : String(payload.error);
         process.stderr.write(`${errorToLog}\n`);
       }
+    };
+
+    const handleOauthDisplayMessage = (payload: OauthDisplayMessagePayload) => {
+      process.stdout.write(formatOauthDisplayMessage(payload));
     };
 
     const startTime = Date.now();
@@ -204,6 +210,7 @@ export async function runNonInteractive(
       setupStdinCancellation();
 
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.on(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
       coreEvents.drainBacklogs();
 
       // Handle EPIPE errors when the output is piped to a command that closes early.
@@ -530,6 +537,7 @@ export async function runNonInteractive(
 
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.off(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
     }
 
     if (errorToHandle) {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -10,6 +10,7 @@ import type {
   UserFeedbackPayload,
   AgentEvent,
   ContentPart,
+  OauthDisplayMessagePayload,
 } from '@google/gemini-cli-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import type { LoadedSettings } from './config/settings.js';
@@ -48,6 +49,7 @@ import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import { handleError, handleToolError } from './utils/errors.js';
 import { TextOutput } from './ui/utils/textOutput.js';
+import { formatOauthDisplayMessage } from './utils/oauthDisplay.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -94,6 +96,10 @@ export async function runNonInteractive({
             : String(payload.error);
         process.stderr.write(`${errorToLog}\n`);
       }
+    };
+
+    const handleOauthDisplayMessage = (payload: OauthDisplayMessagePayload) => {
+      process.stdout.write(formatOauthDisplayMessage(payload));
     };
 
     const startTime = Date.now();
@@ -201,6 +207,7 @@ export async function runNonInteractive({
       setupStdinCancellation();
 
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.on(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
       coreEvents.drainBacklogs();
 
       // Handle EPIPE errors when the output is piped to a command that closes early.
@@ -612,6 +619,7 @@ export async function runNonInteractive({
 
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.off(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
     }
 
     if (errorToHandle) {

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -25,6 +25,7 @@ import {
   makeFakeConfig,
   CoreEvent,
   type UserFeedbackPayload,
+  type OauthDisplayMessagePayload,
   type ResumedSessionData,
   type StartupWarning,
   WarningPriority,
@@ -2838,6 +2839,44 @@ describe('AppContainer State Management', () => {
         expect.objectContaining({
           type: 'error',
           text: 'Test error message',
+        }),
+        expect.any(Number),
+      );
+      unmount!();
+    });
+
+    it('adds auth URL history item when OauthDisplayMessage event is received', async () => {
+      let unmount: () => void;
+      await act(async () => {
+        const result = await renderAppContainer();
+        unmount = result.unmount;
+      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
+
+      const handler = mockCoreEvents.on.mock.calls.find(
+        (call: unknown[]) => call[0] === CoreEvent.OauthDisplayMessage,
+      )?.[1];
+      expect(handler).toBeDefined();
+
+      const payload: OauthDisplayMessagePayload = {
+        heading:
+          'Opening your browser for OAuth sign-in...\nIf the browser does not open, copy and paste this URL into your browser:',
+        url: 'https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid',
+        footerLines: [
+          'TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+        ],
+      };
+
+      act(() => {
+        handler(payload);
+      });
+
+      expect(mockedUseHistory().addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'auth_url',
+          heading: payload.heading,
+          url: payload.url,
+          footerLines: payload.footerLines,
         }),
         expect.any(Number),
       );

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -53,6 +53,7 @@ import {
   type UserTierId,
   type GeminiUserTier,
   type UserFeedbackPayload,
+  type OauthDisplayMessagePayload,
   type HookSystemMessagePayload,
   type AgentDefinition,
   type ApprovalMode,
@@ -2114,6 +2115,18 @@ Logging in with Google... Restarting Gemini CLI to continue.
       }
     };
 
+    const handleOauthDisplayMessage = (payload: OauthDisplayMessagePayload) => {
+      historyManager.addItem(
+        {
+          type: MessageType.AUTH_URL,
+          heading: payload.heading,
+          url: payload.url,
+          footerLines: payload.footerLines,
+        },
+        Date.now(),
+      );
+    };
+
     const handleHookSystemMessage = (payload: HookSystemMessagePayload) => {
       historyManager.addItem(
         {
@@ -2126,6 +2139,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     };
 
     coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
+    coreEvents.on(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
     coreEvents.on(CoreEvent.HookSystemMessage, handleHookSystemMessage);
 
     // Flush any messages that happened during startup before this component
@@ -2134,6 +2148,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
 
     return () => {
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
+      coreEvents.off(CoreEvent.OauthDisplayMessage, handleOauthDisplayMessage);
       coreEvents.off(CoreEvent.HookSystemMessage, handleHookSystemMessage);
     };
   }, [historyManager]);

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -14,7 +14,7 @@ import {
   type SlashCommand,
   type CommandContext,
 } from './types.js';
-import { MessageType, type HistoryItem } from '../types.js';
+import { MessageType, type HistoryItemWithoutId } from '../types.js';
 import {
   refreshServerHierarchicalMemory,
   type Config,
@@ -30,7 +30,7 @@ import * as fs from 'node:fs';
 async function finishAddingDirectories(
   config: Config,
   addItem: (
-    itemData: Omit<HistoryItem, 'id'>,
+    itemData: HistoryItemWithoutId,
     baseTimestamp?: number,
   ) => number,
   added: string[],

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -209,8 +209,8 @@ async function restartAction(
 
   const s = extensionsToRestart.length > 1 ? 's' : '';
 
-  const reloadingMessage = {
-    type: MessageType.INFO,
+  const reloadingMessage: HistoryItemInfo = {
+    type: 'info',
     text: `Reloading ${extensionsToRestart.length} extension${s}...`,
     color: theme.text.primary,
   };

--- a/packages/cli/src/ui/commands/mcpCommand.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.test.ts
@@ -19,10 +19,15 @@ import {
 import type { CallableTool } from '@google/genai';
 import { MessageType, type HistoryItemMcpStatus } from '../types.js';
 
+const mockAuthenticate = vi.hoisted(() => vi.fn());
+const mockCoreEvents = vi.hoisted(() => ({
+  on: vi.fn(),
+  removeListener: vi.fn(),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
-  const mockAuthenticate = vi.fn();
   return {
     ...actual,
     getMCPServerStatus: vi.fn(),
@@ -34,6 +39,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       getToken: vi.fn(),
       isTokenExpired: vi.fn(),
     })),
+    coreEvents: mockCoreEvents,
   };
 });
 
@@ -158,6 +164,54 @@ describe('mcpCommand', () => {
         type: 'message',
         messageType: 'error',
         content: 'Could not retrieve tool registry.',
+      });
+    });
+  });
+
+  describe('/mcp auth', () => {
+    it('does not attach an ad hoc OAuth display listener during authentication', async () => {
+      const mockMcpServers = {
+        secureServer: {
+          command: 'cmd',
+          oauth: { enabled: true },
+        },
+      };
+      const restartServer = vi.fn().mockResolvedValue(undefined);
+      const setTools = vi.fn().mockResolvedValue(undefined);
+
+      mockConfig.getMcpClientManager = vi.fn().mockReturnValue({
+        getBlockedMcpServers: vi.fn().mockReturnValue([]),
+        getMcpServers: vi.fn().mockReturnValue(mockMcpServers),
+        getLastError: vi.fn().mockReturnValue(undefined),
+        restartServer,
+      });
+
+      mockContext = createMockCommandContext({
+        services: {
+          agentContext: {
+            config: mockConfig,
+            toolRegistry: mockConfig.getToolRegistry(),
+            geminiClient: {
+              isInitialized: vi.fn().mockReturnValue(true),
+              setTools,
+            },
+          },
+        },
+      });
+
+      const result = await mcpCommand.action!(mockContext, 'auth secureServer');
+
+      expect(mockAuthenticate).toHaveBeenCalledWith(
+        'secureServer',
+        { enabled: true },
+        undefined,
+      );
+      expect(mockCoreEvents.on).not.toHaveBeenCalled();
+      expect(mockCoreEvents.removeListener).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: "Successfully authenticated and reloaded tools for 'secureServer'",
       });
     });
   });

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -20,8 +20,6 @@ import {
   getErrorMessage,
   MCPOAuthTokenStorage,
   mcpServerRequiresOAuth,
-  CoreEvent,
-  coreEvents,
 } from '@google/gemini-cli-core';
 
 import { MessageType, type HistoryItemMcpStatus } from '../types.js';
@@ -101,11 +99,6 @@ const authCommand: SlashCommand = {
     // Always attempt OAuth authentication, even if not explicitly configured
     // The authentication process will discover OAuth requirements automatically
 
-    const displayListener = (message: string) => {
-      context.ui.addItem({ type: 'info', text: message });
-    };
-
-    coreEvents.on(CoreEvent.OauthDisplayMessage, displayListener);
     try {
       context.ui.addItem({
         type: 'info',
@@ -158,8 +151,6 @@ const authCommand: SlashCommand = {
         messageType: 'error',
         content: `Failed to authenticate with MCP server '${serverName}': ${getErrorMessage(error)}`,
       };
-    } finally {
-      coreEvents.removeListener(CoreEvent.OauthDisplayMessage, displayListener);
     }
   },
   completion: async (context: CommandContext, partialArg: string) => {

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -92,6 +92,29 @@ describe('<HistoryItemDisplay />', () => {
     },
   );
 
+  it('renders AuthUrlMessage for "auth_url" type', async () => {
+    const url =
+      'https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email&state=state-1234567890';
+    const item: HistoryItem = {
+      ...baseItem,
+      type: MessageType.AUTH_URL,
+      heading: 'Opening your browser for OAuth sign-in...',
+      url,
+      footerLines: [
+        'TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+      ],
+    };
+    const { lastFrame, unmount } = await renderWithProviders(
+      <HistoryItemDisplay {...baseItem} item={item} />,
+    );
+    const output = lastFrame();
+
+    expect(output).toContain('Opening your browser for OAuth sign-in...');
+    expect(output).toContain('TIP: Triple-click to select the entire URL');
+    expect(output.replace(/\n/g, '')).toContain(url);
+    unmount();
+  });
+
   it('renders AgentsStatus for "agents_list" type', async () => {
     const item: HistoryItem = {
       ...baseItem,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -36,6 +36,7 @@ import { ChatList } from './views/ChatList.js';
 import { ModelMessage } from './messages/ModelMessage.js';
 import { ThinkingMessage } from './messages/ThinkingMessage.js';
 import { HintMessage } from './messages/HintMessage.js';
+import { AuthUrlMessage } from './messages/AuthUrlMessage.js';
 import { getInlineThinkingMode } from '../utils/inlineThinkingMode.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 
@@ -138,6 +139,13 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           icon={itemForDisplay.icon}
           color={itemForDisplay.color}
           marginBottom={itemForDisplay.marginBottom}
+        />
+      )}
+      {itemForDisplay.type === 'auth_url' && (
+        <AuthUrlMessage
+          heading={itemForDisplay.heading}
+          url={itemForDisplay.url}
+          footerLines={itemForDisplay.footerLines}
         />
       )}
       {itemForDisplay.type === 'warning' && (

--- a/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
+++ b/packages/cli/src/ui/components/MultiFolderTrustDialog.tsx
@@ -16,7 +16,7 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { loadTrustedFolders, TrustLevel } from '../../config/trustedFolders.js';
 import { expandHomeDir } from '../utils/directoryUtils.js';
 import * as path from 'node:path';
-import { MessageType, type HistoryItem } from '../types.js';
+import { MessageType, type HistoryItemWithoutId } from '../types.js';
 import { type Config } from '@google/gemini-cli-core';
 
 export enum MultiFolderTrustChoice {
@@ -33,7 +33,7 @@ export interface MultiFolderTrustDialogProps {
   finishAddingDirectories: (
     config: Config,
     addItem: (
-      itemData: Omit<HistoryItem, 'id'>,
+      itemData: HistoryItemWithoutId,
       baseTimestamp?: number,
     ) => number,
     added: string[],
@@ -41,7 +41,7 @@ export interface MultiFolderTrustDialogProps {
   ) => Promise<void>;
   config: Config;
   addItem: (
-    itemData: Omit<HistoryItem, 'id'>,
+    itemData: HistoryItemWithoutId,
     baseTimestamp?: number,
   ) => number;
 }

--- a/packages/cli/src/ui/components/messages/AuthUrlMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/AuthUrlMessage.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '../../../test-utils/render.js';
+import { AuthUrlMessage } from './AuthUrlMessage.js';
+
+const authUrls = [
+  'https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=https%3A%2F%2Fcodeassist.google.com%2Fauthcode&response_type=code&scope=openid%20email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&state=test-state-value&code_challenge=test-code-challenge&code_challenge_method=S256',
+  'https://login.example.com/oauth2/authorize?client_id=gemini-cli&response_type=code&scope=scope.one%20scope.two%20scope.three&audience=https%3A%2F%2Fapi.example.com&resource=https%3A%2F%2Fapi.example.com%2Fv1%2Foauth%2Fcallback&state=state-with-repeated===equals&&double-ampersand=true',
+  'https://auth.example.com/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A7777%2Foauth%2Fcallback&response_type=code&scope=profile%20email%20offline_access&prompt=consent&login_hint=test.user%40example.com&state=abcdefghijklmnopqrstuvwxyz0123456789',
+];
+
+function extractRenderedUrl(frame: string): string {
+  const lines = frame.replace(/\n$/, '').split('\n');
+  const urlStart = lines.findIndex((line) => line.includes('https://'));
+
+  if (urlStart === -1) {
+    throw new Error(`No auth URL found in rendered output:\n${frame}`);
+  }
+
+  const urlLines: string[] = [];
+  for (let i = urlStart; i < lines.length; i++) {
+    const line = lines[i];
+    if (
+      i > urlStart &&
+      (line.trim() === '' ||
+        line.startsWith('TIP:') ||
+        line.startsWith('Make sure to'))
+    ) {
+      break;
+    }
+    urlLines.push(line);
+  }
+
+  return urlLines.join('');
+}
+
+describe('AuthUrlMessage', () => {
+  const widths = [60, 50, 40];
+  const cases = widths.flatMap((width) =>
+    authUrls.map((url, index) => ({ width, url, index })),
+  );
+
+  it.each(cases)(
+    'preserves the exact auth URL at width $width for case $index',
+    async ({ width, url }) => {
+      const { lastFrame, unmount } = await render(
+        <AuthUrlMessage
+          heading="Opening your browser for OAuth sign-in..."
+          url={url}
+          footerLines={[
+            'TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+            'Make sure to copy the COMPLETE URL - it may wrap across multiple lines.',
+          ]}
+        />,
+        width,
+      );
+
+      const output = lastFrame();
+      expect(extractRenderedUrl(output)).toBe(url);
+      unmount();
+    },
+  );
+});

--- a/packages/cli/src/ui/components/messages/AuthUrlMessage.tsx
+++ b/packages/cli/src/ui/components/messages/AuthUrlMessage.tsx
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+
+interface AuthUrlMessageProps {
+  heading: string;
+  url: string;
+  footerLines?: string[];
+}
+
+export const AuthUrlMessage: React.FC<AuthUrlMessageProps> = ({
+  heading,
+  url,
+  footerLines = [],
+}) => (
+  <Box flexDirection="column" marginTop={1}>
+    <Text wrap="wrap" color={theme.status.warning}>
+      {heading}
+    </Text>
+    <Text>{''}</Text>
+    <Text wrap="wrap" color={theme.text.primary}>
+      {url}
+    </Text>
+    {footerLines.length > 0 && <Text>{''}</Text>}
+    {footerLines.map((line, index) => (
+      <Text wrap="wrap" key={index} color={theme.status.warning}>
+        {line}
+      </Text>
+    ))}
+  </Box>
+);

--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
 import { useHistory } from './useHistoryManager.js';
-import type { HistoryItem } from '../types.js';
+import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 
 describe('useHistoryManager', () => {
   it('should initialize with an empty history', async () => {
@@ -19,7 +19,7 @@ describe('useHistoryManager', () => {
   it('should add an item to history with a unique ID', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData: Omit<HistoryItem, 'id'> = {
+    const itemData: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Hello',
     };
@@ -42,7 +42,7 @@ describe('useHistoryManager', () => {
   it('should generate strictly increasing IDs even if baseTimestamp goes backwards', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = 1000000;
-    const itemData: Omit<HistoryItem, 'id'> = { type: 'info', text: 'First' };
+    const itemData: HistoryItemWithoutId = { type: 'info', text: 'First' };
 
     let id1!: number;
     let id2!: number;
@@ -92,11 +92,11 @@ describe('useHistoryManager', () => {
   it('should generate unique IDs for items added with the same base timestamp', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
+    const itemData1: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'First',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
+    const itemData2: HistoryItemWithoutId = {
       type: 'gemini', // Replaced HistoryItemType.Gemini
       text: 'Second',
     };
@@ -120,7 +120,7 @@ describe('useHistoryManager', () => {
   it('should update an existing history item', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const initialItem: Omit<HistoryItem, 'id'> = {
+    const initialItem: HistoryItemWithoutId = {
       type: 'gemini', // Replaced HistoryItemType.Gemini
       text: 'Initial content',
     };
@@ -146,7 +146,7 @@ describe('useHistoryManager', () => {
   it('should not change history if updateHistoryItem is called with a nonexistent ID', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData: Omit<HistoryItem, 'id'> = {
+    const itemData: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Hello',
     };
@@ -167,11 +167,11 @@ describe('useHistoryManager', () => {
   it('should clear the history', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
+    const itemData1: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'First',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
+    const itemData2: HistoryItemWithoutId = {
       type: 'gemini', // Replaced HistoryItemType.Gemini
       text: 'Second',
     };
@@ -193,19 +193,19 @@ describe('useHistoryManager', () => {
   it('should not add consecutive duplicate user messages', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
+    const itemData1: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Duplicate message',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
+    const itemData2: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Duplicate message',
     };
-    const itemData3: Omit<HistoryItem, 'id'> = {
+    const itemData3: HistoryItemWithoutId = {
       type: 'gemini', // Replaced HistoryItemType.Gemini
       text: 'Gemini response',
     };
-    const itemData4: Omit<HistoryItem, 'id'> = {
+    const itemData4: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Another user message',
     };
@@ -226,15 +226,15 @@ describe('useHistoryManager', () => {
   it('should add duplicate user messages if they are not consecutive', async () => {
     const { result } = await renderHook(() => useHistory());
     const timestamp = Date.now();
-    const itemData1: Omit<HistoryItem, 'id'> = {
+    const itemData1: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Message 1',
     };
-    const itemData2: Omit<HistoryItem, 'id'> = {
+    const itemData2: HistoryItemWithoutId = {
       type: 'gemini', // Replaced HistoryItemType.Gemini
       text: 'Gemini response',
     };
-    const itemData3: Omit<HistoryItem, 'id'> = {
+    const itemData3: HistoryItemWithoutId = {
       type: 'user', // Replaced HistoryItemType.User
       text: 'Message 1', // Duplicate text, but not consecutive
     };
@@ -254,7 +254,7 @@ describe('useHistoryManager', () => {
   it('should use Date.now() as default baseTimestamp if not provided', async () => {
     const { result } = await renderHook(() => useHistory());
     const before = Date.now();
-    const itemData: Omit<HistoryItem, 'id'> = {
+    const itemData: HistoryItemWithoutId = {
       type: 'user',
       text: 'Default timestamp test',
     };

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -5,24 +5,24 @@
  */
 
 import { useState, useRef, useCallback, useMemo } from 'react';
-import type { HistoryItem } from '../types.js';
+import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import type { ChatRecordingService } from '@google/gemini-cli-core/src/services/chatRecordingService.js';
 
 // Type for the updater function passed to updateHistoryItem
 type HistoryItemUpdater = (
   prevItem: HistoryItem,
-) => Partial<Omit<HistoryItem, 'id'>>;
+) => Partial<HistoryItemWithoutId>;
 
 export interface UseHistoryManagerReturn {
   history: HistoryItem[];
   addItem: (
-    itemData: Omit<HistoryItem, 'id'>,
+    itemData: HistoryItemWithoutId,
     baseTimestamp?: number,
     isResuming?: boolean,
   ) => number; // Returns the generated ID
   updateItem: (
     id: number,
-    updates: Partial<Omit<HistoryItem, 'id'>> | HistoryItemUpdater,
+    updates: Partial<HistoryItemWithoutId> | HistoryItemUpdater,
   ) => void;
   clearItems: () => void;
   loadHistory: (newHistory: HistoryItem[]) => void;
@@ -63,12 +63,11 @@ export function useHistory({
   // Adds a new item to the history state with a unique ID.
   const addItem = useCallback(
     (
-      itemData: Omit<HistoryItem, 'id'>,
+      itemData: HistoryItemWithoutId,
       baseTimestamp: number = Date.now(),
       isResuming: boolean = false,
     ): number => {
       const id = getNextMessageId(baseTimestamp);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const newItem: HistoryItem = { ...itemData, id } as HistoryItem;
 
       setHistory((prevHistory) => {
@@ -138,7 +137,7 @@ export function useHistory({
   const updateItem = useCallback(
     (
       id: number,
-      updates: Partial<Omit<HistoryItem, 'id'>> | HistoryItemUpdater,
+      updates: Partial<HistoryItemWithoutId> | HistoryItemUpdater,
     ) => {
       setHistory((prevHistory) =>
         prevHistory.map((item) => {

--- a/packages/cli/src/ui/hooks/useIncludeDirsTrust.tsx
+++ b/packages/cli/src/ui/hooks/useIncludeDirsTrust.tsx
@@ -14,12 +14,12 @@ import {
 } from '@google/gemini-cli-core';
 import { MultiFolderTrustDialog } from '../components/MultiFolderTrustDialog.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
-import { MessageType, type HistoryItem } from '../types.js';
+import { MessageType, type HistoryItemWithoutId } from '../types.js';
 
 async function finishAddingDirectories(
   config: Config,
   addItem: (
-    itemData: Omit<HistoryItem, 'id'>,
+    itemData: HistoryItemWithoutId,
     baseTimestamp?: number,
   ) => number,
   added: string[],

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -180,6 +180,13 @@ export type HistoryItemInfo = HistoryItemBase & {
   marginBottom?: number;
 };
 
+export type HistoryItemAuthUrl = HistoryItemBase & {
+  type: 'auth_url';
+  heading: string;
+  url: string;
+  footerLines?: string[];
+};
+
 export type HistoryItemError = HistoryItemBase & {
   type: 'error';
   text: string;
@@ -386,6 +393,7 @@ export type HistoryItemWithoutId =
   | HistoryItemGemini
   | HistoryItemGeminiContent
   | HistoryItemInfo
+  | HistoryItemAuthUrl
   | HistoryItemError
   | HistoryItemWarning
   | HistoryItemAbout
@@ -412,6 +420,7 @@ export type HistoryItem = HistoryItemWithoutId & { id: number };
 // Message types used by internal command feedback (subset of HistoryItem types)
 export enum MessageType {
   INFO = 'info',
+  AUTH_URL = 'auth_url',
   ERROR = 'error',
   WARNING = 'warning',
   USER = 'user',

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -8,7 +8,7 @@ import type { UpdateObject } from '../ui/utils/updateCheck.js';
 import type { LoadedSettings } from '../config/settings.js';
 import { getInstallationInfo, PackageManager } from './installationInfo.js';
 import { updateEventEmitter } from './updateEventEmitter.js';
-import { MessageType, type HistoryItem } from '../ui/types.js';
+import { MessageType, type HistoryItemWithoutId } from '../ui/types.js';
 import { spawnWrapper } from './spawnWrapper.js';
 import type { spawn } from 'node:child_process';
 import { debugLogger } from '@google/gemini-cli-core';
@@ -163,7 +163,7 @@ export function handleAutoUpdate(
 }
 
 export function setUpdateHandler(
-  addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
+  addItem: (item: HistoryItemWithoutId, timestamp: number) => void,
   setUpdateInfo: (info: UpdateObject | null) => void,
 ) {
   let successfullyInstalled = false;

--- a/packages/cli/src/utils/oauthDisplay.ts
+++ b/packages/cli/src/utils/oauthDisplay.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OauthDisplayMessagePayload } from '@google/gemini-cli-core';
+
+export function formatOauthDisplayMessage(
+  payload: OauthDisplayMessagePayload,
+): string {
+  const parts = [payload.heading, '', payload.url];
+
+  if (payload.footerLines && payload.footerLines.length > 0) {
+    parts.push('', ...payload.footerLines);
+  }
+
+  return `${parts.join('\n')}\n`;
+}

--- a/packages/core/src/agents/auth-provider/oauth2-provider.test.ts
+++ b/packages/core/src/agents/auth-provider/oauth2-provider.test.ts
@@ -71,6 +71,7 @@ vi.mock('../../utils/authConsent.js', () => ({
 vi.mock('../../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
+    emitOauthDisplayMessage: vi.fn(),
   },
 }));
 
@@ -95,6 +96,10 @@ const {
   buildAuthorizationUrl,
 } = await import('../../utils/oauth-flow.js');
 const { getConsentForOauth } = await import('../../utils/authConsent.js');
+const { coreEvents } = await import('../../utils/events.js');
+const { createOauthBrowserDisplayMessage } = await import(
+  '../../utils/oauthDisplay.js'
+);
 
 function createConfig(
   overrides: Partial<OAuth2AuthConfig> = {},
@@ -359,6 +364,11 @@ describe('OAuth2AuthProvider', () => {
       expect(vi.mocked(generatePKCEParams)).toHaveBeenCalled();
       expect(vi.mocked(startCallbackServer)).toHaveBeenCalled();
       expect(vi.mocked(exchangeCodeForToken)).toHaveBeenCalled();
+      expect(coreEvents.emitOauthDisplayMessage).toHaveBeenCalledWith(
+        createOauthBrowserDisplayMessage(
+          'https://auth.example.com/authorize?foo=bar',
+        ),
+      );
       expect(storage.saveToken).toHaveBeenCalledWith(
         'test-agent',
         expect.objectContaining({ accessToken: 'new-access-token' }),

--- a/packages/core/src/agents/auth-provider/oauth2-provider.ts
+++ b/packages/core/src/agents/auth-provider/oauth2-provider.ts
@@ -24,6 +24,7 @@ import { getConsentForOauth } from '../../utils/authConsent.js';
 import { FatalCancellationError, getErrorMessage } from '../../utils/errors.js';
 import { coreEvents } from '../../utils/events.js';
 import { debugLogger } from '../../utils/debugLogger.js';
+import { createOauthBrowserDisplayMessage } from '../../utils/oauthDisplay.js';
 import { Storage } from '../../config/storage.js';
 
 /**
@@ -249,19 +250,8 @@ export class OAuth2AuthProvider extends BaseA2AAuthProvider {
       throw new FatalCancellationError('Authentication cancelled by user.');
     }
 
-    coreEvents.emitFeedback(
-      'info',
-      `→ Opening your browser for OAuth sign-in...
-
-` +
-        `If the browser does not open, copy and paste this URL into your browser:
-` +
-        `${authUrl}
-
-` +
-        `💡 TIP: Triple-click to select the entire URL, then copy and paste it into your browser.
-` +
-        `⚠️  Make sure to copy the COMPLETE URL - it may wrap across multiple lines.`,
+    coreEvents.emitOauthDisplayMessage(
+      createOauthBrowserDisplayMessage(authUrl),
     );
 
     try {

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -47,6 +47,7 @@ import {
 import process from 'node:process';
 import { coreEvents } from '../utils/events.js';
 import { isHeadlessMode } from '../utils/headless.js';
+import { createOauthBrowserDisplayMessage } from '../utils/oauthDisplay.js';
 
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>();
@@ -163,6 +164,10 @@ describe('oauth2', () => {
       const mockGetAccessToken = vi
         .fn()
         .mockResolvedValue({ token: 'mock-access-token' });
+      const emitOauthDisplayMessageSpy = vi.spyOn(
+        coreEvents,
+        'emitOauthDisplayMessage',
+      );
       let tokensListener: ((tokens: Credentials) => void) | undefined;
       const mockOAuth2Client = {
         generateAuthUrl: mockGenerateAuthUrl,
@@ -248,6 +253,9 @@ describe('oauth2', () => {
       expect(client).toBe(mockOAuth2Client);
 
       expect(open).toHaveBeenCalledWith(mockAuthUrl);
+      expect(emitOauthDisplayMessageSpy).toHaveBeenCalledWith(
+        createOauthBrowserDisplayMessage(mockAuthUrl),
+      );
       expect(mockGetToken).toHaveBeenCalledWith({
         code: mockCode,
         redirect_uri: `http://127.0.0.1:${capturedPort}/oauth2callback`,

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -48,6 +48,7 @@ import {
 } from '../utils/terminal.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import { getConsentForOauth } from '../utils/authConsent.js';
+import { createOauthBrowserDisplayMessage } from '../utils/oauthDisplay.js';
 
 export const authEvents = new EventEmitter();
 
@@ -291,12 +292,9 @@ async function initOauthClient(
 
     const webLogin = await authWithWeb(client);
 
-    coreEvents.emit(CoreEvent.UserFeedback, {
-      severity: 'info',
-      message:
-        `\n\nAttempting to open authentication page in your browser.\n` +
-        `Otherwise navigate to:\n\n${webLogin.authUrl}\n\n\n`,
-    });
+    coreEvents.emitOauthDisplayMessage(
+      createOauthBrowserDisplayMessage(webLogin.authUrl),
+    );
     try {
       // Attempt to open the authentication URL in the default browser.
       // We do not use the `wait` option here because the main script's execution

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export * from './utils/thoughtUtils.js';
 export * from './utils/secure-browser-launcher.js';
 export * from './utils/debugLogger.js';
 export * from './utils/events.js';
+export * from './utils/oauthDisplay.js';
 export * from './utils/extensionLoader.js';
 export * from './utils/package.js';
 export * from './utils/version.js';

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -30,6 +30,7 @@ vi.mock('./oauth-token-storage.js', () => {
 vi.mock('../utils/events.js', () => ({
   coreEvents: {
     emitFeedback: vi.fn(),
+    emitOauthDisplayMessage: vi.fn(),
     emitConsoleLog: vi.fn(),
   },
 }));
@@ -72,6 +73,7 @@ import {
 } from './oauth-utils.js';
 import { coreEvents } from '../utils/events.js';
 import { FatalCancellationError } from '../utils/errors.js';
+import { createOauthBrowserDisplayMessage } from '../utils/oauthDisplay.js';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -255,6 +257,15 @@ describe('MCPOAuthProvider', () => {
 
       expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(
         expect.stringContaining('authorize'),
+      );
+      const browserUrl = vi.mocked(mockOpenBrowserSecurely).mock.calls[0]?.[0];
+      expect(browserUrl).toBeTypeOf('string');
+      expect(coreEvents.emitOauthDisplayMessage).toHaveBeenCalledWith(
+        createOauthBrowserDisplayMessage(browserUrl as string),
+      );
+      expect(coreEvents.emitFeedback).not.toHaveBeenCalledWith(
+        'info',
+        expect.stringContaining('copy and paste this URL into your browser'),
       );
       const tokenStorage = new MCPOAuthTokenStorage();
       expect(tokenStorage.saveToken).toHaveBeenCalledWith(

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -14,6 +14,7 @@ import { OAuthUtils, ResourceMismatchError } from './oauth-utils.js';
 import { coreEvents } from '../utils/events.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getConsentForOauth } from '../utils/authConsent.js';
+import { createOauthBrowserDisplayMessage } from '../utils/oauthDisplay.js';
 import {
   generatePKCEParams,
   startCallbackServer,
@@ -284,11 +285,6 @@ export class MCPOAuthProvider {
     config: MCPOAuthConfig,
     mcpServerUrl?: string,
   ): Promise<OAuthToken> {
-    // Helper function to display messages through handler or fallback to console.log
-    const displayMessage = (message: string) => {
-      coreEvents.emitFeedback('info', message);
-    };
-
     // If no authorization URL is provided, try to discover OAuth configuration
     if (!config.authorizationUrl && mcpServerUrl) {
       debugLogger.debug(`Starting OAuth for MCP server "${serverName}"…
@@ -452,13 +448,9 @@ export class MCPOAuthProvider {
       throw new FatalCancellationError('Authentication cancelled by user.');
     }
 
-    displayMessage(`→ Opening your browser for OAuth sign-in...
-
-If the browser does not open, copy and paste this URL into your browser:
-${authUrl}
-
-💡 TIP: Triple-click to select the entire URL, then copy and paste it into your browser.
-⚠️  Make sure to copy the COMPLETE URL - it may wrap across multiple lines.`);
+    coreEvents.emitOauthDisplayMessage(
+      createOauthBrowserDisplayMessage(authUrl),
+    );
 
     // Open browser securely (callback server is already running)
     try {

--- a/packages/core/src/utils/events.test.ts
+++ b/packages/core/src/utils/events.test.ts
@@ -11,6 +11,7 @@ import {
   coreEvents,
   type UserFeedbackPayload,
   type McpProgressPayload,
+  type OauthDisplayMessagePayload,
 } from './events.js';
 
 vi.mock('./debugLogger.js', () => ({
@@ -265,6 +266,41 @@ describe('CoreEventEmitter', () => {
       expect(listener).toHaveBeenCalledTimes(MAX_BACKLOG_SIZE);
       // Verify strictly that the FIRST call was Output 10 (0-9 dropped)
       expect(listener.mock.calls[0][0]).toMatchObject({ chunk: 'Output 10' });
+    });
+  });
+
+  describe('OauthDisplayMessage Event', () => {
+    it('should emit oauth display message immediately when a listener is present', () => {
+      const listener = vi.fn();
+      events.on(CoreEvent.OauthDisplayMessage, listener);
+
+      const payload: OauthDisplayMessagePayload = {
+        heading: 'Open this URL in your browser:',
+        url: 'https://example.com/oauth?response_type=code',
+        footerLines: ['Copy the full URL if it wraps.'],
+      };
+
+      events.emitOauthDisplayMessage(payload);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining(payload));
+    });
+
+    it('should buffer oauth display message when no listener is present', () => {
+      const listener = vi.fn();
+      const payload: OauthDisplayMessagePayload = {
+        heading: 'Open this URL in your browser:',
+        url: 'https://example.com/oauth?response_type=code',
+      };
+
+      events.emitOauthDisplayMessage(payload);
+      expect(listener).not.toHaveBeenCalled();
+
+      events.on(CoreEvent.OauthDisplayMessage, listener);
+      events.drainBacklogs();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining(payload));
     });
   });
 

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -70,6 +70,15 @@ export interface OutputPayload {
 }
 
 /**
+ * Payload for the 'oauth-display-message' event.
+ */
+export interface OauthDisplayMessagePayload {
+  heading: string;
+  url: string;
+  footerLines?: string[];
+}
+
+/**
  * Payload for the 'memory-changed' event.
  */
 export interface MemoryChangedPayload {
@@ -221,7 +230,7 @@ export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.QuotaChanged]: [QuotaChangedPayload];
   [CoreEvent.ExternalEditorClosed]: never[];
   [CoreEvent.McpClientUpdate]: Array<Map<string, McpClient> | never>;
-  [CoreEvent.OauthDisplayMessage]: string[];
+  [CoreEvent.OauthDisplayMessage]: [OauthDisplayMessagePayload];
   [CoreEvent.SettingsChanged]: never[];
   [CoreEvent.HookStart]: [HookStartPayload];
   [CoreEvent.HookEnd]: [HookEndPayload];
@@ -317,6 +326,13 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   ): void {
     const payload: OutputPayload = { isStderr, chunk, encoding };
     this._emitOrQueue(CoreEvent.Output, payload);
+  }
+
+  /**
+   * Broadcasts a copy-sensitive OAuth URL message.
+   */
+  emitOauthDisplayMessage(payload: OauthDisplayMessagePayload): void {
+    this._emitOrQueue(CoreEvent.OauthDisplayMessage, payload);
   }
 
   /**

--- a/packages/core/src/utils/oauthDisplay.test.ts
+++ b/packages/core/src/utils/oauthDisplay.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createOauthBrowserDisplayMessage } from './oauthDisplay.js';
+
+describe('createOauthBrowserDisplayMessage', () => {
+  it('returns a structured payload with a plain auth URL', () => {
+    const url =
+      'https://accounts.example.com/oauth2/auth?response_type=code&scope=openid%20email&state=test-state';
+
+    expect(createOauthBrowserDisplayMessage(url)).toEqual({
+      heading:
+        'Opening your browser for OAuth sign-in...\n' +
+        'If the browser does not open, copy and paste this URL into your browser:',
+      url,
+      footerLines: [
+        'TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+        'Make sure to copy the COMPLETE URL - it may wrap across multiple lines.',
+      ],
+    });
+  });
+});

--- a/packages/core/src/utils/oauthDisplay.ts
+++ b/packages/core/src/utils/oauthDisplay.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OauthDisplayMessagePayload } from './events.js';
+
+export function createOauthBrowserDisplayMessage(
+  url: string,
+): OauthDisplayMessagePayload {
+  return {
+    heading:
+      'Opening your browser for OAuth sign-in...\n' +
+      'If the browser does not open, copy and paste this URL into your browser:',
+    url,
+    footerLines: [
+      'TIP: Triple-click to select the entire URL, then copy and paste it into your browser.',
+      'Make sure to copy the COMPLETE URL - it may wrap across multiple lines.',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

This PR fixes a high-priority auth UX bug where long OAuth login URLs were rendered through the generic info-message pipeline and became truncated or corrupted in narrow terminals. I replaced that with a dedicated auth URL display path that preserves every character across Google login, MCP OAuth, and A2A OAuth flows, and also added safe stdout fallbacks for non-interactive or pre-UI execution.

## Details

- Added a structured `OauthDisplayMessagePayload` with `heading`, `url`, and optional `footerLines`.
- Added a shared core helper to build a consistent OAuth browser-display message for copy-sensitive URLs.
- Moved the active browser-based auth URL flows off the generic `emitFeedback('info', ...)` message path for Google browser login, MCP OAuth, and A2A OAuth.
- Added a dedicated CLI history item and `AuthUrlMessage` component for auth URL rendering.
- Auth URLs now render with plain wrapped `Text` instead of `InfoMessage`, markdown parsing, or styled link rendering, since the previous path could drop characters at wrap boundaries in narrow terminals.
- Added stdout fallback formatting for OAuth display events in CLI startup and non-interactive entry points so auth URLs are not lost before the UI mounts.
- Removed the MCP slash-command's ad hoc OAuth display listener so the auth URL is rendered exactly once through the shared global path.
- Added regression coverage for narrow terminal widths (`60`, `50`, `40`), long URLs with encoded parameters and repeated delimiters, exact URL reconstruction after wrapping, AppContainer event wiring, Google/MCP/A2A auth producer behavior, and MCP no-duplicate auth URL rendering.
- Validated locally with:
  - `npm run build`
  - `npm run lint`
  - `npm run typecheck`
  - focused auth/UI regression suites
  - repeated targeted auth stress runs
- Full local `npm run test:ci` on this Windows environment is still blocked by an unrelated `sea/sea-launch.test.js` runtime-permissions test outside the auth changes.

## Related Issues

Closes #12137  
Related to #23769

## How to Validate

1. Run the automated validation steps:
   - From repo root: `npm run build`
   - From repo root: `npm run lint`
   - From repo root: `npm run typecheck`
   - From `packages/core`:
     `npx vitest run src/utils/events.test.ts src/utils/oauthDisplay.test.ts src/code_assist/oauth2.test.ts src/mcp/oauth-provider.test.ts src/agents/auth-provider/oauth2-provider.test.ts`
   - From `packages/cli`:
     `npx vitest run src/ui/components/messages/AuthUrlMessage.test.tsx src/ui/components/HistoryItemDisplay.test.tsx src/ui/AppContainer.test.tsx src/ui/commands/mcpCommand.test.ts`
2. Validate Google browser login in a narrow terminal:
   - Use a terminal around `40-60` columns wide
   - Trigger Google browser login
   - Confirm the auth URL wraps cleanly across lines without dropped characters
   - Copy the wrapped URL, paste it into a browser, and confirm authentication proceeds
3. Validate MCP OAuth:
   - Configure an OAuth-enabled MCP server
   - Run `/mcp auth <server>`
   - Confirm exactly one auth URL block is shown
   - Confirm the wrapped URL is complete and copyable in a narrow terminal
4. Validate A2A OAuth:
   - Trigger an A2A agent configured with `oauth2`
   - Confirm the same dedicated auth URL block is shown
   - Confirm the URL remains intact when wrapped
5. Check fallback behavior:
   - Confirm auth URL output still appears correctly when the UI has not mounted yet or when a non-interactive output path is used
   - Confirm browser-open failure still leaves the full auth URL visible to the user

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
  - Not needed for this change
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
  - No breaking changes expected
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
