### PR TITLE
fix(cli): restore file path display in edit and write tool confirmations

### DIFF
--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
@@ -14,7 +14,8 @@
     <text x="0" y="19" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</text>
     <text x="0" y="53" fill="#333333" textLength="891" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────────╮</text>
     <text x="0" y="70" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="70" fill="#ffffaf" textLength="54" lengthAdjust="spacingAndGlyphs" font-weight="bold">? Edit</text>
+    <text x="18" y="70" fill="#ffffaf" textLength="63" lengthAdjust="spacingAndGlyphs" font-weight="bold">? Edit </text>
+    <text x="81" y="70" fill="#ffffff" textLength="783" lengthAdjust="spacingAndGlyphs">packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =&gt;   return kittyProto…</text>
     <text x="882" y="70" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="0" y="87" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="87" fill="#333333" textLength="855" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────╮</text>

--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Full Terminal Tool Confirmation Snapshot > renders tool confirmation bo
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ? Edit                                                                                          │
+│ ? Edit packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =>   return kittyProto…  │
 │ ╭─────────────────────────────────────────────────────────────────────────────────────────────╮ │
 │ │ ... first 42 lines hidden (Ctrl+O to show) ...                                              │ │
 │ │ 43   const line43 = true;                                                                   │ │

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
@@ -66,6 +66,44 @@ describe('ToolConfirmationQueue', () => {
     vi.clearAllMocks();
   });
 
+  it('explicitly renders the tool description (containing filename) for edit confirmations', async () => {
+    const confirmingTool = {
+      tool: {
+        callId: 'call-1',
+        name: 'Edit',
+        description: 'Editing src/main.ts',
+        status: CoreToolCallStatus.AwaitingApproval,
+        confirmationDetails: {
+          type: 'edit' as const,
+          title: 'Confirm edit',
+          fileName: 'main.ts',
+          filePath: '/src/main.ts',
+          fileDiff: '--- a/main.ts\n+++ b/main.ts\n@@ -1 +1 @@\n-old\n+new',
+          originalContent: 'old',
+          newContent: 'new',
+        },
+      },
+      index: 1,
+      total: 1,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <ToolConfirmationQueue
+        confirmingTool={confirmingTool as unknown as ConfirmingToolState}
+      />,
+      {
+        config: mockConfig,
+        uiState: {
+          terminalWidth: 80,
+        },
+      },
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Editing src/main.ts');
+    unmount();
+  });
+
   it('renders the confirming tool with progress indicator', async () => {
     const confirmingTool = {
       tool: {

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -98,9 +98,9 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
           <Box flexDirection="row" flexShrink={1} overflow="hidden">
             <Text color={theme.status.warning} bold>
               ? {toolLabel}
-              {!isEdit && !!tool.description && '  '}
+              {!!tool.description && '  '}
             </Text>
-            {!isEdit && !!tool.description && (
+            {!!tool.description && (
               <Box flexShrink={1} overflow="hidden">
                 <Text color={theme.text.primary} wrap="truncate-end">
                   {tool.description}

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue-ToolConfirmationQueue-height-allocation-and-layout-should-render-the-full-queue-wrapper-with-borders-and-content-for-large-edit-diffs.snap.svg
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue-ToolConfirmationQueue-height-allocation-and-layout-should-render-the-full-queue-wrapper-with-borders-and-content-for-large-edit-diffs.snap.svg
@@ -6,7 +6,8 @@
   <g transform="translate(10, 10)">
     <text x="0" y="2" fill="#333333" textLength="720" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────╮</text>
     <text x="0" y="19" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="19" fill="#ffffaf" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">? replace</text>
+    <text x="18" y="19" fill="#ffffaf" textLength="99" lengthAdjust="spacingAndGlyphs" font-weight="bold">? replace  </text>
+    <text x="117" y="19" fill="#ffffff" textLength="234" lengthAdjust="spacingAndGlyphs">Replaces content in a file</text>
     <text x="711" y="19" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="0" y="36" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="36" fill="#333333" textLength="684" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────╮</text>

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ToolConfirmationQueue > calculates availableContentHeight based on availableTerminalHeight from UI state 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  edit file                                                         │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ ╰─... 48 hidden (Ctrl+O) ...───────────────────────────────────────────────╯ │
 │ Apply this change?                                                           │
@@ -17,7 +17,7 @@ exports[`ToolConfirmationQueue > calculates availableContentHeight based on avai
 
 exports[`ToolConfirmationQueue > does not render expansion hint when constrainHeight is false 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  edit file                                                         │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ │                                                                          │ │
 │ │  No changes detected.                                                    │ │
@@ -63,7 +63,7 @@ exports[`ToolConfirmationQueue > height allocation and layout > should handle se
 
 exports[`ToolConfirmationQueue > height allocation and layout > should render the full queue wrapper with borders and content for large edit diffs 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  Replaces content in a file                                        │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ │ ... 13 hidden (Ctrl+O) ...                                               │ │
 │ │  7 + const newLine7 = true;                                              │ │

--- a/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
@@ -34,6 +34,28 @@ describe('DenseToolMessage', () => {
     terminalWidth: 80,
   };
 
+  it('explicitly renders the filename in the header for FileDiff results', async () => {
+    const fileDiff: FileDiff = {
+      fileName: 'test-file.ts',
+      filePath: '/test-file.ts',
+      fileDiff:
+        '--- a/test-file.ts\n+++ b/test-file.ts\n@@ -1 +1 @@\n-old\n+new',
+      originalContent: 'old',
+      newContent: 'new',
+    };
+
+    const { lastFrame, waitUntilReady } = await renderWithProviders(
+      <DenseToolMessage
+        {...defaultProps}
+        name="Edit"
+        resultDisplay={fileDiff as unknown as ToolResultDisplay}
+      />,
+    );
+    await waitUntilReady();
+    const output = lastFrame();
+    expect(output).toContain('test-file.ts');
+  });
+
   it('renders correctly for a successful string result', async () => {
     const { lastFrame, waitUntilReady } = await renderWithProviders(
       <DenseToolMessage {...defaultProps} />,


### PR DESCRIPTION
## Summary

This PR fixes a UI regression where the target file path was missing from the `Edit` and `WriteFile` tool confirmation prompts. 

## Details

PR #24376 introduced a new UI layout for tool confirmations but suppressed the `tool.description` for tools using the `edit` confirmation type. Since `Edit` and `WriteFile` rely on their tool description to communicate the target file path (e.g., `✓ Edit src/main.ts`), this suppression caused only the generic tool name to be displayed, hiding crucial context from the user.

This change removes the `!isEdit` restriction in `ToolConfirmationQueue.tsx`, restoring the description visibility for edit tool confirmations. 

## Related Issues

Fixes #24936

## How to Validate

1. Start the CLI and run a command that triggers an edit, e.g., "Add a comment to the top of `packages/cli/src/nonInteractiveCli.ts`".
2. When prompted for confirmation, verify that the header displays the tool description, which includes the file path (e.g., `? Edit  packages/cli/src/nonInteractiveCli.ts`).
3. This should also work similarly for the `WriteFile` tool when creating a new file.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
