### PR TITLE
fix(core): add empty array guard in A2A duplicate message check

### DIFF
--- a/packages/core/src/agents/a2aUtils.ts
+++ b/packages/core/src/agents/a2aUtils.ts
@@ -125,7 +125,11 @@ export class A2AResultReassembler {
   private pushMessage(message: Message | undefined) {
     if (!message) return;
     const text = extractPartsText(message.parts, '');
-    if (text && this.messageLog[this.messageLog.length - 1] !== text) {
+    if (
+      text &&
+      (this.messageLog.length === 0 ||
+        this.messageLog[this.messageLog.length - 1] !== text)
+    ) {
       this.messageLog.push(text);
     }
   }


### PR DESCRIPTION
Fixes #24894

## Summary

`A2AResultReassembler.pushMessage` checks `messageLog[messageLog.length - 1]` to avoid pushing duplicate consecutive messages. When `messageLog` is empty, `length - 1` is `-1` and `array[-1]` returns `undefined` in JavaScript.

While the current behavior happens to work correctly (since `undefined !== text` evaluates to `true`, the first message still gets pushed), the intent of the duplicate check is clearer with an explicit empty-array guard.

## Changes

- Add `this.messageLog.length === 0` check before accessing the last element

## Test plan

- [x] Verified current behavior with empty array
- [x] Confirmed guard makes intent explicit without changing behavior