### PR TITLE
fix(cli): resolve Ghostty/raw-mode False Cancellation in oauth flow

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -357,7 +357,7 @@ async function initOauthClient(
       // Note that SIGINT might not get raised on Ctrl+C in raw mode
       // so we also need to look for Ctrl+C directly in stdin.
       stdinHandler = (data: Buffer) => {
-        if (data.includes(0x03)) {
+        if (data.length === 1 && data[0] === 0x03) {
           reject(
             new FatalCancellationError('Authentication cancelled by user.'),
           );


### PR DESCRIPTION
## Summary

The [`stdinHandler` in `oauth2.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/code_assist/oauth2.ts#L350) uses `data.includes(0x03)` to detect Ctrl+C during the OAuth browser flow. This checks if `0x03` (ETX) appears **anywhere** in an incoming stdin buffer.

When the CLI runs in raw mode (via Ink's TUI), every raw byte passes through unfiltered. Terminals like **Ghostty** and **VS Code terminal (WSL + Companion extension)** emit control/escape sequences during initialization or resize events that contain `0x03` as an embedded byte — not as an actual Ctrl+C keystroke — triggering a false-positive cancellation with the error `'cancelled by user'`.

## Related Issues

Fixes #24745

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
