### PR TITLE
chore: update ink version to 6.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "ink": "npm:@jrichman/ink@6.6.7",
+        "ink": "npm:@jrichman/ink@6.6.8",
         "latest-version": "^9.0.0",
         "node-fetch-native": "^1.6.7",
         "proper-lockfile": "^4.1.2",
@@ -10049,9 +10049,9 @@
     },
     "node_modules/ink": {
       "name": "@jrichman/ink",
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.7.tgz",
-      "integrity": "sha512-bDzQLpLzK/dn9Ur/Ku88ZZR9totVcMGrGYAgPHidsAAbe9NKztU1fggj/iu0wRp5g1kBeALb3cfagFGdDxAU1w==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.8.tgz",
+      "integrity": "sha512-099iGdvWVIM2ivc3NEWyMF7FT06aLmrx1gMGI02ZYB4wLIFn0v/KQl6+20xEwcM6gyzj8Y8842Sf0UH2z0oTDw==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^7.0.0",
@@ -17526,7 +17526,7 @@
         "fzf": "^0.5.2",
         "glob": "^12.0.0",
         "highlight.js": "^11.11.1",
-        "ink": "npm:@jrichman/ink@6.6.7",
+        "ink": "npm:@jrichman/ink@6.6.8",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "latest-version": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.6.7",
+    "ink": "npm:@jrichman/ink@6.6.8",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"
@@ -137,7 +137,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ink": "npm:@jrichman/ink@6.6.7",
+    "ink": "npm:@jrichman/ink@6.6.8",
     "latest-version": "^9.0.0",
     "node-fetch-native": "^1.6.7",
     "proper-lockfile": "^4.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "fzf": "^0.5.2",
     "glob": "^12.0.0",
     "highlight.js": "^11.11.1",
-    "ink": "npm:@jrichman/ink@6.6.7",
+    "ink": "npm:@jrichman/ink@6.6.8",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "latest-version": "^9.0.0",


### PR DESCRIPTION
## Summary

Update ink version. 
Fixes some memory and performance issues.