### PR TITLE
fix(commands): ignore empty GEMINI.md to allow re-initialization

### DIFF
--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -9,15 +9,18 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { initCommand } from './initCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-import type { CommandContext } from './types.js';
+import type { CommandContext, SlashCommandActionReturn } from './types.js';
 import type { SubmitPromptActionReturn } from '@google/gemini-cli-core';
 
 // Mock the 'fs' module
-vi.mock('fs', async (importOriginal) => {
+vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
     ...actual,
-    existsSync: vi.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+    },
     writeFileSync: vi.fn(),
   };
 });
@@ -45,27 +48,11 @@ describe('initCommand', () => {
     vi.clearAllMocks();
   });
 
-  it('should inform the user if GEMINI.md already exists', async () => {
-    // Arrange: Simulate that the file exists
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    // Act: Run the command's action
-    const result = await initCommand.action!(mockContext, '');
-
-    // Assert: Check for the correct informational message
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'info',
-      content:
-        'A GEMINI.md file already exists in this directory. No changes were made.',
-    });
-    // Assert: Ensure no file was written
-    expect(fs.writeFileSync).not.toHaveBeenCalled();
-  });
-
   it('should create GEMINI.md and submit a prompt if it does not exist', async () => {
-    // Arrange: Simulate that the file does not exist
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+    // Arrange: Simulate that the file does not exist (ENOENT error)
+    vi.mocked(fs.promises.readFile).mockRejectedValueOnce({
+      code: 'ENOENT',
+    } as NodeJS.ErrnoException);
 
     // Act: Run the command's action
     const result = (await initCommand.action!(
@@ -92,6 +79,48 @@ describe('initCommand', () => {
     );
   });
 
+  it('should return a message if GEMINI.md already exists with content', async () => {
+    // Arrange: Simulate that the file exists with content
+    const existingContent =
+      '# Gemini Configuration\nSome existing configuration';
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce(existingContent);
+
+    // Act: Run the command's action
+    const result = (await initCommand.action!(
+      mockContext,
+      '',
+    )) as SlashCommandActionReturn;
+
+    // Assert: Check that writeFileSync was NOT called
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+    // Assert: Check that a message is returned (not a prompt submission)
+    expect(result.type).toBe('message');
+    if (result.type === 'message') {
+      expect(result.messageType).toBe('info');
+      expect(result.content).toBe(
+        'A GEMINI.md file already exists in this directory. No changes were made.',
+      );
+    }
+  });
+
+  it('should create GEMINI.md if it exists but is empty', async () => {
+    // Arrange: Simulate that the file exists but is empty
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce('   \n  ');
+
+    // Act: Run the command's action
+    const result = (await initCommand.action!(
+      mockContext,
+      '',
+    )) as SubmitPromptActionReturn;
+
+    // Assert: Check that writeFileSync was called correctly
+    expect(fs.writeFileSync).toHaveBeenCalledWith(geminiMdPath, '', 'utf8');
+
+    // Assert: Check that the correct prompt is submitted
+    expect(result.type).toBe('submit_prompt');
+  });
+
   it('should return an error if config is not available', async () => {
     // Arrange: Create a context without config
     const noConfigContext = createMockCommandContext();
@@ -108,5 +137,24 @@ describe('initCommand', () => {
       messageType: 'error',
       content: 'Configuration not available.',
     });
+  });
+
+  it('should return an error if reading GEMINI.md fails for reasons other than ENOENT', async () => {
+    // Arrange: Simulate a read error (permission denied, etc.)
+    const readError = new Error('Permission denied');
+    (readError as NodeJS.ErrnoException).code = 'EACCES';
+    vi.mocked(fs.promises.readFile).mockRejectedValueOnce(readError);
+
+    // Act: Run the command's action
+    const result = await initCommand.action!(mockContext, '');
+
+    // Assert: Check for the correct error message
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Failed to read GEMINI.md: Permission denied',
+    });
+    // Assert: Ensure no file was written
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -38,13 +38,14 @@ export const initCommand: SlashCommand = {
       const content = await fs.promises.readFile(geminiMdPath, 'utf8');
       fileHasContent = content.trim().length > 0;
     } catch (e) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const error = e as NodeJS.ErrnoException;
-      if (error.code !== 'ENOENT') {
+      if (
+        e instanceof Error &&
+        (e as NodeJS.ErrnoException).code !== 'ENOENT'
+      ) {
         return {
           type: 'message',
           messageType: 'error',
-          content: `Failed to read GEMINI.md: ${error.message}`,
+          content: `Failed to read GEMINI.md: ${e.message}`,
         };
       }
     }

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -33,7 +33,22 @@ export const initCommand: SlashCommand = {
     const targetDir = context.services.agentContext.config.getTargetDir();
     const geminiMdPath = path.join(targetDir, 'GEMINI.md');
 
-    const result = performInit(fs.existsSync(geminiMdPath));
+    let fileHasContent = false;
+    try {
+      const content = await fs.promises.readFile(geminiMdPath, 'utf8');
+      fileHasContent = content.trim().length > 0;
+    } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const error = e as NodeJS.ErrnoException;
+      if (error.code !== 'ENOENT') {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Failed to read GEMINI.md: ${error.message}`,
+        };
+      }
+    }
+    const result = performInit(fileHasContent);
 
     if (result.type === 'submit_prompt') {
       // Create an empty GEMINI.md file


### PR DESCRIPTION
## Summary

The `/init` command was blocked from re-running if a `GEMINI.md` file existed but was empty — a common state left behind when a previous `/init` was cancelled mid-way. This fix changes the check from file existence to file content, so an empty `GEMINI.md` is treated the same as no file at all.

## Details

Previously, `/init` created an empty `GEMINI.md` before starting the LLM analysis. If the process was cancelled or failed mid-way, this empty file was left behind — permanently blocking re-initialization since the check only tested for file existence, not content.

The fix changes the check from `fs.existsSync()` to also read the file content, so `/init` only blocks if `GEMINI.md` exists AND has non-whitespace content. An empty file is now treated the same as no file.

A new test case was added to cover the empty file scenario.

## Related Issues

Fixes #22757 

## How to Validate

1. Create a dummy project directory: `mkdir /tmp/g-cli-test && cd /tmp/g-cli-test`
2. Simulate a failed `/init`: touch `GEMINI.md`
3. Run `gemini` and type `/init`
4. Expected: `init` proceeds with analysis (not blocked)
5. Also verify: a non-empty `GEMINI.md` still blocks re-initialization

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [X] Linux
    - [X] npm run
    - [ ] npx
    - [ ] Docker