### PR TITLE
feat(cli): add positional argument support to /rewind command

### DIFF
--- a/packages/cli/src/ui/commands/rewindCommand.test.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.test.tsx
@@ -281,10 +281,10 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if config is missing', () => {
+  it('should fail if config is missing', async () => {
     const context = { services: {} } as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -293,7 +293,7 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if client is not initialized', () => {
+  it('should fail if client is not initialized', async () => {
     const context = createMockCommandContext({
       services: {
         agentContext: {
@@ -305,7 +305,7 @@ describe('rewindCommand', () => {
       },
     }) as unknown as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -314,7 +314,7 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if recording service is unavailable', () => {
+  it('should fail if recording service is unavailable', async () => {
     const context = createMockCommandContext({
       services: {
         agentContext: {
@@ -326,7 +326,7 @@ describe('rewindCommand', () => {
       },
     }) as unknown as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -335,10 +335,10 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should return info if no conversation found', () => {
+  it('should return info if no conversation found', async () => {
     mockGetConversation.mockReturnValue(null);
 
-    const result = rewindCommand.action!(mockContext, '');
+    const result = await rewindCommand.action!(mockContext, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -347,18 +347,82 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should return info if no user interactions found', () => {
+  it('should return info if no user interactions found', async () => {
     mockGetConversation.mockReturnValue({
       messages: [{ id: 'msg-1', type: 'gemini', content: 'hello' }],
       sessionId: 'test-session',
     });
 
-    const result = rewindCommand.action!(mockContext, '');
+    const result = await rewindCommand.action!(mockContext, '');
 
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
       content: 'Nothing to rewind to.',
+    });
+  });
+
+  describe('positional argument rewind', () => {
+    beforeEach(() => {
+      mockGetConversation.mockReturnValue({
+        messages: [
+          { id: 'user-0', type: 'user', content: 'static docs' },
+          { id: 'gemini-0', type: 'gemini', content: 'response 0' },
+          { id: 'user-1', type: 'user', content: 'review request' },
+          { id: 'gemini-1', type: 'gemini', content: 'response 1' },
+          { id: 'user-2', type: 'user', content: 'follow up' },
+          { id: 'gemini-2', type: 'gemini', content: 'response 2' },
+        ],
+        sessionId: 'test-session',
+      });
+    });
+
+    it('should rewind to positive index', async () => {
+      const result = await rewindCommand.action!(mockContext, '1');
+      expect(mockRewindTo).toHaveBeenCalledWith('user-1');
+      expect(result).toHaveProperty('messageType', 'info');
+    });
+
+    it('should support negative indexing', async () => {
+      const result = await rewindCommand.action!(mockContext, '-1');
+      expect(mockRewindTo).toHaveBeenCalledWith('user-2');
+      expect(result).toHaveProperty('messageType', 'info');
+    });
+
+    it('should rewind to index 0', async () => {
+      const result = await rewindCommand.action!(mockContext, '0');
+      expect(mockRewindTo).toHaveBeenCalledWith('user-0');
+      expect(result).toHaveProperty('messageType', 'info');
+    });
+
+    it('should return error for non-integer argument', async () => {
+      const result = await rewindCommand.action!(mockContext, 'abc');
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toHaveProperty('messageType', 'error');
+    });
+
+    it('should return error for floating point argument', async () => {
+      const result = await rewindCommand.action!(mockContext, '1.5');
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toHaveProperty('messageType', 'error');
+    });
+
+    it('should return error for out-of-range positive index', async () => {
+      const result = await rewindCommand.action!(mockContext, '5');
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toHaveProperty('messageType', 'error');
+    });
+
+    it('should return error for out-of-range negative index', async () => {
+      const result = await rewindCommand.action!(mockContext, '-5');
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toHaveProperty('messageType', 'error');
+    });
+
+    it('should open TUI when no argument is provided', async () => {
+      const result = await rewindCommand.action!(mockContext, '');
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toHaveProperty('type', 'custom_dialog');
     });
   });
 });

--- a/packages/cli/src/ui/commands/rewindCommand.test.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.test.tsx
@@ -419,6 +419,13 @@ describe('rewindCommand', () => {
       expect(result).toHaveProperty('messageType', 'error');
     });
 
+    it('should return error when rewind fails', async () => {
+      mockRewindTo.mockReturnValue(null);
+      const result = await rewindCommand.action!(mockContext, '1');
+      expect(mockRewindTo).toHaveBeenCalledWith('user-1');
+      expect(result).toHaveProperty('messageType', 'error');
+    });
+
     it('should open TUI when no argument is provided', async () => {
       const result = await rewindCommand.action!(mockContext, '');
       expect(mockRewindTo).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -13,6 +13,7 @@ import { RewindViewer } from '../components/RewindViewer.js';
 import { type HistoryItem } from '../types.js';
 import { convertSessionToHistoryFormats } from '../hooks/useSessionBrowser.js';
 import { revertFileChanges } from '../utils/rewindFileOps.js';
+import { stripReferenceContent } from '../utils/formatters.js';
 import { RewindOutcome } from '../components/RewindConfirmation.js';
 import type { Content } from '@google/genai';
 import {
@@ -21,6 +22,7 @@ import {
   debugLogger,
   logRewind,
   RewindEvent,
+  partToString,
   type ChatRecordingService,
   type GeminiClient,
   convertSessionToClientHistory,
@@ -36,6 +38,7 @@ import {
  * @param recordingService The chat recording service.
  * @param messageId The ID of the message to rewind to.
  * @param newText The new text for the input field after rewinding.
+ * @returns True if the rewind succeeded, false otherwise.
  */
 async function rewindConversation(
   context: CommandContext,
@@ -43,7 +46,7 @@ async function rewindConversation(
   recordingService: ChatRecordingService,
   messageId: string,
   newText: string,
-) {
+): Promise<boolean> {
   try {
     const conversation = recordingService.rewindTo(messageId);
     if (!conversation) {
@@ -51,7 +54,7 @@ async function rewindConversation(
       debugLogger.error(errorMsg);
       context.ui.removeComponent();
       coreEvents.emitFeedback('error', errorMsg);
-      return;
+      return false;
     }
 
     // Convert to UI and Client formats
@@ -81,6 +84,7 @@ async function rewindConversation(
 
     // 2. Load the rewound history and set the input
     context.ui.loadHistory(historyWithIds, newText);
+    return true;
   } catch (error) {
     // If an error occurs, we still want to remove the component if possible
     context.ui.removeComponent();
@@ -88,6 +92,7 @@ async function rewindConversation(
       'error',
       error instanceof Error ? error.message : 'Unknown error during rewind',
     );
+    return false;
   }
 }
 
@@ -168,14 +173,29 @@ export const rewindCommand: SlashCommand = {
         };
       }
 
+      // Extract prompt text to restore in input buffer (matching TUI behavior)
+      const userPrompt = userMessages[resolvedIndex];
+      const contentToUse = userPrompt.displayContent || userPrompt.content;
+      const originalUserText = contentToUse ? partToString(contentToUse) : '';
+      const cleanedText = userPrompt.displayContent
+        ? originalUserText
+        : stripReferenceContent(originalUserText);
+
       logRewind(config, new RewindEvent(RewindOutcome.RewindOnly));
-      await rewindConversation(
+      const success = await rewindConversation(
         context,
         client,
         recordingService,
         userMessages[resolvedIndex].id,
-        '',
+        cleanedText,
       );
+      if (!success) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: 'Rewind failed. Check the debug console for details.',
+        };
+      }
       return {
         type: 'message',
         messageType: 'info',

--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -95,7 +95,7 @@ export const rewindCommand: SlashCommand = {
   name: 'rewind',
   description: 'Jump back to a specific message and restart the conversation',
   kind: CommandKind.BUILT_IN,
-  action: (context) => {
+  action: async (context, args) => {
     const agentContext = context.services.agentContext;
     const config = agentContext?.config;
     if (!config)
@@ -137,6 +137,49 @@ export const rewindCommand: SlashCommand = {
         type: 'message',
         messageType: 'info',
         content: 'Nothing to rewind to.',
+      };
+    }
+
+    // Handle positional argument for stdin-driven rewind
+    const argTrimmed = (args ?? '').trim();
+    if (argTrimmed) {
+      if (!/^-?\d+$/.test(argTrimmed)) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content:
+            'Invalid argument. Usage: /rewind <index> (0-indexed, supports negative indexing)',
+        };
+      }
+
+      const index = parseInt(argTrimmed, 10);
+      const userMessages = conversation.messages.filter(
+        (msg) => msg.type === 'user',
+      );
+
+      // Python-style negative indexing
+      const resolvedIndex = index < 0 ? userMessages.length + index : index;
+
+      if (resolvedIndex < 0 || resolvedIndex >= userMessages.length) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Index out of range. Valid range: -${userMessages.length} to ${userMessages.length - 1} (${userMessages.length} user messages).`,
+        };
+      }
+
+      logRewind(config, new RewindEvent(RewindOutcome.RewindOnly));
+      await rewindConversation(
+        context,
+        client,
+        recordingService,
+        userMessages[resolvedIndex].id,
+        '',
+      );
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Rewound to before user message ${resolvedIndex}.`,
       };
     }
 


### PR DESCRIPTION
Closes #24933

## Summary

Add support for `/rewind <index>` with Python-style indexing, enabling stdin-driven orchestrators to rewind conversations without navigating the TUI.

- `/rewind 1` — rewind to before user message 1 (0-indexed)
- `/rewind -1` — rewind to before the last user message
- `/rewind` (no args) — existing TUI behavior, unchanged

## How it works

Uses the same `conversation.messages.filter(msg => msg.type === 'user')` derivation that `RewindViewer` already uses internally (lines 71-74) to resolve the index to a message ID, then calls the existing `rewindConversation` helper. No changes to the shared helper or the TUI path.

## Testing

- 8 new tests covering positive/negative indexing, edge cases, and error handling
- 5 existing guard-check tests updated to async (required since the action is now async)
- All 21 tests pass, `npm run preflight` clean
