### PR TITLE
feat(core): refine shell tool description display logic

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -768,6 +768,46 @@ describe('ShellTool', () => {
       const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       expect(shellTool.description).not.toContain('Efficiency Guidelines:');
     });
+
+    it('should return the command if description is not provided', () => {
+      const invocation = shellTool.build({
+        command: 'echo "hello"',
+      });
+      expect(invocation.getDescription()).toBe('echo "hello"');
+    });
+
+    it('should return the command if it is short (<= 150 chars), even if description is provided', () => {
+      const invocation = shellTool.build({
+        command: 'echo "hello"',
+        description: 'Prints a friendly greeting.',
+      });
+      expect(invocation.getDescription()).toBe('echo "hello"');
+    });
+
+    it('should return the description if the command is long (> 150 chars)', () => {
+      const longCommand = 'echo "hello" && '.repeat(15) + 'echo "world"'; // Length > 150
+      const invocation = shellTool.build({
+        command: longCommand,
+        description: 'Prints multiple greetings.',
+      });
+      expect(invocation.getDescription()).toBe('Prints multiple greetings.');
+    });
+
+    it('should return the raw command if description is an empty string', () => {
+      const invocation = shellTool.build({
+        command: 'echo hello',
+        description: '',
+      });
+      expect(invocation.getDescription()).toBe('echo hello');
+    });
+
+    it('should return the raw command if description is just whitespace', () => {
+      const invocation = shellTool.build({
+        command: 'echo hello',
+        description: '   ',
+      });
+      expect(invocation.getDescription()).toBe('echo hello');
+    });
   });
 
   describe('getDisplayTitle and getExplanation', () => {
@@ -800,32 +840,6 @@ describe('ShellTool', () => {
       expect(invocation.getExplanation?.()).toBe(
         `[current working directory ${process.cwd()}]`,
       );
-    });
-  });
-
-  describe('invocation getDescription', () => {
-    it('should return the description if it is present and not empty whitespace', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: 'prints hello',
-      });
-      expect(invocation.getDescription()).toBe('prints hello');
-    });
-
-    it('should return the raw command if description is an empty string', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: '',
-      });
-      expect(invocation.getDescription()).toBe('echo hello');
-    });
-
-    it('should return the raw command if description is just whitespace', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: '   ',
-      });
-      expect(invocation.getDescription()).toBe('echo hello');
     });
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -63,6 +63,7 @@ export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
 // Delay so user does not see the output of the process before the process is moved to the background.
 const BACKGROUND_DELAY_MS = 200;
+const SHOW_NL_DESCRIPTION_THRESHOLD = 150;
 
 export interface ShellToolParams {
   command: string;
@@ -136,9 +137,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return this.params.description?.trim()
-      ? this.params.description
-      : this.params.command;
+    const descStr = this.params.description?.trim();
+    const commandStr = this.params.command;
+    return Array.from(commandStr).length <= SHOW_NL_DESCRIPTION_THRESHOLD ||
+      !descStr
+      ? commandStr
+      : descStr;
   }
 
   private simplifyPaths(paths: Set<string>): string[] {


### PR DESCRIPTION
## Summary

Refines the `ShellTool` output logic to dynamically choose between displaying the raw shell command and its natural language description. This provides immediate visual clarity for straightforward routines while leveraging NL descriptions for massive or complex commands.

## Details

- Added a length check (150 characters) to determine whether to prioritize the raw command or the description.
- Falls back to the raw command if no description is provided by the model.
- Added comprehensive unit tests in `shell.test.ts` covering the new branches of the `getDescription` logic.

## Related Issues

Fixes #24901

## How to Validate

1. Check out the branch and run tests: `npm test -w @google/gemini-cli-core -- src/tools/shell.test.ts`
2. Start the CLI and run a simple command (e.g., `echo "hello"`). The output should display the raw command.
3. Run an artificially long shell command or a massive one-liner. The CLI should display the NL description of the command instead of printing a giant block of shell code.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
