### PR TITLE
feat(core): add Strategic Re-evaluation guidance to system prompt

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -762,11 +762,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -914,11 +913,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -1048,11 +1046,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -1706,11 +1703,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -1871,11 +1867,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2040,11 +2035,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2209,11 +2203,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2374,11 +2367,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2541,11 +2533,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2667,11 +2658,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2831,11 +2821,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3123,11 +3112,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3545,11 +3533,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3710,11 +3697,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3989,11 +3975,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -4154,11 +4139,10 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -762,6 +762,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -908,6 +914,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -1035,6 +1047,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -1688,6 +1706,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -1846,6 +1870,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2010,6 +2040,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -2173,6 +2209,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -2331,6 +2373,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2493,6 +2541,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -2612,6 +2666,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -2770,6 +2830,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3056,6 +3122,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3473,6 +3545,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -3631,6 +3709,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 
@@ -3905,6 +3989,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.
@@ -4063,6 +4153,12 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
    - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project. If unsure about these commands, you can ask the user if they'd like you to run them and if so how to.
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -347,6 +347,12 @@ ${workflowStepStrategy(options)}
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
+
 ## New Applications
 
 **Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics. Users judge applications by their visual impact; ensure they feel modern, "alive," and polished through consistent spacing, interactive feedback, and platform-appropriate design.

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -347,11 +347,10 @@ ${workflowStepStrategy(options)}
 
 **Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context. Prioritize comprehensive validation above all else, utilizing redirection and focused analysis to manage high-output tasks without sacrificing depth. Never sacrifice validation rigor for the sake of brevity or to minimize tool-call overhead; partial or isolated checks are insufficient when more comprehensive validation is possible.
 
-**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 5 times without success, you must:
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
 1. Stop and remind yourself of the original task description.
 2. List your current assumptions and identify which ones might be wrong.
 3. Propose a different architectural approach rather than continuing to patch the current one.
-4. If the environment constraints (e.g., single-process shell) fundamentally prevent success, explain the limitation clearly and terminate.
 
 ## New Applications
 


### PR DESCRIPTION
## Summary

Add a "Strategic Re-evaluation" section to the system prompt to guide the agent in rethinking its approach after multiple failed attempts at a task.

## Details

- Added guidance to `packages/core/src/prompts/snippets.ts` instructing the agent to stop, re-evaluate assumptions, and propose a different architectural approach if an implementation fails more than 3 times.
- Updated `packages/core/src/core/__snapshots__/prompts.test.ts.snap` to reflect the changes in the system prompt.

## Related Issues

N/A

## How to Validate

1. Run `npm test -w @google/gemini-cli-core -- src/core/prompts.test.ts` to ensure snapshots match.
2. Inspect the generated system prompt (e.g., via `GEMINI_WRITE_SYSTEM_MD=true`) to verify the inclusion of the "Strategic Re-evaluation" section.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
