### PR TITLE
Memory fix for trace's streamWrapper.

### DIFF
--- a/packages/core/src/telemetry/trace.test.ts
+++ b/packages/core/src/telemetry/trace.test.ts
@@ -4,23 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { trace, SpanStatusCode, diag, type Tracer } from '@opentelemetry/api';
-import { runInDevTraceSpan, truncateForTelemetry } from './trace.js';
+import * as api from '@opentelemetry/api';
+import {diag, SpanStatusCode, trace, type Tracer} from '@opentelemetry/api';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
 import {
   GeminiCliOperation,
-  GEN_AI_CONVERSATION_ID,
   GEN_AI_AGENT_DESCRIPTION,
   GEN_AI_AGENT_NAME,
+  GEN_AI_CONVERSATION_ID,
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_OUTPUT_MESSAGES,
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
-} from './constants.js';
+} from './constants';
+import {runInDevTraceSpan, spanRegistry, truncateForTelemetry} from './trace';
 
 vi.mock('@opentelemetry/api', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@opentelemetry/api')>();
+  const original = (await importOriginal()) as typeof api;
   return {
     ...original,
     trace: {
@@ -58,7 +60,7 @@ describe('truncateForTelemetry', () => {
   });
 
   it('should stringify and truncate objects if exceeding maxLength', () => {
-    const obj = { message: 'hello world', nested: { a: 1 } };
+    const obj = {message: 'hello world', nested: {a: 1}};
     const stringified = JSON.stringify(obj);
     const result = truncateForTelemetry(obj, 10);
     expect(result).toBe(
@@ -68,7 +70,7 @@ describe('truncateForTelemetry', () => {
   });
 
   it('should stringify objects unchanged if within maxLength', () => {
-    const obj = { a: 1 };
+    const obj = {a: 1};
     expect(truncateForTelemetry(obj, 100)).toBe(JSON.stringify(obj));
   });
 
@@ -110,7 +112,7 @@ describe('runInDevTraceSpan', () => {
     const fn = vi.fn(async () => 'result');
 
     const result = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
       fn,
     );
 
@@ -125,8 +127,8 @@ describe('runInDevTraceSpan', () => {
 
   it('should set default attributes on the span metadata', async () => {
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
-      async ({ metadata }) => {
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      async ({metadata}) => {
         expect(metadata.attributes[GEN_AI_OPERATION_NAME]).toBe(
           GeminiCliOperation.LLMCall,
         );
@@ -143,21 +145,21 @@ describe('runInDevTraceSpan', () => {
 
   it('should set span attributes from metadata on completion', async () => {
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
-      async ({ metadata }) => {
-        metadata.input = { query: 'hello' };
-        metadata.output = { response: 'world' };
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      async ({metadata}) => {
+        metadata.input = {query: 'hello'};
+        metadata.output = {response: 'world'};
         metadata.attributes['custom.attr'] = 'value';
       },
     );
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       GEN_AI_INPUT_MESSAGES,
-      JSON.stringify({ query: 'hello' }),
+      JSON.stringify({query: 'hello'}),
     );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       GEN_AI_OUTPUT_MESSAGES,
-      JSON.stringify({ response: 'world' }),
+      JSON.stringify({response: 'world'}),
     );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('custom.attr', 'value');
     expect(mockSpan.setStatus).toHaveBeenCalledWith({
@@ -170,7 +172,7 @@ describe('runInDevTraceSpan', () => {
     const error = new Error('test error');
     await expect(
       runInDevTraceSpan(
-        { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+        {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
         async () => {
           throw error;
         },
@@ -192,7 +194,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
       async () => testStream(),
     );
 
@@ -207,6 +209,45 @@ describe('runInDevTraceSpan', () => {
     expect(mockSpan.end).toHaveBeenCalled();
   });
 
+  it('should register async generators with spanRegistry', async () => {
+    const spy = vi.spyOn(spanRegistry, 'register');
+    async function* testStream() {
+      yield 1;
+    }
+
+    const resultStream = await runInDevTraceSpan(
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      async () => testStream(),
+    );
+
+    expect(spy).toHaveBeenCalledWith(resultStream, expect.any(Function));
+  });
+
+  it('should be idempotent and call span.end only once', async () => {
+    vi.spyOn(spanRegistry, 'register');
+    async function* testStream() {
+      yield 1;
+    }
+
+    const resultStream = await runInDevTraceSpan(
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      async () => testStream(),
+    );
+
+    // Simulate completion
+    for await (const _ of resultStream) {
+    }
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+
+    // Try to end again (simulating registry or double call)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const endSpanFn = vi.mocked(spanRegistry.register).mock
+      .calls[0][1] as () => void;
+    endSpanFn();
+
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+  });
+
   it('should end span automatically on error in async iterators', async () => {
     const error = new Error('streaming error');
     async function* errorStream() {
@@ -215,7 +256,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
       async () => errorStream(),
     );
 
@@ -234,8 +275,8 @@ describe('runInDevTraceSpan', () => {
     });
 
     await runInDevTraceSpan(
-      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
-      async ({ metadata }) => {
+      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      async ({metadata}) => {
         metadata.input = 'trigger error';
       },
     );

--- a/packages/core/src/telemetry/trace.test.ts
+++ b/packages/core/src/telemetry/trace.test.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as api from '@opentelemetry/api';
-import {diag, SpanStatusCode, trace} from '@opentelemetry/api';
-import type {Tracer} from '@opentelemetry/api';
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import { diag, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Tracer } from '@opentelemetry/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   GEN_AI_AGENT_DESCRIPTION,
@@ -20,19 +19,22 @@ import {
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
 } from './constants.js';
-import {runInDevTraceSpan, spanRegistry, truncateForTelemetry} from './trace.js';
+import {
+  runInDevTraceSpan,
+  spanRegistry,
+  truncateForTelemetry,
+} from './trace.js';
 
 vi.mock('@opentelemetry/api', async (importOriginal) => {
   const original = await importOriginal();
-  return {
-    ...original,
+  return Object.assign({}, original, {
     trace: {
       getTracer: vi.fn(),
     },
     diag: {
       error: vi.fn(),
     },
-  };
+  });
 });
 
 vi.mock('../utils/session.js', () => ({
@@ -61,7 +63,7 @@ describe('truncateForTelemetry', () => {
   });
 
   it('should stringify and truncate objects if exceeding maxLength', () => {
-    const obj = {message: 'hello world', nested: {a: 1}};
+    const obj = { message: 'hello world', nested: { a: 1 } };
     const stringified = JSON.stringify(obj);
     const result = truncateForTelemetry(obj, 10);
     expect(result).toBe(
@@ -71,7 +73,7 @@ describe('truncateForTelemetry', () => {
   });
 
   it('should stringify objects unchanged if within maxLength', () => {
-    const obj = {a: 1};
+    const obj = { a: 1 };
     expect(truncateForTelemetry(obj, 100)).toBe(JSON.stringify(obj));
   });
 
@@ -113,7 +115,7 @@ describe('runInDevTraceSpan', () => {
     const fn = vi.fn(async () => 'result');
 
     const result = await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       fn,
     );
 
@@ -128,8 +130,8 @@ describe('runInDevTraceSpan', () => {
 
   it('should set default attributes on the span metadata', async () => {
     await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
-      async ({metadata}) => {
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      async ({ metadata }) => {
         expect(metadata.attributes[GEN_AI_OPERATION_NAME]).toBe(
           GeminiCliOperation.LLMCall,
         );
@@ -146,21 +148,21 @@ describe('runInDevTraceSpan', () => {
 
   it('should set span attributes from metadata on completion', async () => {
     await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
-      async ({metadata}) => {
-        metadata.input = {query: 'hello'};
-        metadata.output = {response: 'world'};
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      async ({ metadata }) => {
+        metadata.input = { query: 'hello' };
+        metadata.output = { response: 'world' };
         metadata.attributes['custom.attr'] = 'value';
       },
     );
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       GEN_AI_INPUT_MESSAGES,
-      JSON.stringify({query: 'hello'}),
+      JSON.stringify({ query: 'hello' }),
     );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       GEN_AI_OUTPUT_MESSAGES,
-      JSON.stringify({response: 'world'}),
+      JSON.stringify({ response: 'world' }),
     );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith('custom.attr', 'value');
     expect(mockSpan.setStatus).toHaveBeenCalledWith({
@@ -173,7 +175,7 @@ describe('runInDevTraceSpan', () => {
     const error = new Error('test error');
     await expect(
       runInDevTraceSpan(
-        {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+        { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
         async () => {
           throw error;
         },
@@ -195,7 +197,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => testStream(),
     );
 
@@ -217,7 +219,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => testStream(),
     );
 
@@ -231,7 +233,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => testStream(),
     );
 
@@ -242,8 +244,8 @@ describe('runInDevTraceSpan', () => {
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
 
     // Try to end again (simulating registry or double call)
-    const endSpanFn = vi.mocked(spanRegistry.register).mock.calls[0][1] as () =>
-      void;
+    const endSpanFn = vi.mocked(spanRegistry.register).mock
+      .calls[0][1] as () => void;
     endSpanFn();
 
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
@@ -257,7 +259,7 @@ describe('runInDevTraceSpan', () => {
     }
 
     const resultStream = await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
       async () => errorStream(),
     );
 
@@ -276,8 +278,8 @@ describe('runInDevTraceSpan', () => {
     });
 
     await runInDevTraceSpan(
-      {operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id'},
-      async ({metadata}) => {
+      { operation: GeminiCliOperation.LLMCall, sessionId: 'test-session-id' },
+      async ({ metadata }) => {
         metadata.input = 'trigger error';
       },
     );

--- a/packages/core/src/telemetry/trace.test.ts
+++ b/packages/core/src/telemetry/trace.test.ts
@@ -4,25 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as api from '@opentelemetry/api';
-import {diag, SpanStatusCode, trace, type Tracer} from '@opentelemetry/api';
+import type * as api from '@opentelemetry/api';
+import {diag, SpanStatusCode, trace} from '@opentelemetry/api';
+import type {Tracer} from '@opentelemetry/api';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {
-  GeminiCliOperation,
   GEN_AI_AGENT_DESCRIPTION,
   GEN_AI_AGENT_NAME,
   GEN_AI_CONVERSATION_ID,
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_OUTPUT_MESSAGES,
+  GeminiCliOperation,
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
-} from './constants';
-import {runInDevTraceSpan, spanRegistry, truncateForTelemetry} from './trace';
+} from './constants.js';
+import {runInDevTraceSpan, spanRegistry, truncateForTelemetry} from './trace.js';
 
 vi.mock('@opentelemetry/api', async (importOriginal) => {
-  const original = (await importOriginal()) as typeof api;
+  const original = await importOriginal();
   return {
     ...original,
     trace: {
@@ -236,13 +237,13 @@ describe('runInDevTraceSpan', () => {
 
     // Simulate completion
     for await (const _ of resultStream) {
+      // iterate
     }
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
 
     // Try to end again (simulating registry or double call)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const endSpanFn = vi.mocked(spanRegistry.register).mock
-      .calls[0][1] as () => void;
+    const endSpanFn = vi.mocked(spanRegistry.register).mock.calls[0][1] as () =>
+      void;
     endSpanFn();
 
     expect(mockSpan.end).toHaveBeenCalledTimes(1);

--- a/packages/core/src/telemetry/trace.ts
+++ b/packages/core/src/telemetry/trace.ts
@@ -11,7 +11,10 @@ import {
   type AttributeValue,
   type SpanOptions,
 } from '@opentelemetry/api';
-import {safeJsonStringify} from '../utils/safeJsonStringify';
+
+import {debugLogger} from '../utils/debugLogger.js';
+import {safeJsonStringify} from '../utils/safeJsonStringify.js';
+import {truncateString} from '../utils/textUtils.js';
 import {
   GEN_AI_AGENT_DESCRIPTION,
   GEN_AI_AGENT_NAME,
@@ -22,9 +25,7 @@ import {
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
   type GeminiCliOperation,
-} from './constants';
-
-import {truncateString} from '../utils/textUtils';
+} from './constants.js';
 
 const TRACER_NAME = 'gemini-cli';
 const TRACER_VERSION = 'v1';
@@ -60,7 +61,7 @@ export function truncateForTelemetry(
       value,
       maxLength,
       `...[TRUNCATED: original length ${value.length}]`,
-    );
+    ) as AttributeValue;
   }
   if (typeof value === 'object' && value !== null) {
     const stringified = safeJsonStringify(value);
@@ -68,10 +69,10 @@ export function truncateForTelemetry(
       stringified,
       maxLength,
       `...[TRUNCATED: original length ${stringified.length}]`,
-    );
+    ) as AttributeValue;
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
-    return value;
+    return value as AttributeValue;
   }
   return undefined;
 }
@@ -104,12 +105,15 @@ export interface SpanMetadata {
  *
  * @example
  * ```typescript
- * runInDevTraceSpan({ name: 'my-operation' }, ({ metadata }) => {
- *   metadata.input = { foo: 'bar' };
- *   // ... do work ...
- *   metadata.output = { result: 'baz' };
- *   metadata.attributes['my.custom.attribute'] = 'some-value';
- * });
+ * await runInDevTraceSpan(
+ *   { operation: GeminiCliOperation.LLMCall, sessionId: 'my-session' },
+ *   async ({ metadata }) => {
+ *     metadata.input = { foo: 'bar' };
+ *     // ... do work ...
+ *     metadata.output = { result: 'baz' };
+ *     metadata.attributes['my.custom.attribute'] = 'some-value';
+ *   }
+ * );
  * ```
  *
  * @param opts The options for the span.
@@ -158,7 +162,10 @@ export async function runInDevTraceSpan<R>(
             }
           }
         }
-        for (const [key, value] of Object.entries(meta.attributes)) {
+        for (const [key, value] of Object.entries(meta.attributes) as [
+          string,
+          AttributeValue,
+        ][]) {
           const truncated = truncateForTelemetry(value);
           if (truncated !== undefined) {
             span.setAttribute(key, truncated);
@@ -196,7 +203,7 @@ export async function runInDevTraceSpan<R>(
         const streamWrapper = (async function* () {
           try {
             yield* result;
-          } catch (e) {
+          } catch (e: unknown) {
             meta.error = e;
             throw e;
           } finally {
@@ -209,7 +216,7 @@ export async function runInDevTraceSpan<R>(
         return finalResult;
       }
       return result;
-    } catch (e) {
+    } catch (e: unknown) {
       meta.error = e;
       throw e;
     } finally {
@@ -233,5 +240,5 @@ function getErrorMessage(e: unknown): string {
   if (typeof e === 'string') {
     return e;
   }
-  return safeJsonStringify(e);
+  return safeJsonStringify(e) as string;
 }

--- a/packages/core/src/telemetry/trace.ts
+++ b/packages/core/src/telemetry/trace.ts
@@ -12,9 +12,9 @@ import {
   type SpanOptions,
 } from '@opentelemetry/api';
 
-import {debugLogger} from '../utils/debugLogger.js';
-import {safeJsonStringify} from '../utils/safeJsonStringify.js';
-import {truncateString} from '../utils/textUtils.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import { truncateString } from '../utils/textUtils.js';
 import {
   GEN_AI_AGENT_DESCRIPTION,
   GEN_AI_AGENT_NAME,
@@ -126,9 +126,9 @@ export async function runInDevTraceSpan<R>(
     logPrompts?: boolean;
     sessionId: string;
   },
-  fn: ({metadata}: {metadata: SpanMetadata}) => Promise<R>,
+  fn: ({ metadata }: { metadata: SpanMetadata }) => Promise<R>,
 ): Promise<R> {
-  const {operation, logPrompts, sessionId, ...restOfSpanOpts} = opts;
+  const { operation, logPrompts, sessionId, ...restOfSpanOpts } = opts;
 
   const tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
   return tracer.startActiveSpan(operation, restOfSpanOpts, async (span) => {
@@ -162,10 +162,7 @@ export async function runInDevTraceSpan<R>(
             }
           }
         }
-        for (const [key, value] of Object.entries(meta.attributes) as [
-          string,
-          AttributeValue,
-        ][]) {
+        for (const [key, value] of Object.entries(meta.attributes)) {
           const truncated = truncateForTelemetry(value);
           if (truncated !== undefined) {
             span.setAttribute(key, truncated);
@@ -180,7 +177,7 @@ export async function runInDevTraceSpan<R>(
             span.recordException(meta.error);
           }
         } else {
-          span.setStatus({code: SpanStatusCode.OK});
+          span.setStatus({ code: SpanStatusCode.OK });
         }
       } catch (e) {
         // Log the error but don't rethrow, to ensure span.end() is called.
@@ -196,7 +193,7 @@ export async function runInDevTraceSpan<R>(
 
     let isStream = false;
     try {
-      const result = await fn({metadata: meta});
+      const result = await fn({ metadata: meta });
 
       if (isAsyncIterable(result)) {
         isStream = true;
@@ -240,5 +237,5 @@ function getErrorMessage(e: unknown): string {
   if (typeof e === 'string') {
     return e;
   }
-  return safeJsonStringify(e) as string;
+  return safeJsonStringify(e);
 }

--- a/packages/core/src/telemetry/trace.ts
+++ b/packages/core/src/telemetry/trace.ts
@@ -11,9 +11,8 @@ import {
   type AttributeValue,
   type SpanOptions,
 } from '@opentelemetry/api';
-import { safeJsonStringify } from '../utils/safeJsonStringify.js';
+import {safeJsonStringify} from '../utils/safeJsonStringify';
 import {
-  type GeminiCliOperation,
   GEN_AI_AGENT_DESCRIPTION,
   GEN_AI_AGENT_NAME,
   GEN_AI_CONVERSATION_ID,
@@ -22,16 +21,39 @@ import {
   GEN_AI_OUTPUT_MESSAGES,
   SERVICE_DESCRIPTION,
   SERVICE_NAME,
-} from './constants.js';
+  type GeminiCliOperation,
+} from './constants';
 
-import { truncateString } from '../utils/textUtils.js';
+import {truncateString} from '../utils/textUtils';
 
 const TRACER_NAME = 'gemini-cli';
 const TRACER_VERSION = 'v1';
 
+/**
+ * Registry used to ensure that spans are properly ended when their associated
+ * async objects are garbage collected.
+ */
+export const spanRegistry = new FinalizationRegistry((endSpan: () => void) => {
+  try {
+    endSpan();
+  } catch (e) {
+    debugLogger.warn(
+      'Error in FinalizationRegistry callback for span cleanup',
+      e,
+    );
+  }
+});
+
+/**
+ * Truncates a value for inclusion in telemetry attributes.
+ *
+ * @param value The value to truncate.
+ * @param maxLength The maximum length of the stringified value.
+ * @returns The truncated value, or undefined if the value type is not supported.
+ */
 export function truncateForTelemetry(
   value: unknown,
-  maxLength: number = 10000,
+  maxLength = 10000,
 ): AttributeValue | undefined {
   if (typeof value === 'string') {
     return truncateString(
@@ -100,9 +122,9 @@ export async function runInDevTraceSpan<R>(
     logPrompts?: boolean;
     sessionId: string;
   },
-  fn: ({ metadata }: { metadata: SpanMetadata }) => Promise<R>,
+  fn: ({metadata}: {metadata: SpanMetadata}) => Promise<R>,
 ): Promise<R> {
-  const { operation, logPrompts, sessionId, ...restOfSpanOpts } = opts;
+  const {operation, logPrompts, sessionId, ...restOfSpanOpts} = opts;
 
   const tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
   return tracer.startActiveSpan(operation, restOfSpanOpts, async (span) => {
@@ -115,7 +137,12 @@ export async function runInDevTraceSpan<R>(
         [GEN_AI_CONVERSATION_ID]: sessionId,
       },
     };
+    let spanEnded = false;
     const endSpan = () => {
+      if (spanEnded) {
+        return;
+      }
+      spanEnded = true;
       try {
         if (logPrompts !== false) {
           if (meta.input !== undefined) {
@@ -146,7 +173,7 @@ export async function runInDevTraceSpan<R>(
             span.recordException(meta.error);
           }
         } else {
-          span.setStatus({ code: SpanStatusCode.OK });
+          span.setStatus({code: SpanStatusCode.OK});
         }
       } catch (e) {
         // Log the error but don't rethrow, to ensure span.end() is called.
@@ -162,7 +189,7 @@ export async function runInDevTraceSpan<R>(
 
     let isStream = false;
     try {
-      const result = await fn({ metadata: meta });
+      const result = await fn({metadata: meta});
 
       if (isAsyncIterable(result)) {
         isStream = true;
@@ -177,7 +204,9 @@ export async function runInDevTraceSpan<R>(
           }
         })();
 
-        return Object.assign(streamWrapper, result);
+        const finalResult = Object.assign(streamWrapper, result);
+        spanRegistry.register(finalResult, endSpan);
+        return finalResult;
       }
       return result;
     } catch (e) {


### PR DESCRIPTION
## Summary

If the streamWrapper is interrupted, it has a chance of skipping its try/catch/finally block, causing the span to not be ended properly and then leak. This change ensures it can still be ended correctly in such a scenario.

## Details

This seems to mitigate and/or eliminate the occurrence of `FATAL ERROR: ExternalEntityTable::AllocateSegment Allocation failed - process out of memory` crashes when Alternate Screen Buffer is enabled.

## Related Issues

## How to Validate

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
