### PR TITLE
fix(mcp): add httpMethod config option for StreamableHTTP transport

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -472,6 +472,7 @@ export class MCPServerConfig {
     // For streamable http transport
     readonly httpUrl?: string,
     readonly headers?: Record<string, string>,
+    readonly httpMethod?: 'GET' | 'POST',
     // For websocket transport
     readonly tcp?: string,
     // Transport type (optional, for use with 'url' field)
@@ -2325,9 +2326,8 @@ export class Config implements McpContext, AgentLoopContext {
     if (this.experimentalJitContext && this.memoryContextManager) {
       await this.memoryContextManager.refresh();
     } else {
-      const { refreshServerHierarchicalMemory } = await import(
-        '../utils/memoryDiscovery.js'
-      );
+      const { refreshServerHierarchicalMemory } =
+        await import('../utils/memoryDiscovery.js');
       await refreshServerHierarchicalMemory(this);
     }
     if (this._geminiClient?.isInitialized()) {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -997,12 +997,18 @@ function createTransportRequestInit(
     }
   }
 
-  return {
+  const requestInit: RequestInit = {
     headers: {
       ...expandedHeaders,
       ...headers,
     },
   };
+
+  if (mcpServerConfig.httpMethod) {
+    requestInit.method = mcpServerConfig.httpMethod;
+  }
+
+  return requestInit;
 }
 
 /**


### PR DESCRIPTION
This PR adds an optional `httpMethod` field to MCPServerConfig, allowing users to specify the HTTP method (GET or POST) for Streamable HTTP transport handshakes. This fixes the issue where some MCP servers (e.g., n8n) require POST for the initial connection.\n\nFixes #24838