### PR TITLE
fix(core): silently handle EPERM when listing dir structure

### DIFF
--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -113,7 +113,9 @@ async function readFullStructure(
     } catch (error: unknown) {
       if (
         isNodeError(error) &&
-        (error.code === 'EACCES' || error.code === 'ENOENT')
+        (error.code === 'EACCES' ||
+          error.code === 'ENOENT' ||
+          error.code === 'EPERM')
       ) {
         debugLogger.warn(
           `Warning: Could not read directory ${currentPath}: ${error.message}`,
@@ -121,7 +123,7 @@ async function readFullStructure(
         if (currentPath === rootPath && error.code === 'ENOENT') {
           return null; // Root directory itself not found
         }
-        // For other EACCES/ENOENT on subdirectories, just skip them.
+        // For other EACCES/ENOENT/EPERM on subdirectories, just skip them.
         continue;
       }
       throw error;


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Gemini CLI would crash or report an error when attempting to list the directory structure of a workspace containing directories with restricted permissions (e.g., `~/.Trash` on macOS).

## Details

Modified `packages/core/src/utils/getFolderStructure.ts` to include `EPERM` in the list of handled node errors during directory traversal. When an `EPERM` error is encountered on a subdirectory, it is now logged as a warning and skipped, allowing the rest of the directory structure to be processed. This aligns with how `EACCES` and `ENOENT` are already handled.

## Related Issues

Fixes #25019

## How to Validate

1. Ensure you have a directory with restricted permissions in your workspace (e.g., `~/.Trash` on macOS).
2. Run the Gemini CLI in the parent directory.
3. Observe that it no longer crashes when building the session context and successfully lists the accessible parts of the directory structure.
4. Run core utility tests: `npm test -w @google/gemini-cli-core -- src/utils/getFolderStructure.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - Existing tests cover the logic; added EPERM to the same handler as EACCES.
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
