### PR TITLE
fix(core): emit quota data for non-auto models in footer

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -833,18 +833,16 @@ export class Config implements McpContext, AgentLoopContext {
   private lastEmittedQuotaLimit: number | undefined;
 
   private emitQuotaChangedEvent(): void {
-    const pooled = this.getPooledQuota();
+    const remaining = this.getQuotaRemaining();
+    const limit = this.getQuotaLimit();
+    const resetTime = this.getQuotaResetTime();
     if (
-      this.lastEmittedQuotaRemaining !== pooled.remaining ||
-      this.lastEmittedQuotaLimit !== pooled.limit
+      this.lastEmittedQuotaRemaining !== remaining ||
+      this.lastEmittedQuotaLimit !== limit
     ) {
-      this.lastEmittedQuotaRemaining = pooled.remaining;
-      this.lastEmittedQuotaLimit = pooled.limit;
-      coreEvents.emitQuotaChanged(
-        pooled.remaining,
-        pooled.limit,
-        pooled.resetTime,
-      );
+      this.lastEmittedQuotaRemaining = remaining;
+      this.lastEmittedQuotaLimit = limit;
+      coreEvents.emitQuotaChanged(remaining, limit, resetTime);
     }
   }
 


### PR DESCRIPTION

## Summary

Footer quota section renders nothing when a user selects a non-auto model via `/model` (e.g. `gemini-3.1-pro-preview`), even though `/stats` displays the quota correctly.

## Details

`emitQuotaChangedEvent()` calls `getPooledQuota()` directly, which returns an empty object for non-auto models (`isAutoModel()` check fails). The event is emitted with `undefined` values, and the footer skips rendering.

The public getters (`getQuotaRemaining()`, `getQuotaLimit()`, `getQuotaResetTime()`) each have a fallback that resolves the specific model and looks it up in `modelQuotas`. Both `/stats` and the footer initialization already use these getters — only the event-emission path was missing the fallback.

The fix replaces the direct `getPooledQuota()` call in `emitQuotaChangedEvent()` with the public getters, making the event path consistent with the initialization path and `/stats`.

## Related Issues

Fixes #25065

## How to Validate

1. Start gemini-cli and run `/model` to select a specific model (e.g. `gemini-3.1-pro-preview`)
2. Run `/footer` and enable the quota section
3. Use the CLI until quota data is available
4. Run `/stats` — verify quota info is shown
5. Verify the footer now also displays quota percentage

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
  - [ ] Linux
