### PR TITLE
fix(ui): use wrap instead of truncate for tool confirmation prompt text

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -920,7 +920,7 @@ export const ToolConfirmationMessage: React.FC<
     ) => {
       if (item.value === ToolConfirmationOutcome.ProceedAlwaysAndSave) {
         return (
-          <Text color={titleColor} wrap="truncate">
+          <Text color={titleColor} wrap="wrap">
             {item.label}{' '}
             <Text color={theme.text.secondary}>
               ~/.gemini/policies/auto-saved.toml
@@ -929,7 +929,7 @@ export const ToolConfirmationMessage: React.FC<
         );
       }
       return (
-        <Text color={titleColor} wrap="truncate">
+        <Text color={titleColor} wrap="wrap">
           {item.label}
         </Text>
       );


### PR DESCRIPTION
## Summary

Tool confirmation radio items used `wrap="truncate"`, silently cutting off long parameters, web-fetch URLs, shell commands, file paths, at the terminal width. Users could not see the full content of what they were approving, creating both a UX and security concern.

## Details

In `ToolConfirmationMessage.tsx`, the `renderRadioItem` callback renders two `<Text>` elements: one for the "Allow for all future sessions" option (which also shows the policy file path) and one for all other options. Both used `wrap="truncate"`.

Affects all tool types, web-fetch URLs, shell commands, file paths, and any other long parameter values passed to the confirmation dialog.

Changed both to `wrap="wrap"` so long labels flow onto multiple lines instead of being silently cut off. The fix is 2 lines across 1 file.

## Related Issues

Fixes #21602

## How to Validate

1. Trigger a tool confirmation for a web-fetch with a long URL or a shell command with long arguments
2. Verify the full text is now visible, wrapping to additional lines instead of ending with `...`

## Pre-Merge Checklist

- [x] No breaking changes — `wrap="wrap"` is the correct Ink behavior for this use case
- [x] 27/27 tests pass, build succeeds
- [x] Validated on Windows