### PR TITLE
fix: pass session UUID to deleteSession to ensure tool-output cleanup

### DIFF
--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -101,14 +101,14 @@ export const useSessionBrowser = (
       async (session: SessionInfo) => {
         // Note: Chat sessions are stored on disk using a filename derived from
         // the session, e.g. "session-<timestamp>-<sessionIdPrefix>.json".
-        // The ChatRecordingService.deleteSession API expects this file basename
-        // (without the ".json" extension), not the full session UUID.
+        // Pass both the file basename and the session UUID so that tool-output
+        // directories are cleaned up even if the session file cannot be read.
         try {
           const chatRecordingService = config
             .getGeminiClient()
             ?.getChatRecordingService();
           if (chatRecordingService) {
-            await chatRecordingService.deleteSession(session.file);
+            await chatRecordingService.deleteSession(session.file, session.id);
           }
         } catch (error) {
           coreEvents.emitFeedback('error', 'Error deleting session:', error);

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -97,7 +97,10 @@ export async function deleteSession(
   try {
     // Use ChatRecordingService to delete the session
     const chatRecordingService = new ChatRecordingService(config);
-    await chatRecordingService.deleteSession(sessionToDelete.file);
+    await chatRecordingService.deleteSession(
+      sessionToDelete.file,
+      sessionToDelete.id,
+    );
 
     const time = formatRelativeTime(sessionToDelete.lastUpdated);
     writeToStdout(

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -661,6 +661,76 @@ describe('ChatRecordingService', () => {
         chatRecordingService.deleteSession('non-existent'),
       ).resolves.not.toThrow();
     });
+
+    it('should use fallbackSessionId to clean up artifacts when session file is corrupted', async () => {
+      const fallbackId = 'fallback-session-uuid';
+      const shortId = 'abcd1234';
+      const chatsDir = path.join(testTempDir, 'chats');
+      const logsDir = path.join(testTempDir, 'logs');
+      const toolOutputsDir = path.join(testTempDir, 'tool-outputs');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      fs.mkdirSync(logsDir, { recursive: true });
+      fs.mkdirSync(toolOutputsDir, { recursive: true });
+      // Write a corrupted (non-JSON) session file
+      const sessionFile = path.join(
+        chatsDir,
+        `session-2023-01-01T00-00-${shortId}.json`,
+      );
+      fs.writeFileSync(sessionFile, 'NOT VALID JSON {{{{');
+      // Create artifacts using the fallback UUID
+      const logFile = path.join(logsDir, `session-${fallbackId}.jsonl`);
+      fs.writeFileSync(logFile, '{}');
+      const toolOutputDir = path.join(toolOutputsDir, `session-${fallbackId}`);
+      fs.mkdirSync(toolOutputDir, { recursive: true });
+      // Pass fallbackSessionId explicitly
+      await chatRecordingService.deleteSession(
+        `session-2023-01-01T00-00-${shortId}`,
+        fallbackId,
+      );
+      expect(fs.existsSync(sessionFile)).toBe(false);
+      expect(fs.existsSync(logFile)).toBe(false);
+      expect(fs.existsSync(toolOutputDir)).toBe(false);
+    });
+    it('should prefer sessionId from file over fallbackSessionId when file is readable', async () => {
+      const fileSessionId = 'file-session-uuid';
+      const fallbackId = 'fallback-session-uuid';
+      const shortId = 'efgh5678';
+      const chatsDir = path.join(testTempDir, 'chats');
+      const logsDir = path.join(testTempDir, 'logs');
+      const toolOutputsDir = path.join(testTempDir, 'tool-outputs');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      fs.mkdirSync(logsDir, { recursive: true });
+      fs.mkdirSync(toolOutputsDir, { recursive: true });
+      // Write a valid session file with its own sessionId
+      const sessionFile = path.join(
+        chatsDir,
+        `session-2023-01-01T00-00-${shortId}.json`,
+      );
+      fs.writeFileSync(
+        sessionFile,
+        JSON.stringify({ sessionId: fileSessionId }),
+      );
+      // Create artifacts under fileSessionId (not fallbackId)
+      const logFile = path.join(logsDir, `session-${fileSessionId}.jsonl`);
+      fs.writeFileSync(logFile, '{}');
+      const toolOutputDir = path.join(
+        toolOutputsDir,
+        `session-${fileSessionId}`,
+      );
+      fs.mkdirSync(toolOutputDir, { recursive: true });
+      // Artifacts under fallbackId should NOT be touched
+      const fallbackLog = path.join(logsDir, `session-${fallbackId}.jsonl`);
+      fs.writeFileSync(fallbackLog, '{}');
+      await chatRecordingService.deleteSession(
+        `session-2023-01-01T00-00-${shortId}`,
+        fallbackId,
+      );
+      expect(fs.existsSync(sessionFile)).toBe(false);
+      expect(fs.existsSync(logFile)).toBe(false);
+      expect(fs.existsSync(toolOutputDir)).toBe(false);
+      // fallback artifacts must be untouched
+      expect(fs.existsSync(fallbackLog)).toBe(true);
+    });
   });
 
   describe('recordDirectories', () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -642,7 +642,10 @@ export class ChatRecordingService {
    *
    * @throws {Error} If shortId validation fails.
    */
-  async deleteSession(sessionIdOrBasename: string): Promise<void> {
+  async deleteSession(
+    sessionIdOrBasename: string,
+    fallbackSessionId?: string,
+  ): Promise<void> {
     try {
       const tempDir = this.context.config.storage.getProjectTempDir();
       const chatsDir = path.join(tempDir, 'chats');
@@ -657,7 +660,12 @@ export class ChatRecordingService {
       const matchingFiles = this.getMatchingSessionFiles(chatsDir, shortId);
 
       for (const file of matchingFiles) {
-        await this.deleteSessionAndArtifacts(chatsDir, file, tempDir);
+        await this.deleteSessionAndArtifacts(
+          chatsDir,
+          file,
+          tempDir,
+          fallbackSessionId,
+        );
       }
     } catch (error) {
       debugLogger.error('Error deleting session file.', error);
@@ -705,23 +713,25 @@ export class ChatRecordingService {
     chatsDir: string,
     file: string,
     tempDir: string,
+    fallbackSessionId?: string,
   ): Promise<void> {
     const filePath = path.join(chatsDir, file);
     try {
-      const fileContent = await fs.promises.readFile(filePath, 'utf8');
-      const content = JSON.parse(fileContent) as unknown;
-
-      let fullSessionId: string | undefined;
-      if (content && typeof content === 'object' && 'sessionId' in content) {
-        const id = (content as Record<string, unknown>)['sessionId'];
-        if (typeof id === 'string') {
-          fullSessionId = id;
+      let fullSessionId: string | undefined = fallbackSessionId;
+      try {
+        const fileContent = await fs.promises.readFile(filePath, 'utf8');
+        const content = JSON.parse(fileContent) as unknown;
+        if (content && typeof content === 'object' && 'sessionId' in content) {
+          const id = (content as Record<string, unknown>)['sessionId'];
+          if (typeof id === 'string') {
+            fullSessionId = id;
+          }
         }
+      } catch {
+        // File unreadable or corrupted — fall through using fallbackSessionId
       }
-
-      // Delete the session file
+      // Always delete the session file
       await fs.promises.unlink(filePath);
-
       if (fullSessionId) {
         // Delegate to shared utility!
         await deleteSessionArtifactsAsync(fullSessionId, tempDir);


### PR DESCRIPTION
## Summary

`deleteSession` was silently skipping tool-output directory cleanup whenever a session file was corrupted or unreadable. This caused orphaned `tool-outputs/session-*` directories to accumulate on disk after manual deletion via `--delete-session` or the interactive session browser.

## Details

`deleteSessionAndArtifacts` read the session UUID from the JSON file content in order to locate and delete associated artifacts (logs, tool-output dirs, session subdirectory). If that read or parse failed for any reason, `fullSessionId` stayed `undefined` and all artifact cleanup was silently skipped, even though both callers already held the correct UUID in `session.id`, separately from `session.file`.

**Fix:** Accept an optional `fallbackSessionId` parameter in both `deleteSession` and `deleteSessionAndArtifacts`. The UUID read from the file still takes precedence when available; the fallback is only used when the file is missing, corrupted, or unparseable. Both callers (`sessions.ts` and `useSessionBrowser.ts`) now pass `session.id` as the fallback.

The inner read/parse is wrapped in its own try-catch so a corrupted file no longer prevents the session file itself from being deleted.

## Related Issues

Fixes #21568

## How to Validate

1. Create a session and note its UUID from `--list-sessions`
2. Corrupt the session JSON file on disk (e.g. overwrite with invalid text)
3. Run `gemini --delete-session <uuid>`
4. Verify the session file **and** its `tool-outputs/session-<uuid>/`
   directory are both removed

To test the normal path:
1. Create a session with tool use (generates tool-output files)
2. Delete it via `--delete-session` or the session browser
3. Confirm `~/.gemini/tmp/<hash>/tool-outputs/session-<uuid>/` is gone

## Pre-Merge Checklist

- [x] Added/updated tests (2 new tests in `chatRecordingService.test.ts`)
- [x] No breaking changes (parameter is optional, existing callers unaffected)
- [x] Validated on Windows (npm run — 37/37 tests pass, build succeeds)
- [ ] Updated relevant documentation and README (not needed)