### PR TITLE
fix(cli): remove hardcoded padding from terminal titles to fix trailing spaces in tmux

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1400,9 +1400,7 @@ describe('AppContainer State Management', () => {
       );
 
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${'✦  Working… (workspace)'.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(`\x1b]0;${'✦  Working… (workspace)'}\x07`);
       unmount();
     });
 
@@ -1435,9 +1433,7 @@ describe('AppContainer State Management', () => {
       );
 
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${'Gemini CLI (workspace)'.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(`\x1b]0;${'Gemini CLI (workspace)'}\x07`);
       unmount();
     });
 
@@ -1497,7 +1493,7 @@ describe('AppContainer State Management', () => {
 
       expect(titleWrites).toHaveLength(1);
       expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${`✦  ${thoughtSubject} (workspace)`.padEnd(80, ' ')}\x07`,
+        `\x1b]0;${`✦  ${thoughtSubject} (workspace)`}\x07`,
       );
       unmount();
     });
@@ -1527,9 +1523,7 @@ describe('AppContainer State Management', () => {
       );
 
       expect(titleWrites).toHaveLength(1);
-      expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${'◇  Ready (workspace)'.padEnd(80, ' ')}\x07`,
-      );
+      expect(titleWrites[0][0]).toBe(`\x1b]0;${'◇  Ready (workspace)'}\x07`);
       unmount();
     });
 
