### PR TITLE
fix(cli): mark /settings as unsafe to run concurrently

### DIFF
--- a/packages/cli/src/ui/commands/settingsCommand.ts
+++ b/packages/cli/src/ui/commands/settingsCommand.ts
@@ -15,7 +15,6 @@ export const settingsCommand: SlashCommand = {
   description: 'View and edit Gemini CLI settings',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  isSafeConcurrent: true,
   action: (_context, _args): OpenDialogActionReturn => ({
     type: 'dialog',
     dialog: 'settings',


### PR DESCRIPTION
## Summary

`/settings` was added to the list of commands that are safe to run concurrently but isn't safe as bad things happen when the settings dialog is open and an approval dialog needs to be shown.

Disabling until we handle that case properly.