### PR TITLE
fix(core): remove buffer slice to prevent OOM on large output streams

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1610,6 +1610,22 @@ describe('ShellExecutionService child_process fallback', () => {
         'exit',
       ]);
     });
+
+    it('should correctly measure sniffedBytes with >20 small chunks to prevent OOM (regression #22170)', async () => {
+      mockIsBinary.mockReturnValue(false);
+
+      await simulateExecution('cat lots_of_chunks', (cp) => {
+        for (let i = 0; i < 25; i++) {
+          cp.stdout?.emit('data', Buffer.alloc(10, 'a'));
+        }
+        cp.emit('exit', 0, null);
+        cp.emit('close', 0, null);
+      });
+
+      const lastCallBuffer =
+        mockIsBinary.mock.calls[mockIsBinary.mock.calls.length - 1][0];
+      expect(lastCallBuffer.length).toBe(250);
+    });
   });
 
   describe('Platform-Specific Behavior', () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -630,7 +630,7 @@ export class ShellExecutionService {
         }
 
         if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-          const sniffBuffer = Buffer.concat(state.sniffChunks.slice(0, 20));
+          const sniffBuffer = Buffer.concat(state.sniffChunks);
           sniffedBytes = sniffBuffer.length;
 
           if (isBinary(sniffBuffer)) {
@@ -1094,7 +1094,7 @@ export class ShellExecutionService {
               }
 
               if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-                const sniffBuffer = Buffer.concat(sniffChunks.slice(0, 20));
+                const sniffBuffer = Buffer.concat(sniffChunks);
                 sniffedBytes = sniffBuffer.length;
 
                 if (isBinary(sniffBuffer)) {


### PR DESCRIPTION
## Summary

Fixes an unbounded memory leak when dealing with large shell output streams that caused the CLI to crash with Out Of Memory (OOM) errors. 

## Details

The root cause was in the raw buffering phase (used to detect if a stream is binary) in `packages/core/src/services/shellExecutionService.ts`. In both the `childProcessFallback` and PTY paths, the code accumulated incoming chunks into `sniffChunks`. The size check was flawed: `Buffer.concat(state.sniffChunks.slice(0, 20))`. This artificially capped the `sniffedBytes` calculation to the first 20 chunks. If the first 20 chunks were small, `sniffedBytes` never reached `MAX_SNIFF_SIZE` (4096), causing the array to grow infinitely for large streams.

This PR removes the `.slice(0, 20)` operation in both execution paths, allowing the buffer size check to accurately evaluate the total accumulated size and correctly stop buffering.

## Related Issues

Fixes #22170

## How to Validate

1. Start Gemini CLI
2. Ask it to run a command that produces continuous large output (e.g., `cat /dev/urandom` or a large `git log`).
3. Ensure the `outputChunks` array does not grow unbounded in memory and no OOM crashes occur.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker