### PR TITLE
Fix stale @ completion for files/folders created during active sessions

### DIFF
--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import { FileSearchFactory, AbortError, filter } from './fileSearch.js';
 import { createTmpDir, cleanupTmpDir } from '@google/gemini-cli-test-utils';
 import * as crawler from './crawler.js';
@@ -678,6 +679,73 @@ describe('FileSearch', () => {
     // Although we can't directly inspect ResultCache.hits/misses from here,
     // the correctness of specificResults after a broad search implicitly
     // verifies that the caching mechanism, including bestBaseQuery, is working.
+  });
+
+  it('should include new root-level paths created after initialization', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.mkdir(path.join(tmpDir, 'new-folder'));
+    await fs.writeFile(path.join(tmpDir, 'new-folder', 'new-file.ts'), '');
+
+    expect(await fileSearch.search('new-fo')).toContain('new-folder/');
+    expect(await fileSearch.search('new-folder/')).toEqual([
+      'new-folder/',
+      'new-folder/new-file.ts',
+    ]);
+  });
+
+  it('should include new nested paths created after initialization', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.mkdir(path.join(tmpDir, 'src', 'new-folder'));
+    await fs.writeFile(
+      path.join(tmpDir, 'src', 'new-folder', 'new-file.ts'),
+      '',
+    );
+
+    expect(await fileSearch.search('src/new-fo')).toContain('src/new-folder/');
+    expect(await fileSearch.search('src/new-folder/')).toEqual([
+      'src/new-folder/',
+      'src/new-folder/new-file.ts',
+    ]);
   });
 
   it('should be case-insensitive by default', async () => {

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -123,6 +123,64 @@ export interface SearchOptions {
   maxResults?: number;
 }
 
+async function searchCandidates(
+  candidates: string[],
+  pattern: string,
+  options: {
+    signal?: AbortSignal;
+    enableFuzzySearch: boolean;
+  },
+): Promise<string[]> {
+  if (pattern.includes('*') || !options.enableFuzzySearch) {
+    return filter(candidates, pattern, options.signal);
+  }
+
+  const fzf = new AsyncFzf(candidates, {
+    fuzzy: candidates.length > 20000 ? 'v1' : 'v2',
+    forward: false,
+    tiebreakers: [byBasenamePrefix, byMatchPosFromEnd, byLengthAsc],
+  });
+
+  return fzf
+    .find(pattern)
+    .then((results: Array<FzfResultItem<string>>) =>
+      results.map((entry: FzfResultItem<string>) => entry.item),
+    )
+    .catch(() => []);
+}
+
+function mergeCandidates(
+  primary: string[],
+  secondary: string[],
+): string[] {
+  if (secondary.length === 0) {
+    return primary;
+  }
+
+  const merged = [...primary];
+  const seen = new Set(primary);
+  for (const candidate of secondary) {
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      merged.push(candidate);
+    }
+  }
+  return merged;
+}
+
+function normalizeLiveResults(
+  results: string[],
+  rootRelativeDir: string,
+): string[] {
+  if (!rootRelativeDir || rootRelativeDir === '.') {
+    return results;
+  }
+
+  return results.map((entry) =>
+    entry === rootRelativeDir && !entry.endsWith('/') ? `${entry}/` : entry,
+  );
+}
+
 export interface FileSearch {
   initialize(): Promise<void>;
   search(pattern: string, options?: SearchOptions): Promise<string[]>;
@@ -178,25 +236,35 @@ class RecursiveFileSearch implements FileSearch {
       filteredCandidates = candidates;
     } else {
       let shouldCache = true;
-      if (pattern.includes('*') || !this.fzf) {
-        filteredCandidates = await filter(candidates, pattern, options.signal);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        filteredCandidates = await this.fzf
-          .find(pattern)
-          .then((results: Array<FzfResultItem<string>>) =>
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            results.map((entry: FzfResultItem<string>) => entry.item),
-          )
-          .catch(() => {
-            shouldCache = false;
-            return [];
-          });
-      }
+      filteredCandidates = await searchCandidates(candidates, pattern, {
+        signal: options.signal,
+        enableFuzzySearch: this.options.enableFuzzySearch && !!this.fzf,
+      }).catch((error: unknown) => {
+        shouldCache = false;
+        throw error;
+      });
 
       if (shouldCache) {
         this.resultCache.set(pattern, filteredCandidates);
       }
+    }
+
+    const liveCandidates = await this.searchFreshCandidates(
+      pattern,
+      options.signal,
+    );
+    filteredCandidates = mergeCandidates(filteredCandidates, liveCandidates);
+
+    if (filteredCandidates.length === 0 && pattern !== '*') {
+      const recursiveLiveCandidates = await this.searchFreshCandidates(
+        pattern,
+        options.signal,
+        true,
+      );
+      filteredCandidates = mergeCandidates(
+        filteredCandidates,
+        recursiveLiveCandidates,
+      );
     }
 
     const fileFilter = this.ignore.getFileFilter();
@@ -220,6 +288,49 @@ class RecursiveFileSearch implements FileSearch {
       }
     }
     return results;
+  }
+
+  private async searchFreshCandidates(
+    pattern: string,
+    signal: AbortSignal | undefined,
+    recursive = false,
+  ): Promise<string[]> {
+    if (!this.ignore) {
+      return [];
+    }
+
+    const dir =
+      !recursive && pattern !== '*' && !pattern.endsWith('/')
+        ? path.dirname(pattern)
+        : pattern.endsWith('/')
+          ? pattern
+          : '.';
+    const crawlDirectory = recursive
+      ? this.options.projectRoot
+      : path.join(this.options.projectRoot, dir);
+    const rootRelativeDir = recursive
+      ? '.'
+      : path
+          .relative(this.options.projectRoot, crawlDirectory)
+          .split(path.sep)
+          .join(path.posix.sep);
+    const results = normalizeLiveResults(
+      await crawl({
+        crawlDirectory,
+        cwd: this.options.projectRoot,
+        maxDepth: recursive ? this.options.maxDepth : 0,
+        maxFiles: this.options.maxFiles ?? 20000,
+        ignore: this.ignore,
+        cache: false,
+        cacheTtl: 0,
+      }),
+      rootRelativeDir,
+    );
+
+    return searchCandidates(results, pattern, {
+      signal,
+      enableFuzzySearch: this.options.enableFuzzySearch,
+    });
   }
 
   private buildResultCache(): void {


### PR DESCRIPTION
## Summary

Fixes stale `@` completion/indexing when files or folders are created after Gemini CLI has already started.

Previously, recursive `@` completion could miss newly created paths until the CLI was restarted, because the file search layer relied on a snapshot built during initialization.

## What changed

- Updated recursive file search to supplement the cached snapshot with a live filesystem refresh during search
- Kept the existing cached index as the primary fast path
- Added a fallback refresh path for newly created nested matches that are not present in the original snapshot
- Added regression tests covering:
  - new root-level paths created after initialization
  - new nested paths created after initialization

## Why

`@` completion builds an index once per workspace directory and does not currently refresh when files/folders are added inside an already-tracked workspace directory. This makes completion stale during long-running sessions.

This change makes newly created paths visible to `@` completion without requiring a restart.

## Validation

```bash
npx vitest run src/utils/filesearch/fileSearch.test.ts
```

in `packages/core`.

## Notes

This PR is scoped to `@` completion/indexing behavior during active sessions. Direct exact-path `@path` resolution uses a separate path-resolution flow.

Fixes #25104