### PR TITLE
fix(cli): pass session id to interactive shell executions

### DIFF
--- a/packages/cli/src/ui/hooks/useExecutionLifecycle.test.tsx
+++ b/packages/cli/src/ui/hooks/useExecutionLifecycle.test.tsx
@@ -133,6 +133,7 @@ describe('useExecutionLifecycle', () => {
     mockConfig = {
       getTargetDir: () => '/test/dir',
       getEnableInteractiveShell: () => false,
+      getSessionId: () => 'test-session-id',
       getShellExecutionConfig: () => ({
         terminalHeight: 20,
         terminalWidth: 80,
@@ -246,9 +247,30 @@ describe('useExecutionLifecycle', () => {
       expect.any(Function),
       expect.any(Object),
       false,
-      expect.any(Object),
+      expect.objectContaining({
+        sessionId: 'test-session-id',
+      }),
     );
     expect(onExecMock).toHaveBeenCalledWith(expect.any(Promise));
+  });
+
+  it('should pass the config sessionId into shell execution config', async () => {
+    const { result } = await renderProcessorHook();
+
+    await act(async () => {
+      result.current.handleShellCommand('top', new AbortController().signal);
+    });
+
+    expect(mockShellExecutionService).toHaveBeenCalledWith(
+      expect.any(String),
+      '/test/dir',
+      expect.any(Function),
+      expect.any(Object),
+      false,
+      expect.objectContaining({
+        sessionId: 'test-session-id',
+      }),
+    );
   });
 
   it('should handle successful execution and update history correctly', async () => {

--- a/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
+++ b/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
@@ -409,6 +409,7 @@ export const useExecutionLifecycle = (
           const activeTheme = themeManager.getActiveTheme();
           const shellExecutionConfig = {
             ...config.getShellExecutionConfig(),
+            sessionId: config.getSessionId(),
             terminalWidth,
             terminalHeight,
             defaultFg: activeTheme.colors.Foreground,


### PR DESCRIPTION
Fixes #25111 

## Summary
- pass `config.getSessionId()` into interactive shell execution config
- add a targeted hook test asserting the session ID is propagated to `ShellExecutionService.execute()`

## Why
Backgrounding an interactive shell currently goes through `ShellExecutionService.background(pid)`. Recent shell background tracking expects executions to be associated with a session ID. The interactive UI path was not passing one into `ShellExecutionService.execute(...)`, which made the runtime repro fail with `Session ID is required for background operations`.

## Testing
- `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useExecutionLifecycle.test.tsx`
