### PR TITLE
debugging(ui): add optional debugRainbow setting

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -202,6 +202,12 @@ their corresponding top-level category object in your `settings.json` file.
 
 #### `ui`
 
+- **`ui.debugRainbow`** (boolean):
+  - **Description:** Enable debug rainbow rendering. Only useful for debugging
+    rendering bugs and performance issues.
+  - **Default:** `false`
+  - **Requires restart:** Yes
+
 - **`ui.theme`** (string):
   - **Description:** The color theme for the UI. See the CLI themes guide for
     available options.

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -439,6 +439,16 @@ const SETTINGS_SCHEMA = {
     description: 'User interface settings.',
     showInDialog: false,
     properties: {
+      debugRainbow: {
+        type: 'boolean',
+        label: 'Debug Rainbow',
+        category: 'UI',
+        requiresRestart: true,
+        default: false,
+        description:
+          'Enable debug rainbow rendering. Only useful for debugging rendering bugs and performance issues.',
+        showInDialog: false,
+      },
       theme: {
         type: 'string',
         label: 'Theme',

--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -163,6 +163,7 @@ export async function startInteractiveUI(
         settings.merged.ui.incrementalRendering !== false &&
         useAlternateBuffer &&
         !isShpool,
+      debugRainbow: settings.merged.ui.debugRainbow === true,
     },
   );
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -230,6 +230,13 @@
       "default": {},
       "type": "object",
       "properties": {
+        "debugRainbow": {
+          "title": "Debug Rainbow",
+          "description": "Enable debug rainbow rendering. Only useful for debugging rendering bugs and performance issues.",
+          "markdownDescription": "Enable debug rainbow rendering. Only useful for debugging rendering bugs and performance issues.\n\n- Category: `UI`\n- Requires restart: `yes`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "theme": {
           "title": "Theme",
           "description": "The color theme for the UI. See the CLI themes guide for available options.",


### PR DESCRIPTION
## Summary

adds ui.debugRainbow setting that turns on the debug rainbow option in Ink to make it easier to debug rendering issues.
If the layout is correct only modified content should update and when content is scrolled lines that existed in the UI before the scroll should not change background color. If they are updated then their background color will change indicating room for improving Gemini CLI or the ink fork to avoid unneeded renders.
![Uploading image.png…]()
