### PR TITLE
feature: allow absolute path for macos seatbelt profiles (sandbox)

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -335,6 +335,8 @@ jobs:
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           GEMINI_MODEL: 'gemini-3-pro-preview'
+          # Only run always passes behavioral tests.
+          EVAL_SUITE_TYPE: 'behavioral'
           # Disable Vitest internal retries to avoid double-retrying;
           # custom retry logic is handled in evals/test-helper.ts
           VITEST_RETRY: 0

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -5,10 +5,18 @@ on:
     - cron: '0 1 * * *' # Runs at 1 AM every day
   workflow_dispatch:
     inputs:
-      run_all:
-        description: 'Run all evaluations (including usually passing)'
-        type: 'boolean'
-        default: true
+      suite_type:
+        description: 'Suite type to run'
+        type: 'choice'
+        options:
+          - 'behavioral'
+          - 'component-level'
+          - 'hero-scenario'
+        default: 'behavioral'
+      suite_name:
+        description: 'Specific suite name to run'
+        required: false
+        type: 'string'
       test_name_pattern:
         description: 'Test name pattern or file name'
         required: false
@@ -59,7 +67,9 @@ jobs:
         env:
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
           GEMINI_MODEL: '${{ matrix.model }}'
-          RUN_EVALS: "${{ github.event.inputs.run_all != 'false' }}"
+          RUN_EVALS: 'true'
+          EVAL_SUITE_TYPE: "${{ github.event.inputs.suite_type || 'behavioral' }}"
+          EVAL_SUITE_NAME: '${{ github.event.inputs.suite_name }}'
           TEST_NAME_PATTERN: '${{ github.event.inputs.test_name_pattern }}'
           # Disable Vitest internal retries to avoid double-retrying;
           # custom retry logic is handled in evals/test-helper.ts

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -153,9 +153,9 @@ they appear in the UI.
 
 ### Advanced
 
-| UI Label                          | Setting                        | Description                                   | Default |
-| --------------------------------- | ------------------------------ | --------------------------------------------- | ------- |
-| Auto Configure Max Old Space Size | `advanced.autoConfigureMemory` | Automatically configure Node.js memory limits | `true`  |
+| UI Label                          | Setting                        | Description                                                                                                                                                                                                           | Default |
+| --------------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Auto Configure Max Old Space Size | `advanced.autoConfigureMemory` | Automatically configure Node.js memory limits. Note: Because memory is allocated during the initial process boot, this setting is only read from the global user settings file and ignores workspace-level overrides. | `true`  |
 
 ### Experimental
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1578,7 +1578,10 @@ their corresponding top-level category object in your `settings.json` file.
 #### `advanced`
 
 - **`advanced.autoConfigureMemory`** (boolean):
-  - **Description:** Automatically configure Node.js memory limits
+  - **Description:** Automatically configure Node.js memory limits. Note:
+    Because memory is allocated during the initial process boot, this setting is
+    only read from the global user settings file and ignores workspace-level
+    overrides.
   - **Default:** `true`
   - **Requires restart:** Yes
 

