### PR TITLE
Move sandbox manager tests to use a test directory and to clean up after

### DIFF
--- a/packages/core/src/services/sandboxManager.integration.test.ts
+++ b/packages/core/src/services/sandboxManager.integration.test.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -9,6 +9,7 @@ import { ShellExecutionService } from './shellExecutionService.js';
 import { getSecureSanitizationConfig } from './environmentSanitization.js';
 import {
   type SandboxedCommand,
+  type SandboxManager,
   NoopSandboxManager,
   LocalSandboxManager,
 } from './sandboxManager.js';
@@ -143,16 +144,27 @@ function ensureSandboxAvailable(): boolean {
 }
 
 describe('SandboxManager Integration', () => {
-  const workspace = process.cwd();
-  const manager = createSandboxManager({ enabled: true }, { workspace });
+  let workspace: string;
+  let manager: SandboxManager;
+
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-integration-'));
+    manager = createSandboxManager({ enabled: true }, { workspace });
+  });
+
+  afterAll(() => {
+    if (workspace && fs.existsSync(workspace)) {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
 
   // Skip if we are on an unsupported platform or if it's a NoopSandboxManager
-  const shouldSkip =
+  const shouldSkip = () =>
     manager instanceof NoopSandboxManager ||
     manager instanceof LocalSandboxManager ||
     !ensureSandboxAvailable();
 
-  describe.skipIf(shouldSkip)('Cross-platform Sandbox Behavior', () => {
+  describe.skipIf(shouldSkip())('Cross-platform Sandbox Behavior', () => {
     describe('Basic Execution', () => {
       it('executes commands within the workspace', async () => {
         const { command, args } = Platform.echo('sandbox test');


### PR DESCRIPTION
## Summary
Modifies the sandbox manager tests to use a temporary test directory and cleanup afterwards.

## Details
This fixes the issue where the sandbox manager integration tests are orphaning files packages/core/.gitignore and packages/core/.geminiignore during a test run.

## Related Issues
Fixes #25003

## How to Validate
`npm run test` without change will result in these files.
`npm run test` with this change will no longer drop these files.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
