### PR TITLE
fix(core): fallback to system rg on non-FHS environments

### DIFF
--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -32,17 +32,11 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { PassThrough, Readable } from 'node:stream';
 import EventEmitter from 'node:events';
 import { downloadRipGrep } from '@joshua.litt/get-ripgrep';
-import which from 'which';
+import * as shellUtils from '../utils/shell-utils.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 // Mock dependencies for canUseRipgrep
 vi.mock('@joshua.litt/get-ripgrep', () => ({
   downloadRipGrep: vi.fn(),
-}));
-
-vi.mock('which', () => ({
-  default: {
-    sync: vi.fn(),
-  },
 }));
 
 // Mock child_process for ripgrep calls
@@ -52,7 +46,7 @@ vi.mock('child_process', () => ({
 
 const mockSpawn = vi.mocked(spawn);
 const downloadRipGrepMock = vi.mocked(downloadRipGrep);
-const whichSyncMock = vi.mocked(which.sync);
+const resolveExecutableSpy = vi.spyOn(shellUtils, 'resolveExecutable');
 const originalGetGlobalBinDir = Storage.getGlobalBinDir.bind(Storage);
 const storageSpy = vi.spyOn(Storage, 'getGlobalBinDir');
 
@@ -67,7 +61,8 @@ describe('canUseRipgrep', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
-    whichSyncMock.mockReset();
+    resolveExecutableSpy.mockReset();
+    resolveExecutableSpy.mockResolvedValue(undefined);
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));
     binDir = path.join(tempRootDir, 'bin');
     await fs.mkdir(binDir, { recursive: true });
@@ -89,12 +84,12 @@ describe('canUseRipgrep', () => {
   });
 
   it('should return true using system rg when managed binary is missing', async () => {
-    whichSyncMock.mockReturnValue('/usr/bin/rg');
+    resolveExecutableSpy.mockResolvedValue('/usr/bin/rg');
 
     const result = await canUseRipgrep();
 
     expect(result).toBe(true);
-    expect(whichSyncMock).toHaveBeenCalledWith('rg', { nothrow: true });
+    expect(resolveExecutableSpy).toHaveBeenCalledWith('rg');
     expect(downloadRipGrepMock).not.toHaveBeenCalled();
   });
 
@@ -160,7 +155,8 @@ describe('ensureRgPath', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
-    whichSyncMock.mockReset();
+    resolveExecutableSpy.mockReset();
+    resolveExecutableSpy.mockResolvedValue(undefined);
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));
     binDir = path.join(tempRootDir, 'bin');
     await fs.mkdir(binDir, { recursive: true });
@@ -183,12 +179,12 @@ describe('ensureRgPath', () => {
 
   it('should return system rg path when managed binary is missing', async () => {
     const systemRgPath = '/usr/bin/rg';
-    whichSyncMock.mockReturnValue(systemRgPath);
+    resolveExecutableSpy.mockResolvedValue(systemRgPath);
 
     const rgPath = await ensureRgPath();
 
     expect(rgPath).toBe(systemRgPath);
-    expect(whichSyncMock).toHaveBeenCalledWith('rg', { nothrow: true });
+    expect(resolveExecutableSpy).toHaveBeenCalledWith('rg');
     expect(downloadRipGrep).not.toHaveBeenCalled();
   });
 
@@ -299,7 +295,8 @@ describe('RipGrepTool', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
-    whichSyncMock.mockReset();
+    resolveExecutableSpy.mockReset();
+    resolveExecutableSpy.mockResolvedValue(undefined);
     mockSpawn.mockReset();
     mockSpawn.mockImplementation(createMockSpawn());
     tempBinRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -32,10 +32,17 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { PassThrough, Readable } from 'node:stream';
 import EventEmitter from 'node:events';
 import { downloadRipGrep } from '@joshua.litt/get-ripgrep';
+import which from 'which';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 // Mock dependencies for canUseRipgrep
 vi.mock('@joshua.litt/get-ripgrep', () => ({
   downloadRipGrep: vi.fn(),
+}));
+
+vi.mock('which', () => ({
+  default: {
+    sync: vi.fn(),
+  },
 }));
 
 // Mock child_process for ripgrep calls
@@ -45,6 +52,7 @@ vi.mock('child_process', () => ({
 
 const mockSpawn = vi.mocked(spawn);
 const downloadRipGrepMock = vi.mocked(downloadRipGrep);
+const whichSyncMock = vi.mocked(which.sync);
 const originalGetGlobalBinDir = Storage.getGlobalBinDir.bind(Storage);
 const storageSpy = vi.spyOn(Storage, 'getGlobalBinDir');
 
@@ -59,6 +67,7 @@ describe('canUseRipgrep', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
+    whichSyncMock.mockReset();
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));
     binDir = path.join(tempRootDir, 'bin');
     await fs.mkdir(binDir, { recursive: true });
@@ -76,6 +85,16 @@ describe('canUseRipgrep', () => {
 
     const result = await canUseRipgrep();
     expect(result).toBe(true);
+    expect(downloadRipGrepMock).not.toHaveBeenCalled();
+  });
+
+  it('should return true using system rg when managed binary is missing', async () => {
+    whichSyncMock.mockReturnValue('/usr/bin/rg');
+
+    const result = await canUseRipgrep();
+
+    expect(result).toBe(true);
+    expect(whichSyncMock).toHaveBeenCalledWith('rg', { nothrow: true });
     expect(downloadRipGrepMock).not.toHaveBeenCalled();
   });
 
@@ -141,6 +160,7 @@ describe('ensureRgPath', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
+    whichSyncMock.mockReset();
     tempRootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));
     binDir = path.join(tempRootDir, 'bin');
     await fs.mkdir(binDir, { recursive: true });
@@ -158,6 +178,17 @@ describe('ensureRgPath', () => {
 
     const rgPath = await ensureRgPath();
     expect(rgPath).toBe(existingPath);
+    expect(downloadRipGrep).not.toHaveBeenCalled();
+  });
+
+  it('should return system rg path when managed binary is missing', async () => {
+    const systemRgPath = '/usr/bin/rg';
+    whichSyncMock.mockReturnValue(systemRgPath);
+
+    const rgPath = await ensureRgPath();
+
+    expect(rgPath).toBe(systemRgPath);
+    expect(whichSyncMock).toHaveBeenCalledWith('rg', { nothrow: true });
     expect(downloadRipGrep).not.toHaveBeenCalled();
   });
 
@@ -268,6 +299,7 @@ describe('RipGrepTool', () => {
   beforeEach(async () => {
     downloadRipGrepMock.mockReset();
     downloadRipGrepMock.mockResolvedValue(undefined);
+    whichSyncMock.mockReset();
     mockSpawn.mockReset();
     mockSpawn.mockImplementation(createMockSpawn());
     tempBinRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ripgrep-bin-'));

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -29,7 +29,7 @@ import {
   COMMON_DIRECTORY_EXCLUDES,
 } from '../utils/ignorePatterns.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
-import { execStreaming } from '../utils/shell-utils.js';
+import { execStreaming, resolveExecutable } from '../utils/shell-utils.js';
 import {
   DEFAULT_TOTAL_MAX_MATCHES,
   DEFAULT_SEARCH_TIMEOUT_MS,
@@ -37,7 +37,6 @@ import {
 import { RIP_GREP_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { type GrepMatch, formatGrepResults } from './grep-utils.js';
-import which from 'which';
 
 function getRgCandidateFilenames(): readonly string[] {
   return process.platform === 'win32' ? ['rg.exe', 'rg'] : ['rg'];
@@ -53,7 +52,7 @@ async function resolveExistingRgPath(): Promise<string | null> {
   }
 
   // Fallback: managed binary unavailable or incompatible (e.g. Termux/non-FHS)
-  const systemRg = which.sync('rg', { nothrow: true });
+  const systemRg = await resolveExecutable('rg');
   if (systemRg) return systemRg;
 
   return null;

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -37,6 +37,7 @@ import {
 import { RIP_GREP_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { type GrepMatch, formatGrepResults } from './grep-utils.js';
+import which from 'which';
 
 function getRgCandidateFilenames(): readonly string[] {
   return process.platform === 'win32' ? ['rg.exe', 'rg'] : ['rg'];
@@ -50,6 +51,11 @@ async function resolveExistingRgPath(): Promise<string | null> {
       return candidatePath;
     }
   }
+
+  // Fallback: managed binary unavailable or incompatible (e.g. Termux/non-FHS)
+  const systemRg = which.sync('rg', { nothrow: true });
+  if (systemRg) return systemRg;
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

On non-FHS environments like `Termux` (Android), the managed `ripgrep` binary fails with `ENOENT` at spawn time because it is compiled for standard GNU/Linux and hardcodes the dynamic linker path `/lib/ld-linux-aarch64.so.1`, which does not exist in Termux. This PR adds a fallback in `resolveExistingRgPath()` to use the system-installed `rg` from `$PATH` when the managed binary is unavailable or incompatible.

## Details

The managed `ripgrep` binary is downloaded via the `@joshua.litt/get-ripgrep` third-party dependency, which does not account for non-FHS environments. Rather than internalizing the dependency, this PR takes a pragmatic approach: if no managed binary is found, fall back to the system `rg` binary via `which`. This keeps the diff minimal and leaves existing behavior on standard platforms completely unchanged. The managed binary still takes priority on all standard GNU/Linux, macOS, and Windows environments.

## Related Issues

Fixes #21836 

## How to Validate

1. On a Termux (Android aarch64) environment, install ripgrep via `pkg install ripgrep`
2. Run `gemini` and invoke a `grep_search` tool call
3. Confirm it no longer throws `spawn .../rg ENOENT` and uses the system `rg` instead
4. On a standard Linux/macOS machine, confirm existing behavior is unchanged — managed binary is still used

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Added/updated tests for the fallback logic in `ripGrep.test.ts`
- [x] No changes to managed binary behavior on standard platforms