### PR TITLE
chore: switch from keytar to @github/keytar

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -62,7 +62,7 @@ const external = [
   '@lydell/node-pty-linux-x64',
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
-  'keytar',
+  '@github/keytar',
   '@google/gemini-cli-devtools',
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,13 +74,13 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
+        "@github/keytar": "^7.9.0",
         "@lydell/node-pty": "1.1.0",
         "@lydell/node-pty-darwin-arm64": "1.1.0",
         "@lydell/node-pty-darwin-x64": "1.1.0",
         "@lydell/node-pty-linux-x64": "1.1.0",
         "@lydell/node-pty-win32-arm64": "1.1.0",
         "@lydell/node-pty-win32-x64": "1.1.0",
-        "keytar": "^7.9.0",
         "node-pty": "^1.0.0"
       }
     },
@@ -1097,6 +1097,27 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@github/keytar": {
+      "version": "7.10.6",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@github/keytar/-/keytar-7.10.6.tgz",
+      "integrity": "sha512-mRW6cUsSG+nj4jp5gp8e91zPySaT73r+2JM6VyMZfrEgksjPmjSMr+tPGNOK3HUHV+GUU9B1LAiiYy/wmAnIxA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0"
+      }
+    },
+    "node_modules/@github/keytar/node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -11201,6 +11222,7 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
       "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11214,6 +11236,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nop/-/nop-1.0.0.tgz",
       "integrity": "sha512-XdkOuXGx0DTwlqb0DWTcDqelgU/F3YyZ+PTRaecpDVpkYskcnh3OeUYKfvjcRQ2D1diTIGxi/a3eHVjW5yPupQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12243,6 +12266,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -17768,13 +17792,13 @@
         "node": ">=20"
       },
       "optionalDependencies": {
+        "@github/keytar": "^7.9.0",
         "@lydell/node-pty": "1.1.0",
         "@lydell/node-pty-darwin-arm64": "1.1.0",
         "@lydell/node-pty-darwin-x64": "1.1.0",
         "@lydell/node-pty-linux-x64": "1.1.0",
         "@lydell/node-pty-win32-arm64": "1.1.0",
         "@lydell/node-pty-win32-x64": "1.1.0",
-        "keytar": "^7.9.0",
         "node-pty": "^1.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@github/keytar": "^7.9.0",
+        "@github/keytar": "^7.10.6",
         "@lydell/node-pty": "1.1.0",
         "@lydell/node-pty-darwin-arm64": "1.1.0",
         "@lydell/node-pty-darwin-x64": "1.1.0",
@@ -17762,7 +17762,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@github/keytar": "^7.9.0",
+        "@github/keytar": "^7.10.6",
         "@lydell/node-pty": "1.1.0",
         "@lydell/node-pty-darwin-arm64": "1.1.0",
         "@lydell/node-pty-darwin-x64": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,7 +1101,7 @@
     },
     "node_modules/@github/keytar": {
       "version": "7.10.6",
-      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@github/keytar/-/keytar-7.10.6.tgz",
+      "resolved": "https://registry.npmjs.org/@github/keytar/-/keytar-7.10.6.tgz",
       "integrity": "sha512-mRW6cUsSG+nj4jp5gp8e91zPySaT73r+2JM6VyMZfrEgksjPmjSMr+tPGNOK3HUHV+GUU9B1LAiiYy/wmAnIxA==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -1112,7 +1112,7 @@
     },
     "node_modules/@github/keytar/node_modules/node-addon-api": {
       "version": "8.7.0",
-      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
       "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
       "license": "MIT",
       "optional": true,
@@ -11218,28 +11218,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keytar": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
-      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.0.1"
-      }
-    },
-    "node_modules/keytar/node_modules/prebuild-install": {
-      "name": "nop",
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nop/-/nop-1.0.0.tgz",
-      "integrity": "sha512-XdkOuXGx0DTwlqb0DWTcDqelgU/F3YyZ+PTRaecpDVpkYskcnh3OeUYKfvjcRQ2D1diTIGxi/a3eHVjW5yPupQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12261,14 +12239,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     },
     "glob": "^12.0.0",
     "node-domexception": "npm:empty@^0.10.1",
-    "keytar": "npm:@github/keytar@^7.10.6",
     "prebuild-install": "npm:nop@1.0.0",
     "cross-spawn": "^7.0.6",
     "minimatch": "^10.2.2"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     },
     "glob": "^12.0.0",
     "node-domexception": "npm:empty@^0.10.1",
-    "prebuild-install": "npm:nop@1.0.0",
     "cross-spawn": "^7.0.6",
     "minimatch": "^10.2.2"
   },
@@ -150,13 +149,13 @@
     "simple-git": "^3.28.0"
   },
   "optionalDependencies": {
+    "@github/keytar": "^7.9.0",
     "@lydell/node-pty": "1.1.0",
     "@lydell/node-pty-darwin-arm64": "1.1.0",
     "@lydell/node-pty-darwin-x64": "1.1.0",
     "@lydell/node-pty-linux-x64": "1.1.0",
     "@lydell/node-pty-win32-arm64": "1.1.0",
     "@lydell/node-pty-win32-x64": "1.1.0",
-    "keytar": "^7.9.0",
     "node-pty": "^1.0.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     },
     "glob": "^12.0.0",
     "node-domexception": "npm:empty@^0.10.1",
+    "keytar": "npm:@github/keytar@^7.10.6",
+    "prebuild-install": "npm:nop@1.0.0",
     "cross-spawn": "^7.0.6",
     "minimatch": "^10.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "simple-git": "^3.28.0"
   },
   "optionalDependencies": {
-    "@github/keytar": "^7.9.0",
+    "@github/keytar": "^7.10.6",
     "@lydell/node-pty": "1.1.0",
     "@lydell/node-pty-darwin-arm64": "1.1.0",
     "@lydell/node-pty-darwin-x64": "1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,13 +91,13 @@
     "zod-to-json-schema": "^3.25.1"
   },
   "optionalDependencies": {
+    "@github/keytar": "^7.9.0",
     "@lydell/node-pty": "1.1.0",
     "@lydell/node-pty-darwin-arm64": "1.1.0",
     "@lydell/node-pty-darwin-x64": "1.1.0",
     "@lydell/node-pty-linux-x64": "1.1.0",
     "@lydell/node-pty-win32-arm64": "1.1.0",
     "@lydell/node-pty-win32-x64": "1.1.0",
-    "keytar": "^7.9.0",
     "node-pty": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "zod-to-json-schema": "^3.25.1"
   },
   "optionalDependencies": {
-    "@github/keytar": "^7.9.0",
+    "@github/keytar": "^7.10.6",
     "@lydell/node-pty": "1.1.0",
     "@lydell/node-pty-darwin-arm64": "1.1.0",
     "@lydell/node-pty-darwin-x64": "1.1.0",

--- a/packages/core/src/services/keychainService.test.ts
+++ b/packages/core/src/services/keychainService.test.ts
@@ -42,7 +42,7 @@ const mockFileKeychain: MockKeychain = {
   findCredentials: vi.fn(),
 };
 
-vi.mock('keytar', () => ({ default: mockKeytar }));
+vi.mock('@github/keytar', () => ({ default: mockKeytar }));
 
 vi.mock('./fileKeychain.js', () => ({
   FileKeychain: vi.fn(() => mockFileKeychain),

--- a/packages/core/src/services/keychainService.ts
+++ b/packages/core/src/services/keychainService.ts
@@ -22,7 +22,7 @@ import { FileKeychain } from './fileKeychain.js';
 export const FORCE_FILE_STORAGE_ENV_VAR = 'GEMINI_FORCE_FILE_STORAGE';
 
 /**
- * Service for interacting with OS-level secure storage (e.g. keytar).
+ * Service for interacting with OS-level secure storage (e.g. @github/keytar).
  */
 export class KeychainService {
   // Track an ongoing initialization attempt to avoid race conditions.
@@ -119,7 +119,7 @@ export class KeychainService {
   }
 
   /**
-   * Attempts to load and verify the native keychain module (keytar).
+   * Attempts to load and verify the native keychain module (@github/keytar).
    */
   private async getNativeKeychain(): Promise<Keychain | null> {
     try {
@@ -152,7 +152,7 @@ export class KeychainService {
 
   // Low-level dynamic loading and structural validation.
   private async loadKeychainModule(): Promise<Keychain | null> {
-    const moduleName = 'keytar';
+    const moduleName = '@github/keytar';
     const module: unknown = await import(moduleName);
     const potential = (isRecord(module) && module['default']) || module;
 
@@ -189,7 +189,7 @@ export class KeychainService {
    */
   private isMacOSKeychainAvailable(): boolean {
     // Probing via the `security` CLI avoids a blocking OS-level popup that
-    // occurs when calling keytar without a configured keychain.
+    // occurs when calling @github/keytar without a configured keychain.
     const result = spawnSync('security', ['default-keychain'], {
       encoding: 'utf8',
       // We pipe stdout to read the path, but ignore stderr to suppress

--- a/packages/core/src/services/keychainTypes.ts
+++ b/packages/core/src/services/keychainTypes.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 
 /**
  * Interface for OS-level secure storage operations.
- * Note: Method names must match the underlying library (e.g. keytar)
+ * Note: Method names must match the underlying library (e.g. @github/keytar)
  * to support correct dynamic loading and schema validation.
  */
 export interface Keychain {


### PR DESCRIPTION
Closes #21537. Switches from the deprecated keytar to the maintained @github/keytar fork to resolve installation warnings.