### PR TITLE
fix: correct redirect count increment in fetchJson

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -31,7 +31,7 @@ export async function fetchJson<T>(
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          fetchJson<T>(res.headers.location, redirectCount++)
+          fetchJson<T>(res.headers.location, redirectCount + 1)
             .then(resolve)
             .catch(reject);
           return;


### PR DESCRIPTION
Fixes #24893

## Summary

`fetchJson` in `github_fetch.ts` uses post-increment (`redirectCount++`) when passing the redirect count to the recursive call. Post-increment evaluates to the current value *before* incrementing, so every recursive call receives the original value (0). This means the redirect limit check (`redirectCount >= 10`) on line 28 never triggers, allowing unbounded redirects.

The sibling function `downloadFile` in `github.ts:546` correctly uses `redirectCount + 1`.

## Changes

- Replace `redirectCount++` with `redirectCount + 1` in `fetchJson` recursive call (one-line change)