@@ -1564,7 +1558,7 @@ describe('AppContainer State Management', () => {
 
       expect(titleWrites).toHaveLength(1);
       expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${'✋  Action Required (workspace)'.padEnd(80, ' ')}\x07`,
+        `\x1b]0;${'✋  Action Required (workspace)'}\x07`,
       );
       unmount();
     });
@@ -1839,7 +1833,7 @@ describe('AppContainer State Management', () => {
       });
     });
 
-    it('should pad title to exactly 80 characters', async () => {
+    it('should not pad title with trailing spaces', async () => {
       // Arrange: Set up mock settings with showStatusInTitle enabled
       const mockSettingsWithTitleEnabled = createMockSettings({
         ui: {
@@ -1863,16 +1857,23 @@ describe('AppContainer State Management', () => {
         }),
       );
 
-      // Assert: Check that title is padded to exactly 80 characters
+      // Assert: Check that title has no trailing spaces and is <= 80 characters
       const titleWrites = mocks.mockStdout.write.mock.calls.filter((call) =>
         call[0].includes('\x1b]0;'),
       );
 
       expect(titleWrites).toHaveLength(1);
       const calledWith = titleWrites[0][0];
-      const expectedTitle = `✦  ${shortTitle} (workspace)`.padEnd(80, ' ');
+      const expectedTitle = `✦  ${shortTitle} (workspace)`;
       const expectedEscapeSequence = `\x1b]0;${expectedTitle}\x07`;
       expect(calledWith).toBe(expectedEscapeSequence);
+
+      // Title should not have trailing spaces
+      const emittedTitle = calledWith
+        .replace('\x1b]0;', '')
+        .replace('\x07', '');
+      expect(emittedTitle).toBe(emittedTitle.trimEnd());
+      expect(emittedTitle.length).toBeLessThanOrEqual(80);
       unmount();
     });
 
@@ -1906,7 +1907,7 @@ describe('AppContainer State Management', () => {
       );
 
       expect(titleWrites).toHaveLength(1);
-      const expectedEscapeSequence = `\x1b]0;${`✦  ${title} (workspace)`.padEnd(80, ' ')}\x07`;
+      const expectedEscapeSequence = `\x1b]0;${`✦  ${title} (workspace)`}\x07`;
       expect(titleWrites[0][0]).toBe(expectedEscapeSequence);
       unmount();
     });
@@ -1943,7 +1944,7 @@ describe('AppContainer State Management', () => {
 
       expect(titleWrites).toHaveLength(1);
       expect(titleWrites[0][0]).toBe(
-        `\x1b]0;${'✦  Working… (Custom Gemini Title)'.padEnd(80, ' ')}\x07`,
+        `\x1b]0;${'✦  Working… (Custom Gemini Title)'}\x07`,
       );
       unmount();
     });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2082,7 +2082,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     // Respect hideWindowTitle settings
     if (settings.merged.ui.hideWindowTitle) return;
 
-    const paddedTitle = computeTerminalTitle({
+    const terminalTitle = computeTerminalTitle({
       streamingState,
       thoughtSubject: thought?.subject,
       isConfirming:
@@ -2094,9 +2094,9 @@ Logging in with Google... Restarting Gemini CLI to continue.
     });
 
     // Only update the title if it's different from the last value we set
-    if (lastTitleRef.current !== paddedTitle) {
-      lastTitleRef.current = paddedTitle;
-      stdout.write(`\x1b]0;${paddedTitle}\x07`);
+    if (lastTitleRef.current !== terminalTitle) {
+      lastTitleRef.current = terminalTitle;
+      stdout.write(`\x1b]0;${terminalTitle}\x07`);
     }
     // Note: We don't need to reset the window title on exit because Gemini CLI is already doing that elsewhere
   }, [

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -39,7 +39,7 @@ describe('computeTerminalTitle', () => {
         showThoughts: true,
         useDynamicTitle: false,
       } as TerminalTitleOptions,
-      expected: 'Gemini CLI (my-project)'.padEnd(80, ' '),
+      expected: 'Gemini CLI (my-project)',
       exact: true,
     },
     {
@@ -82,7 +82,7 @@ describe('computeTerminalTitle', () => {
         showThoughts: true,
         useDynamicTitle: true,
       } as TerminalTitleOptions,
-      expected: '✦  Working… (my-project)'.padEnd(80, ' '),
+      expected: '✦  Working… (my-project)',
       exact: true,
     },
     {
@@ -116,7 +116,7 @@ describe('computeTerminalTitle', () => {
     } else {
       expect(title).toContain(expected);
     }
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
   });
 
   it('should return active state title with thought subject and NO suffix when thoughts are very long', () => {
@@ -133,7 +133,7 @@ describe('computeTerminalTitle', () => {
 
     expect(title).not.toContain('(my-project)');
     expect(title).toContain('✦  AAAAAAAAAAAAAAAA');
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
   });
 
   it('should truncate long thought subjects when thoughts are enabled', () => {
@@ -148,9 +148,9 @@ describe('computeTerminalTitle', () => {
       useDynamicTitle: true,
     });
 
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
     expect(title).toContain('…');
-    expect(title.trimEnd().length).toBe(80);
+    expect(title.trimEnd().length).toBe(title.length);
   });
 
   it('should strip control characters from the title', () => {
@@ -168,7 +168,7 @@ describe('computeTerminalTitle', () => {
     expect(title).not.toContain('\x00');
     expect(title).not.toContain('\x07');
     expect(title).not.toContain('\x1B');
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
   });
 
   it('should prioritize CLI_TITLE environment variable over folder name when thoughts are disabled', () => {
@@ -185,7 +185,7 @@ describe('computeTerminalTitle', () => {
 
     expect(title).toContain('◇  Ready (EnvOverride)');
     expect(title).not.toContain('my-project');
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
   });
 
   it.each([
@@ -216,7 +216,7 @@ describe('computeTerminalTitle', () => {
         useDynamicTitle: true,
       });
 
-      expect(title.length).toBe(80);
+      expect(title.length).toBeLessThanOrEqual(80);
       expect(title).toContain(expected);
       expect(title).toContain('…)');
     },
@@ -233,7 +233,7 @@ describe('computeTerminalTitle', () => {
       useDynamicTitle: false,
     });
 
-    expect(title.length).toBe(80);
+    expect(title.length).toBeLessThanOrEqual(80);
     expect(title).toContain('Gemini CLI (CCCCC');
     expect(title).toContain('…)');
   });

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -240,7 +240,7 @@ describe('computeTerminalTitle', () => {
 
   it('should safely truncate strings containing emojis and surrogate pairs without splitting them', () => {
     // 💥 is a surrogate pair (UTF-16 length 2). 50 of them = 100 UTF-16 code units.
-    const emojiThought = '💥'.repeat(50);
+    const emojiThought = '💥'.repeat(100);
     const title = computeTerminalTitle({
       streamingState: StreamingState.Responding,
       thoughtSubject: emojiThought,

--- a/packages/cli/src/utils/windowTitle.test.ts
+++ b/packages/cli/src/utils/windowTitle.test.ts
@@ -237,4 +237,24 @@ describe('computeTerminalTitle', () => {
     expect(title).toContain('Gemini CLI (CCCCC');
     expect(title).toContain('…)');
   });
+
+  it('should safely truncate strings containing emojis and surrogate pairs without splitting them', () => {
+    // 💥 is a surrogate pair (UTF-16 length 2). 50 of them = 100 UTF-16 code units.
+    const emojiThought = '💥'.repeat(50);
+    const title = computeTerminalTitle({
+      streamingState: StreamingState.Responding,
+      thoughtSubject: emojiThought,
+      isConfirming: false,
+      isSilentWorking: false,
+      folderName: 'my-project',
+      showThoughts: true,
+      useDynamicTitle: true,
+    });
+
+    // Array.from slices by code points, so we measure by code points.
+    expect(Array.from(title).length).toBeLessThanOrEqual(80);
+    expect(title).toContain('…');
+    // Ensure we actually retained emojis and didn't mangle them
+    expect(title).toContain('💥');
+  });
 });

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -17,10 +17,11 @@ export interface TerminalTitleOptions {
 }
 
 function truncate(text: string, maxLen: number): string {
-  if (text.length <= maxLen) {
+  const chars = Array.from(text);
+  if (chars.length <= maxLen) {
     return text;
   }
-  return text.substring(0, maxLen - 1) + '…';
+  return chars.slice(0, maxLen - 1).join('') + '…';
 }
 
 /**
@@ -48,7 +49,7 @@ export function computeTerminalTitle({
     // Max context length is 80 - base.length - 2 (for brackets)
     const maxContextLen = MAX_LEN - base.length - 2;
     displayContext = truncate(displayContext, maxContextLen);
-    return `${base}(${displayContext})`.substring(0, MAX_LEN);
+    return Array.from(`${base}(${displayContext})`).slice(0, MAX_LEN).join('');
   }
 
   // Pre-calculate suffix but keep it flexible
@@ -110,5 +111,5 @@ export function computeTerminalTitle({
   const safeTitle = title.replace(/[\x00-\x1F\x7F]/g, '');
 
   // Truncate to ensure it NEVER exceeds MAX_LEN.
-  return safeTitle.substring(0, MAX_LEN);
+  return Array.from(safeTitle).slice(0, MAX_LEN).join('');
 }

--- a/packages/cli/src/utils/windowTitle.ts
+++ b/packages/cli/src/utils/windowTitle.ts
@@ -27,7 +27,7 @@ function truncate(text: string, maxLen: number): string {
  * Computes the dynamic terminal window title based on the current CLI state.
  *
  * @param options - The current state of the CLI and environment context
- * @returns A formatted string padded to 80 characters for the terminal title
+ * @returns A formatted string for the terminal title, truncated to at most 80 characters
  */
 export function computeTerminalTitle({
   streamingState,
@@ -48,7 +48,7 @@ export function computeTerminalTitle({
     // Max context length is 80 - base.length - 2 (for brackets)
     const maxContextLen = MAX_LEN - base.length - 2;
     displayContext = truncate(displayContext, maxContextLen);
-    return `${base}(${displayContext})`.padEnd(MAX_LEN, ' ');
+    return `${base}(${displayContext})`.substring(0, MAX_LEN);
   }
 
   // Pre-calculate suffix but keep it flexible
@@ -109,7 +109,6 @@ export function computeTerminalTitle({
   // eslint-disable-next-line no-control-regex
   const safeTitle = title.replace(/[\x00-\x1F\x7F]/g, '');
 
-  // Pad the title to a fixed width to prevent taskbar icon resizing/jitter.
-  // We also slice it to ensure it NEVER exceeds MAX_LEN.
-  return safeTitle.padEnd(MAX_LEN, ' ').substring(0, MAX_LEN);
+  // Truncate to ensure it NEVER exceeds MAX_LEN.
+  return safeTitle.substring(0, MAX_LEN);
 }


### PR DESCRIPTION

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Removes hardcoded 80-character space padding from terminal titles to fix trailing spaces in `tmux` panes. Additionally, updates title truncation to be Unicode-safe so it doesn't break multi-byte characters like emojis.

> **Note:** The padding was originally added to prevent taskbar icon jitter when the title length changes dynamically. This PR prioritizes the `tmux` experience, treating the potential return of icon jitter on some OS environments as an acceptable tradeoff.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
- **`windowTitle.ts`**: 
  - Removed `.padEnd(80, ' ')`.
  - Replaced `.substring` with `Array.from().slice` to safely truncate strings without splitting surrogate pairs or emojis.
- **`AppContainer.tsx`**: Renamed `paddedTitle` -> `terminalTitle` for better clarity.
- **Tests**: Cleaned up integration tests to verify the emitted string has no trailing spaces. Added an emoji truncation test (`'💥'.repeat(100)`) to `windowTitle.test.ts`

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #24211

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
1. Run `npm start` inside a `tmux` session.
2. In a separate pane, run `tmux list-panes -sF '#{pane_title}'`.
3. Verify the title is printed cleanly without huge blocks of trailing spaces. 
4. Check that tests pass via `npm run preflight`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
