### PR TITLE
feature: feature: allow absolute path for macos seatbelt profiles (sa…

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -171,6 +171,39 @@ describe('sandbox', () => {
       );
     });
 
+    it('should handle absolute path for SEATBELT_PROFILE', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      process.env['SEATBELT_PROFILE'] = '/absolute/path/to/profile.sb';
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const promise = start_sandbox(config);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      await expect(promise).resolves.toBe(0);
+      expect(spawn).toHaveBeenCalledWith(
+        'sandbox-exec',
+        expect.arrayContaining(['-f', '/absolute/path/to/profile.sb']),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+    });
+
     it('should throw FatalSandboxError if seatbelt profile is missing', async () => {
       vi.mocked(os.platform).mockReturnValue('darwin');
       vi.mocked(fs.existsSync).mockReturnValue(false);

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -65,26 +65,14 @@ export async function start_sandbox(
       }
 
       const profile = (process.env['SEATBELT_PROFILE'] ??= 'permissive-open');
-      const trimmedProfile = profile.trim();
-      let profileFile;
-      if (path.isAbsolute(trimmedProfile)) {
-        profileFile = trimmedProfile;
-      } else {
-        if (trimmedProfile.includes('..') || trimmedProfile.includes('\0')) {
-          throw new FatalSandboxError(
-            'Invalid seatbelt profile name: ' + trimmedProfile,
-          );
-        }
-        profileFile = fileURLToPath(
-          new URL(`sandbox-macos-${trimmedProfile}.sb`, import.meta.url),
-        );
-        // if profile name is not recognized, then look for file under project settings directory
-        if (!BUILTIN_SEATBELT_PROFILES.includes(trimmedProfile)) {
-          profileFile = path.join(
-            GEMINI_DIR,
-            `sandbox-macos-${trimmedProfile}.sb`,
-          );
-        }
+      let profileFile = fileURLToPath(
+        new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
+      );
+      // if profile name is not recognized, then look for absolute path or file under project settings directory
+      if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
+        profileFile = path.isAbsolute(profile)
+          ? profile
+          : path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`);
       }
       if (!fs.existsSync(profileFile)) {
         throw new FatalSandboxError(

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -65,12 +65,26 @@ export async function start_sandbox(
       }
 
       const profile = (process.env['SEATBELT_PROFILE'] ??= 'permissive-open');
-      let profileFile = fileURLToPath(
-        new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
-      );
-      // if profile name is not recognized, then look for file under project settings directory
-      if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-        profileFile = path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`);
+      const trimmedProfile = profile.trim();
+      let profileFile;
+      if (path.isAbsolute(trimmedProfile)) {
+        profileFile = trimmedProfile;
+      } else {
+        if (trimmedProfile.includes('..') || trimmedProfile.includes('\0')) {
+          throw new FatalSandboxError(
+            'Invalid seatbelt profile name: ' + trimmedProfile,
+          );
+        }
+        profileFile = fileURLToPath(
+          new URL(`sandbox-macos-${trimmedProfile}.sb`, import.meta.url),
+        );
+        // if profile name is not recognized, then look for file under project settings directory
+        if (!BUILTIN_SEATBELT_PROFILES.includes(trimmedProfile)) {
+          profileFile = path.join(
+            GEMINI_DIR,
+            `sandbox-macos-${trimmedProfile}.sb`,
+          );
+        }
       }
       if (!fs.existsSync(profileFile)) {
         throw new FatalSandboxError(


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Enhance macOS Seatbelt configuration flexibility by allowing the `SEATBELT_PROFILE`  environment variable to accept absolute paths. This enables developers to maintain centralized sandbox policies across multiple repositories without duplicating configuration into every project's `.gemini` folder.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

Updated the sandbox utility to check if the `SEATBELT_PROFILE` value is an absolute path.
   - If absolute: Uses the path directly.
 - If relative/name: Continues with existing logic (checking built-in profiles or the project `.gemini` folder).

This change is non-breaking and preserves all existing workflows.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Closes #24991

## How to Validate

``
GEMINI_SANDBOX=sandbox-exec SEATBELT_PROFILE=$(pwd)/bundle/sandbox-macos-permissive-open.sb node bundle/gemini.js -s
``

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [X] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
