### PR TITLE
fix(core): dispose Scheduler to prevent McpProgress listener leak

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -71,6 +71,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     Scheduler: class {
       schedule = mockSchedulerSchedule;
       cancelAll = vi.fn();
+      dispose = vi.fn();
     },
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
     ChatRecordingService: MockChatRecordingService,

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -528,6 +528,7 @@ export async function runNonInteractive(
       // Cleanup stdin cancellation before other cleanup
       cleanupStdinCancellation();
 
+      scheduler.dispose();
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
     }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -187,6 +187,7 @@ export async function runNonInteractive(
     };
 
     let errorToHandle: unknown | undefined;
+    let scheduler: Scheduler | undefined;
     try {
       consolePatcher.patch();
 
@@ -215,7 +216,7 @@ export async function runNonInteractive(
       });
 
       const geminiClient = config.getGeminiClient();
-      const scheduler = new Scheduler({
+      scheduler = new Scheduler({
         context: config,
         messageBus: config.getMessageBus(),
         getPreferredEditor: () => undefined,
@@ -528,7 +529,7 @@ export async function runNonInteractive(
       // Cleanup stdin cancellation before other cleanup
       cleanupStdinCancellation();
 
-      scheduler.dispose();
+      scheduler?.dispose();
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
     }

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -71,6 +71,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     Scheduler: class {
       schedule = mockSchedulerSchedule;
       cancelAll = vi.fn();
+      dispose = vi.fn();
     },
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
     ChatRecordingService: MockChatRecordingService,

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -610,6 +610,7 @@ export async function runNonInteractive({
       cleanupStdinCancellation();
       abortController.signal.removeEventListener('abort', abortSession);
 
+      scheduler.dispose();
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
     }

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -183,6 +183,7 @@ export async function runNonInteractive({
     };
 
     let errorToHandle: unknown | undefined;
+    let scheduler: Scheduler | undefined;
     let abortSession = () => {};
     try {
       consolePatcher.patch();
@@ -214,7 +215,7 @@ export async function runNonInteractive({
       });
 
       const geminiClient = config.getGeminiClient();
-      const scheduler = new Scheduler({
+      scheduler = new Scheduler({
         context: config,
         messageBus: config.getMessageBus(),
         getPreferredEditor: () => undefined,
@@ -610,7 +611,7 @@ export async function runNonInteractive({
       cleanupStdinCancellation();
       abortController.signal.removeEventListener('abort', abortSession);
 
-      scheduler.dispose();
+      scheduler?.dispose();
       consolePatcher.cleanup();
       coreEvents.off(CoreEvent.UserFeedback, handleUserFeedback);
     }

--- a/packages/core/src/agents/agent-scheduler.test.ts
+++ b/packages/core/src/agents/agent-scheduler.test.ts
@@ -15,6 +15,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 vi.mock('../scheduler/scheduler.js', () => ({
   Scheduler: vi.fn().mockImplementation(() => ({
     schedule: vi.fn().mockResolvedValue([{ status: 'success' }]),
+    dispose: vi.fn(),
   })),
 }));
 
@@ -123,6 +124,57 @@ describe('agent-scheduler', () => {
     const schedulerConfig = vi.mocked(Scheduler).mock.calls[0][0].context;
     expect(schedulerConfig.toolRegistry).toBe(agentRegistry);
     expect(schedulerConfig.toolRegistry).not.toBe(mainRegistry);
+  });
+
+  it('should dispose the scheduler after schedule completes', async () => {
+    const mockConfig = {
+      getPromptRegistry: vi.fn(),
+      getResourceRegistry: vi.fn(),
+      messageBus: mockMessageBus,
+      toolRegistry: mockToolRegistry,
+    } as unknown as Mocked<Config>;
+
+    const options = {
+      schedulerId: 'subagent-1',
+      toolRegistry: mockToolRegistry as unknown as ToolRegistry,
+      signal: new AbortController().signal,
+    };
+
+    await scheduleAgentTools(mockConfig as unknown as Config, [], options);
+
+    const schedulerInstance = vi.mocked(Scheduler).mock.results[0].value;
+    expect(schedulerInstance.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('should dispose the scheduler even when schedule throws', async () => {
+    const scheduleError = new Error('schedule failed');
+    vi.mocked(Scheduler).mockImplementationOnce(
+      () =>
+        ({
+          schedule: vi.fn().mockRejectedValue(scheduleError),
+          dispose: vi.fn(),
+        }) as unknown as Scheduler,
+    );
+
+    const mockConfig = {
+      getPromptRegistry: vi.fn(),
+      getResourceRegistry: vi.fn(),
+      messageBus: mockMessageBus,
+      toolRegistry: mockToolRegistry,
+    } as unknown as Mocked<Config>;
+
+    const options = {
+      schedulerId: 'subagent-1',
+      toolRegistry: mockToolRegistry as unknown as ToolRegistry,
+      signal: new AbortController().signal,
+    };
+
+    await expect(
+      scheduleAgentTools(mockConfig as unknown as Config, [], options),
+    ).rejects.toThrow('schedule failed');
+
+    const schedulerInstance = vi.mocked(Scheduler).mock.results[0].value;
+    expect(schedulerInstance.dispose).toHaveBeenCalledOnce();
   });
 
   it('should create an AgentLoopContext that has a defined .config property', async () => {

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -85,5 +85,9 @@ export async function scheduleAgentTools(
     onWaitingForConfirmation,
   });
 
-  return scheduler.schedule(requests, signal);
+  try {
+    return await scheduler.schedule(requests, signal);
+  } finally {
+    scheduler.dispose();
+  }
 }


### PR DESCRIPTION
Fixes #21006

Picks up where #21004 left off (closed due to 14-day inactivity before `help wanted` was added). This version covers an additional leak site that the earlier PR missed.

## What

`Scheduler` instances subscribe to `CoreEvent.McpProgress` on construction and require `dispose()` to unsubscribe. Three call sites never called it:

| Call site | Fix |
|-----------|-----|
| `agent-scheduler.ts` | Wrap `schedule()` in `try/finally` with `dispose()` |
| `nonInteractiveCli.ts` | Add `scheduler.dispose()` to existing `finally` block |
| `nonInteractiveCliAgentSession.ts` | Same (missed in #21004) |

The other two sites (`useToolScheduler.ts` line 114, `a2a-server/task.ts` line 410) already dispose correctly.

This leaks one listener per tool-scheduling batch. After ~10 batches in a session, Node emits `MaxListenersExceededWarning` and memory grows as each orphaned listener retains the full Scheduler instance graph.

## Tests

- Added: `dispose()` called after successful `schedule()`
- Added: `dispose()` called even when `schedule()` rejects
- All 5 agent-scheduler tests pass
- All 142 scheduler tests pass
- Pre-commit hooks (lint + prettier) pass
