### PR TITLE
feat(plan): require user confirmation for activate_skill in Plan Mode

### DIFF
--- a/packages/core/src/policy/policies/plan.toml
+++ b/packages/core/src/policy/policies/plan.toml
@@ -80,13 +80,6 @@ priority = 40
 modes = ["plan"]
 denyMessage = "You are in Plan Mode with access to read-only tools. Execution of scripts (including those from skills) is blocked."
 
-# Explicitly Allow Read-Only Tools in Plan mode.
-[[rule]]
-toolName = ["activate_skill"]
-decision = "allow"
-priority = 50
-modes = ["plan"]
-
 [[rule]]
 toolName = "*"
 mcpName = "*"
@@ -106,14 +99,14 @@ modes = ["plan"]
 interactive = false
 
 [[rule]]
-toolName = ["ask_user", "save_memory", "web_fetch"]
+toolName = ["ask_user", "save_memory", "web_fetch", "activate_skill"]
 decision = "ask_user"
 priority = 50
 modes = ["plan"]
 interactive = true
 
 [[rule]]
-toolName = ["ask_user", "save_memory", "web_fetch"]
+toolName = ["ask_user", "save_memory", "web_fetch", "activate_skill"]
 decision = "deny"
 priority = 50
 modes = ["plan"]


### PR DESCRIPTION
## Summary

Hardens the Plan Mode policy by requiring explicit user confirmation before activating a skill.

## Details

Previously, `activate_skill` was explicitly allowed in Plan Mode. This PR removes that rule and includes `activate_skill` in the `ask_user` group for Plan Mode. This ensures that even though skills are generally safe, the user is notified and must confirm when a skill is being activated during the planning phase, as it may introduce new instructions or capabilities.

## Related Issues

https://github.com/google-gemini/gemini-cli/issues/24942

## How to Validate

1. Enter Plan Mode: `enter_plan_mode`
2. Try to activate a skill, for example: `activate_skill(name='test-expert')`
3. Verify that the CLI asks for confirmation instead of automatically activating the skill.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt