### PR TITLE
fix(core): suppress verbose 429 retry errors in non-interactive mode

### DIFF
--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -120,6 +120,7 @@ describe('BaseLlmClient', () => {
       setActiveModel: vi.fn(),
       getUserTier: vi.fn().mockReturnValue(undefined),
       getRetryFetchErrors: vi.fn().mockReturnValue(true),
+      getDebugMode: vi.fn().mockReturnValue(false),
       getMaxAttempts: vi.fn().mockReturnValue(3),
       getModel: vi.fn().mockReturnValue('test-model'),
       getActiveModel: vi.fn().mockReturnValue('test-model'),

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -337,6 +337,7 @@ export class BaseLlmClient {
         authType:
           this.authType ?? this.config.getContentGeneratorConfig()?.authType,
         retryFetchErrors: this.config.getRetryFetchErrors(),
+        logErrorDetails: this.config.getDebugMode(),
         onRetry: (attempt, error, delayMs) => {
           const actualMaxAttempts =
             availabilityMaxAttempts ?? maxAttempts ?? DEFAULT_MAX_ATTEMPTS;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1135,6 +1135,7 @@ export class GeminiClient {
         authType: this.config.getContentGeneratorConfig()?.authType,
         maxAttempts: availabilityMaxAttempts,
         retryFetchErrors: this.config.getRetryFetchErrors(),
+        logErrorDetails: this.config.getDebugMode(),
         getAvailabilityContext,
         onRetry: (attempt, error, delayMs) => {
           coreEvents.emitRetryAttempt({

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -687,6 +687,7 @@ export class GeminiChat {
       onValidationRequired: onValidationRequiredCallback,
       authType: this.context.config.getContentGeneratorConfig()?.authType,
       retryFetchErrors: this.context.config.getRetryFetchErrors(),
+      logErrorDetails: this.context.config.getDebugMode(),
       signal: abortSignal,
       maxAttempts:
         availabilityMaxAttempts ?? this.context.config.getMaxAttempts(),

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -283,6 +283,7 @@ describe('WebFetchTool', () => {
       get geminiClient() {
         return mockGetGeminiClient();
       },
+      getDebugMode: vi.fn().mockReturnValue(false),
       getRetryFetchErrors: vi.fn().mockReturnValue(false),
       getMaxAttempts: vi.fn().mockReturnValue(3),
       getDirectWebFetch: vi.fn().mockReturnValue(false),

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -310,6 +310,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       },
       {
         retryFetchErrors: this.context.config.getRetryFetchErrors(),
+        logErrorDetails: this.context.config.getDebugMode(),
         onRetry: (attempt, error, delayMs) =>
           this.handleRetry(attempt, error, delayMs),
         signal,
@@ -644,6 +645,7 @@ ${aggregatedContent}
         },
         {
           retryFetchErrors: this.context.config.getRetryFetchErrors(),
+          logErrorDetails: this.context.config.getDebugMode(),
           onRetry: (attempt, error, delayMs) =>
             this.handleRetry(attempt, error, delayMs),
           signal,

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -200,6 +200,49 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(2);
   });
 
+  it('logs only the retry summary by default for 429 errors', async () => {
+    const mockFn = vi.fn(async () => {
+      throw new ApiError({ message: 'Too Many Requests', status: 429 });
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 2,
+      initialDelayMs: 10,
+    });
+
+    await Promise.all([
+      expect(promise).rejects.toThrow('Too Many Requests'),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(debugLogger.warn).toHaveBeenCalledWith(
+      'Attempt 1 failed with status 429. Retrying with backoff...',
+    );
+  });
+
+  it('logs retry error details when logErrorDetails is enabled', async () => {
+    const error = new ApiError({ message: 'Too Many Requests', status: 429 });
+    const mockFn = vi.fn(async () => {
+      throw error;
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 2,
+      initialDelayMs: 10,
+      logErrorDetails: true,
+    });
+
+    await Promise.all([
+      expect(promise).rejects.toThrow('Too Many Requests'),
+      vi.runAllTimersAsync(),
+    ]);
+
+    expect(debugLogger.warn).toHaveBeenCalledWith(
+      'Attempt 1 failed with status 429. Retrying with backoff...',
+      error,
+    );
+  });
+
   it('should use default shouldRetry if not provided, not retrying on ApiError 400', async () => {
     const mockFn = vi.fn(async () => {
       throw new ApiError({ message: 'Bad Request', status: 400 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -23,6 +23,7 @@ export interface RetryOptions {
   maxAttempts: number;
   initialDelayMs: number;
   maxDelayMs: number;
+  logErrorDetails: boolean;
   shouldRetryOnError: (error: Error, retryFetchErrors?: boolean) => boolean;
   shouldRetryOnContent?: (content: GenerateContentResponse) => boolean;
   onPersistent429?: (
@@ -43,6 +44,7 @@ const DEFAULT_RETRY_OPTIONS: RetryOptions = {
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   initialDelayMs: 5000,
   maxDelayMs: 30000, // 30 seconds
+  logErrorDetails: false,
   shouldRetryOnError: isRetryableError,
 };
 
@@ -224,6 +226,7 @@ export async function retryWithBackoff<T>(
     signal,
     getAvailabilityContext,
     onRetry,
+    logErrorDetails,
   } = {
     ...DEFAULT_RETRY_OPTIONS,
     shouldRetryOnError: isRetryableError,
@@ -370,7 +373,7 @@ export async function retryWithBackoff<T>(
           continue;
         } else {
           const errorStatus = getErrorStatus(error);
-          logRetryAttempt(attempt, error, errorStatus);
+          logRetryAttempt(attempt, error, errorStatus, logErrorDetails);
 
           // Exponential backoff with jitter for non-quota errors
           const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
@@ -394,7 +397,7 @@ export async function retryWithBackoff<T>(
       }
 
       const errorStatus = getErrorStatus(error);
-      logRetryAttempt(attempt, error, errorStatus);
+      logRetryAttempt(attempt, error, errorStatus, logErrorDetails);
 
       // Exponential backoff with jitter for non-quota errors
       const jitter = currentDelay * 0.3 * (Math.random() * 2 - 1);
@@ -420,32 +423,39 @@ function logRetryAttempt(
   attempt: number,
   error: unknown,
   errorStatus?: number,
+  logErrorDetails: boolean = false,
 ): void {
   let message = `Attempt ${attempt} failed. Retrying with backoff...`;
   if (errorStatus) {
     message = `Attempt ${attempt} failed with status ${errorStatus}. Retrying with backoff...`;
   }
 
+  const logWarning = (warningMessage: string) => {
+    if (logErrorDetails) {
+      debugLogger.warn(warningMessage, error);
+    } else {
+      debugLogger.warn(warningMessage);
+    }
+  };
+
   if (errorStatus === 429) {
-    debugLogger.warn(message, error);
+    logWarning(message);
   } else if (errorStatus && errorStatus >= 500 && errorStatus < 600) {
-    debugLogger.warn(message, error);
+    logWarning(message);
   } else if (error instanceof Error) {
     // Fallback for errors that might not have a status but have a message
     if (error.message.includes('429')) {
-      debugLogger.warn(
+      logWarning(
         `Attempt ${attempt} failed with 429 error (no Retry-After header). Retrying with backoff...`,
-        error,
       );
     } else if (error.message.match(/5\d{2}/)) {
-      debugLogger.warn(
+      logWarning(
         `Attempt ${attempt} failed with 5xx error. Retrying with backoff...`,
-        error,
       );
     } else {
-      debugLogger.warn(message, error); // Default to warn for other errors
+      logWarning(message); // Default to warn for other errors
     }
   } else {
-    debugLogger.warn(message, error); // Default to warn if error type is unknown
+    logWarning(message); // Default to warn if error type is unknown
   }
 }


### PR DESCRIPTION
## Summary

Reduce non-interactive retry noise for 429s by logging a concise retry message by default instead of dumping the full error object to stderr.

When debug mode is enabled, preserve the existing detailed retry logging so troubleshooting output is still available.

## Details

This change adds a `logErrorDetails` option to `retryWithBackoff()` and uses it to control whether retry warnings include the original error object.

The main config-backed retry callers now pass `config.getDebugMode()`, so:
- normal non-interactive runs get a short, readable retry line
- debug runs still include full retry details

Regression coverage was added for both summary-only and debug-detailed retry logging, and the affected caller test fixtures were updated to include `getDebugMode()`.

## Related Issues

Closes #25017

## How to Validate

1. Run the targeted core test suite:
   ```bash
   cd /Users/nilptr/dev/open-source/gemini-cli/packages/core
   npx vitest run --coverage.enabled=false src/utils/retry.test.ts src/core/baseLlmClient.test.ts src/core/client.test.ts src/core/geminiChat.test.ts src/tools/web-fetch.test.ts
   ```
   Expected result: all 5 test files pass.

2. Verify the default retry logging behavior in code/tests:
   - `retry.test.ts` should confirm that 429 retries log only:
     `Attempt 1 failed with status 429. Retrying with backoff...`
   - No full error object should be attached in the default case.

3. Verify debug behavior in code/tests:
   - `retry.test.ts` should confirm that when `logErrorDetails` is enabled, the retry log still includes the original error object.

4. Optional manual validation:
   - Trigger a non-interactive run that hits retryable 429s.
   - Expected result: stderr shows a short retry message without the verbose serialized error payload unless debug mode is enabled.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker