### PR TITLE
fix(cli): stabilize resetFileSearchState closure in useAtCompletion

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer, useRef, useCallback } from 'react';
 import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 import * as path from 'node:path';
 import {
@@ -224,15 +224,15 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
     setIsLoadingSuggestions(state.isLoading);
   }, [state.isLoading, setIsLoadingSuggestions]);
 
-  const resetFileSearchState = () => {
+  const resetFileSearchState = useCallback(() => {
     fileSearchMap.current.clear();
     initEpoch.current += 1;
     dispatch({ type: 'RESET' });
-  };
+  }, []);
 
   useEffect(() => {
     resetFileSearchState();
-  }, [cwd, config]);
+  }, [cwd, config, resetFileSearchState]);
 
   useEffect(() => {
     const workspaceContext = config?.getWorkspaceContext?.();
@@ -242,7 +242,7 @@ export function useAtCompletion(props: UseAtCompletionProps): void {
       workspaceContext.onDirectoriesChanged(resetFileSearchState);
 
     return unsubscribe;
-  }, [config]);
+  }, [config, resetFileSearchState]);
 
   // Reacts to user input (`pattern`) ONLY.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Stabilizes the `resetFileSearchState` closure in `useAtCompletion` to prevent stale React Fiber nodes from being kept alive in memory.

## Details

In `useAtCompletion.ts`, `resetFileSearchState` captured an initial stale closure to the Ink/React FiberNodes and held it forever in the global workspace context event listener. Wrapping the function in `useCallback` ensures a stable, non-stale closure.

*This is 4 of 4 atomic PRs split from the monolithic memory leak PR #24963.*

## Related Issues

<!-- Fixes #... -->

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker