### PR TITLE
fix(core): cap chat history at 1000 items to prevent unbounded memory growth

### DIFF
--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -83,7 +83,12 @@ export function useHistory({
             return prevHistory; // Don't add the duplicate
           }
         }
-        return [...prevHistory, newItem];
+        const newHistory = [...prevHistory, newItem];
+        // Enforce a hard limit of 1000 items to prevent unbounded memory growth
+        if (newHistory.length > 1000) {
+          return newHistory.slice(newHistory.length - 1000);
+        }
+        return newHistory;
       });
 
       // Record UI-specific messages, but don't do it if we're actually loading

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -577,6 +577,12 @@ export class ChatRecordingService {
   ) {
     const conversation = this.readConversation();
     updateFn(conversation);
+    // Enforce a hard limit of 1000 items to prevent unbounded memory and file growth
+    if (conversation.messages.length > 1000) {
+      conversation.messages = conversation.messages.slice(
+        conversation.messages.length - 1000,
+      );
+    }
     this.writeConversation(conversation);
   }
 


### PR DESCRIPTION
## Summary

Addresses a memory leak caused by unbounded growth of the chat history and recording service by capping the history array at 1000 items.

## Details

`ChatRecordingService` was holding ~350MB on its own because the `historyManager` array grew indefinitely without any truncation mechanism. The fix enforces a hard limit of 1000 items via an LRU-style slice in `useHistoryManager.ts` and `chatRecordingService.ts`.

*This is 2 of 4 atomic PRs split from the monolithic memory leak PR #24963.*

## Related Issues

<!-- Fixes #... -->

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker