### PR TITLE
chore(core): increase codebase investigator turn limits to 50

### DIFF
--- a/packages/core/src/agents/codebase-investigator.ts
+++ b/packages/core/src/agents/codebase-investigator.ts
@@ -110,8 +110,8 @@ export const CodebaseInvestigatorAgent = (
     },
 
     runConfig: {
-      maxTimeMinutes: 3,
-      maxTurns: 10,
+      maxTimeMinutes: 10,
+      maxTurns: 50,
     },
 
     toolConfig: {


### PR DESCRIPTION
## Summary

Increase the `maxTurns` and `maxTimeMinutes` for the `codebase_investigator` subagent to allow for deeper research.

## Details

The previous limit of 10 turns was found to be insufficient for the "deep investigation" tasks that the `codebase_investigator` is designed for. It frequently hit the turn limit before completing its analysis. This PR increases the limit to 50 turns and 10 minutes, aligning it with the browser agent's defaults to allow for more comprehensive research.

## Related Issues

None.

## How to Validate

1. Run unit tests: `npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts`
2. Run full preflight: `npm run preflight`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
