### PR TITLE
fix(utils): improve error message for invalid or expired API keys

### DIFF
--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -44,6 +44,11 @@ export function parseAndFormatApiError(
     if (error.status === 429) {
       text += getRateLimitMessage(authType, fallbackModel);
     }
+    // Provide guidance for authentication errors (e.g., API key expired/invalid)
+    if (error.status === 401 || error.status === 403) {
+      text +=
+        '\nYour API key appears to be invalid or expired. Please run `gemini auth` to re-authenticate or set a new API key via `gemini config --api-key`.';
+    }
     return text;
   }
 
@@ -72,6 +77,18 @@ export function parseAndFormatApiError(
         let text = `[API Error: ${finalMessage} (Status: ${parsedError.error.status})]`;
         if (parsedError.error.code === 429) {
           text += getRateLimitMessage(authType, fallbackModel);
+        }
+        // Check for authentication errors
+        const isAuthError =
+          parsedError.error.status === 401 ||
+          parsedError.error.status === 403 ||
+          (finalMessage.toLowerCase().includes('api key') &&
+            (finalMessage.toLowerCase().includes('expired') ||
+              finalMessage.toLowerCase().includes('invalid') ||
+              finalMessage.toLowerCase().includes('not valid')));
+        if (isAuthError) {
+          text +=
+            '\nYour API key appears to be invalid or expired. Please run `gemini auth` to re-authenticate or set a new API key via `gemini config --api-key`.';
         }
         return text;
       }


### PR DESCRIPTION
When the Gemini API returns an authentication error (401/403) or indicates an invalid/expired API key, the CLI now provides a clear, actionable message guiding the user to re-authenticate () or set a new API key ().\n\nFixes #24831