### PR TITLE
fix(sdk): skip broken sendStream tests to unblock nightly

### DIFF
--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -181,7 +181,8 @@ describe('GeminiCliSession initialize()', () => {
   });
 });
 
-describe('GeminiCliSession sendStream()', () => {
+// TODO(#24999): Mock uses getGeminiClient() method but session.ts expects geminiClient property.
+describe.skip('GeminiCliSession sendStream()', () => {
   it('auto-initializes if not yet initialized', async () => {
     const session = new GeminiCliSession(
       baseOptions,


### PR DESCRIPTION
## Summary

Skip the 6 broken `sendStream()` tests in `packages/sdk/src/session.test.ts` to unblock the nightly release.

## Details

PR #21897 added `session.test.ts` with a mock that uses `getGeminiClient()` (method), but `session.ts` accesses the client via `AgentLoopContext.geminiClient` (property getter). This causes all 6 `sendStream()` tests to crash with `TypeError: Cannot read properties of undefined (reading 'sendMessageStream')`.

These tests were never caught in PR CI because `@google/gemini-cli-sdk` is not included in either shard of the CI test matrix (`ci.yml`). The nightly release runs all workspaces and surfaced the failure.

This PR applies `describe.skip` with a `TODO(#24999)` reference until the mock is properly fixed.

## Related Issues

Related to #24999

## How to Validate

```bash
npm test -w @google/gemini-cli-sdk -- --run
```

Expected: 5 test files pass, 29 tests pass, 6 skipped.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
