### PR TITLE
fix(ui): hydrate telemetry on restore to fix incorrect session ID

### DIFF
--- a/packages/cli/src/ui/hooks/useSessionResume.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.ts
@@ -10,6 +10,7 @@ import {
   type Config,
   type ResumedSessionData,
   convertSessionToClientHistory,
+  uiTelemetryService,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import type { HistoryItemWithoutId } from '../types.js';
@@ -109,6 +110,8 @@ export function useSessionResume({
       !hasLoadedResumedSession.current
     ) {
       hasLoadedResumedSession.current = true;
+      // Hydrate telemetry service with the resumed conversation to restore session ID and metrics
+      uiTelemetryService.hydrate(resumedSessionData.conversation);
       const historyData = convertSessionToHistoryFormats(
         resumedSessionData.conversation.messages,
       );


### PR DESCRIPTION
This PR ensures that when resuming a session via `--resume`, the telemetry service is properly hydrated with the conversation data. This fixes the issue where the quit summary displayed an incorrect session ID in the resume command.\n\nFixes #24820