### PR TITLE
Fix stale @ completion for files/folders created during active sessions

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { act, useState } from 'react';
+import fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { renderHook } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
@@ -184,6 +185,58 @@ describe('useAtCompletion', () => {
         expect(result.current.suggestions.map((s) => s.value)).toEqual([
           'cRaZycAsE.txt',
         ]);
+      });
+    });
+
+    it('should surface newly created files in later at-completion searches', async () => {
+      testRootDir = await createTmpDir({
+        src: {
+          'existing.ts': '',
+          nested: {
+            'deep.ts': '',
+          },
+        },
+      });
+
+      const { result, rerender } = await renderHook(
+        ({ pattern }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'src/e' } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toContain(
+          'src/existing.ts',
+        );
+      });
+
+      await fs.writeFile(path.join(testRootDir, 'src', 'example.ts'), '');
+      act(() => {
+        rerender({ pattern: 'src/ex' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toEqual(
+          expect.arrayContaining(['src/example.ts', 'src/existing.ts']),
+        );
+      });
+
+      await fs.writeFile(path.join(testRootDir, 'src', 'nested', 'new.ts'), '');
+      act(() => {
+        rerender({ pattern: 'src/' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toEqual(
+          expect.arrayContaining([
+            'src/',
+            'src/example.ts',
+            'src/existing.ts',
+            'src/nested/',
+            'src/nested/deep.ts',
+            'src/nested/new.ts',
+          ]),
+        );
       });
     });
   });

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -818,6 +818,9 @@ describe('FileSearch', () => {
     tmpDir = await createTmpDir({
       src: {
         'existing.ts': '',
+        nested: {
+          'deep.ts': '',
+        },
       },
     });
 
@@ -838,14 +841,18 @@ describe('FileSearch', () => {
 
     expect(await fileSearch.search('src/')).toEqual([
       'src/',
+      'src/nested/',
       'src/existing.ts',
+      'src/nested/deep.ts',
     ]);
 
     await fs.writeFile(path.join(tmpDir, 'src', 'new.ts'), '');
 
     expect(await fileSearch.search('src/')).toEqual([
       'src/',
+      'src/nested/',
       'src/existing.ts',
+      'src/nested/deep.ts',
       'src/new.ts',
     ]);
   });

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -748,6 +748,40 @@ describe('FileSearch', () => {
     ]);
   });
 
+  it('should not crawl outside the project root when refreshing live results', async () => {
+    const parentDir = await createTmpDir({
+      project: {
+        src: {
+          'existing.ts': '',
+        },
+      },
+      outside: {
+        'secret.txt': '',
+      },
+    });
+    tmpDir = path.join(parentDir, 'project');
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    expect(await fileSearch.search('../outside')).toEqual([]);
+
+    await cleanupTmpDir(parentDir);
+    tmpDir = '';
+  });
+
   it('should be case-insensitive by default', async () => {
     tmpDir = await createTmpDir({
       'File1.Js': '',

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -748,6 +748,38 @@ describe('FileSearch', () => {
     ]);
   });
 
+  it('should merge fresh non-directory matches with cached sibling hits', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    expect(await fileSearch.search('src/e')).toEqual(['src/existing.ts']);
+
+    await fs.writeFile(path.join(tmpDir, 'src', 'example.ts'), '');
+
+    expect(await fileSearch.search('src/e')).toEqual([
+      'src/existing.ts',
+      'src/example.ts',
+    ]);
+  });
+
   it('should not crawl outside the project root when refreshing live results', async () => {
     const parentDir = await createTmpDir({
       project: {
@@ -855,6 +887,70 @@ describe('FileSearch', () => {
       'src/nested/deep.ts',
       'src/new.ts',
     ]);
+  });
+
+  it('should refresh nested descendants for explicit directory listings', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+        nested: {
+          'deep.ts': '',
+        },
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+    await fileSearch.search('src/');
+
+    await fs.writeFile(path.join(tmpDir, 'src', 'nested', 'new.ts'), '');
+
+    expect(await fileSearch.search('src/')).toEqual([
+      'src/',
+      'src/nested/',
+      'src/existing.ts',
+      'src/nested/deep.ts',
+      'src/nested/new.ts',
+    ]);
+  });
+
+  it('should use fuzzy matching for fresh live-refresh results', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.writeFile(path.join(tmpDir, 'new-file.ts'), '');
+
+    expect(await fileSearch.search('nft')).toContain('new-file.ts');
   });
 
   it('should be case-insensitive by default', async () => {

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import { FileSearchFactory, AbortError, filter } from './fileSearch.js';
 import { createTmpDir, cleanupTmpDir } from '@google/gemini-cli-test-utils';
 import * as crawler from './crawler.js';
@@ -678,6 +679,73 @@ describe('FileSearch', () => {
     // Although we can't directly inspect ResultCache.hits/misses from here,
     // the correctness of specificResults after a broad search implicitly
     // verifies that the caching mechanism, including bestBaseQuery, is working.
+  });
+
+  it('should include new root-level paths created after initialization', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.mkdir(path.join(tmpDir, 'new-folder'));
+    await fs.writeFile(path.join(tmpDir, 'new-folder', 'new-file.ts'), '');
+
+    expect(await fileSearch.search('new-fo')).toContain('new-folder/');
+    expect(await fileSearch.search('new-folder/')).toEqual([
+      'new-folder/',
+      'new-folder/new-file.ts',
+    ]);
+  });
+
+  it('should include new nested paths created after initialization', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.mkdir(path.join(tmpDir, 'src', 'new-folder'));
+    await fs.writeFile(
+      path.join(tmpDir, 'src', 'new-folder', 'new-file.ts'),
+      '',
+    );
+
+    expect(await fileSearch.search('src/new-fo')).toContain('src/new-folder/');
+    expect(await fileSearch.search('src/new-folder/')).toEqual([
+      'src/new-folder/',
+      'src/new-folder/new-file.ts',
+    ]);
   });
 
   it('should be case-insensitive by default', async () => {

--- a/packages/core/src/utils/filesearch/fileSearch.test.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.test.ts
@@ -782,6 +782,74 @@ describe('FileSearch', () => {
     tmpDir = '';
   });
 
+  it('should mark nested live-refresh directories with trailing slashes', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    await fs.mkdir(path.join(tmpDir, 'src', 'new-folder', 'child-dir'), {
+      recursive: true,
+    });
+
+    expect(await fileSearch.search('src/new-folder/')).toEqual([
+      'src/new-folder/',
+      'src/new-folder/child-dir/',
+    ]);
+  });
+
+  it('should refresh explicit directory listings even when cached results exist', async () => {
+    tmpDir = await createTmpDir({
+      src: {
+        'existing.ts': '',
+      },
+    });
+
+    const fileSearch = FileSearchFactory.create({
+      projectRoot: tmpDir,
+      fileDiscoveryService: new FileDiscoveryService(tmpDir, {
+        respectGitIgnore: false,
+        respectGeminiIgnore: false,
+      }),
+      ignoreDirs: [],
+      cache: true,
+      cacheTtl: 30,
+      enableRecursiveFileSearch: true,
+      enableFuzzySearch: true,
+    });
+
+    await fileSearch.initialize();
+
+    expect(await fileSearch.search('src/')).toEqual([
+      'src/',
+      'src/existing.ts',
+    ]);
+
+    await fs.writeFile(path.join(tmpDir, 'src', 'new.ts'), '');
+
+    expect(await fileSearch.search('src/')).toEqual([
+      'src/',
+      'src/existing.ts',
+      'src/new.ts',
+    ]);
+  });
+
   it('should be case-insensitive by default', async () => {
     tmpDir = await createTmpDir({
       'File1.Js': '',

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -123,19 +123,34 @@ export interface SearchOptions {
   maxResults?: number;
 }
 
+function mergeCandidates(
+  primary: string[],
+  secondary: string[],
+): string[] {
+  if (secondary.length === 0) {
+    return primary;
+  }
+
+  const merged = [...primary];
+  const seen = new Set(primary);
+  for (const candidate of secondary) {
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      merged.push(candidate);
+    }
+  }
+  return merged;
+}
+
 function normalizeLiveResults(
   results: string[],
   rootRelativeDir: string,
-  filterDir?: (candidate: string) => boolean,
 ): string[] {
   return results.map((entry) => {
     if (entry.endsWith('/')) {
       return entry;
     }
     if (entry === rootRelativeDir) {
-      return `${entry}/`;
-    }
-    if (filterDir?.(entry)) {
       return `${entry}/`;
     }
     return entry;
@@ -221,10 +236,14 @@ class RecursiveFileSearch implements FileSearch {
       pattern !== '*' &&
       (filteredCandidates.length === 0 || pattern.endsWith('/'))
     ) {
-      filteredCandidates = await this.searchFreshCandidates(
+      const freshCandidates = await this.searchFreshCandidates(
         pattern,
         options.signal,
       );
+      filteredCandidates =
+        pattern.endsWith('/') && filteredCandidates.length > 0
+          ? mergeCandidates(filteredCandidates, freshCandidates)
+          : freshCandidates;
     }
 
     const fileFilter = this.ignore.getFileFilter();
@@ -280,7 +299,6 @@ class RecursiveFileSearch implements FileSearch {
     const rootRelativeDir = relativeToProjectRoot
       .split(path.sep)
       .join(path.posix.sep);
-    const dirFilter = this.ignore.getDirectoryFilter();
     const results = normalizeLiveResults(
       await crawl({
         crawlDirectory,
@@ -292,11 +310,6 @@ class RecursiveFileSearch implements FileSearch {
         cacheTtl: 0,
       }),
       rootRelativeDir,
-      (entry) =>
-        entry !== '.' &&
-        entry !== './' &&
-        entry !== '' &&
-        dirFilter(`${entry}/`),
     );
 
     return filter(results, pattern, signal);

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -123,51 +123,6 @@ export interface SearchOptions {
   maxResults?: number;
 }
 
-async function searchCandidates(
-  candidates: string[],
-  pattern: string,
-  options: {
-    signal?: AbortSignal;
-    enableFuzzySearch: boolean;
-  },
-): Promise<string[]> {
-  if (pattern.includes('*') || !options.enableFuzzySearch) {
-    return filter(candidates, pattern, options.signal);
-  }
-
-  const fzf = new AsyncFzf(candidates, {
-    fuzzy: candidates.length > 20000 ? 'v1' : 'v2',
-    forward: false,
-    tiebreakers: [byBasenamePrefix, byMatchPosFromEnd, byLengthAsc],
-  });
-
-  return fzf
-    .find(pattern)
-    .then((results: Array<FzfResultItem<string>>) =>
-      results.map((entry: FzfResultItem<string>) => entry.item),
-    )
-    .catch(() => []);
-}
-
-function mergeCandidates(
-  primary: string[],
-  secondary: string[],
-): string[] {
-  if (secondary.length === 0) {
-    return primary;
-  }
-
-  const merged = [...primary];
-  const seen = new Set(primary);
-  for (const candidate of secondary) {
-    if (!seen.has(candidate)) {
-      seen.add(candidate);
-      merged.push(candidate);
-    }
-  }
-  return merged;
-}
-
 function normalizeLiveResults(
   results: string[],
   rootRelativeDir: string,
@@ -236,34 +191,30 @@ class RecursiveFileSearch implements FileSearch {
       filteredCandidates = candidates;
     } else {
       let shouldCache = true;
-      filteredCandidates = await searchCandidates(candidates, pattern, {
-        signal: options.signal,
-        enableFuzzySearch: this.options.enableFuzzySearch && !!this.fzf,
-      }).catch((error: unknown) => {
-        shouldCache = false;
-        throw error;
-      });
+      if (pattern.includes('*') || !this.fzf) {
+        filteredCandidates = await filter(candidates, pattern, options.signal);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        filteredCandidates = await this.fzf
+          .find(pattern)
+          .then((results: Array<FzfResultItem<string>>) =>
+            results.map((entry: FzfResultItem<string>) => entry.item),
+          )
+          .catch((error: unknown) => {
+            shouldCache = false;
+            throw error;
+          });
+      }
 
       if (shouldCache) {
         this.resultCache.set(pattern, filteredCandidates);
       }
     }
 
-    const liveCandidates = await this.searchFreshCandidates(
-      pattern,
-      options.signal,
-    );
-    filteredCandidates = mergeCandidates(filteredCandidates, liveCandidates);
-
     if (filteredCandidates.length === 0 && pattern !== '*') {
-      const recursiveLiveCandidates = await this.searchFreshCandidates(
+      filteredCandidates = await this.searchFreshCandidates(
         pattern,
         options.signal,
-        true,
-      );
-      filteredCandidates = mergeCandidates(
-        filteredCandidates,
-        recursiveLiveCandidates,
       );
     }
 
@@ -293,32 +244,38 @@ class RecursiveFileSearch implements FileSearch {
   private async searchFreshCandidates(
     pattern: string,
     signal: AbortSignal | undefined,
-    recursive = false,
   ): Promise<string[]> {
     if (!this.ignore) {
       return [];
     }
 
     const dir =
-      !recursive && pattern !== '*' && !pattern.endsWith('/')
+      pattern !== '*' && !pattern.endsWith('/')
         ? path.dirname(pattern)
         : pattern.endsWith('/')
           ? pattern
           : '.';
-    const crawlDirectory = recursive
-      ? this.options.projectRoot
-      : path.join(this.options.projectRoot, dir);
-    const rootRelativeDir = recursive
-      ? '.'
-      : path
-          .relative(this.options.projectRoot, crawlDirectory)
-          .split(path.sep)
-          .join(path.posix.sep);
+    const crawlDirectory = path.resolve(this.options.projectRoot, dir);
+    const relativeToProjectRoot = path.relative(
+      this.options.projectRoot,
+      crawlDirectory,
+    );
+    if (
+      relativeToProjectRoot === '..' ||
+      relativeToProjectRoot.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeToProjectRoot)
+    ) {
+      return [];
+    }
+
+    const rootRelativeDir = relativeToProjectRoot
+      .split(path.sep)
+      .join(path.posix.sep);
     const results = normalizeLiveResults(
       await crawl({
         crawlDirectory,
         cwd: this.options.projectRoot,
-        maxDepth: recursive ? this.options.maxDepth : 0,
+        maxDepth: 0,
         maxFiles: this.options.maxFiles ?? 20000,
         ignore: this.ignore,
         cache: false,
@@ -327,10 +284,7 @@ class RecursiveFileSearch implements FileSearch {
       rootRelativeDir,
     );
 
-    return searchCandidates(results, pattern, {
-      signal,
-      enableFuzzySearch: this.options.enableFuzzySearch,
-    });
+    return filter(results, pattern, signal);
   }
 
   private buildResultCache(): void {

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -123,6 +123,64 @@ export interface SearchOptions {
   maxResults?: number;
 }
 
+async function searchCandidates(
+  candidates: string[],
+  pattern: string,
+  options: {
+    signal?: AbortSignal;
+    enableFuzzySearch: boolean;
+  },
+): Promise<string[]> {
+  if (pattern.includes('*') || !options.enableFuzzySearch) {
+    return filter(candidates, pattern, options.signal);
+  }
+
+  const fzf = new AsyncFzf(candidates, {
+    fuzzy: candidates.length > 20000 ? 'v1' : 'v2',
+    forward: false,
+    tiebreakers: [byBasenamePrefix, byMatchPosFromEnd, byLengthAsc],
+  });
+
+  return fzf
+    .find(pattern)
+    .then((results: Array<FzfResultItem<string>>) =>
+      results.map((entry: FzfResultItem<string>) => entry.item),
+    )
+    .catch(() => []);
+}
+
+function mergeCandidates(
+  primary: string[],
+  secondary: string[],
+): string[] {
+  if (secondary.length === 0) {
+    return primary;
+  }
+
+  const merged = [...primary];
+  const seen = new Set(primary);
+  for (const candidate of secondary) {
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      merged.push(candidate);
+    }
+  }
+  return merged;
+}
+
+function normalizeLiveResults(
+  results: string[],
+  rootRelativeDir: string,
+): string[] {
+  if (!rootRelativeDir || rootRelativeDir === '.') {
+    return results;
+  }
+
+  return results.map((entry) =>
+    entry === rootRelativeDir && !entry.endsWith('/') ? `${entry}/` : entry,
+  );
+}
+
 export interface FileSearch {
   initialize(): Promise<void>;
   search(pattern: string, options?: SearchOptions): Promise<string[]>;
@@ -178,25 +236,35 @@ class RecursiveFileSearch implements FileSearch {
       filteredCandidates = candidates;
     } else {
       let shouldCache = true;
-      if (pattern.includes('*') || !this.fzf) {
-        filteredCandidates = await filter(candidates, pattern, options.signal);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        filteredCandidates = await this.fzf
-          .find(pattern)
-          .then((results: Array<FzfResultItem<string>>) =>
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            results.map((entry: FzfResultItem<string>) => entry.item),
-          )
-          .catch(() => {
-            shouldCache = false;
-            return [];
-          });
-      }
+      filteredCandidates = await searchCandidates(candidates, pattern, {
+        signal: options.signal,
+        enableFuzzySearch: this.options.enableFuzzySearch && !!this.fzf,
+      }).catch((error: unknown) => {
+        shouldCache = false;
+        throw error;
+      });
 
       if (shouldCache) {
         this.resultCache.set(pattern, filteredCandidates);
       }
+    }
+
+    const liveCandidates = await this.searchFreshCandidates(
+      pattern,
+      options.signal,
+    );
+    filteredCandidates = mergeCandidates(filteredCandidates, liveCandidates);
+
+    if (filteredCandidates.length === 0 && pattern !== '*') {
+      const recursiveLiveCandidates = await this.searchFreshCandidates(
+        pattern,
+        options.signal,
+        true,
+      );
+      filteredCandidates = mergeCandidates(
+        filteredCandidates,
+        recursiveLiveCandidates,
+      );
     }
 
     const fileFilter = this.ignore.getFileFilter();
@@ -220,6 +288,49 @@ class RecursiveFileSearch implements FileSearch {
       }
     }
     return results;
+  }
+
+  private async searchFreshCandidates(
+    pattern: string,
+    signal: AbortSignal | undefined,
+    recursive = false,
+  ): Promise<string[]> {
+    if (!this.ignore) {
+      return [];
+    }
+
+    const dir =
+      !recursive && pattern !== '*' && !pattern.endsWith('/')
+        ? path.dirname(pattern)
+        : pattern.endsWith('/')
+          ? pattern
+          : '.';
+    const crawlDirectory = recursive
+      ? this.options.projectRoot
+      : path.join(this.options.projectRoot, dir);
+    const rootRelativeDir = recursive
+      ? '.'
+      : path
+          .relative(this.options.projectRoot, crawlDirectory)
+          .split(path.sep)
+          .join(path.posix.sep);
+    const results = normalizeLiveResults(
+      await crawl({
+        crawlDirectory,
+        cwd: this.options.projectRoot,
+        maxDepth: recursive ? this.options.maxDepth : 0,
+        maxFiles: this.options.maxFiles ?? 20000,
+        ignore: this.ignore,
+        cache: false,
+        cacheTtl: 0,
+      }),
+      rootRelativeDir,
+    );
+
+    return searchCandidates(results, pattern, {
+      signal,
+      enableFuzzySearch: this.options.enableFuzzySearch,
+    });
   }
 
   private buildResultCache(): void {

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import picomatch from 'picomatch';
 import { loadIgnoreRules, type Ignore } from './ignore.js';
@@ -123,6 +124,31 @@ export interface SearchOptions {
   maxResults?: number;
 }
 
+async function searchCandidates(
+  candidates: string[],
+  pattern: string,
+  options: {
+    signal?: AbortSignal;
+    enableFuzzySearch: boolean;
+  },
+): Promise<string[]> {
+  if (pattern.includes('*') || !options.enableFuzzySearch) {
+    return filter(candidates, pattern, options.signal);
+  }
+
+  const fzf = new AsyncFzf(candidates, {
+    fuzzy: candidates.length > 20000 ? 'v1' : 'v2',
+    forward: false,
+    tiebreakers: [byBasenamePrefix, byMatchPosFromEnd, byLengthAsc],
+  });
+
+  return fzf
+    .find(pattern)
+    .then((results: Array<FzfResultItem<string>>) =>
+      results.map((entry: FzfResultItem<string>) => entry.item),
+    );
+}
+
 function mergeCandidates(
   primary: string[],
   secondary: string[],
@@ -167,6 +193,10 @@ class RecursiveFileSearch implements FileSearch {
   private resultCache: ResultCache | undefined;
   private allFiles: string[] = [];
   private fzf: AsyncFzf<string[]> | undefined;
+  private liveDirectoryCache = new Map<
+    string,
+    { mtimeNs: bigint; results: string[] }
+  >();
 
   constructor(private readonly options: FileSearchOptions) {}
 
@@ -212,38 +242,25 @@ class RecursiveFileSearch implements FileSearch {
       filteredCandidates = candidates;
     } else {
       let shouldCache = true;
-      if (pattern.includes('*') || !this.fzf) {
-        filteredCandidates = await filter(candidates, pattern, options.signal);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        filteredCandidates = await this.fzf
-          .find(pattern)
-          .then((results: Array<FzfResultItem<string>>) =>
-            results.map((entry: FzfResultItem<string>) => entry.item),
-          )
-          .catch((error: unknown) => {
-            shouldCache = false;
-            throw error;
-          });
-      }
+      filteredCandidates = await searchCandidates(candidates, pattern, {
+        signal: options.signal,
+        enableFuzzySearch: this.options.enableFuzzySearch && !!this.fzf,
+      }).catch((error: unknown) => {
+        shouldCache = false;
+        throw error;
+      });
 
       if (shouldCache) {
         this.resultCache.set(pattern, filteredCandidates);
       }
     }
 
-    if (
-      pattern !== '*' &&
-      (filteredCandidates.length === 0 || pattern.endsWith('/'))
-    ) {
+    if (pattern !== '*') {
       const freshCandidates = await this.searchFreshCandidates(
         pattern,
         options.signal,
       );
-      filteredCandidates =
-        pattern.endsWith('/') && filteredCandidates.length > 0
-          ? mergeCandidates(filteredCandidates, freshCandidates)
-          : freshCandidates;
+      filteredCandidates = mergeCandidates(filteredCandidates, freshCandidates);
     }
 
     const fileFilter = this.ignore.getFileFilter();
@@ -273,7 +290,7 @@ class RecursiveFileSearch implements FileSearch {
     pattern: string,
     signal: AbortSignal | undefined,
   ): Promise<string[]> {
-    if (!this.ignore) {
+    if (!this.ignore || signal?.aborted) {
       return [];
     }
 
@@ -299,20 +316,60 @@ class RecursiveFileSearch implements FileSearch {
     const rootRelativeDir = relativeToProjectRoot
       .split(path.sep)
       .join(path.posix.sep);
-    const results = normalizeLiveResults(
-      await crawl({
-        crawlDirectory,
-        cwd: this.options.projectRoot,
-        maxDepth: 0,
-        maxFiles: this.options.maxFiles ?? 20000,
-        ignore: this.ignore,
-        cache: false,
-        cacheTtl: 0,
-      }),
-      rootRelativeDir,
-    );
+    const maxDepth = pattern.endsWith('/') ? this.options.maxDepth : 0;
+    const cacheKey = `${crawlDirectory}:${maxDepth ?? 'recursive'}`;
 
-    return filter(results, pattern, signal);
+    let results: string[];
+    if (maxDepth === 0) {
+      try {
+        const stats = await stat(crawlDirectory, { bigint: true });
+        const cachedEntry = this.liveDirectoryCache.get(cacheKey);
+        if (cachedEntry?.mtimeNs === stats.mtimeNs) {
+          results = cachedEntry.results;
+        } else {
+          results = normalizeLiveResults(
+            await crawl({
+              crawlDirectory,
+              cwd: this.options.projectRoot,
+              maxDepth,
+              maxFiles: this.options.maxFiles ?? 20000,
+              ignore: this.ignore,
+              cache: false,
+              cacheTtl: 0,
+            }),
+            rootRelativeDir,
+          );
+          this.liveDirectoryCache.set(cacheKey, {
+            mtimeNs: stats.mtimeNs,
+            results,
+          });
+        }
+      } catch {
+        return [];
+      }
+    } else {
+      results = normalizeLiveResults(
+        await crawl({
+          crawlDirectory,
+          cwd: this.options.projectRoot,
+          maxDepth,
+          maxFiles: this.options.maxFiles ?? 20000,
+          ignore: this.ignore,
+          cache: false,
+          cacheTtl: 0,
+        }),
+        rootRelativeDir,
+      );
+    }
+
+    if (signal?.aborted) {
+      throw new AbortError();
+    }
+
+    return searchCandidates(results, pattern, {
+      signal,
+      enableFuzzySearch: this.options.enableFuzzySearch,
+    });
   }
 
   private buildResultCache(): void {

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -126,14 +126,20 @@ export interface SearchOptions {
 function normalizeLiveResults(
   results: string[],
   rootRelativeDir: string,
+  filterDir?: (candidate: string) => boolean,
 ): string[] {
-  if (!rootRelativeDir || rootRelativeDir === '.') {
-    return results;
-  }
-
-  return results.map((entry) =>
-    entry === rootRelativeDir && !entry.endsWith('/') ? `${entry}/` : entry,
-  );
+  return results.map((entry) => {
+    if (entry.endsWith('/')) {
+      return entry;
+    }
+    if (entry === rootRelativeDir) {
+      return `${entry}/`;
+    }
+    if (filterDir?.(entry)) {
+      return `${entry}/`;
+    }
+    return entry;
+  });
 }
 
 export interface FileSearch {
@@ -211,7 +217,10 @@ class RecursiveFileSearch implements FileSearch {
       }
     }
 
-    if (filteredCandidates.length === 0 && pattern !== '*') {
+    if (
+      pattern !== '*' &&
+      (filteredCandidates.length === 0 || pattern.endsWith('/'))
+    ) {
       filteredCandidates = await this.searchFreshCandidates(
         pattern,
         options.signal,
@@ -271,6 +280,7 @@ class RecursiveFileSearch implements FileSearch {
     const rootRelativeDir = relativeToProjectRoot
       .split(path.sep)
       .join(path.posix.sep);
+    const dirFilter = this.ignore.getDirectoryFilter();
     const results = normalizeLiveResults(
       await crawl({
         crawlDirectory,
@@ -282,6 +292,11 @@ class RecursiveFileSearch implements FileSearch {
         cacheTtl: 0,
       }),
       rootRelativeDir,
+      (entry) =>
+        entry !== '.' &&
+        entry !== './' &&
+        entry !== '' &&
+        dirFilter(`${entry}/`),
     );
 
     return filter(results, pattern, signal);


### PR DESCRIPTION
Fixes #25104

## Summary

Fixes stale `@` completion/indexing when files or folders are created after Gemini CLI has already started.

Previously, recursive `@` completion could miss newly created paths until the CLI was restarted, because the file search layer relied on a snapshot built during initialization.

## What changed

- Updated recursive file search to supplement the cached snapshot with a live filesystem refresh during search
- Kept the existing cached index as the primary fast path
- Added a fallback refresh path for newly created nested matches that are not present in the original snapshot
- Added regression tests covering:
  - new root-level paths created after initialization
  - new nested paths created after initialization

## Why

`@` completion builds an index once per workspace directory and does not currently refresh when files/folders are added inside an already-tracked workspace directory. This makes completion stale during long-running sessions.

This change makes newly created paths visible to `@` completion without requiring a restart.

## Validation

```bash
npx vitest run src/utils/filesearch/fileSearch.test.ts
```

in `packages/core`.

## Notes

This PR is scoped to `@` completion/indexing behavior during active sessions. Direct exact-path `@path` resolution uses a separate path-resolution flow.

