### PR TITLE
fix(cli): resolve drive letter casing mismatch in workspace trust check

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -587,7 +587,9 @@ export async function loadCliConfig(
       const trimmedPath = p.trim();
       if (!trimmedPath) return false;
       try {
-        return resolveToRealPath(trimmedPath) !== realCwd;
+        // Safely check if paths differ, ignoring OS case insensitivity
+        const realIdePath = resolveToRealPath(trimmedPath);
+        return path.relative(realCwd, realIdePath) !== '';
       } catch (e) {
         debugLogger.debug(
           `[IDE] Skipping inaccessible workspace folder: ${trimmedPath} (${e instanceof Error ? e.message : String(e)})`,


### PR DESCRIPTION
### Why
This PR fixes a bug where users on Windows are incorrectly prompted to trust their workspace folder even if it is already trusted. 

The issue was caused by strict string comparison (`!==`) used to filter the `cwd` from the IDE-provided workspace paths. On Windows, the IDE (VS Code) often provides paths with a lowercase drive letter (`c:\`), while the `cwd` might resolve with an uppercase letter (`C:\`). This mismatch causes the `cwd` to be erroneously added to `includeDirectories` a second time, triggering a redundant trust verification flow. 

This is a regression introduced in PR #21380.

### How
Replaced the strict string comparison with `path.relative()`. Since `path.relative(a, b) === ''` handles OS-specific path normalization and case-insensitivity natively, it reliably identifies when an IDE workspace folder matches the `cwd`, regardless of drive letter casing.

### Fixes
Fixes #25085