### PR TITLE
docs: specify .gemini directory for custom commands

### DIFF
--- a/docs/extensions/writing-extensions.md
+++ b/docs/extensions/writing-extensions.md
@@ -185,7 +185,7 @@ asking: "fetch posts".
 
 ## Step 5: Add a custom command
 
-Custom commands create shortcuts for complex prompts.
+Custom commands create shortcuts for complex prompts.  These must be located within a `.gemini` configuration directory (either in your project root or your home directory).
 
 1.  Create a `commands` directory and a subdirectory for your command group:
 


### PR DESCRIPTION
## Summary
Update Step 5 of the custom commands documentation to clarify that the commands directory must reside within a .gemini configuration folder.

## Details
Previously, the instructions lacked context regarding the required root path, which could lead to users creating directories in locations where the CLI cannot detect them. Added explicit directory navigation to the code examples for macOS, Linux, and Windows.
