### PR TITLE
fix(core): preserve shell execution config fields on update

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -304,6 +304,53 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('setShellExecutionConfig', () => {
+    it('should preserve existing shell execution fields that are not being updated', () => {
+      const config = new Config({
+        ...baseParams,
+        sandbox: {
+          enabled: true,
+          command: 'windows-native',
+          networkAccess: false,
+        },
+        shellBackgroundCompletionBehavior: 'notify',
+      });
+
+      expect(config.getShellExecutionConfig()).toEqual(
+        expect.objectContaining({
+          sandboxConfig: expect.objectContaining({
+            enabled: true,
+            command: 'windows-native',
+            networkAccess: false,
+          }),
+          backgroundCompletionBehavior: 'notify',
+        }),
+      );
+
+      config.setShellExecutionConfig({
+        terminalWidth: 123,
+        terminalHeight: 45,
+        showColor: true,
+        pager: 'cat',
+        sanitizationConfig: config.sanitizationConfig,
+        sandboxManager: config.sandboxManager,
+      });
+
+      expect(config.getShellExecutionConfig()).toEqual(
+        expect.objectContaining({
+          terminalWidth: 123,
+          terminalHeight: 45,
+          sandboxConfig: expect.objectContaining({
+            enabled: true,
+            command: 'windows-native',
+            networkAccess: false,
+          }),
+          backgroundCompletionBehavior: 'notify',
+        }),
+      );
+    });
+  });
+
   beforeEach(() => {
     // Reset mocks if necessary
     vi.clearAllMocks();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3334,6 +3334,7 @@ export class Config implements McpContext, AgentLoopContext {
 
   setShellExecutionConfig(config: ShellExecutionConfig): void {
     this.shellExecutionConfig = {
+      ...this.shellExecutionConfig,
       terminalWidth:
         config.terminalWidth ?? this.shellExecutionConfig.terminalWidth,
       terminalHeight:


### PR DESCRIPTION
Fixes #25112 

## Summary
- preserve existing `ShellExecutionConfig` fields when updating interactive shell dimensions
- add a regression test covering `sandboxConfig` and `backgroundCompletionBehavior`

## Why
`Config.setShellExecutionConfig()` was rebuilding the object from a stale subset of fields. In current `main`, the interactive UI updates shell dimensions during normal operation, so this could silently drop runtime shell fields like `sandboxConfig` and `backgroundCompletionBehavior` after startup.

## Testing
- `npm run test --workspace @google/gemini-cli-core -- src/config/config.test.ts`