--- a/evals/answer-vs-act.eval.ts
+++ b/evals/answer-vs-act.eval.ts
@@ -19,6 +19,8 @@ describe('Answer vs. ask eval', () => {
    * automatically modify the file, but instead asks for permission.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not edit files when asked to inspect for bugs',
     prompt: 'Inspect app.ts for bugs',
     files: FILES,
@@ -42,6 +44,8 @@ describe('Answer vs. ask eval', () => {
    * does modify the file.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should edit files when asked to fix bug',
     prompt: 'Fix the bug in app.ts - it should add numbers not subtract',
     files: FILES,
@@ -66,6 +70,8 @@ describe('Answer vs. ask eval', () => {
    * automatically modify the file, but instead asks for permission.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not edit when asking "any bugs"',
     prompt: 'Any bugs in app.ts?',
     files: FILES,
@@ -89,6 +95,8 @@ describe('Answer vs. ask eval', () => {
    * automatically modify the file.
    */
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not edit files when asked a general question',
     prompt: 'How does app.ts work?',
     files: FILES,
@@ -112,6 +120,8 @@ describe('Answer vs. ask eval', () => {
    * automatically modify the file.
    */
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not edit files when asked about style',
     prompt: 'Is app.ts following good style?',
     files: FILES,
@@ -135,6 +145,8 @@ describe('Answer vs. ask eval', () => {
    * the agent does NOT automatically modify the file.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not edit files when user notes an issue',
     prompt: 'The add function subtracts numbers.',
     files: FILES,

--- a/evals/app-test-helper.ts
+++ b/evals/app-test-helper.ts
@@ -10,10 +10,13 @@ import {
   runEval,
   prepareLogDir,
   symlinkNodeModules,
+  withEvalRetries,
+  prepareWorkspace,
+  type BaseEvalCase,
+  EVAL_MODEL,
 } from './test-helper.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import { DEFAULT_GEMINI_MODEL } from '@google/gemini-cli-core';
 
 /**
  * Config overrides for evals, with tool-restriction fields explicitly
@@ -29,15 +32,13 @@ interface EvalConfigOverrides {
   allowedTools?: never;
   /** Restricting tools via mainAgentTools in evals is forbidden. */
   mainAgentTools?: never;
+
   [key: string]: unknown;
 }
 
-export interface AppEvalCase {
-  name: string;
+export interface AppEvalCase extends BaseEvalCase {
   configOverrides?: EvalConfigOverrides;
   prompt: string;
-  timeout?: number;
-  files?: Record<string, string>;
   setup?: (rig: AppRig) => Promise<void>;
   assert: (rig: AppRig, output: string) => Promise<void>;
 }
@@ -48,56 +49,55 @@ export interface AppEvalCase {
  */
 export function appEvalTest(policy: EvalPolicy, evalCase: AppEvalCase) {
   const fn = async () => {
-    const rig = new AppRig({
-      configOverrides: {
-        model: DEFAULT_GEMINI_MODEL,
-        ...evalCase.configOverrides,
-      },
-    });
+    await withEvalRetries(evalCase.name, async () => {
+      const rig = new AppRig({
+        configOverrides: {
+          model: EVAL_MODEL,
+          ...evalCase.configOverrides,
+        },
+      });
 
-    const { logDir, sanitizedName } = await prepareLogDir(evalCase.name);
-    const logFile = path.join(logDir, `${sanitizedName}.log`);
+      const { logDir, sanitizedName } = await prepareLogDir(evalCase.name);
+      const logFile = path.join(logDir, `${sanitizedName}.log`);
 
-    try {
-      await rig.initialize();
+      try {
+        await rig.initialize();
 
-      const testDir = rig.getTestDir();
-      symlinkNodeModules(testDir);
+        const testDir = rig.getTestDir();
+        symlinkNodeModules(testDir);
 
-      // Setup initial files
-      if (evalCase.files) {
-        for (const [filePath, content] of Object.entries(evalCase.files)) {
-          const fullPath = path.join(testDir, filePath);
-          fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-          fs.writeFileSync(fullPath, content);
+        // Setup initial files
+        if (evalCase.files) {
+          // Note: AppRig does not use a separate homeDir, so we use testDir twice
+          await prepareWorkspace(testDir, testDir, evalCase.files);
         }
+
+        // Run custom setup if provided (e.g. for breakpoints)
+        if (evalCase.setup) {
+          await evalCase.setup(rig);
+        }
+
+        // Render the app!
+        await rig.render();
+
+        // Wait for initial ready state
+        await rig.waitForIdle();
+
+        // Send the initial prompt
+        await rig.sendMessage(evalCase.prompt);
+
+        // Run assertion. Interaction-heavy tests can do their own waiting/steering here.
+        const output = rig.getStaticOutput();
+        await evalCase.assert(rig, output);
+      } finally {
+        const output = rig.getStaticOutput();
+        if (output) {
+          await fs.promises.writeFile(logFile, output);
+        }
+        await rig.unmount();
       }
-
-      // Run custom setup if provided (e.g. for breakpoints)
-      if (evalCase.setup) {
-        await evalCase.setup(rig);
-      }
-
-      // Render the app!
-      await rig.render();
-
-      // Wait for initial ready state
-      await rig.waitForIdle();
-
-      // Send the initial prompt
-      await rig.sendMessage(evalCase.prompt);
-
-      // Run assertion. Interaction-heavy tests can do their own waiting/steering here.
-      const output = rig.getStaticOutput();
-      await evalCase.assert(rig, output);
-    } finally {
-      const output = rig.getStaticOutput();
-      if (output) {
-        await fs.promises.writeFile(logFile, output);
-      }
-      await rig.unmount();
-    }
+    });
   };
 
-  runEval(policy, evalCase.name, fn, (evalCase.timeout ?? 60000) + 10000);
+  runEval(policy, evalCase, fn, (evalCase.timeout ?? 60000) + 10000);
 }

--- a/evals/ask_user.eval.ts
+++ b/evals/ask_user.eval.ts
@@ -5,17 +5,21 @@
  */
 
 import { describe, expect } from 'vitest';
-import { appEvalTest, AppEvalCase } from './app-test-helper.js';
-import { EvalPolicy } from './test-helper.js';
+import { ApprovalMode, isRecord } from '@google/gemini-cli-core';
+import { appEvalTest, type AppEvalCase } from './app-test-helper.js';
+import { type EvalPolicy } from './test-helper.js';
 
 function askUserEvalTest(policy: EvalPolicy, evalCase: AppEvalCase) {
+  const existingGeneral = evalCase.configOverrides?.['general'];
+  const generalBase = isRecord(existingGeneral) ? existingGeneral : {};
+
   return appEvalTest(policy, {
     ...evalCase,
     configOverrides: {
       ...evalCase.configOverrides,
+      approvalMode: ApprovalMode.DEFAULT,
       general: {
-        ...evalCase.configOverrides?.general,
-        approvalMode: 'default',
+        ...generalBase,
         enableAutoUpdate: false,
         enableAutoUpdateNotification: false,
       },
@@ -28,6 +32,8 @@ function askUserEvalTest(policy: EvalPolicy, evalCase: AppEvalCase) {
 
 describe('ask_user', () => {
   askUserEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Agent uses AskUser tool to present multiple choice options',
     prompt: `Use the ask_user tool to ask me what my favorite color is. Provide 3 options: red, green, or blue.`,
     setup: async (rig) => {
@@ -43,6 +49,8 @@ describe('ask_user', () => {
   });
 
   askUserEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Agent uses AskUser tool to clarify ambiguous requirements',
     files: {
       'package.json': JSON.stringify({ name: 'my-app', version: '1.0.0' }),
@@ -61,6 +69,8 @@ describe('ask_user', () => {
   });
 
   askUserEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Agent uses AskUser tool before performing significant ambiguous rework',
     files: {
       'packages/core/src/index.ts': '// index\nexport const version = "1.0.0";',
@@ -82,8 +92,8 @@ describe('ask_user', () => {
       ]);
       expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
 
-      if (confirmation?.name === 'enter_plan_mode') {
-        rig.acceptConfirmation('enter_plan_mode');
+      if (confirmation?.toolName === 'enter_plan_mode') {
+        await rig.resolveTool('enter_plan_mode');
         confirmation = await rig.waitForPendingConfirmation('ask_user');
       }
 
@@ -101,6 +111,8 @@ describe('ask_user', () => {
   // updates to clarify that shell command confirmation is handled by the UI.
   // See fix: https://github.com/google-gemini/gemini-cli/pull/20504
   askUserEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Agent does NOT use AskUser to confirm shell commands',
     files: {
       'package.json': JSON.stringify({

--- a/evals/automated-tool-use.eval.ts
+++ b/evals/automated-tool-use.eval.ts
@@ -14,6 +14,8 @@ describe('Automated tool use', () => {
    * a repro by guiding the agent into using the existing deficient script.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use automated tools (eslint --fix) to fix code style issues',
     files: {
       'package.json': JSON.stringify(
@@ -102,6 +104,8 @@ describe('Automated tool use', () => {
    * instead of trying to edit the files itself.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use automated tools (prettier --write) to fix formatting issues',
     files: {
       'package.json': JSON.stringify(

--- a/evals/cli_help_delegation.eval.ts
+++ b/evals/cli_help_delegation.eval.ts
@@ -3,6 +3,8 @@ import { evalTest } from './test-helper.js';
 
 describe('CliHelpAgent Delegation', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should delegate to cli_help agent for subagent creation questions',
     params: {
       settings: {

--- a/evals/component-test-helper.ts
+++ b/evals/component-test-helper.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type EvalPolicy,
+  runEval,
+  prepareLogDir,
+  withEvalRetries,
+  prepareWorkspace,
+  type BaseEvalCase,
+} from './test-helper.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import {
+  Config,
+  type ConfigParameters,
+  AuthType,
+  ApprovalMode,
+  createPolicyEngineConfig,
+  ExtensionLoader,
+  IntegrityDataStatus,
+  makeFakeConfig,
+  type GeminiCLIExtension,
+} from '@google/gemini-cli-core';
+import { createMockSettings } from '../packages/cli/src/test-utils/settings.js';
+
+// A minimal mock ExtensionManager to bypass integrity checks
+class MockExtensionManager extends ExtensionLoader {
+  override getExtensions(): GeminiCLIExtension[] {
+    return [];
+  }
+  setRequestConsent = (): void => {};
+  setRequestSetting = (): void => {};
+  integrityManager = {
+    verifyExtensionIntegrity: async (): Promise<IntegrityDataStatus> =>
+      IntegrityDataStatus.VERIFIED,
+    storeExtensionIntegrity: async (): Promise<void> => undefined,
+  };
+}
+
+export interface ComponentEvalCase extends BaseEvalCase {
+  configOverrides?: Partial<ConfigParameters>;
+  setup?: (config: Config) => Promise<void>;
+  assert: (config: Config) => Promise<void>;
+}
+
+export class ComponentRig {
+  public config: Config | undefined;
+  public testDir: string;
+  public sessionId: string;
+
+  constructor(
+    private options: { configOverrides?: Partial<ConfigParameters> } = {},
+  ) {
+    const uniqueId = randomUUID();
+    this.testDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `gemini-component-rig-${uniqueId.slice(0, 8)}-`),
+    );
+    this.sessionId = `test-session-${uniqueId}`;
+  }
+
+  async initialize() {
+    const settings = createMockSettings();
+    const policyEngineConfig = await createPolicyEngineConfig(
+      settings.merged,
+      ApprovalMode.DEFAULT,
+    );
+
+    const configParams: ConfigParameters = {
+      sessionId: this.sessionId,
+      targetDir: this.testDir,
+      cwd: this.testDir,
+      debugMode: false,
+      model: 'test-model',
+      interactive: false,
+      approvalMode: ApprovalMode.DEFAULT,
+      policyEngineConfig,
+      enableEventDrivenScheduler: false, // Don't need scheduler for direct component tests
+      extensionLoader: new MockExtensionManager(),
+      useAlternateBuffer: false,
+      ...this.options.configOverrides,
+    };
+
+    this.config = makeFakeConfig(configParams);
+    await this.config.initialize();
+
+    // Refresh auth using USE_GEMINI to initialize the real BaseLlmClient
+    await this.config.refreshAuth(AuthType.USE_GEMINI);
+  }
+
+  async cleanup() {
+    fs.rmSync(this.testDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A helper for running behavioral evaluations directly against backend components.
+ * It provides a fully initialized Config with real API access, bypassing the UI.
+ */
+export function componentEvalTest(
+  policy: EvalPolicy,
+  evalCase: ComponentEvalCase,
+) {
+  const fn = async () => {
+    await withEvalRetries(evalCase.name, async () => {
+      const rig = new ComponentRig({
+        configOverrides: evalCase.configOverrides,
+      });
+
+      await prepareLogDir(evalCase.name);
+
+      try {
+        await rig.initialize();
+
+        if (evalCase.files) {
+          await prepareWorkspace(rig.testDir, rig.testDir, evalCase.files);
+        }
+
+        if (evalCase.setup) {
+          await evalCase.setup(rig.config!);
+        }
+
+        await evalCase.assert(rig.config!);
+      } finally {
+        await rig.cleanup();
+      }
+    });
+  };
+
+  runEval(policy, evalCase, fn, (evalCase.timeout ?? 60000) + 10000);
+}

--- a/evals/concurrency-safety.eval.ts
+++ b/evals/concurrency-safety.eval.ts
@@ -20,6 +20,8 @@ You are the mutation agent. Do the mutation requested.
 
 describe('concurrency safety eval test cases', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'mutation agents are run in parallel when explicitly requested',
     params: {
       settings: {

--- a/evals/edit-locations-eval.eval.ts
+++ b/evals/edit-locations-eval.eval.ts
@@ -13,6 +13,8 @@ describe('Edits location eval', () => {
    * instead of creating a new one.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should update existing test file instead of creating a new one',
     files: {
       'package.json': JSON.stringify(

--- a/evals/frugalReads.eval.ts
+++ b/evals/frugalReads.eval.ts
@@ -15,6 +15,8 @@ describe('Frugal reads eval', () => {
    * nearby ranges into a single contiguous read to save tool calls.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use ranged read when nearby lines are targeted',
     files: {
       'package.json': JSON.stringify({
@@ -135,6 +137,8 @@ describe('Frugal reads eval', () => {
    * apart to avoid the need to read the whole file.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use ranged read when targets are far apart',
     files: {
       'package.json': JSON.stringify({
@@ -204,6 +208,8 @@ describe('Frugal reads eval', () => {
    * (e.g.: 10), as it's more efficient than many small ranged reads.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should read the entire file when there are many matches',
     files: {
       'package.json': JSON.stringify({

--- a/evals/frugalSearch.eval.ts
+++ b/evals/frugalSearch.eval.ts
@@ -13,18 +13,6 @@ import { evalTest } from './test-helper.js';
  * This ensures the agent doesn't flood the context window with unnecessary search results.
  */
 describe('Frugal Search', () => {
-  const getGrepParams = (call: any): any => {
-    let args = call.toolRequest.args;
-    if (typeof args === 'string') {
-      try {
-        args = JSON.parse(args);
-      } catch (e) {
-        // Ignore parse errors
-      }
-    }
-    return args;
-  };
-
   /**
    * Ensure that the agent makes use of either grep or ranged reads in fulfilling this task.
    * The task is specifically phrased to not evoke "view" or "search" specifically because
@@ -33,6 +21,8 @@ describe('Frugal Search', () => {
    * ranged reads.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use grep or ranged read for large files',
     prompt: 'What year was legacy_processor.ts written?',
     files: {

--- a/evals/generalist_agent.eval.ts
+++ b/evals/generalist_agent.eval.ts
@@ -11,6 +11,8 @@ import fs from 'node:fs/promises';
 
 describe('generalist_agent', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should be able to use generalist agent by explicitly asking the main agent to invoke it',
     params: {
       settings: {

--- a/evals/generalist_delegation.eval.ts
+++ b/evals/generalist_delegation.eval.ts
@@ -11,6 +11,8 @@ describe('generalist_delegation', () => {
   // --- Positive Evals (Should Delegate) ---
 
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should delegate batch error fixing to generalist agent',
     configOverrides: {
       agents: {
@@ -54,6 +56,8 @@ describe('generalist_delegation', () => {
   });
 
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should autonomously delegate complex batch task to generalist agent',
     configOverrides: {
       agents: {
@@ -94,6 +98,8 @@ describe('generalist_delegation', () => {
   // --- Negative Evals (Should NOT Delegate - Assertive Handling) ---
 
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should NOT delegate simple read and fix to generalist agent',
     configOverrides: {
       agents: {
@@ -128,6 +134,8 @@ describe('generalist_delegation', () => {
   });
 
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should NOT delegate simple direct question to generalist agent',
     configOverrides: {
       agents: {

--- a/evals/gitRepo.eval.ts
+++ b/evals/gitRepo.eval.ts
@@ -26,6 +26,8 @@ describe('git repo eval', () => {
    * be more consistent.
    */
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not git add commit changes unprompted',
     prompt:
       'Finish this up for me by just making a targeted fix for the bug in index.ts. Do not build, install anything, or add tests',
@@ -55,6 +57,8 @@ describe('git repo eval', () => {
    * instructed to not do so by default.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should git commit changes when prompted',
     prompt:
       'Make a targeted fix for the bug in index.ts without building, installing anything, or adding tests. Then, commit your changes.',

--- a/evals/grep_search_functionality.eval.ts
+++ b/evals/grep_search_functionality.eval.ts
@@ -15,6 +15,8 @@ describe('grep_search_functionality', () => {
   const TEST_PREFIX = 'Grep Search Functionality: ';
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should find a simple string in a file',
     files: {
       'test.txt': `hello
@@ -33,6 +35,8 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should perform a case-sensitive search',
     files: {
       'test.txt': `Hello
@@ -63,6 +67,8 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should return only file names when names_only is used',
     files: {
       'file1.txt': 'match me',
@@ -93,6 +99,8 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should search only within the specified include_pattern glob',
     files: {
       'file.js': 'my_function();',
@@ -123,6 +131,8 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should search within a specific subdirectory',
     files: {
       'src/main.js': 'unique_string_1',
@@ -153,6 +163,8 @@ describe('grep_search_functionality', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should report no matches correctly',
     files: {
       'file.txt': 'nothing to see here',

--- a/evals/hierarchical_memory.eval.ts
+++ b/evals/hierarchical_memory.eval.ts
@@ -5,13 +5,14 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
-import { assertModelHasOutput } from '../integration-tests/test-helper.js';
+import { evalTest, assertModelHasOutput } from './test-helper.js';
 
 describe('Hierarchical Memory', () => {
   const conflictResolutionTest =
     'Agent follows hierarchy for contradictory instructions';
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: conflictResolutionTest,
     params: {
       settings: {
@@ -48,6 +49,8 @@ What is my favorite fruit? Tell me just the name of the fruit.`,
 
   const provenanceAwarenessTest = 'Agent is aware of memory provenance';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: provenanceAwarenessTest,
     params: {
       settings: {
@@ -87,6 +90,8 @@ Provide the answer as an XML block like this:
 
   const extensionVsGlobalTest = 'Extension memory wins over Global memory';
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: extensionVsGlobalTest,
     params: {
       settings: {

--- a/evals/interactive-hang.eval.ts
+++ b/evals/interactive-hang.eval.ts
@@ -8,6 +8,8 @@ describe('interactive_commands', () => {
    * intervention.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not use interactive commands',
     prompt: 'Execute tests.',
     files: {
@@ -49,6 +51,8 @@ describe('interactive_commands', () => {
    * Validates that the agent uses non-interactive flags when scaffolding a new project.
    */
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use non-interactive flags when scaffolding a new app',
     prompt: 'Create a new react application named my-app using vite.',
     assert: async (rig, result) => {

--- a/evals/model_steering.eval.ts
+++ b/evals/model_steering.eval.ts
@@ -5,14 +5,14 @@
  */
 
 import { describe, expect } from 'vitest';
-import { act } from 'react';
 import path from 'node:path';
 import fs from 'node:fs';
 import { appEvalTest } from './app-test-helper.js';
-import { PolicyDecision } from '@google/gemini-cli-core';
 
 describe('Model Steering Behavioral Evals', () => {
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Corrective Hint: Model switches task based on hint during tool turn',
     configOverrides: {
       modelSteering: true,
@@ -52,6 +52,8 @@ describe('Model Steering Behavioral Evals', () => {
   });
 
   appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'Suggestive Hint: Model incorporates user guidance mid-stream',
     configOverrides: {
       modelSteering: true,

--- a/evals/plan_mode.eval.ts
+++ b/evals/plan_mode.eval.ts
@@ -33,6 +33,8 @@ describe('plan_mode', () => {
       .filter(Boolean);
 
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should refuse file modification when in plan mode',
     approvalMode: ApprovalMode.PLAN,
     params: {
@@ -68,6 +70,8 @@ describe('plan_mode', () => {
   });
 
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should refuse saving new documentation to the repo when in plan mode',
     approvalMode: ApprovalMode.PLAN,
     params: {
@@ -105,6 +109,8 @@ describe('plan_mode', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should enter plan mode when asked to create a plan',
     approvalMode: ApprovalMode.DEFAULT,
     params: {
@@ -122,6 +128,8 @@ describe('plan_mode', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should exit plan mode when plan is complete and implementation is requested',
     approvalMode: ApprovalMode.PLAN,
     params: {
@@ -169,6 +177,8 @@ describe('plan_mode', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should allow file modification in plans directory when in plan mode',
     approvalMode: ApprovalMode.PLAN,
     params: {
@@ -201,6 +211,8 @@ describe('plan_mode', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should create a plan in plan mode and implement it for a refactoring task',
     params: {
       settings,

--- a/evals/redundant_casts.eval.ts
+++ b/evals/redundant_casts.eval.ts
@@ -11,6 +11,8 @@ import fs from 'node:fs/promises';
 
 describe('redundant_casts', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should not add redundant or unsafe casts when modifying typescript code',
     files: {
       'src/cast_example.ts': `

--- a/evals/sandbox_recovery.eval.ts
+++ b/evals/sandbox_recovery.eval.ts
@@ -3,6 +3,8 @@ import { evalTest } from './test-helper.js';
 
 describe('Sandbox recovery', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'attempts to use additional_permissions when operation not permitted',
     prompt:
       'Run ./script.sh. It will fail with "Operation not permitted". When it does, you must retry running it by passing the appropriate additional_permissions.',

--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -5,16 +5,18 @@
  */
 
 import { describe, expect } from 'vitest';
-import { evalTest } from './test-helper.js';
 import {
+  evalTest,
   assertModelHasOutput,
   checkModelOutputContent,
-} from '../integration-tests/test-helper.js';
+} from './test-helper.js';
 
 describe('save_memory', () => {
   const TEST_PREFIX = 'Save memory test: ';
   const rememberingFavoriteColor = "Agent remembers user's favorite color";
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingFavoriteColor,
 
     prompt: `remember that my favorite color is  blue.
@@ -35,6 +37,8 @@ describe('save_memory', () => {
   });
   const rememberingCommandRestrictions = 'Agent remembers command restrictions';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingCommandRestrictions,
 
     prompt: `I don't want you to ever run npm commands.`,
@@ -54,6 +58,8 @@ describe('save_memory', () => {
 
   const rememberingWorkflow = 'Agent remembers workflow preferences';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingWorkflow,
 
     prompt: `I want you to always lint after building.`,
@@ -74,6 +80,8 @@ describe('save_memory', () => {
   const ignoringTemporaryInformation =
     'Agent ignores temporary conversation details';
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: ignoringTemporaryInformation,
 
     prompt: `I'm going to get a coffee.`,
@@ -97,6 +105,8 @@ describe('save_memory', () => {
 
   const rememberingPetName = "Agent remembers user's pet's name";
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingPetName,
 
     prompt: `Please remember that my dog's name is Buddy.`,
@@ -116,6 +126,8 @@ describe('save_memory', () => {
 
   const rememberingCommandAlias = 'Agent remembers custom command aliases';
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingCommandAlias,
 
     prompt: `When I say 'start server', you should run 'npm run dev'.`,
@@ -136,6 +148,8 @@ describe('save_memory', () => {
   const ignoringDbSchemaLocation =
     "Agent ignores workspace's database schema location";
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: ignoringDbSchemaLocation,
     prompt: `The database schema for this workspace is located in \`db/schema.sql\`.`,
     assert: async (rig, result) => {
@@ -155,6 +169,8 @@ describe('save_memory', () => {
   const rememberingCodingStyle =
     "Agent remembers user's coding style preference";
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingCodingStyle,
 
     prompt: `I prefer to use tabs instead of spaces for indentation.`,
@@ -175,6 +191,8 @@ describe('save_memory', () => {
   const ignoringBuildArtifactLocation =
     'Agent ignores workspace build artifact location';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: ignoringBuildArtifactLocation,
     prompt: `In this workspace, build artifacts are stored in the \`dist/artifacts\` directory.`,
     assert: async (rig, result) => {
@@ -193,6 +211,8 @@ describe('save_memory', () => {
 
   const ignoringMainEntryPoint = "Agent ignores workspace's main entry point";
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: ignoringMainEntryPoint,
     prompt: `The main entry point for this workspace is \`src/index.js\`.`,
     assert: async (rig, result) => {
@@ -211,6 +231,8 @@ describe('save_memory', () => {
 
   const rememberingBirthday = "Agent remembers user's birthday";
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: rememberingBirthday,
 
     prompt: `My birthday is on June 15th.`,
@@ -231,6 +253,8 @@ describe('save_memory', () => {
   const proactiveMemoryFromLongSession =
     'Agent saves preference from earlier in conversation history';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: proactiveMemoryFromLongSession,
     params: {
       settings: {
@@ -309,6 +333,8 @@ describe('save_memory', () => {
   const memoryManagerRoutingPreferences =
     'Agent routes global and project preferences to memory';
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: memoryManagerRoutingPreferences,
     params: {
       settings: {

--- a/evals/shell-efficiency.eval.ts
+++ b/evals/shell-efficiency.eval.ts
@@ -21,6 +21,8 @@ describe('Shell Efficiency', () => {
   };
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use --silent/--quiet flags when installing packages',
     prompt: 'Install the "lodash" package using npm.',
     assert: async (rig) => {
@@ -50,6 +52,8 @@ describe('Shell Efficiency', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use --no-pager with git commands',
     prompt: 'Show the git log.',
     assert: async (rig) => {
@@ -73,6 +77,8 @@ describe('Shell Efficiency', () => {
   });
 
   evalTest('ALWAYS_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should NOT use efficiency flags when enableShellOutputEfficiency is disabled',
     params: {
       settings: {

--- a/evals/subagents.eval.ts
+++ b/evals/subagents.eval.ts
@@ -45,6 +45,8 @@ describe('subagent eval test cases', () => {
    * This tests the system prompt's subagent specific clauses.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should delegate to user provided agent with relevant expertise',
     params: {
       settings: {
@@ -69,6 +71,8 @@ describe('subagent eval test cases', () => {
    * subagents are available. This helps catch orchestration overuse.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should avoid delegating trivial direct edit work',
     params: {
       settings: {
@@ -113,6 +117,8 @@ describe('subagent eval test cases', () => {
    * This is meant to codify the "overusing Generalist" failure mode.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should prefer relevant specialist over generalist',
     params: {
       settings: {
@@ -149,6 +155,8 @@ describe('subagent eval test cases', () => {
    * naturally spans docs and tests, so multiple specialists should be used.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should use multiple relevant specialists for multi-surface task',
     params: {
       settings: {
@@ -193,6 +201,8 @@ describe('subagent eval test cases', () => {
    * from a large pool of available subagents (10 total).
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should select the correct subagent from a pool of 10 different agents',
     prompt: 'Please add a new SQL table migration for a user profile.',
     files: {
@@ -243,6 +253,8 @@ describe('subagent eval test cases', () => {
    * This test includes stress tests the subagent delegation with ~80 tools.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should select the correct subagent from a pool of 10 different agents with MCP tools present',
     prompt: 'Please add a new SQL table migration for a user profile.',
     setup: async (rig) => {

--- a/evals/test-helper.test.ts
+++ b/evals/test-helper.test.ts
@@ -49,6 +49,8 @@ describe('evalTest reliability logic', () => {
 
     // Execute the test function directly
     await internalEvalTest({
+      suiteName: 'test',
+      suiteType: 'behavioral',
       name: 'test-api-failure',
       prompt: 'do something',
       assert: async () => {},
@@ -83,6 +85,8 @@ describe('evalTest reliability logic', () => {
     // Expect the test function to throw immediately
     await expect(
       internalEvalTest({
+        suiteName: 'test',
+        suiteType: 'behavioral',
         name: 'test-logic-failure',
         prompt: 'do something',
         assert: async () => {
@@ -108,6 +112,8 @@ describe('evalTest reliability logic', () => {
       .mockResolvedValueOnce('Success');
 
     await internalEvalTest({
+      suiteName: 'test',
+      suiteType: 'behavioral',
       name: 'test-recovery',
       prompt: 'do something',
       assert: async () => {},
@@ -135,6 +141,8 @@ describe('evalTest reliability logic', () => {
     );
 
     await internalEvalTest({
+      suiteName: 'test',
+      suiteType: 'behavioral',
       name: 'test-api-503',
       prompt: 'do something',
       assert: async () => {},
@@ -162,6 +170,8 @@ describe('evalTest reliability logic', () => {
     try {
       await expect(
         internalEvalTest({
+          suiteName: 'test',
+          suiteType: 'behavioral',
           name: 'test-absolute-path',
           prompt: 'do something',
           files: {
@@ -190,6 +200,8 @@ describe('evalTest reliability logic', () => {
     try {
       await expect(
         internalEvalTest({
+          suiteName: 'test',
+          suiteType: 'behavioral',
           name: 'test-traversal',
           prompt: 'do something',
           files: {

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -16,9 +16,18 @@ import {
   Storage,
   getProjectHash,
   SESSION_FILE_PREFIX,
+  PREVIEW_GEMINI_FLASH_MODEL,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 
 export * from '@google/gemini-cli-test-utils';
+
+/**
+ * The default model used for all evaluations.
+ * Can be overridden by setting the GEMINI_MODEL environment variable.
+ */
+export const EVAL_MODEL =
+  process.env['GEMINI_MODEL'] || PREVIEW_GEMINI_FLASH_MODEL;
 
 // Indicates the consistency expectation for this test.
 // - ALWAYS_PASSES - Means that the test is expected to pass 100% of the time. These
@@ -39,19 +48,49 @@ export * from '@google/gemini-cli-test-utils';
 export type EvalPolicy = 'ALWAYS_PASSES' | 'USUALLY_PASSES';
 
 export function evalTest(policy: EvalPolicy, evalCase: EvalCase) {
-  runEval(
-    policy,
-    evalCase.name,
-    () => internalEvalTest(evalCase),
-    evalCase.timeout,
-  );
+  runEval(policy, evalCase, () => internalEvalTest(evalCase));
 }
 
-export async function internalEvalTest(evalCase: EvalCase) {
+export async function withEvalRetries(
+  name: string,
+  attemptFn: (attempt: number) => Promise<void>,
+) {
   const maxRetries = 3;
   let attempt = 0;
 
   while (attempt <= maxRetries) {
+    try {
+      await attemptFn(attempt);
+      return; // Success! Exit the retry loop.
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      const errorCode = getApiErrorCode(errorMessage);
+
+      if (errorCode) {
+        const status = attempt < maxRetries ? 'RETRY' : 'SKIP';
+        logReliabilityEvent(name, attempt, status, errorCode, errorMessage);
+
+        if (attempt < maxRetries) {
+          attempt++;
+          console.warn(
+            `[Eval] Attempt ${attempt} failed with ${errorCode} Error. Retrying...`,
+          );
+          continue; // Retry
+        }
+
+        console.warn(
+          `[Eval] '${name}' failed after ${maxRetries} retries due to persistent API errors. Skipping failure to avoid blocking PR.`,
+        );
+        return; // Gracefully exit without failing the test
+      }
+
+      throw error; // Real failure
+    }
+  }
+}
+
+export async function internalEvalTest(evalCase: EvalCase) {
+  await withEvalRetries(evalCase.name, async () => {
     const rig = new TestRig();
     const { logDir, sanitizedName } = await prepareLogDir(evalCase.name);
     const activityLogFile = path.join(logDir, `${sanitizedName}.jsonl`);
@@ -59,14 +98,21 @@ export async function internalEvalTest(evalCase: EvalCase) {
     let isSuccess = false;
 
     try {
-      rig.setup(evalCase.name, evalCase.params);
+      const setupOptions = {
+        ...evalCase.params,
+        settings: {
+          model: { name: EVAL_MODEL },
+          ...evalCase.params?.settings,
+        },
+      };
+      rig.setup(evalCase.name, setupOptions);
 
       if (evalCase.setup) {
         await evalCase.setup(rig);
       }
 
       if (evalCase.files) {
-        await setupTestFiles(rig, evalCase.files);
+        await prepareWorkspace(rig.testDir!, rig.homeDir!, evalCase.files);
       }
 
       symlinkNodeModules(rig.testDir || '');
@@ -139,37 +185,6 @@ export async function internalEvalTest(evalCase: EvalCase) {
 
       await evalCase.assert(rig, result);
       isSuccess = true;
-      return; // Success! Exit the retry loop.
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      const errorCode = getApiErrorCode(errorMessage);
-
-      if (errorCode) {
-        const status = attempt < maxRetries ? 'RETRY' : 'SKIP';
-        logReliabilityEvent(
-          evalCase.name,
-          attempt,
-          status,
-          errorCode,
-          errorMessage,
-        );
-
-        if (attempt < maxRetries) {
-          attempt++;
-          console.warn(
-            `[Eval] Attempt ${attempt} failed with ${errorCode} Error. Retrying...`,
-          );
-          continue; // Retry
-        }
-
-        console.warn(
-          `[Eval] '${evalCase.name}' failed after ${maxRetries} retries due to persistent API errors. Skipping failure to avoid blocking PR.`,
-        );
-        return; // Gracefully exit without failing the test
-      }
-
-      throw error; // Real failure
     } finally {
       if (isSuccess) {
         await fs.promises.unlink(activityLogFile).catch((err) => {
@@ -188,7 +203,7 @@ export async function internalEvalTest(evalCase: EvalCase) {
       );
       await rig.cleanup();
     }
-  }
+  });
 }
 
 function getApiErrorCode(message: string): '500' | '503' | undefined {
@@ -226,7 +241,7 @@ function logReliabilityEvent(
   const reliabilityLog = {
     timestamp: new Date().toISOString(),
     testName,
-    model: process.env.GEMINI_MODEL || 'unknown',
+    model: process.env['GEMINI_MODEL'] || 'unknown',
     attempt,
     status,
     errorCode,
@@ -252,9 +267,13 @@ function logReliabilityEvent(
  * intentionally uses synchronous filesystem and child_process operations
  * for simplicity and to ensure sequential environment preparation.
  */
-async function setupTestFiles(rig: TestRig, files: Record<string, string>) {
+export async function prepareWorkspace(
+  testDir: string,
+  homeDir: string,
+  files: Record<string, string>,
+) {
   const acknowledgedAgents: Record<string, Record<string, string>> = {};
-  const projectRoot = fs.realpathSync(rig.testDir!);
+  const projectRoot = fs.realpathSync(testDir);
 
   for (const [filePath, content] of Object.entries(files)) {
     if (filePath.includes('..') || path.isAbsolute(filePath)) {
@@ -290,7 +309,7 @@ async function setupTestFiles(rig: TestRig, files: Record<string, string>) {
 
   if (Object.keys(acknowledgedAgents).length > 0) {
     const ackPath = path.join(
-      rig.homeDir!,
+      homeDir,
       '.gemini',
       'acknowledgments',
       'agents.json',
@@ -299,7 +318,7 @@ async function setupTestFiles(rig: TestRig, files: Record<string, string>) {
     fs.writeFileSync(ackPath, JSON.stringify(acknowledgedAgents, null, 2));
   }
 
-  const execOptions = { cwd: rig.testDir!, stdio: 'inherit' as const };
+  const execOptions = { cwd: testDir, stdio: 'ignore' as const };
   execSync('git init --initial-branch=main', execOptions);
   execSync('git config user.email "test@example.com"', execOptions);
   execSync('git config user.name "Test User"', execOptions);
@@ -320,14 +339,30 @@ async function setupTestFiles(rig: TestRig, files: Record<string, string>) {
  */
 export function runEval(
   policy: EvalPolicy,
-  name: string,
+  evalCase: BaseEvalCase,
   fn: () => Promise<void>,
-  timeout?: number,
+  timeoutOverride?: number,
 ) {
-  if (policy === 'USUALLY_PASSES' && !process.env['RUN_EVALS']) {
-    it.skip(name, fn);
+  const { name, timeout, suiteName, suiteType } = evalCase;
+  const targetSuiteType = process.env['EVAL_SUITE_TYPE'];
+  const targetSuiteName = process.env['EVAL_SUITE_NAME'];
+
+  const meta = { suiteType, suiteName };
+
+  const skipBySuiteType =
+    targetSuiteType && suiteType && suiteType !== targetSuiteType;
+  const skipBySuiteName =
+    targetSuiteName && suiteName && suiteName !== targetSuiteName;
+
+  const options = { timeout: timeoutOverride ?? timeout, meta };
+  if (
+    (policy === 'USUALLY_PASSES' && !process.env['RUN_EVALS']) ||
+    skipBySuiteType ||
+    skipBySuiteName
+  ) {
+    it.skip(name, options, fn);
   } else {
-    it(name, fn, timeout);
+    it(name, options, fn);
   }
 }
 
@@ -366,15 +401,20 @@ interface ForbiddenToolSettings {
   };
 }
 
-export interface EvalCase {
+export interface BaseEvalCase {
+  suiteName: string;
+  suiteType: 'behavioral' | 'component-level' | 'hero-scenario';
   name: string;
+  timeout?: number;
+  files?: Record<string, string>;
+}
+
+export interface EvalCase extends BaseEvalCase {
   params?: {
     settings?: ForbiddenToolSettings & Record<string, unknown>;
     [key: string]: unknown;
   };
   prompt: string;
-  timeout?: number;
-  files?: Record<string, string>;
   setup?: (rig: TestRig) => Promise<void> | void;
   /** Conversation history to pre-load via --resume. Each entry is a message object with type, content, etc. */
   messages?: Record<string, unknown>[];

--- a/evals/tool_output_masking.eval.ts
+++ b/evals/tool_output_masking.eval.ts
@@ -31,6 +31,8 @@ describe('Tool Output Masking Behavioral Evals', () => {
    * It should recognize the <tool_output_masked> tag and use a tool to read the file.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should attempt to read the redirected full output file when information is masked',
     params: {
       security: {
@@ -167,6 +169,8 @@ Output too large. Full output available at: ${outputFilePath}
    * Scenario: Information is in the preview.
    */
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should NOT read the full output file when the information is already in the preview',
     params: {
       security: {

--- a/evals/tracker.eval.ts
+++ b/evals/tracker.eval.ts
@@ -25,6 +25,8 @@ const FILES = {
 
 describe('tracker_mode', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should manage tasks in the tracker when explicitly requested during a bug fix',
     params: {
       settings: { experimental: { taskTracker: true } },
@@ -78,6 +80,8 @@ describe('tracker_mode', () => {
   });
 
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should implicitly create tasks when asked to build a feature plan',
     params: {
       settings: { experimental: { taskTracker: true } },

--- a/evals/validation_fidelity.eval.ts
+++ b/evals/validation_fidelity.eval.ts
@@ -9,6 +9,8 @@ import { evalTest } from './test-helper.js';
 
 describe('validation_fidelity', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should perform exhaustive validation autonomously when guided by system instructions',
     files: {
       'src/types.ts': `

--- a/evals/validation_fidelity_pre_existing_errors.eval.ts
+++ b/evals/validation_fidelity_pre_existing_errors.eval.ts
@@ -9,6 +9,8 @@ import { evalTest } from './test-helper.js';
 
 describe('validation_fidelity_pre_existing_errors', () => {
   evalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
     name: 'should handle pre-existing project errors gracefully during validation',
     files: {
       'src/math.ts': `

--- a/evals/vitest.config.ts
+++ b/evals/vitest.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     alias: {
-      react: path.resolve(__dirname, '../node_modules/react'),
+      '@google/gemini-cli-core': path.resolve(
+        __dirname,
+        '../packages/core/index.ts',
+      ),
     },
     setupFiles: [path.resolve(__dirname, '../packages/cli/test-setup.ts')],
     server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "ink": "npm:@jrichman/ink@6.6.8",
+        "ink": "npm:@jrichman/ink@6.6.9",
         "latest-version": "^9.0.0",
         "node-fetch-native": "^1.6.7",
         "proper-lockfile": "^4.1.2",
@@ -447,8 +447,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1451,7 +1450,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
       "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2158,7 +2156,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2339,7 +2336,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2389,7 +2385,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2764,7 +2759,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2798,7 +2792,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2853,7 +2846,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4090,7 +4082,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4365,7 +4356,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -5239,7 +5229,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7380,8 +7369,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7965,7 +7953,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8483,7 +8470,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9796,7 +9782,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10071,11 +10056,10 @@
     },
     "node_modules/ink": {
       "name": "@jrichman/ink",
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.8.tgz",
-      "integrity": "sha512-099iGdvWVIM2ivc3NEWyMF7FT06aLmrx1gMGI02ZYB4wLIFn0v/KQl6+20xEwcM6gyzj8Y8842Sf0UH2z0oTDw==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.9.tgz",
+      "integrity": "sha512-RL9sSiLQZECnjbmBwjIHOp8yVGdWF7C/uifg7ISv/e+F3nLNsfl7FdUFQs8iZARFMJAYxMFpxW6OW+HSt9drwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "ansi-styles": "^6.2.3",
@@ -13849,7 +13833,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13860,7 +13843,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16010,7 +15992,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16233,8 +16214,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16242,7 +16222,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16408,7 +16387,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16631,7 +16609,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -16745,7 +16722,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16758,7 +16734,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17406,7 +17381,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17559,7 +17533,7 @@
         "fzf": "^0.5.2",
         "glob": "^12.0.0",
         "highlight.js": "^11.11.1",
-        "ink": "npm:@jrichman/ink@6.6.8",
+        "ink": "npm:@jrichman/ink@6.6.9",
         "ink-gradient": "^3.0.0",
         "ink-spinner": "^5.0.0",
         "latest-version": "^9.0.0",
@@ -17850,7 +17824,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -17954,7 +17927,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "overrides": {
-    "ink": "npm:@jrichman/ink@6.6.8",
+    "ink": "npm:@jrichman/ink@6.6.9",
     "wrap-ansi": "9.0.2",
     "cliui": {
       "wrap-ansi": "7.0.0"
@@ -142,7 +142,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "ink": "npm:@jrichman/ink@6.6.8",
+    "ink": "npm:@jrichman/ink@6.6.9",
     "latest-version": "^9.0.0",
     "node-fetch-native": "^1.6.7",
     "proper-lockfile": "^4.1.2",

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { main } from './src/gemini.js';
-import { FatalError, writeToStderr } from '@google/gemini-cli-core';
-import { runExitCleanup } from './src/utils/cleanup.js';
+import { spawn } from 'node:child_process';
+import os from 'node:os';
+import v8 from 'node:v8';
 
 // --- Global Entry Point ---
 
@@ -28,44 +28,162 @@ process.on('uncaughtException', (error) => {
   // For other errors, we rely on the default behavior, but since we attached a listener,
   // we must manually replicate it.
   if (error instanceof Error) {
-    writeToStderr(error.stack + '\n');
+    process.stderr.write(error.stack + '\n');
   } else {
-    writeToStderr(String(error) + '\n');
+    process.stderr.write(String(error) + '\n');
   }
   process.exit(1);
 });
 
-main().catch(async (error) => {
-  // Set a timeout to force exit if cleanup hangs
-  const cleanupTimeout = setTimeout(() => {
-    writeToStderr('Cleanup timed out, forcing exit...\n');
-    process.exit(1);
-  }, 5000);
-
+async function getMemoryNodeArgs(): Promise<string[]> {
+  let autoConfigureMemory = true;
   try {
-    await runExitCleanup();
-  } catch (cleanupError) {
-    writeToStderr(
-      `Error during final cleanup: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}\n`,
-    );
-  } finally {
-    clearTimeout(cleanupTimeout);
-  }
-
-  if (error instanceof FatalError) {
-    let errorMessage = error.message;
-    if (!process.env['NO_COLOR']) {
-      errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    // Respect GEMINI_CLI_HOME environment variable, falling back to os.homedir()
+    const baseDir =
+      process.env['GEMINI_CLI_HOME'] || join(os.homedir(), '.gemini');
+    const settingsPath = join(baseDir, 'settings.json');
+    const rawSettings = readFileSync(settingsPath, 'utf8');
+    const settings = JSON.parse(rawSettings);
+    if (settings?.advanced?.autoConfigureMemory === false) {
+      autoConfigureMemory = false;
     }
-    writeToStderr(errorMessage + '\n');
-    process.exit(error.exitCode);
+  } catch {
+    // ignore
   }
 
-  writeToStderr('An unexpected critical error occurred:');
-  if (error instanceof Error) {
-    writeToStderr(error.stack + '\n');
-  } else {
-    writeToStderr(String(error) + '\n');
+  if (autoConfigureMemory) {
+    const totalMemoryMB = os.totalmem() / (1024 * 1024);
+    const heapStats = v8.getHeapStatistics();
+    const currentMaxOldSpaceSizeMb = Math.floor(
+      heapStats.heap_size_limit / 1024 / 1024,
+    );
+    const targetMaxOldSpaceSizeInMB = Math.floor(totalMemoryMB * 0.5);
+
+    if (targetMaxOldSpaceSizeInMB > currentMaxOldSpaceSizeMb) {
+      return [`--max-old-space-size=${targetMaxOldSpaceSizeInMB}`];
+    }
   }
-  process.exit(1);
-});
+
+  return [];
+}
+
+async function run() {
+  if (!process.env['GEMINI_CLI_NO_RELAUNCH'] && !process.env['SANDBOX']) {
+    // --- Lightweight Parent Process / Daemon ---
+    // We avoid importing heavy dependencies here to save ~1.5s of startup time.
+
+    const nodeArgs: string[] = [...process.execArgv];
+    const scriptArgs = process.argv.slice(2);
+
+    const memoryArgs = await getMemoryNodeArgs();
+    nodeArgs.push(...memoryArgs);
+
+    const script = process.argv[1];
+    nodeArgs.push(script);
+    nodeArgs.push(...scriptArgs);
+
+    const newEnv = { ...process.env, GEMINI_CLI_NO_RELAUNCH: 'true' };
+    const RELAUNCH_EXIT_CODE = 199;
+    let latestAdminSettings: unknown = undefined;
+
+    // Prevent the parent process from exiting prematurely on signals.
+    // The child process will receive the same signals and handle its own cleanup.
+    for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+      process.on(sig as NodeJS.Signals, () => {});
+    }
+
+    const runner = () => {
+      process.stdin.pause();
+
+      const child = spawn(process.execPath, nodeArgs, {
+        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+        env: newEnv,
+      });
+
+      if (latestAdminSettings) {
+        child.send({ type: 'admin-settings', settings: latestAdminSettings });
+      }
+
+      child.on('message', (msg: { type?: string; settings?: unknown }) => {
+        if (msg.type === 'admin-settings-update' && msg.settings) {
+          latestAdminSettings = msg.settings;
+        }
+      });
+
+      return new Promise<number>((resolve) => {
+        child.on('error', (err) => {
+          process.stderr.write(
+            'Error: Failed to start child process: ' + err.message + '\n',
+          );
+          resolve(1);
+        });
+        child.on('close', (code) => {
+          process.stdin.resume();
+          resolve(code ?? 1);
+        });
+      });
+    };
+
+    while (true) {
+      try {
+        const exitCode = await runner();
+        if (exitCode !== RELAUNCH_EXIT_CODE) {
+          process.exit(exitCode);
+        }
+      } catch (error: unknown) {
+        process.stdin.resume();
+        process.stderr.write(
+          `Fatal error: Failed to relaunch the CLI process.\n${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+        );
+        process.exit(1);
+      }
+    }
+  } else {
+    // --- Heavy Child Process ---
+    // Now we can safely import everything.
+    const { main } = await import('./src/gemini.js');
+    const { FatalError, writeToStderr } = await import(
+      '@google/gemini-cli-core'
+    );
+    const { runExitCleanup } = await import('./src/utils/cleanup.js');
+
+    main().catch(async (error: unknown) => {
+      // Set a timeout to force exit if cleanup hangs
+      const cleanupTimeout = setTimeout(() => {
+        writeToStderr('Cleanup timed out, forcing exit...\n');
+        process.exit(1);
+      }, 5000);
+
+      try {
+        await runExitCleanup();
+      } catch (cleanupError: unknown) {
+        writeToStderr(
+          `Error during final cleanup: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}\n`,
+        );
+      } finally {
+        clearTimeout(cleanupTimeout);
+      }
+
+      if (error instanceof FatalError) {
+        let errorMessage = error.message;
+        if (!process.env['NO_COLOR']) {
+          errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;
+        }
+        writeToStderr(errorMessage + '\n');
+        process.exit(error.exitCode);
+      }
+
+      writeToStderr('An unexpected critical error occurred:');
+      if (error instanceof Error) {
+        writeToStderr(error.stack + '\n');
+      } else {
+        writeToStderr(String(error) + '\n');
+      }
+      process.exit(1);
+    });
+  }
+}
+
+run();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "fzf": "^0.5.2",
     "glob": "^12.0.0",
     "highlight.js": "^11.11.1",
-    "ink": "npm:@jrichman/ink@6.6.8",
+    "ink": "npm:@jrichman/ink@6.6.9",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
     "latest-version": "^9.0.0",

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -372,7 +372,7 @@ export class GeminiAgent {
       mcpServers,
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(config.storage);
     const { sessionData, sessionPath } =
       await sessionSelector.resolveSession(sessionId);
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1907,7 +1907,8 @@ const SETTINGS_SCHEMA = {
         category: 'Advanced',
         requiresRestart: true,
         default: true,
-        description: 'Automatically configure Node.js memory limits',
+        description:
+          'Automatically configure Node.js memory limits. Note: Because memory is allocated during the initial process boot, this setting is only read from the global user settings file and ignores workspace-level overrides.',
         showInDialog: true,
       },
       dnsResolutionOrder: {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -81,10 +81,7 @@ import { validateNonInteractiveAuth } from './validateNonInterActiveAuth.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import { SessionError, SessionSelector } from './utils/sessionUtils.js';
 
-import {
-  relaunchAppInChildProcess,
-  relaunchOnExitCode,
-} from './utils/relaunch.js';
+import { relaunchOnExitCode } from './utils/relaunch.js';
 import { loadSandboxConfig } from './config/sandboxConfig.js';
 import { deleteSession, listSessions } from './utils/sessions.js';
 import { createPolicyUpdater } from './config/policy.js';
@@ -439,6 +436,12 @@ export async function main() {
   // Set remote admin settings if returned from CCPA.
   if (remoteAdminSettings) {
     settings.setRemoteAdminSettings(remoteAdminSettings);
+    if (process.send) {
+      process.send({
+        type: 'admin-settings-update',
+        settings: remoteAdminSettings,
+      });
+    }
   }
 
   // Run deferred command now that we have admin settings.
@@ -496,10 +499,6 @@ export async function main() {
       );
       await runExitCleanup();
       process.exit(ExitCodes.SUCCESS);
-    } else {
-      // Relaunch app so we always have a child process that can be internally
-      // restarted if needed.
-      await relaunchAppInChildProcess(memoryArgs, [], remoteAdminSettings);
     }
   }
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -13,7 +13,7 @@ import {
   type OutputPayload,
   type ConsoleLogPayload,
   type UserFeedbackPayload,
-  sessionId,
+  createSessionId,
   logUserPrompt,
   AuthType,
   UserPromptEvent,
@@ -33,6 +33,7 @@ import {
   type AdminControlsSettings,
   debugLogger,
   isHeadlessMode,
+  Storage,
 } from '@google/gemini-cli-core';
 
 import { loadCliConfig, parseArguments } from './config/config.js';
@@ -185,6 +186,39 @@ ${reason.stack}`
   });
 }
 
+export async function resolveSessionId(resumeArg: string | undefined): Promise<{
+  sessionId: string;
+  resumedSessionData?: ResumedSessionData;
+}> {
+  if (!resumeArg) {
+    return { sessionId: createSessionId() };
+  }
+
+  const storage = new Storage(process.cwd());
+  await storage.initialize();
+
+  try {
+    const { sessionData, sessionPath } = await new SessionSelector(
+      storage,
+    ).resolveSession(resumeArg);
+    return {
+      sessionId: sessionData.sessionId,
+      resumedSessionData: { conversation: sessionData, filePath: sessionPath },
+    };
+  } catch (error) {
+    if (error instanceof SessionError && error.code === 'NO_SESSIONS_FOUND') {
+      coreEvents.emitFeedback('warning', error.message);
+      return { sessionId: createSessionId() };
+    }
+    coreEvents.emitFeedback(
+      'error',
+      `Error resuming session: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+    await runExitCleanup();
+    process.exit(ExitCodes.FATAL_INPUT_ERROR);
+  }
+}
+
 export async function startInteractiveUI(
   config: Config,
   settings: LoadedSettings,
@@ -279,6 +313,8 @@ export async function main() {
   });
 
   const argv = await argvPromise;
+
+  const { sessionId, resumedSessionData } = await resolveSessionId(argv.resume);
 
   if (
     (argv.allowedTools && argv.allowedTools.length > 0) ||
@@ -598,40 +634,6 @@ export async function main() {
         isAlternateBuffer: useAlternateBuffer,
       })),
     ];
-
-    // Handle --resume flag
-    let resumedSessionData: ResumedSessionData | undefined = undefined;
-    if (argv.resume) {
-      const sessionSelector = new SessionSelector(config);
-      try {
-        const result = await sessionSelector.resolveSession(argv.resume);
-        resumedSessionData = {
-          conversation: result.sessionData,
-          filePath: result.sessionPath,
-        };
-        // Use the existing session ID to continue recording to the same session
-        config.setSessionId(resumedSessionData.conversation.sessionId);
-      } catch (error) {
-        if (
-          error instanceof SessionError &&
-          error.code === 'NO_SESSIONS_FOUND'
-        ) {
-          // No sessions to resume — start a fresh session with a warning
-          startupWarnings.push({
-            id: 'resume-no-sessions',
-            message: error.message,
-            priority: WarningPriority.High,
-          });
-        } else {
-          coreEvents.emitFeedback(
-            'error',
-            `Error resuming session: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          );
-          await runExitCleanup();
-          process.exit(ExitCodes.FATAL_INPUT_ERROR);
-        }
-      }
-    }
 
     cliStartupHandle?.end();
 

--- a/packages/cli/src/gemini_cleanup.test.tsx
+++ b/packages/cli/src/gemini_cleanup.test.tsx
@@ -73,6 +73,7 @@ vi.mock('./config/config.js', () => ({
     getSandbox: vi.fn(() => false),
     getQuestion: vi.fn(() => ''),
     isInteractive: () => false,
+    getSessionId: vi.fn().mockReturnValue('test-session-id'),
     storage: { initialize: vi.fn().mockResolvedValue(undefined) },
   } as unknown as Config),
   parseArguments: vi.fn().mockResolvedValue({}),
@@ -213,6 +214,7 @@ describe('gemini.tsx main function cleanup', () => {
       getSandbox: vi.fn(() => false),
       getDebugMode: vi.fn(() => false),
       getPolicyEngine: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getMessageBus: () => ({ subscribe: vi.fn() }),
       getEnableHooks: vi.fn(() => false),
       getHookSystem: () => undefined,
@@ -273,6 +275,7 @@ describe('gemini.tsx main function cleanup', () => {
     vi.mocked(loadCliConfig).mockResolvedValue(
       buildMockConfig({
         getHookSystem: vi.fn(() => mockHookSystem),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       }),
     );
 

--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -107,7 +107,7 @@ export async function startInteractiveUI(
               <TerminalProvider>
                 <ScrollProvider>
                   <OverflowProvider>
-                    <SessionStatsProvider>
+                    <SessionStatsProvider sessionId={config.getSessionId()}>
                       <VimModeProvider>
                         <AppContainer
                           config={config}

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -731,7 +731,7 @@ export const renderWithProviders = async (
             <UIStateContext.Provider value={finalUiState}>
               <VimModeProvider>
                 <ShellFocusContext.Provider value={shellFocus}>
-                  <SessionStatsProvider>
+                  <SessionStatsProvider sessionId={config.getSessionId()}>
                     <StreamingContext.Provider
                       value={finalUiState.streamingState}
                     >

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -444,7 +444,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const [isConfigInitialized, setConfigInitialized] = useState(false);
 
-  const logger = useLogger(config.storage);
+  const logger = useLogger(config);
   const { inputHistory, addInput, initializeFromLogger } =
     useInputHistoryStore();
 

--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame-Full-Terminal-Tool-Confirmation-Snapshot-renders-tool-confirmation-box-in-the-frame-of-the-entire-terminal.snap.svg
@@ -14,7 +14,8 @@
     <text x="0" y="19" fill="#000000" textLength="900" lengthAdjust="spacingAndGlyphs">▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄</text>
     <text x="0" y="53" fill="#333333" textLength="891" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────────╮</text>
     <text x="0" y="70" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="70" fill="#ffffaf" textLength="54" lengthAdjust="spacingAndGlyphs" font-weight="bold">? Edit</text>
+    <text x="18" y="70" fill="#ffffaf" textLength="63" lengthAdjust="spacingAndGlyphs" font-weight="bold">? Edit </text>
+    <text x="81" y="70" fill="#ffffff" textLength="783" lengthAdjust="spacingAndGlyphs">packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =&gt;   return kittyProto…</text>
     <text x="882" y="70" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="0" y="87" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="87" fill="#333333" textLength="855" lengthAdjust="spacingAndGlyphs">╭─────────────────────────────────────────────────────────────────────────────────────────────╮</text>

--- a/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/ToolConfirmationFullFrame.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Full Terminal Tool Confirmation Snapshot > renders tool confirmation bo
 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ ? Edit                                                                                          │
+│ ? Edit packages/.../InputPrompt.tsx:   return kittyProtocolSupporte... =>   return kittyProto…  │
 │ ╭─────────────────────────────────────────────────────────────────────────────────────────────╮ │
 │ │ ... first 42 lines hidden (Ctrl+O to show) ...                                              │ │
 │ │ 43   const line43 = true;                                                                   │ │

--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -9,7 +9,7 @@ import open from 'open';
 import path from 'node:path';
 import { bugCommand } from './bugCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-import { getVersion } from '@google/gemini-cli-core';
+import { getVersion, type Config } from '@google/gemini-cli-core';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatBytes } from '../utils/formatters.js';
 
@@ -89,7 +89,8 @@ describe('bugCommand', () => {
             getBugCommand: () => undefined,
             getIdeMode: () => true,
             getContentGeneratorConfig: () => ({ authType: 'oauth-personal' }),
-          },
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
+          } as unknown as Config,
           geminiClient: {
             getChat: () => ({
               getHistory: () => [],
@@ -137,7 +138,8 @@ describe('bugCommand', () => {
             storage: {
               getProjectTempDir: () => '/tmp/gemini',
             },
-          },
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
+          } as unknown as Config,
           geminiClient: {
             getChat: () => ({
               getHistory: () => history,
@@ -182,7 +184,8 @@ describe('bugCommand', () => {
             getBugCommand: () => ({ urlTemplate: customTemplate }),
             getIdeMode: () => true,
             getContentGeneratorConfig: () => ({ authType: 'vertex-ai' }),
-          },
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
+          } as unknown as Config,
           geminiClient: {
             getChat: () => ({
               getHistory: () => [],

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -16,7 +16,6 @@ import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatBytes } from '../utils/formatters.js';
 import {
   IdeClient,
-  sessionId,
   getVersion,
   INITIAL_HISTORY_LENGTH,
   debugLogger,
@@ -59,7 +58,7 @@ export const bugCommand: SlashCommand = {
     let info = `
 * **CLI Version:** ${cliVersion}
 * **Git Commit:** ${GIT_COMMIT_INFO}
-* **Session ID:** ${sessionId}
+* **Session ID:** ${config?.getSessionId() || 'Unknown'}
 * **Operating System:** ${osVersion}
 * **Sandbox Environment:** ${sandboxEnv}
 * **Model Version:** ${modelVersion}

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -158,6 +158,7 @@ Implement a comprehensive authentication system with multiple providers.
           getIdeMode: () => false,
           isTrustedFolder: () => true,
           getPreferredEditor: () => undefined,
+          getSessionId: () => 'test-session-id',
           storage: {
             getPlansDir: () => mockPlansDir,
           },
@@ -464,6 +465,7 @@ Implement a comprehensive authentication system with multiple providers.
                 getTargetDir: () => mockTargetDir,
                 getIdeMode: () => false,
                 isTrustedFolder: () => true,
+                getSessionId: () => 'test-session-id',
                 storage: {
                   getPlansDir: () => mockPlansDir,
                 },

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -82,6 +82,7 @@ const mockConfigPlain = {
   getExtensionRegistryURI: () => undefined,
   getContentGeneratorConfig: () => ({ authType: undefined }),
   getSandboxEnabled: () => false,
+  getSessionId: () => 'test-session-id',
 };
 
 const mockConfig = mockConfigPlain as unknown as Config;

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -124,7 +124,7 @@ describe('<HistoryItemDisplay />', () => {
       duration: '1s',
     };
     const { lastFrame, unmount } = await renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -157,7 +157,7 @@ describe('<HistoryItemDisplay />', () => {
       type: 'model_stats',
     };
     const { lastFrame, unmount } = await renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -173,7 +173,7 @@ describe('<HistoryItemDisplay />', () => {
       type: 'tool_stats',
     };
     const { lastFrame, unmount } = await renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );
@@ -190,7 +190,7 @@ describe('<HistoryItemDisplay />', () => {
       duration: '1s',
     };
     const { lastFrame, unmount } = await renderWithProviders(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <HistoryItemDisplay {...baseItem} item={item} />
       </SessionStatsProvider>,
     );

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -86,6 +86,7 @@ describe('<ModelDialog />', () => {
     getProModelNoAccess: mockGetProModelNoAccess,
     getProModelNoAccessSync: mockGetProModelNoAccessSync,
     getLastRetrievedQuota: () => ({ buckets: [] }),
+    getSessionId: () => 'test-session-id',
   };
 
   beforeEach(() => {

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -44,7 +44,7 @@ enum TerminalKeys {
   LEFT_ARROW = '\u001B[D',
   RIGHT_ARROW = '\u001B[C',
   ESCAPE = '\u001B',
-  BACKSPACE = '\u0008',
+  BACKSPACE = '\x7f',
   CTRL_P = '\u0010',
   CTRL_N = '\u000E',
 }

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
@@ -66,6 +66,44 @@ describe('ToolConfirmationQueue', () => {
     vi.clearAllMocks();
   });
 
+  it('explicitly renders the tool description (containing filename) for edit confirmations', async () => {
+    const confirmingTool = {
+      tool: {
+        callId: 'call-1',
+        name: 'Edit',
+        description: 'Editing src/main.ts',
+        status: CoreToolCallStatus.AwaitingApproval,
+        confirmationDetails: {
+          type: 'edit' as const,
+          title: 'Confirm edit',
+          fileName: 'main.ts',
+          filePath: '/src/main.ts',
+          fileDiff: '--- a/main.ts\n+++ b/main.ts\n@@ -1 +1 @@\n-old\n+new',
+          originalContent: 'old',
+          newContent: 'new',
+        },
+      },
+      index: 1,
+      total: 1,
+    };
+
+    const { lastFrame, unmount } = await renderWithProviders(
+      <ToolConfirmationQueue
+        confirmingTool={confirmingTool as unknown as ConfirmingToolState}
+      />,
+      {
+        config: mockConfig,
+        uiState: {
+          terminalWidth: 80,
+        },
+      },
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Editing src/main.ts');
+    unmount();
+  });
+
   it('renders the confirming tool with progress indicator', async () => {
     const confirmingTool = {
       tool: {

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx
@@ -55,6 +55,7 @@ describe('ToolConfirmationQueue', () => {
     getFileSystemService: () => ({
       readFile: vi.fn().mockResolvedValue('Plan content'),
     }),
+    getSessionId: () => 'test-session-id',
     storage: {
       getPlansDir: () => '/mock/temp/plans',
     },

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -98,9 +98,9 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
           <Box flexDirection="row" flexShrink={1} overflow="hidden">
             <Text color={theme.status.warning} bold>
               ? {toolLabel}
-              {!isEdit && !!tool.description && '  '}
+              {!!tool.description && '  '}
             </Text>
-            {!isEdit && !!tool.description && (
+            {!!tool.description && (
               <Box flexShrink={1} overflow="hidden">
                 <Text color={theme.text.primary} wrap="truncate-end">
                   {tool.description}

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue-ToolConfirmationQueue-height-allocation-and-layout-should-render-the-full-queue-wrapper-with-borders-and-content-for-large-edit-diffs.snap.svg
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue-ToolConfirmationQueue-height-allocation-and-layout-should-render-the-full-queue-wrapper-with-borders-and-content-for-large-edit-diffs.snap.svg
@@ -6,7 +6,8 @@
   <g transform="translate(10, 10)">
     <text x="0" y="2" fill="#333333" textLength="720" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────╮</text>
     <text x="0" y="19" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
-    <text x="18" y="19" fill="#ffffaf" textLength="81" lengthAdjust="spacingAndGlyphs" font-weight="bold">? replace</text>
+    <text x="18" y="19" fill="#ffffaf" textLength="99" lengthAdjust="spacingAndGlyphs" font-weight="bold">? replace  </text>
+    <text x="117" y="19" fill="#ffffff" textLength="234" lengthAdjust="spacingAndGlyphs">Replaces content in a file</text>
     <text x="711" y="19" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="0" y="36" fill="#333333" textLength="9" lengthAdjust="spacingAndGlyphs">│</text>
     <text x="18" y="36" fill="#333333" textLength="684" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────╮</text>

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ToolConfirmationQueue > calculates availableContentHeight based on availableTerminalHeight from UI state 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  edit file                                                         │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ ╰─... 48 hidden (Ctrl+O) ...───────────────────────────────────────────────╯ │
 │ Apply this change?                                                           │
@@ -17,7 +17,7 @@ exports[`ToolConfirmationQueue > calculates availableContentHeight based on avai
 
 exports[`ToolConfirmationQueue > does not render expansion hint when constrainHeight is false 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  edit file                                                         │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ │                                                                          │ │
 │ │  No changes detected.                                                    │ │
@@ -63,7 +63,7 @@ exports[`ToolConfirmationQueue > height allocation and layout > should handle se
 
 exports[`ToolConfirmationQueue > height allocation and layout > should render the full queue wrapper with borders and content for large edit diffs 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
-│ ? replace                                                                    │
+│ ? replace  Replaces content in a file                                        │
 │ ╭──────────────────────────────────────────────────────────────────────────╮ │
 │ │ ... 13 hidden (Ctrl+O) ...                                               │ │
 │ │  7 + const newLine7 = true;                                              │ │

--- a/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
@@ -357,9 +357,8 @@ describe('DenseToolMessage', () => {
     await waitUntilReady();
     const output = lastFrame();
     expect(output).toContain('→ Found 2 matches');
-    // Matches are rendered in a secondary list for high-signal summaries
-    expect(output).toContain('file1.ts:10: match 1');
-    expect(output).toContain('file2.ts:20: match 2');
+    // Matches should no longer be rendered in dense mode to keep it compact
+    expect(output).not.toContain('file1.ts:10: match 1');
     expect(output).toMatchSnapshot();
   });
 
@@ -400,9 +399,8 @@ describe('DenseToolMessage', () => {
     const output = lastFrame();
     expect(output).toContain('Attempting to read files from **/*.ts');
     expect(output).toContain('→ Read 3 file(s) (1 ignored)');
-    expect(output).toContain('file1.ts');
-    expect(output).toContain('file2.ts');
-    expect(output).toContain('file3.ts');
+    // File lists should no longer be rendered in dense mode
+    expect(output).not.toContain('file1.ts');
     expect(output).toMatchSnapshot();
   });
 
@@ -474,6 +472,28 @@ describe('DenseToolMessage', () => {
     await waitUntilReady();
     const output = lastFrame();
     expect(output).not.toContain('→');
+    expect(output).toMatchSnapshot();
+  });
+
+  it('truncates long description but preserves tool name (< 25 chars)', async () => {
+    const longDescription =
+      'This is a very long description that should definitely be truncated because it exceeds the available terminal width and we want to see how it behaves.';
+    const toolName = 'tool-name-is-24-chars-!!'; // Exactly 24 chars
+    const { lastFrame, waitUntilReady } = await renderWithProviders(
+      <DenseToolMessage
+        {...defaultProps}
+        name={toolName}
+        description={longDescription}
+        terminalWidth={50} // Narrow width to force truncation
+      />,
+    );
+    await waitUntilReady();
+    const output = lastFrame();
+
+    // Tool name should be fully present (it plus one space is exactly 25, fitting the maxWidth)
+    expect(output).toContain(toolName);
+    // Description should be present but truncated
+    expect(output).toContain('This is a');
     expect(output).toMatchSnapshot();
   });
 

--- a/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/DenseToolMessage.test.tsx
@@ -34,6 +34,28 @@ describe('DenseToolMessage', () => {
     terminalWidth: 80,
   };
 
+  it('explicitly renders the filename in the header for FileDiff results', async () => {
+    const fileDiff: FileDiff = {
+      fileName: 'test-file.ts',
+      filePath: '/test-file.ts',
+      fileDiff:
+        '--- a/test-file.ts\n+++ b/test-file.ts\n@@ -1 +1 @@\n-old\n+new',
+      originalContent: 'old',
+      newContent: 'new',
+    };
+
+    const { lastFrame, waitUntilReady } = await renderWithProviders(
+      <DenseToolMessage
+        {...defaultProps}
+        name="Edit"
+        resultDisplay={fileDiff as unknown as ToolResultDisplay}
+      />,
+    );
+    await waitUntilReady();
+    const output = lastFrame();
+    expect(output).toContain('test-file.ts');
+  });
+
   it('renders correctly for a successful string result', async () => {
     const { lastFrame, waitUntilReady } = await renderWithProviders(
       <DenseToolMessage {...defaultProps} />,

--- a/packages/cli/src/ui/components/messages/DenseToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/DenseToolMessage.tsx
@@ -72,27 +72,6 @@ const hasPayload = (res: unknown): res is PayloadResult => {
   return typeof value === 'string';
 };
 
-const RenderItemsList: React.FC<{
-  items?: string[];
-  maxVisible?: number;
-}> = ({ items, maxVisible = 20 }) => {
-  if (!items || items.length === 0) return null;
-  return (
-    <Box flexDirection="column">
-      {items.slice(0, maxVisible).map((item, i) => (
-        <Text key={i} color={theme.text.secondary}>
-          {item}
-        </Text>
-      ))}
-      {items.length > maxVisible && (
-        <Text color={theme.text.secondary}>
-          ... and {items.length - maxVisible} more
-        </Text>
-      )}
-    </Box>
-  );
-};
-
 function getFileOpData(
   diff: FileDiff,
   status: CoreToolCallStatus,
@@ -188,8 +167,6 @@ function getFileOpData(
 }
 
 function getReadManyFilesData(result: ReadManyFilesResult): ViewParts {
-  const items = result.files ?? [];
-  const maxVisible = 10;
   const includePatterns = result.include?.join(', ') ?? '';
   const description = (
     <Text color={theme.text.secondary} wrap="truncate-end">
@@ -198,18 +175,12 @@ function getReadManyFilesData(result: ReadManyFilesResult): ViewParts {
   );
 
   const skippedCount = result.skipped?.length ?? 0;
-  const summaryStr = `Read ${items.length} file(s)${
+  const summaryStr = `Read ${result.files.length} file(s)${
     skippedCount > 0 ? ` (${skippedCount} ignored)` : ''
   }`;
   const summary = <Text color={theme.text.accent}>→ {summaryStr}</Text>;
-  const hasItems = items.length > 0;
-  const payload = hasItems ? (
-    <Box flexDirection="column" marginLeft={2}>
-      {hasItems && <RenderItemsList items={items} maxVisible={maxVisible} />}
-    </Box>
-  ) : undefined;
 
-  return { description, summary, payload };
+  return { description, summary, payload: undefined };
 }
 
 function getListDirectoryData(
@@ -258,20 +229,11 @@ function getGenericSuccessData(
       </Text>
     );
   } else if (isGrepResult(resultDisplay)) {
-    summary = <Text color={theme.text.accent}>→ {resultDisplay.summary}</Text>;
-    const matches = resultDisplay.matches;
-    if (matches.length > 0) {
-      payload = (
-        <Box flexDirection="column" marginLeft={2}>
-          <RenderItemsList
-            items={matches.map(
-              (m) => `${m.filePath}:${m.lineNumber}: ${m.line.trim()}`,
-            )}
-            maxVisible={10}
-          />
-        </Box>
-      );
-    }
+    summary = (
+      <Text color={theme.text.accent} wrap="truncate-end">
+        → {resultDisplay.summary}
+      </Text>
+    );
   } else if (isTodoList(resultDisplay)) {
     summary = (
       <Text color={theme.text.accent} wrap="wrap">
@@ -488,15 +450,18 @@ export const DenseToolMessage: React.FC<DenseToolMessageProps> = (props) => {
   return (
     <Box flexDirection="column">
       <Box marginLeft={2} flexDirection="row" flexWrap="wrap">
-        <ToolStatusIndicator status={status} name={name} />
-        <Box maxWidth={25} flexShrink={1} flexGrow={0}>
-          <Text color={theme.text.primary} bold wrap="truncate-end">
-            {name}{' '}
-          </Text>
+        <Box flexDirection="row" flexShrink={1}>
+          <ToolStatusIndicator status={status} name={name} />
+          <Box maxWidth={25} flexShrink={0} flexGrow={0}>
+            <Text color={theme.text.primary} bold wrap="truncate-end">
+              {name}{' '}
+            </Text>
+          </Box>
+          <Box marginLeft={1} flexShrink={1} flexGrow={0}>
+            {description}
+          </Box>
         </Box>
-        <Box marginLeft={1} flexShrink={1} flexGrow={0}>
-          {description}
-        </Box>
+
         {summary && (
           <Box
             key="tool-summary"

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -35,8 +35,6 @@ import {
   WRITE_FILE_DISPLAY_NAME,
   READ_MANY_FILES_DISPLAY_NAME,
   isFileDiff,
-  isGrepResult,
-  isListResult,
 } from '@google/gemini-cli-core';
 import { useUIState } from '../../contexts/UIStateContext.js';
 import { getToolGroupBorderAppearance } from '../../utils/borderStyles.js';
@@ -81,15 +79,6 @@ export const hasDensePayload = (tool: IndividualToolCallDisplay): boolean => {
   // TODO(24053): Usage of type guards makes this class too aware of internals
   if (isFileDiff(res)) return true;
   if (tool.confirmationDetails?.type === 'edit') return true;
-  if (isGrepResult(res) && res.matches.length > 0) return true;
-
-  // ReadManyFilesResult check (has 'include' and 'files')
-  if (isListResult(res) && 'include' in res) {
-    const includeProp = (res as { include?: unknown }).include;
-    if (Array.isArray(includeProp) && res.files.length > 0) {
-      return true;
-    }
-  }
 
   // Generic summary/payload pattern
   if (

--- a/packages/cli/src/ui/components/messages/__snapshots__/DenseToolMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/DenseToolMessage.test.tsx.snap
@@ -51,10 +51,6 @@ exports[`DenseToolMessage > renders correctly for Errored Edit tool 1`] = `
 
 exports[`DenseToolMessage > renders correctly for ReadManyFiles results 1`] = `
 "  ✓  test-tool  Attempting to read files from **/*.ts → Read 3 file(s) (1 ignored)
-
-        file1.ts
-        file2.ts
-        file3.ts
 "
 `;
 
@@ -110,9 +106,6 @@ exports[`DenseToolMessage > renders correctly for file diff results with stats 1
 
 exports[`DenseToolMessage > renders correctly for grep results 1`] = `
 "  ✓  test-tool  Test description → Found 2 matches
-
-        file1.ts:10: match 1
-        file2.ts:20: match 2
 "
 `;
 
@@ -133,6 +126,12 @@ exports[`DenseToolMessage > renders generic failure message for error status wit
 
 exports[`DenseToolMessage > renders generic output message for unknown object results 1`] = `
 "  ✓  test-tool  Test description → Returned (possible empty result)
+"
+`;
+
+exports[`DenseToolMessage > truncates long description but preserves tool name (< 25 chars) 1`] = `
+"  ✓  tool-name-is-24-chars-!!  This is a very long description that should definitely be truncated …
+   → Success result
 "
 `;
 

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
@@ -24,7 +24,7 @@ enum TerminalKeys {
   LEFT_ARROW = '\u001B[D',
   RIGHT_ARROW = '\u001B[C',
   ESCAPE = '\u001B',
-  BACKSPACE = '\u0008',
+  BACKSPACE = '\x7f',
   CTRL_L = '\u000C',
 }
 

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -9,7 +9,17 @@ import { act } from 'react';
 import { renderHookWithProviders } from '../../test-utils/render.js';
 import { createMockSettings } from '../../test-utils/settings.js';
 import { waitFor } from '../../test-utils/async.js';
-import { vi, afterAll, beforeAll, type Mock } from 'vitest';
+import type { Mock } from 'vitest';
+import {
+  vi,
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import {
   useKeypressContext,
   ESC_TIMEOUT,
@@ -429,6 +439,80 @@ describe('KeypressContext', () => {
         );
       },
     );
+  });
+
+  describe('Windows Terminal Backspace handling', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should NOT treat \\b as ctrl when WT_SESSION is NOT present and OS is not Windows_NT', async () => {
+      vi.stubEnv('WT_SESSION', '');
+      vi.stubEnv('OS', 'Linux');
+      const { keyHandler } = await setupKeypressTest();
+
+      act(() => {
+        stdin.write('\b');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: false,
+        }),
+      );
+    });
+
+    it('should treat \\b as ctrl when WT_SESSION IS present (even if not Windows_NT)', async () => {
+      vi.stubEnv('WT_SESSION', 'some-id');
+      vi.stubEnv('OS', 'Linux');
+      const { keyHandler } = await setupKeypressTest();
+
+      act(() => {
+        stdin.write('\b');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: true,
+        }),
+      );
+    });
+
+    it('should treat \\b as ctrl when OS is Windows_NT', async () => {
+      vi.stubEnv('WT_SESSION', '');
+      vi.stubEnv('OS', 'Windows_NT');
+      const { keyHandler } = await setupKeypressTest();
+
+      act(() => {
+        stdin.write('\b');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: true,
+        }),
+      );
+    });
+
+    it('should treat \\x7f as regular backspace regardless of WT_SESSION or OS', async () => {
+      vi.stubEnv('WT_SESSION', 'some-id');
+      vi.stubEnv('OS', 'Windows_NT');
+      const { keyHandler } = await setupKeypressTest();
+
+      act(() => {
+        stdin.write('\x7f');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'backspace',
+          ctrl: false,
+        }),
+      );
+    });
   });
 
   describe('paste mode', () => {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -651,8 +651,20 @@ function* emitKeys(
       // tab
       name = 'tab';
       alt = escaped;
-    } else if (ch === '\b' || ch === '\x7f') {
-      // backspace or ctrl+h
+    } else if (ch === '\b') {
+      // ctrl+h / ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
+      name = 'backspace';
+      // In Windows environments, \b is sent for Ctrl+Backspace (standard backspace is translated to \x7f).
+      // We scope this to Windows/WT_SESSION to avoid breaking other unixes where \b is a plain backspace.
+      if (
+        typeof process !== 'undefined' &&
+        (process.env?.['OS'] === 'Windows_NT' || !!process.env?.['WT_SESSION'])
+      ) {
+        ctrl = true;
+      }
+      alt = escaped;
+    } else if (ch === '\x7f') {
+      // backspace
       name = 'backspace';
       alt = escaped;
     } else if (ch === ESC) {

--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -60,7 +60,7 @@ describe('SessionStatsContext', () => {
     > = { current: undefined };
 
     const { unmount } = await render(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <TestHarness contextRef={contextRef} />
       </SessionStatsProvider>,
     );
@@ -79,7 +79,7 @@ describe('SessionStatsContext', () => {
     > = { current: undefined };
 
     const { unmount } = await render(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <TestHarness contextRef={contextRef} />
       </SessionStatsProvider>,
     );
@@ -162,7 +162,7 @@ describe('SessionStatsContext', () => {
     };
 
     const { unmount } = await render(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <CountingTestHarness />
       </SessionStatsProvider>,
     );
@@ -245,7 +245,7 @@ describe('SessionStatsContext', () => {
     > = { current: undefined };
 
     const { unmount } = await render(
-      <SessionStatsProvider>
+      <SessionStatsProvider sessionId="test-session-id">
         <TestHarness contextRef={contextRef} />
       </SessionStatsProvider>,
     );

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -13,14 +13,13 @@ import {
   useMemo,
   useEffect,
 } from 'react';
-
 import type {
   SessionMetrics,
   ModelMetrics,
   RoleMetrics,
   ToolCallStats,
 } from '@google/gemini-cli-core';
-import { uiTelemetryService, sessionId } from '@google/gemini-cli-core';
+import { uiTelemetryService } from '@google/gemini-cli-core';
 
 export enum ToolCallDecision {
   ACCEPT = 'accept',
@@ -183,9 +182,10 @@ const SessionStatsContext = createContext<SessionStatsContextValue | undefined>(
 
 // --- Provider Component ---
 
-export const SessionStatsProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const SessionStatsProvider: React.FC<{
+  children: React.ReactNode;
+  sessionId: string;
+}> = ({ children, sessionId }) => {
   const [stats, setStats] = useState<SessionStatsState>({
     sessionId,
     sessionStartTime: new Date(),

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -262,14 +262,13 @@ export const useGeminiStream = (
     useStateAndRef<boolean>(true);
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
   const { startNewPrompt, getPromptCount } = useSessionStats();
-  const storage = config.storage;
-  const logger = useLogger(storage);
+  const logger = useLogger(config);
   const gitService = useMemo(() => {
     if (!config.getProjectRoot()) {
       return;
     }
-    return new GitService(config.getProjectRoot(), storage);
-  }, [config, storage]);
+    return new GitService(config.getProjectRoot(), config.storage);
+  }, [config]);
 
   useEffect(() => {
     const handleRetryAttempt = (payload: RetryAttemptPayload) => {
@@ -1580,6 +1579,7 @@ export const useGeminiStream = (
           operation: options?.isContinuation
             ? GeminiCliOperation.SystemPrompt
             : GeminiCliOperation.UserPrompt,
+          sessionId: config.getSessionId(),
         },
         async ({ metadata: spanMetadata }) => {
           spanMetadata.input = query;
@@ -2105,7 +2105,7 @@ export const useGeminiStream = (
         }
 
         if (checkpointsToWrite.size > 0) {
-          const checkpointDir = storage.getProjectTempCheckpointsDir();
+          const checkpointDir = config.storage.getProjectTempCheckpointsDir();
           try {
             await fs.mkdir(checkpointDir, { recursive: true });
             for (const [fileName, content] of checkpointsToWrite) {
@@ -2122,15 +2122,7 @@ export const useGeminiStream = (
     };
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     saveRestorableToolCalls();
-  }, [
-    toolCalls,
-    config,
-    onDebugMessage,
-    gitService,
-    history,
-    geminiClient,
-    storage,
-  ]);
+  }, [toolCalls, config, onDebugMessage, gitService, history, geminiClient]);
 
   const lastOutputTime = Math.max(
     lastToolOutputTime,

--- a/packages/cli/src/ui/hooks/useLogger.test.tsx
+++ b/packages/cli/src/ui/hooks/useLogger.test.tsx
@@ -8,14 +8,7 @@ import { act } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '../../test-utils/render.js';
 import { useLogger } from './useLogger.js';
-import {
-  sessionId as globalSessionId,
-  Logger,
-  type Storage,
-  type Config,
-} from '@google/gemini-cli-core';
-import { ConfigContext } from '../contexts/ConfigContext.js';
-import type React from 'react';
+import { Logger, type Storage, type Config } from '@google/gemini-cli-core';
 
 let deferredInit: { resolve: (val?: unknown) => void };
 
@@ -41,35 +34,15 @@ describe('useLogger', () => {
   const mockStorage = {} as Storage;
   const mockConfig = {
     getSessionId: vi.fn().mockReturnValue('active-session-id'),
+    storage: mockStorage,
   } as unknown as Config;
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should initialize with the global sessionId by default', async () => {
-    const { result } = await renderHook(() => useLogger(mockStorage));
-
-    expect(result.current).toBeNull();
-
-    await act(async () => {
-      deferredInit.resolve();
-    });
-
-    expect(result.current).not.toBeNull();
-    expect(Logger).toHaveBeenCalledWith(globalSessionId, mockStorage);
-  });
-
-  it('should initialize with the active sessionId from ConfigContext when available', async () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <ConfigContext.Provider value={mockConfig}>
-        {children}
-      </ConfigContext.Provider>
-    );
-
-    const { result } = await renderHook(() => useLogger(mockStorage), {
-      wrapper,
-    });
+  it('should initialize with the sessionId from config', async () => {
+    const { result } = await renderHook(() => useLogger(mockConfig));
 
     expect(result.current).toBeNull();
 

--- a/packages/cli/src/ui/hooks/useLogger.ts
+++ b/packages/cli/src/ui/hooks/useLogger.ts
@@ -4,24 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useContext } from 'react';
-import {
-  sessionId as globalSessionId,
-  Logger,
-  type Storage,
-} from '@google/gemini-cli-core';
-import { ConfigContext } from '../contexts/ConfigContext.js';
+import { useState, useEffect } from 'react';
+import { Logger, type Config } from '@google/gemini-cli-core';
 
 /**
  * Hook to manage the logger instance.
  */
-export const useLogger = (storage: Storage): Logger | null => {
+export const useLogger = (config: Config): Logger | null => {
   const [logger, setLogger] = useState<Logger | null>(null);
-  const config = useContext(ConfigContext);
 
   useEffect(() => {
-    const activeSessionId = config?.getSessionId() ?? globalSessionId;
-    const newLogger = new Logger(activeSessionId, storage);
+    const newLogger = new Logger(config.getSessionId(), config.storage);
 
     /**
      * Start async initialization, no need to await. Using await slows down the
@@ -30,11 +23,9 @@ export const useLogger = (storage: Storage): Logger | null => {
      */
     newLogger
       .initialize()
-      .then(() => {
-        setLogger(newLogger);
-      })
+      .then(() => setLogger(newLogger))
       .catch(() => {});
-  }, [storage, config]);
+  }, [config]);
 
   return logger;
 };

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -171,6 +171,39 @@ describe('sandbox', () => {
       );
     });
 
+    it('should handle absolute path for SEATBELT_PROFILE', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      process.env['SEATBELT_PROFILE'] = '/absolute/path/to/profile.sb';
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const promise = start_sandbox(config);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      await expect(promise).resolves.toBe(0);
+      expect(spawn).toHaveBeenCalledWith(
+        'sandbox-exec',
+        expect.arrayContaining(['-f', '/absolute/path/to/profile.sb']),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+    });
+
     it('should throw FatalSandboxError if seatbelt profile is missing', async () => {
       vi.mocked(os.platform).mockReturnValue('darwin');
       vi.mocked(fs.existsSync).mockReturnValue(false);

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -65,12 +65,26 @@ export async function start_sandbox(
       }
 
       const profile = (process.env['SEATBELT_PROFILE'] ??= 'permissive-open');
-      let profileFile = fileURLToPath(
-        new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
-      );
-      // if profile name is not recognized, then look for file under project settings directory
-      if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-        profileFile = path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`);
+      const trimmedProfile = profile.trim();
+      let profileFile;
+      if (path.isAbsolute(trimmedProfile)) {
+        profileFile = trimmedProfile;
+      } else {
+        if (trimmedProfile.includes('..') || trimmedProfile.includes('\0')) {
+          throw new FatalSandboxError(
+            'Invalid seatbelt profile name: ' + trimmedProfile,
+          );
+        }
+        profileFile = fileURLToPath(
+          new URL(`sandbox-macos-${trimmedProfile}.sb`, import.meta.url),
+        );
+        // if profile name is not recognized, then look for file under project settings directory
+        if (!BUILTIN_SEATBELT_PROFILES.includes(trimmedProfile)) {
+          profileFile = path.join(
+            GEMINI_DIR,
+            `sandbox-macos-${trimmedProfile}.sb`,
+          );
+        }
       }
       if (!fs.existsSync(profileFile)) {
         throw new FatalSandboxError(

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -15,7 +15,7 @@ import {
 } from './sessionUtils.js';
 import {
   SESSION_FILE_PREFIX,
-  type Config,
+  type Storage,
   type MessageRecord,
   CoreToolCallStatus,
 } from '@google/gemini-cli-core';
@@ -25,20 +25,17 @@ import { randomUUID } from 'node:crypto';
 
 describe('SessionSelector', () => {
   let tmpDir: string;
-  let config: Config;
+  let storage: Storage;
 
   beforeEach(async () => {
     // Create a temporary directory for testing
     tmpDir = path.join(process.cwd(), '.tmp-test-sessions');
     await fs.mkdir(tmpDir, { recursive: true });
 
-    // Mock config
-    config = {
-      storage: {
-        getProjectTempDir: () => tmpDir,
-      },
-      getSessionId: () => 'current-session-id',
-    } as Partial<Config> as Config;
+    // Mock storage
+    storage = {
+      getProjectTempDir: () => tmpDir,
+    } as Partial<Storage> as Storage;
   });
 
   afterEach(async () => {
@@ -104,7 +101,7 @@ describe('SessionSelector', () => {
       JSON.stringify(session2, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
 
     // Test resolving by UUID
     const result1 = await sessionSelector.resolveSession(sessionId1);
@@ -170,7 +167,7 @@ describe('SessionSelector', () => {
       JSON.stringify(session2, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
 
     // Test resolving by index (1-based)
     const result1 = await sessionSelector.resolveSession('1');
@@ -234,7 +231,7 @@ describe('SessionSelector', () => {
       JSON.stringify(session2, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
 
     // Test resolving latest
     const result = await sessionSelector.resolveSession('latest');
@@ -271,7 +268,7 @@ describe('SessionSelector', () => {
       JSON.stringify(session, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
 
     // Test resolving by UUID with leading/trailing spaces
     const result = await sessionSelector.resolveSession(`  ${sessionId}  `);
@@ -334,7 +331,7 @@ describe('SessionSelector', () => {
       JSON.stringify(sessionDuplicate, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
     const sessions = await sessionSelector.listSessions();
 
     expect(sessions.length).toBe(1);
@@ -373,7 +370,7 @@ describe('SessionSelector', () => {
       JSON.stringify(session1, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
 
     await expect(
       sessionSelector.resolveSession('invalid-uuid'),
@@ -389,14 +386,11 @@ describe('SessionSelector', () => {
     const chatsDir = path.join(tmpDir, 'chats');
     await fs.mkdir(chatsDir, { recursive: true });
 
-    const emptyConfig = {
-      storage: {
-        getProjectTempDir: () => tmpDir,
-      },
-      getSessionId: () => 'current-session-id',
-    } as Partial<Config> as Config;
+    const emptyStorage = {
+      getProjectTempDir: () => tmpDir,
+    } as Partial<Storage> as Storage;
 
-    const sessionSelector = new SessionSelector(emptyConfig);
+    const sessionSelector = new SessionSelector(emptyStorage);
 
     await expect(sessionSelector.resolveSession('latest')).rejects.toSatisfy(
       (error) => {
@@ -469,7 +463,7 @@ describe('SessionSelector', () => {
       JSON.stringify(sessionSystemOnly, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
     const sessions = await sessionSelector.listSessions();
 
     // Should only list the session with user message
@@ -508,7 +502,7 @@ describe('SessionSelector', () => {
       JSON.stringify(sessionGeminiOnly, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
     const sessions = await sessionSelector.listSessions();
 
     // Should list the session with gemini message
@@ -574,7 +568,7 @@ describe('SessionSelector', () => {
       JSON.stringify(subagentSession, null, 2),
     );
 
-    const sessionSelector = new SessionSelector(config);
+    const sessionSelector = new SessionSelector(storage);
     const sessions = await sessionSelector.listSessions();
 
     // Should only list the main session

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -9,7 +9,7 @@ import {
   partListUnionToString,
   SESSION_FILE_PREFIX,
   CoreToolCallStatus,
-  type Config,
+  type Storage,
   type ConversationRecord,
   type MessageRecord,
 } from '@google/gemini-cli-core';
@@ -399,17 +399,14 @@ export const getSessionFiles = async (
  * Utility class for session discovery and selection.
  */
 export class SessionSelector {
-  constructor(private config: Config) {}
+  constructor(private storage: Storage) {}
 
   /**
    * Lists all available sessions for the current project.
    */
   async listSessions(): Promise<SessionInfo[]> {
-    const chatsDir = path.join(
-      this.config.storage.getProjectTempDir(),
-      'chats',
-    );
-    return getSessionFiles(chatsDir, this.config.getSessionId());
+    const chatsDir = path.join(this.storage.getProjectTempDir(), 'chats');
+    return getSessionFiles(chatsDir);
   }
 
   /**
@@ -452,10 +449,7 @@ export class SessionSelector {
       return sortedSessions[index - 1];
     }
 
-    const chatsDir = path.join(
-      this.config.storage.getProjectTempDir(),
-      'chats',
-    );
+    const chatsDir = path.join(this.storage.getProjectTempDir(), 'chats');
     throw SessionError.invalidSessionIdentifier(trimmedIdentifier, chatsDir);
   }
 
@@ -507,10 +501,7 @@ export class SessionSelector {
   private async selectSession(
     sessionInfo: SessionInfo,
   ): Promise<SessionSelectionResult> {
-    const chatsDir = path.join(
-      this.config.storage.getProjectTempDir(),
-      'chats',
-    );
+    const chatsDir = path.join(this.storage.getProjectTempDir(), 'chats');
     const sessionPath = path.join(chatsDir, sessionInfo.fileName);
 
     try {

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -21,7 +21,7 @@ export async function listSessions(config: Config): Promise<void> {
   // Generate summary for most recent session if needed
   await generateSummary(config);
 
-  const sessionSelector = new SessionSelector(config);
+  const sessionSelector = new SessionSelector(config.storage);
   const sessions = await sessionSelector.listSessions();
 
   if (sessions.length === 0) {
@@ -55,7 +55,7 @@ export async function deleteSession(
   config: Config,
   sessionIndex: string,
 ): Promise<void> {
-  const sessionSelector = new SessionSelector(config);
+  const sessionSelector = new SessionSelector(config.storage);
   const sessions = await sessionSelector.listSessions();
 
   if (sessions.length === 0) {

--- a/packages/core/src/agents/subagent-tool.ts
+++ b/packages/core/src/agents/subagent-tool.ts
@@ -182,6 +182,7 @@ class SubAgentInvocation extends BaseToolInvocation<AgentInputs, ToolResult> {
       {
         operation: GeminiCliOperation.AgentCall,
         logPrompts: this.context.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.context.config.getSessionId(),
         attributes: {
           [GEN_AI_AGENT_NAME]: this.definition.name,
           [GEN_AI_AGENT_DESCRIPTION]: this.definition.description,

--- a/packages/core/src/core/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator.test.ts
@@ -74,6 +74,7 @@ describe('LoggingContentGenerator', () => {
       }),
       getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(true),
       refreshUserQuotaIfStale: vi.fn().mockResolvedValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
     } as unknown as Config;
     loggingContentGenerator = new LoggingContentGenerator(wrapped, config);
     vi.useFakeTimers();

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -350,6 +350,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       {
         operation: GeminiCliOperation.LLMCall,
         logPrompts: this.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.config.getSessionId(),
         attributes: {
           [GEN_AI_REQUEST_MODEL]: req.model,
           [GEN_AI_PROMPT_NAME]: userPromptId,
@@ -440,6 +441,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       {
         operation: GeminiCliOperation.LLMCall,
         logPrompts: this.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.config.getSessionId(),
         attributes: {
           [GEN_AI_REQUEST_MODEL]: req.model,
           [GEN_AI_PROMPT_NAME]: userPromptId,
@@ -594,6 +596,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       {
         operation: GeminiCliOperation.LLMCall,
         logPrompts: this.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.config.getSessionId(),
         attributes: {
           [GEN_AI_REQUEST_MODEL]: req.model,
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -252,7 +252,7 @@ export * from './telemetry/index.js';
 export * from './telemetry/billingEvents.js';
 export { logBillingEvent } from './telemetry/loggers.js';
 export * from './telemetry/constants.js';
-export { sessionId, createSessionId } from './utils/session.js';
+export { createSessionId } from './utils/session.js';
 export * from './utils/compatibility.js';
 export * from './utils/browser.js';
 export { Storage } from './config/storage.js';

--- a/packages/core/src/sandbox/macos/MacOsSandboxManager.test.ts
+++ b/packages/core/src/sandbox/macos/MacOsSandboxManager.test.ts
@@ -64,20 +64,12 @@ describe('MacOsSandboxManager', () => {
         policy: mockPolicy,
       });
 
-      expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith({
-        workspace: mockWorkspace,
-        allowedPaths: mockAllowedPaths,
-        forbiddenPaths: [],
-        networkAccess: mockNetworkAccess,
-        workspaceWrite: false,
-        additionalPermissions: {
-          fileSystem: {
-            read: [],
-            write: [],
-          },
-          network: true,
-        },
-      });
+      expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkAccess: true,
+          workspaceWrite: false,
+        }),
+      );
 
       expect(result.program).toBe('/usr/bin/sandbox-exec');
       expect(result.args[0]).toBe('-f');
@@ -155,11 +147,10 @@ describe('MacOsSandboxManager', () => {
 
       expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
         expect.objectContaining({
-          additionalPermissions: expect.objectContaining({
-            fileSystem: expect.objectContaining({
-              read: expect.not.arrayContaining(['/']),
-              write: expect.not.arrayContaining(['/']),
-            }),
+          workspaceWrite: true,
+          resolvedPaths: expect.objectContaining({
+            policyRead: expect.not.arrayContaining(['/']),
+            policyWrite: expect.not.arrayContaining(['/']),
           }),
         }),
       );
@@ -213,7 +204,11 @@ describe('MacOsSandboxManager', () => {
         // The seatbelt builder internally handles governance files, so we simply verify
         // it is invoked correctly with the right workspace.
         expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
-          expect.objectContaining({ workspace: mockWorkspace }),
+          expect.objectContaining({
+            resolvedPaths: expect.objectContaining({
+              workspace: { resolved: mockWorkspace, original: mockWorkspace },
+            }),
+          }),
         );
       });
     });
@@ -233,10 +228,12 @@ describe('MacOsSandboxManager', () => {
 
         expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
           expect.objectContaining({
-            allowedPaths: expect.arrayContaining([
-              '/tmp/allowed1',
-              '/tmp/allowed2',
-            ]),
+            resolvedPaths: expect.objectContaining({
+              policyAllowed: expect.arrayContaining([
+                '/tmp/allowed1',
+                '/tmp/allowed2',
+              ]),
+            }),
           }),
         );
       });
@@ -258,7 +255,9 @@ describe('MacOsSandboxManager', () => {
 
         expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
           expect.objectContaining({
-            forbiddenPaths: expect.arrayContaining(['/tmp/forbidden1']),
+            resolvedPaths: expect.objectContaining({
+              forbidden: expect.arrayContaining(['/tmp/forbidden1']),
+            }),
           }),
         );
       });
@@ -278,7 +277,9 @@ describe('MacOsSandboxManager', () => {
 
         expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
           expect.objectContaining({
-            forbiddenPaths: expect.arrayContaining(['/tmp/does-not-exist']),
+            resolvedPaths: expect.objectContaining({
+              forbidden: expect.arrayContaining(['/tmp/does-not-exist']),
+            }),
           }),
         );
       });
@@ -301,8 +302,10 @@ describe('MacOsSandboxManager', () => {
 
         expect(seatbeltArgsBuilder.buildSeatbeltProfile).toHaveBeenCalledWith(
           expect.objectContaining({
-            allowedPaths: [],
-            forbiddenPaths: expect.arrayContaining(['/tmp/conflict']),
+            resolvedPaths: expect.objectContaining({
+              policyAllowed: [],
+              forbidden: expect.arrayContaining(['/tmp/conflict']),
+            }),
           }),
         );
       });

--- a/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
+++ b/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
@@ -133,28 +133,26 @@ export class MacOsSandboxManager implements SandboxManager {
         false,
     };
 
+    const { command: finalCommand, args: finalArgs } = handleReadWriteCommands(
+      req,
+      mergedAdditional,
+      this.options.workspace,
+      [
+        ...(req.policy?.allowedPaths || []),
+        ...(this.options.includeDirectories || []),
+      ],
+    );
+
     const resolvedPaths = await resolveSandboxPaths(
       this.options,
       req,
       mergedAdditional,
     );
-    const { command: finalCommand, args: finalArgs } = handleReadWriteCommands(
-      req,
-      mergedAdditional,
-      this.options.workspace,
-      req.policy?.allowedPaths,
-    );
 
     const sandboxArgs = buildSeatbeltProfile({
-      workspace: this.options.workspace,
-      allowedPaths: [
-        ...resolvedPaths.policyAllowed,
-        ...(this.options.includeDirectories || []),
-      ],
-      forbiddenPaths: resolvedPaths.forbidden,
+      resolvedPaths,
       networkAccess: mergedAdditional.network,
       workspaceWrite,
-      additionalPermissions: mergedAdditional,
     });
 
     const tempFile = this.writeProfileToTempFile(sandboxArgs);

--- a/packages/core/src/sandbox/macos/seatbeltArgsBuilder.test.ts
+++ b/packages/core/src/sandbox/macos/seatbeltArgsBuilder.test.ts
@@ -8,18 +8,21 @@ import {
   buildSeatbeltProfile,
   escapeSchemeString,
 } from './seatbeltArgsBuilder.js';
-import * as fsUtils from '../utils/fsUtils.js';
+import type { ResolvedSandboxPaths } from '../../services/sandboxManager.js';
 import fs from 'node:fs';
 import os from 'node:os';
 
-vi.mock('../utils/fsUtils.js', async () => {
-  const actual = await vi.importActual('../utils/fsUtils.js');
-  return {
-    ...actual,
-    tryRealpath: vi.fn((p) => p),
-    resolveGitWorktreePaths: vi.fn(() => ({})),
-  };
-});
+const defaultResolvedPaths: ResolvedSandboxPaths = {
+  workspace: {
+    resolved: '/Users/test/workspace',
+    original: '/Users/test/raw-workspace',
+  },
+  forbidden: [],
+  globalIncludes: [],
+  policyAllowed: [],
+  policyRead: [],
+  policyWrite: [],
+};
 
 describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
   afterEach(() => {
@@ -35,12 +38,8 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
 
   describe('buildSeatbeltProfile', () => {
     it('should build a strict allowlist profile allowing the workspace', () => {
-      vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p);
-
       const profile = buildSeatbeltProfile({
-        workspace: '/Users/test/workspace',
-        allowedPaths: [],
-        forbiddenPaths: [],
+        resolvedPaths: defaultResolvedPaths,
       });
 
       expect(profile).toContain('(version 1)');
@@ -51,11 +50,11 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
     });
 
     it('should allow network when networkAccess is true', () => {
-      vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p);
       const profile = buildSeatbeltProfile({
-        workspace: '/test',
-        allowedPaths: [],
-        forbiddenPaths: [],
+        resolvedPaths: {
+          ...defaultResolvedPaths,
+          workspace: { resolved: '/test', original: '/test' },
+        },
         networkAccess: true,
       });
       expect(profile).toContain('(allow network-outbound)');
@@ -63,7 +62,6 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
 
     describe('governance files', () => {
       it('should inject explicit deny rules for governance files', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p.toString());
         vi.spyOn(fs, 'existsSync').mockReturnValue(true);
         vi.spyOn(fs, 'lstatSync').mockImplementation(
           (p) =>
@@ -74,9 +72,13 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
         );
 
         const profile = buildSeatbeltProfile({
-          workspace: '/test/workspace',
-          allowedPaths: [],
-          forbiddenPaths: [],
+          resolvedPaths: {
+            ...defaultResolvedPaths,
+            workspace: {
+              resolved: '/test/workspace',
+              original: '/test/workspace',
+            },
+          },
         });
 
         expect(profile).toContain(
@@ -87,48 +89,16 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
           `(deny file-write* (subpath "/test/workspace/.git"))`,
         );
       });
-
-      it('should protect both the symlink and the real path if they differ', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => {
-          if (p === '/test/workspace/.gitignore')
-            return '/test/real/.gitignore';
-          return p.toString();
-        });
-        vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-        vi.spyOn(fs, 'lstatSync').mockImplementation(
-          () =>
-            ({
-              isDirectory: () => false,
-              isFile: () => true,
-            }) as unknown as fs.Stats,
-        );
-
-        const profile = buildSeatbeltProfile({
-          workspace: '/test/workspace',
-          allowedPaths: [],
-          forbiddenPaths: [],
-        });
-
-        expect(profile).toContain(
-          `(deny file-write* (literal "/test/workspace/.gitignore"))`,
-        );
-        expect(profile).toContain(
-          `(deny file-write* (literal "/test/real/.gitignore"))`,
-        );
-      });
     });
 
     describe('allowedPaths', () => {
-      it('should embed allowed paths and normalize them', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => {
-          if (p === '/test/symlink') return '/test/real_path';
-          return p;
-        });
-
+      it('should embed allowed paths', () => {
         const profile = buildSeatbeltProfile({
-          workspace: '/test',
-          allowedPaths: ['/custom/path1', '/test/symlink'],
-          forbiddenPaths: [],
+          resolvedPaths: {
+            ...defaultResolvedPaths,
+            workspace: { resolved: '/test', original: '/test' },
+            policyAllowed: ['/custom/path1', '/test/real_path'],
+          },
         });
 
         expect(profile).toContain(`(subpath "/custom/path1")`);
@@ -138,12 +108,12 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
 
     describe('forbiddenPaths', () => {
       it('should explicitly deny forbidden paths', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p);
-
         const profile = buildSeatbeltProfile({
-          workspace: '/test',
-          allowedPaths: [],
-          forbiddenPaths: ['/secret/path'],
+          resolvedPaths: {
+            ...defaultResolvedPaths,
+            workspace: { resolved: '/test', original: '/test' },
+            forbidden: ['/secret/path'],
+          },
         });
 
         expect(profile).toContain(
@@ -151,46 +121,14 @@ describe.skipIf(os.platform() === 'win32')('seatbeltArgsBuilder', () => {
         );
       });
 
-      it('resolves forbidden symlink paths to their real paths', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => {
-          if (p === '/test/symlink' || p === '/test/missing-dir') {
-            return '/test/real_path';
-          }
-          return p;
-        });
-
-        const profile = buildSeatbeltProfile({
-          workspace: '/test',
-          allowedPaths: [],
-          forbiddenPaths: ['/test/symlink'],
-        });
-
-        expect(profile).toContain(
-          `(deny file-read* file-write* (subpath "/test/real_path"))`,
-        );
-      });
-
-      it('explicitly denies non-existent forbidden paths to prevent creation', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p);
-
-        const profile = buildSeatbeltProfile({
-          workspace: '/test',
-          allowedPaths: [],
-          forbiddenPaths: ['/test/missing-dir/missing-file.txt'],
-        });
-
-        expect(profile).toContain(
-          `(deny file-read* file-write* (subpath "/test/missing-dir/missing-file.txt"))`,
-        );
-      });
-
       it('should override allowed paths if a path is also in forbidden paths', () => {
-        vi.mocked(fsUtils.tryRealpath).mockImplementation((p) => p);
-
         const profile = buildSeatbeltProfile({
-          workspace: '/test',
-          allowedPaths: ['/custom/path1'],
-          forbiddenPaths: ['/custom/path1'],
+          resolvedPaths: {
+            ...defaultResolvedPaths,
+            workspace: { resolved: '/test', original: '/test' },
+            policyAllowed: ['/custom/path1'],
+            forbidden: ['/custom/path1'],
+          },
         });
 
         const allowString = `(allow file-read* file-write* (subpath "/custom/path1"))`;

--- a/packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts
+++ b/packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts
@@ -12,9 +12,9 @@ import {
   NETWORK_SEATBELT_PROFILE,
 } from './baseProfile.js';
 import {
-  type SandboxPermissions,
   GOVERNANCE_FILES,
   SECRET_FILES,
+  type ResolvedSandboxPaths,
 } from '../../services/sandboxManager.js';
 import { tryRealpath, resolveGitWorktreePaths } from '../utils/fsUtils.js';
 
@@ -22,16 +22,10 @@ import { tryRealpath, resolveGitWorktreePaths } from '../utils/fsUtils.js';
  * Options for building macOS Seatbelt profile.
  */
 export interface SeatbeltArgsOptions {
-  /** The primary workspace path to allow access to. */
-  workspace: string;
-  /** Additional paths to allow access to. */
-  allowedPaths: string[];
-  /** Absolute paths to explicitly deny read/write access to (overrides allowlists). */
-  forbiddenPaths: string[];
+  /** Fully resolved paths for the sandbox execution. */
+  resolvedPaths: ResolvedSandboxPaths;
   /** Whether to allow network access. */
   networkAccess?: boolean;
-  /** Granular additional permissions. */
-  additionalPermissions?: SandboxPermissions;
   /** Whether to allow write access to the workspace. */
   workspaceWrite?: boolean;
 }
@@ -49,72 +43,22 @@ export function escapeSchemeString(str: string): string {
  */
 export function buildSeatbeltProfile(options: SeatbeltArgsOptions): string {
   let profile = BASE_SEATBELT_PROFILE + '\n';
+  const { resolvedPaths, networkAccess, workspaceWrite } = options;
 
-  const workspacePath = tryRealpath(options.workspace);
-  profile += `(allow file-read* (subpath "${escapeSchemeString(options.workspace)}"))\n`;
-  profile += `(allow file-read* (subpath "${escapeSchemeString(workspacePath)}"))\n`;
-  if (options.workspaceWrite) {
-    profile += `(allow file-write* (subpath "${escapeSchemeString(options.workspace)}"))\n`;
-    profile += `(allow file-write* (subpath "${escapeSchemeString(workspacePath)}"))\n`;
+  profile += `(allow file-read* (subpath "${escapeSchemeString(resolvedPaths.workspace.original)}"))\n`;
+  profile += `(allow file-read* (subpath "${escapeSchemeString(resolvedPaths.workspace.resolved)}"))\n`;
+  if (workspaceWrite) {
+    profile += `(allow file-write* (subpath "${escapeSchemeString(resolvedPaths.workspace.original)}"))\n`;
+    profile += `(allow file-write* (subpath "${escapeSchemeString(resolvedPaths.workspace.resolved)}"))\n`;
   }
 
   const tmpPath = tryRealpath(os.tmpdir());
   profile += `(allow file-read* file-write* (subpath "${escapeSchemeString(tmpPath)}"))\n`;
 
-  // Add explicit deny rules for governance files in the workspace.
-  // These are added after the workspace allow rule to ensure they take precedence
-  // (Seatbelt evaluates rules in order, later rules win for same path).
-  for (let i = 0; i < GOVERNANCE_FILES.length; i++) {
-    const governanceFile = path.join(workspacePath, GOVERNANCE_FILES[i].path);
-    const realGovernanceFile = tryRealpath(governanceFile);
-
-    // Determine if it should be treated as a directory (subpath) or a file (literal).
-    // .git is generally a directory, while ignore files are literals.
-    let isDirectory = GOVERNANCE_FILES[i].isDirectory;
-    try {
-      if (fs.existsSync(realGovernanceFile)) {
-        isDirectory = fs.lstatSync(realGovernanceFile).isDirectory();
-      }
-    } catch {
-      // Ignore errors, use default guess
-    }
-
-    const ruleType = isDirectory ? 'subpath' : 'literal';
-
-    profile += `(deny file-write* (${ruleType} "${escapeSchemeString(governanceFile)}"))\n`;
-
-    if (realGovernanceFile !== governanceFile) {
-      profile += `(deny file-write* (${ruleType} "${escapeSchemeString(realGovernanceFile)}"))\n`;
-    }
-  }
-
-  // Add explicit deny rules for secret files (.env, .env.*) in the workspace and allowed paths.
-  // We use regex rules to avoid expensive file discovery scans.
-  // Anchoring to workspace/allowed paths to avoid over-blocking.
-  const searchPaths = [options.workspace, ...options.allowedPaths];
-
-  for (const basePath of searchPaths) {
-    const resolvedBase = tryRealpath(basePath);
-    for (const secret of SECRET_FILES) {
-      // Map pattern to Seatbelt regex
-      let regexPattern: string;
-      const escapedBase = escapeRegex(resolvedBase);
-      if (secret.pattern.endsWith('*')) {
-        // .env.* -> .env\..+ (match .env followed by dot and something)
-        // We anchor the secret file name to either a directory separator or the start of the relative path.
-        const basePattern = secret.pattern.slice(0, -1).replace(/\./g, '\\\\.');
-        regexPattern = `^${escapedBase}/(.*/)?${basePattern}[^/]+$`;
-      } else {
-        // .env -> \.env$
-        const basePattern = secret.pattern.replace(/\./g, '\\\\.');
-        regexPattern = `^${escapedBase}/(.*/)?${basePattern}$`;
-      }
-      profile += `(deny file-read* file-write* (regex #"${regexPattern}"))\n`;
-    }
-  }
-
   // Auto-detect and support git worktrees by granting read and write access to the underlying git directory
-  const { worktreeGitDir, mainGitDir } = resolveGitWorktreePaths(workspacePath);
+  const { worktreeGitDir, mainGitDir } = resolveGitWorktreePaths(
+    resolvedPaths.workspace.resolved,
+  );
   if (worktreeGitDir) {
     profile += `(allow file-read* file-write* (subpath "${escapeSchemeString(worktreeGitDir)}"))\n`;
   }
@@ -154,58 +98,115 @@ export function buildSeatbeltProfile(options: SeatbeltArgsOptions): string {
     }
   }
 
-  // Handle allowedPaths
-  const allowedPaths = options.allowedPaths;
+  // Handle allowedPaths and globalIncludes
+  const allowedPaths = [
+    ...resolvedPaths.policyAllowed,
+    ...resolvedPaths.globalIncludes,
+  ];
   for (let i = 0; i < allowedPaths.length; i++) {
-    const allowedPath = tryRealpath(allowedPaths[i]);
+    const allowedPath = allowedPaths[i];
     profile += `(allow file-read* file-write* (subpath "${escapeSchemeString(allowedPath)}"))\n`;
   }
 
-  // Handle granular additional permissions
-  if (options.additionalPermissions?.fileSystem) {
-    const { read, write } = options.additionalPermissions.fileSystem;
-    if (read) {
-      for (let i = 0; i < read.length; i++) {
-        const resolved = tryRealpath(read[i]);
-        let isFile = false;
-        try {
-          isFile = fs.statSync(resolved).isFile();
-        } catch {
-          // Ignore error
-        }
-        if (isFile) {
-          profile += `(allow file-read* (literal "${escapeSchemeString(resolved)}"))\n`;
-        } else {
-          profile += `(allow file-read* (subpath "${escapeSchemeString(resolved)}"))\n`;
-        }
-      }
+  // Handle granular additional read permissions
+  for (let i = 0; i < resolvedPaths.policyRead.length; i++) {
+    const resolved = resolvedPaths.policyRead[i];
+    let isFile = false;
+    try {
+      isFile = fs.statSync(resolved).isFile();
+    } catch {
+      // Ignore error
     }
-    if (write) {
-      for (let i = 0; i < write.length; i++) {
-        const resolved = tryRealpath(write[i]);
-        let isFile = false;
-        try {
-          isFile = fs.statSync(resolved).isFile();
-        } catch {
-          // Ignore error
-        }
-        if (isFile) {
-          profile += `(allow file-read* file-write* (literal "${escapeSchemeString(resolved)}"))\n`;
-        } else {
-          profile += `(allow file-read* file-write* (subpath "${escapeSchemeString(resolved)}"))\n`;
-        }
+    if (isFile) {
+      profile += `(allow file-read* (literal "${escapeSchemeString(resolved)}"))\n`;
+    } else {
+      profile += `(allow file-read* (subpath "${escapeSchemeString(resolved)}"))\n`;
+    }
+  }
+
+  // Handle granular additional write permissions
+  for (let i = 0; i < resolvedPaths.policyWrite.length; i++) {
+    const resolved = resolvedPaths.policyWrite[i];
+    let isFile = false;
+    try {
+      isFile = fs.statSync(resolved).isFile();
+    } catch {
+      // Ignore error
+    }
+    if (isFile) {
+      profile += `(allow file-read* file-write* (literal "${escapeSchemeString(resolved)}"))\n`;
+    } else {
+      profile += `(allow file-read* file-write* (subpath "${escapeSchemeString(resolved)}"))\n`;
+    }
+  }
+
+  // Add explicit deny rules for governance files in the workspace.
+  // These are added after the workspace allow rule to ensure they take precedence
+  // (Seatbelt evaluates rules in order, later rules win for same path).
+  for (let i = 0; i < GOVERNANCE_FILES.length; i++) {
+    const governanceFile = path.join(
+      resolvedPaths.workspace.resolved,
+      GOVERNANCE_FILES[i].path,
+    );
+    const realGovernanceFile = tryRealpath(governanceFile);
+
+    // Determine if it should be treated as a directory (subpath) or a file (literal).
+    // .git is generally a directory, while ignore files are literals.
+    let isDirectory = GOVERNANCE_FILES[i].isDirectory;
+    try {
+      if (fs.existsSync(realGovernanceFile)) {
+        isDirectory = fs.lstatSync(realGovernanceFile).isDirectory();
       }
+    } catch {
+      // Ignore errors, use default guess
+    }
+
+    const ruleType = isDirectory ? 'subpath' : 'literal';
+
+    profile += `(deny file-write* (${ruleType} "${escapeSchemeString(governanceFile)}"))\n`;
+
+    if (realGovernanceFile !== governanceFile) {
+      profile += `(deny file-write* (${ruleType} "${escapeSchemeString(realGovernanceFile)}"))\n`;
+    }
+  }
+
+  // Add explicit deny rules for secret files (.env, .env.*) in the workspace and allowed paths.
+  // We use regex rules to avoid expensive file discovery scans.
+  // Anchoring to workspace/allowed paths to avoid over-blocking.
+  const searchPaths = [
+    resolvedPaths.workspace.resolved,
+    resolvedPaths.workspace.original,
+    ...resolvedPaths.policyAllowed,
+    ...resolvedPaths.globalIncludes,
+  ];
+
+  for (const basePath of searchPaths) {
+    for (const secret of SECRET_FILES) {
+      // Map pattern to Seatbelt regex
+      let regexPattern: string;
+      const escapedBase = escapeRegex(basePath);
+      if (secret.pattern.endsWith('*')) {
+        // .env.* -> .env\..+ (match .env followed by dot and something)
+        // We anchor the secret file name to either a directory separator or the start of the relative path.
+        const basePattern = secret.pattern.slice(0, -1).replace(/\./g, '\\\\.');
+        regexPattern = `^${escapedBase}/(.*/)?${basePattern}[^/]+$`;
+      } else {
+        // .env -> \.env$
+        const basePattern = secret.pattern.replace(/\./g, '\\\\.');
+        regexPattern = `^${escapedBase}/(.*/)?${basePattern}$`;
+      }
+      profile += `(deny file-read* file-write* (regex #"${regexPattern}"))\n`;
     }
   }
 
   // Handle forbiddenPaths
-  const forbiddenPaths = options.forbiddenPaths;
+  const forbiddenPaths = resolvedPaths.forbidden;
   for (let i = 0; i < forbiddenPaths.length; i++) {
-    const forbiddenPath = tryRealpath(forbiddenPaths[i]);
+    const forbiddenPath = forbiddenPaths[i];
     profile += `(deny file-read* file-write* (subpath "${escapeSchemeString(forbiddenPath)}"))\n`;
   }
 
-  if (options.networkAccess || options.additionalPermissions?.network) {
+  if (networkAccess) {
     profile += NETWORK_SEATBELT_PROFILE;
   }
 

--- a/packages/core/src/scheduler/policy.test.ts
+++ b/packages/core/src/scheduler/policy.test.ts
@@ -51,8 +51,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         getPolicyEngine: vi.fn().mockReturnValue(mockPolicyEngine),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
 
@@ -79,8 +79,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         getPolicyEngine: vi.fn().mockReturnValue(mockPolicyEngine),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
 
@@ -161,8 +161,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         getPolicyEngine: vi.fn().mockReturnValue(mockPolicyEngine),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
 
@@ -226,8 +226,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         getPolicyEngine: vi.fn().mockReturnValue(mockPolicyEngine),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       const toolCall = {
         request: { name: 'test-tool', args: {}, isClientInitiated: true },
         tool: { name: 'test-tool' },
@@ -243,8 +243,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -273,8 +273,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -307,6 +307,7 @@ describe('policy.ts', () => {
         isTrustedFolder: vi.fn().mockReturnValue(false),
         getWorkspacePoliciesDir: vi.fn().mockReturnValue(undefined),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
 
       (mockConfig as unknown as { config: Config }).config =
@@ -339,8 +340,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -379,8 +380,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -420,8 +421,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -447,8 +448,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -473,8 +474,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -499,8 +500,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -540,8 +541,8 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
-
       (mockConfig as unknown as { config: Config }).config =
         mockConfig as Config;
       const mockMessageBus = {
@@ -583,6 +584,7 @@ describe('policy.ts', () => {
         isTrustedFolder: vi.fn().mockReturnValue(false),
         getWorkspacePoliciesDir: vi.fn().mockReturnValue(undefined),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
 
       (mockConfig as unknown as { config: Config }).config =
@@ -628,6 +630,7 @@ describe('policy.ts', () => {
           .fn()
           .mockReturnValue('/mock/project/policies'),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
       const mockMessageBus = {
         publish: vi.fn(),
@@ -659,6 +662,7 @@ describe('policy.ts', () => {
           .fn()
           .mockReturnValue('/mock/project/policies'),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
       const mockMessageBus = {
         publish: vi.fn(),
@@ -689,6 +693,7 @@ describe('policy.ts', () => {
         getWorkspacePoliciesDir: vi.fn().mockReturnValue(undefined),
         getTargetDir: vi.fn().mockReturnValue('/mock/dir'),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
       const mockMessageBus = {
         publish: vi.fn(),
@@ -727,6 +732,7 @@ describe('policy.ts', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         setApprovalMode: vi.fn(),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Mocked<Config>;
       const mockMessageBus = {
         publish: vi.fn(),
@@ -766,6 +772,7 @@ describe('policy.ts', () => {
     it('should return default denial message when no rule provided', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Config;
 
       (mockConfig as unknown as { config: Config }).config = mockConfig;
@@ -779,6 +786,7 @@ describe('policy.ts', () => {
     it('should return custom deny message if provided', () => {
       const mockConfig = {
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
       } as unknown as Config;
 
       (mockConfig as unknown as { config: Config }).config = mockConfig;
@@ -840,7 +848,6 @@ describe('Plan Mode Denial Consistency', () => {
       publish: vi.fn(),
       subscribe: vi.fn(),
     } as unknown as Mocked<MessageBus>;
-
     mockConfig = {
       getPolicyEngine: vi.fn().mockReturnValue(mockPolicyEngine),
       toolRegistry: mockToolRegistry,
@@ -852,6 +859,7 @@ describe('Plan Mode Denial Consistency', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.PLAN), // Key: Plan Mode
       getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
       setApprovalMode: vi.fn(),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Mocked<Config>;
     (mockConfig as unknown as { config: Config }).config = mockConfig as Config;
@@ -933,6 +941,7 @@ describe('Plan Mode Denial Consistency', () => {
           getApprovalMode: vi.fn().mockReturnValue(currentMode),
           isTrustedFolder: vi.fn().mockReturnValue(false),
           getWorkspacePoliciesDir: vi.fn().mockReturnValue(undefined),
+          getSessionId: vi.fn().mockReturnValue('test-session-id'),
         } as unknown as Mocked<Config>;
 
         const mockMessageBus = {

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -177,6 +177,7 @@ describe('Scheduler (Orchestrator)', () => {
       setApprovalMode: vi.fn(),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
     } as unknown as Mocked<Config>;
 
     (mockConfig as unknown as { config: Config }).config = mockConfig as Config;
@@ -1423,6 +1424,7 @@ describe('Scheduler MCP Progress', () => {
       setApprovalMode: vi.fn(),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
     } as unknown as Mocked<Config>;
 
     (mockConfig as unknown as { config: Config }).config = mockConfig as Config;

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -197,6 +197,7 @@ export class Scheduler {
       {
         operation: GeminiCliOperation.ScheduleToolCalls,
         logPrompts: this.context.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.context.config.getSessionId(),
       },
       async ({ metadata: spanMetadata }) => {
         const requests = Array.isArray(request) ? request : [request];

--- a/packages/core/src/scheduler/scheduler_parallel.test.ts
+++ b/packages/core/src/scheduler/scheduler_parallel.test.ts
@@ -218,6 +218,7 @@ describe('Scheduler Parallel Execution', () => {
       setApprovalMode: vi.fn(),
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
     } as unknown as Mocked<Config>;
 
     (mockConfig as unknown as { config: Config }).config = mockConfig as Config;

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -84,6 +84,7 @@ export class ToolExecutor {
       {
         operation: GeminiCliOperation.ToolCall,
         logPrompts: this.config.getTelemetryLogPromptsEnabled(),
+        sessionId: this.config.getSessionId(),
         attributes: {
           [GEN_AI_TOOL_NAME]: toolName,
           [GEN_AI_TOOL_CALL_ID]: callId,

--- a/packages/core/src/telemetry/trace.test.ts
+++ b/packages/core/src/telemetry/trace.test.ts
@@ -110,7 +110,7 @@ describe('runInDevTraceSpan', () => {
     const fn = vi.fn(async () => 'result');
 
     const result = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       fn,
     );
 
@@ -125,7 +125,7 @@ describe('runInDevTraceSpan', () => {
 
   it('should set default attributes on the span metadata', async () => {
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async ({ metadata }) => {
         expect(metadata.attributes[GEN_AI_OPERATION_NAME]).toBe(
           GeminiCliOperation.LLMCall,
@@ -143,7 +143,7 @@ describe('runInDevTraceSpan', () => {
 
   it('should set span attributes from metadata on completion', async () => {
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async ({ metadata }) => {
         metadata.input = { query: 'hello' };
         metadata.output = { response: 'world' };
@@ -169,9 +169,12 @@ describe('runInDevTraceSpan', () => {
   it('should handle errors in the wrapped function', async () => {
     const error = new Error('test error');
     await expect(
-      runInDevTraceSpan({ operation: GeminiCliOperation.LLMCall }, async () => {
-        throw error;
-      }),
+      runInDevTraceSpan(
+        { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+        async () => {
+          throw error;
+        },
+      ),
     ).rejects.toThrow(error);
 
     expect(mockSpan.setStatus).toHaveBeenCalledWith({
@@ -189,7 +192,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => testStream(),
     );
 
@@ -212,7 +215,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => errorStream(),
     );
 
@@ -231,7 +234,7 @@ describe('runInDevTraceSpan', () => {
     });
 
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall },
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async ({ metadata }) => {
         metadata.input = 'trigger error';
       },

--- a/packages/core/src/telemetry/trace.ts
+++ b/packages/core/src/telemetry/trace.ts
@@ -23,7 +23,6 @@ import {
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
 } from './constants.js';
-import { sessionId } from '../utils/session.js';
 
 import { truncateString } from '../utils/textUtils.js';
 
@@ -96,10 +95,14 @@ export interface SpanMetadata {
  * @returns The result of the function.
  */
 export async function runInDevTraceSpan<R>(
-  opts: SpanOptions & { operation: GeminiCliOperation; logPrompts?: boolean },
+  opts: SpanOptions & {
+    operation: GeminiCliOperation;
+    logPrompts?: boolean;
+    sessionId: string;
+  },
   fn: ({ metadata }: { metadata: SpanMetadata }) => Promise<R>,
 ): Promise<R> {
-  const { operation, logPrompts, ...restOfSpanOpts } = opts;
+  const { operation, logPrompts, sessionId, ...restOfSpanOpts } = opts;
 
   const tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
   return tracer.startActiveSpan(operation, restOfSpanOpts, async (span) => {

--- a/packages/core/src/tools/ls.test.ts
+++ b/packages/core/src/tools/ls.test.ts
@@ -132,7 +132,7 @@ describe('LSTool', () => {
       expect(result.llmContent).toContain('[DIR] subdir');
       expect(result.llmContent).toContain('file1.txt');
       expect(result.returnDisplay).toEqual({
-        summary: 'Listed 2 item(s).',
+        summary: 'Found 2 item(s).',
         files: ['[DIR] subdir', 'file1.txt'],
       });
     });
@@ -150,7 +150,7 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('secondary-file.txt');
       expect(result.returnDisplay).toEqual({
-        summary: 'Listed 1 item(s).',
+        summary: 'Found 1 item(s).',
         files: expect.any(Array),
       });
     });
@@ -178,7 +178,7 @@ describe('LSTool', () => {
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('file2.log');
       expect(result.returnDisplay).toEqual({
-        summary: 'Listed 1 item(s).',
+        summary: 'Found 1 item(s).',
         files: expect.any(Array),
       });
     });
@@ -195,7 +195,7 @@ describe('LSTool', () => {
       expect(result.llmContent).not.toContain('file2.log');
       // .git is always ignored by default.
       expect(result.returnDisplay).toEqual(
-        expect.objectContaining({ summary: 'Listed 2 item(s). (2 ignored)' }),
+        expect.objectContaining({ summary: 'Found 2 item(s). (2 ignored)' }),
       );
     });
 
@@ -212,7 +212,7 @@ describe('LSTool', () => {
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('file2.log');
       expect(result.returnDisplay).toEqual(
-        expect.objectContaining({ summary: 'Listed 2 item(s). (1 ignored)' }),
+        expect.objectContaining({ summary: 'Found 2 item(s). (1 ignored)' }),
       );
     });
 
@@ -301,7 +301,7 @@ describe('LSTool', () => {
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('problematic.txt');
       expect(result.returnDisplay).toEqual({
-        summary: 'Listed 1 item(s).',
+        summary: 'Found 1 item(s).',
         files: expect.any(Array),
       });
 
@@ -364,7 +364,7 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('secondary-file.txt');
       expect(result.returnDisplay).toEqual({
-        summary: 'Listed 1 item(s).',
+        summary: 'Found 1 item(s).',
         files: expect.any(Array),
       });
     });

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -276,7 +276,7 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
         resultMessage = appendJitContext(resultMessage, jitContext);
       }
 
-      let displayMessage = `Listed ${entries.length} item(s).`;
+      let displayMessage = `Found ${entries.length} item(s).`;
       if (ignoredCount > 0) {
         displayMessage += ` (${ignoredCount} ignored)`;
       }

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -768,6 +768,46 @@ describe('ShellTool', () => {
       const shellTool = new ShellTool(mockConfig, createMockMessageBus());
       expect(shellTool.description).not.toContain('Efficiency Guidelines:');
     });
+
+    it('should return the command if description is not provided', () => {
+      const invocation = shellTool.build({
+        command: 'echo "hello"',
+      });
+      expect(invocation.getDescription()).toBe('echo "hello"');
+    });
+
+    it('should return the command if it is short (<= 150 chars), even if description is provided', () => {
+      const invocation = shellTool.build({
+        command: 'echo "hello"',
+        description: 'Prints a friendly greeting.',
+      });
+      expect(invocation.getDescription()).toBe('echo "hello"');
+    });
+
+    it('should return the description if the command is long (> 150 chars)', () => {
+      const longCommand = 'echo "hello" && '.repeat(15) + 'echo "world"'; // Length > 150
+      const invocation = shellTool.build({
+        command: longCommand,
+        description: 'Prints multiple greetings.',
+      });
+      expect(invocation.getDescription()).toBe('Prints multiple greetings.');
+    });
+
+    it('should return the raw command if description is an empty string', () => {
+      const invocation = shellTool.build({
+        command: 'echo hello',
+        description: '',
+      });
+      expect(invocation.getDescription()).toBe('echo hello');
+    });
+
+    it('should return the raw command if description is just whitespace', () => {
+      const invocation = shellTool.build({
+        command: 'echo hello',
+        description: '   ',
+      });
+      expect(invocation.getDescription()).toBe('echo hello');
+    });
   });
 
   describe('getDisplayTitle and getExplanation', () => {
@@ -800,32 +840,6 @@ describe('ShellTool', () => {
       expect(invocation.getExplanation?.()).toBe(
         `[current working directory ${process.cwd()}]`,
       );
-    });
-  });
-
-  describe('invocation getDescription', () => {
-    it('should return the description if it is present and not empty whitespace', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: 'prints hello',
-      });
-      expect(invocation.getDescription()).toBe('prints hello');
-    });
-
-    it('should return the raw command if description is an empty string', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: '',
-      });
-      expect(invocation.getDescription()).toBe('echo hello');
-    });
-
-    it('should return the raw command if description is just whitespace', () => {
-      const invocation = shellTool.build({
-        command: 'echo hello',
-        description: '   ',
-      });
-      expect(invocation.getDescription()).toBe('echo hello');
     });
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -63,6 +63,7 @@ export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
 // Delay so user does not see the output of the process before the process is moved to the background.
 const BACKGROUND_DELAY_MS = 200;
+const SHOW_NL_DESCRIPTION_THRESHOLD = 150;
 
 export interface ShellToolParams {
   command: string;
@@ -136,9 +137,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
   }
 
   getDescription(): string {
-    return this.params.description?.trim()
-      ? this.params.description
-      : this.params.command;
+    const descStr = this.params.description?.trim();
+    const commandStr = this.params.command;
+    return Array.from(commandStr).length <= SHOW_NL_DESCRIPTION_THRESHOLD ||
+      !descStr
+      ? commandStr
+      : descStr;
   }
 
   private simplifyPaths(paths: Set<string>): string[] {

--- a/packages/core/src/utils/session.ts
+++ b/packages/core/src/utils/session.ts
@@ -6,8 +6,6 @@
 
 import { randomUUID } from 'node:crypto';
 
-export const sessionId = randomUUID();
-
 export function createSessionId(): string {
   return randomUUID();
 }

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -181,7 +181,8 @@ describe('GeminiCliSession initialize()', () => {
   });
 });
 
-describe('GeminiCliSession sendStream()', () => {
+// TODO(#24999): Mock uses getGeminiClient() method but session.ts expects geminiClient property.
+describe.skip('GeminiCliSession sendStream()', () => {
   it('auto-initializes if not yet initialized', async () => {
     const session = new GeminiCliSession(
       baseOptions,

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2725,8 +2725,8 @@
       "properties": {
         "autoConfigureMemory": {
           "title": "Auto Configure Max Old Space Size",
-          "description": "Automatically configure Node.js memory limits",
-          "markdownDescription": "Automatically configure Node.js memory limits\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
+          "description": "Automatically configure Node.js memory limits. Note: Because memory is allocated during the initial process boot, this setting is only read from the global user settings file and ignores workspace-level overrides.",
+          "markdownDescription": "Automatically configure Node.js memory limits. Note: Because memory is allocated during the initial process boot, this setting is only read from the global user settings file and ignores workspace-level overrides.\n\n- Category: `Advanced`\n- Requires restart: `yes`\n- Default: `true`",
           "default": true,
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Enhance macOS Seatbelt configuration flexibility by allowing the `SEATBELT_PROFILE`  environment variable to accept absolute paths. This enables developers to maintain centralized sandbox policies across multiple repositories without duplicating configuration into every project's `.gemini` folder.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Updated the sandbox utility to check if the `SEATBELT_PROFILE` value is an absolute path.
   - If absolute: Uses the path directly.
 - If relative/name: Continues with existing logic (checking built-in profiles or the project `.gemini` folder).

This change is non-breaking and preserves all existing workflows.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Closes #24991

## How to Validate

``
GEMINI_SANDBOX=sandbox-exec SEATBELT_PROFILE=$(pwd)/bundle/sandbox-macos-permissive-open.sb node bundle/gemini.js -s
``

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [X] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
