### PR TITLE
feat(cli): Add `/rewind <N>` index argument for non-interactive use

### DIFF
--- a/docs/cli/rewind.md
+++ b/docs/cli/rewind.md
@@ -12,6 +12,31 @@ To use the rewind feature, simply type `/rewind` into the input prompt and press
 
 Alternatively, you can use the keyboard shortcut: **Press `Esc` twice**.
 
+### Non-interactive usage
+
+You can also rewind directly to a specific user message by passing an index:
+
+```
+/rewind <index>
+```
+
+The index is **0-based** and supports **negative indexing** (Python-style):
+
+| Command      | Effect                                      |
+| ------------ | ------------------------------------------- |
+| `/rewind 0`  | Rewind to before the first user message     |
+| `/rewind 1`  | Rewind to before the second user message    |
+| `/rewind -1` | Rewind to before the last user message      |
+| `/rewind -2` | Rewind to before the second-to-last message |
+
+This is useful for **stdin-driven orchestrators** and automated workflows where
+navigating the interactive TUI is not practical. The rewound message's prompt
+text is restored into the input buffer, matching the behavior of the interactive
+TUI.
+
+> **Note:** Non-interactive rewind only rewinds the conversation history. To
+> revert file changes, use the interactive TUI (`/rewind` without arguments).
+
 ## Interface
 
 When you trigger a rewind, an interactive list of your previous interactions

--- a/packages/cli/src/ui/commands/rewindCommand.test.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.test.tsx
@@ -281,10 +281,10 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if config is missing', () => {
+  it('should fail if config is missing', async () => {
     const context = { services: {} } as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -293,7 +293,7 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if client is not initialized', () => {
+  it('should fail if client is not initialized', async () => {
     const context = createMockCommandContext({
       services: {
         agentContext: {
@@ -305,7 +305,7 @@ describe('rewindCommand', () => {
       },
     }) as unknown as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -314,7 +314,7 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should fail if recording service is unavailable', () => {
+  it('should fail if recording service is unavailable', async () => {
     const context = createMockCommandContext({
       services: {
         agentContext: {
@@ -326,7 +326,7 @@ describe('rewindCommand', () => {
       },
     }) as unknown as CommandContext;
 
-    const result = rewindCommand.action!(context, '');
+    const result = await rewindCommand.action!(context, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -335,10 +335,10 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should return info if no conversation found', () => {
+  it('should return info if no conversation found', async () => {
     mockGetConversation.mockReturnValue(null);
 
-    const result = rewindCommand.action!(mockContext, '');
+    const result = await rewindCommand.action!(mockContext, '');
 
     expect(result).toEqual({
       type: 'message',
@@ -347,18 +347,126 @@ describe('rewindCommand', () => {
     });
   });
 
-  it('should return info if no user interactions found', () => {
+  it('should return info if no user interactions found', async () => {
     mockGetConversation.mockReturnValue({
       messages: [{ id: 'msg-1', type: 'gemini', content: 'hello' }],
       sessionId: 'test-session',
     });
 
-    const result = rewindCommand.action!(mockContext, '');
+    const result = await rewindCommand.action!(mockContext, '');
 
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
       content: 'Nothing to rewind to.',
+    });
+  });
+
+  describe('index-based rewind (/rewind <N>)', () => {
+    beforeEach(() => {
+      mockGetConversation.mockReturnValue({
+        messages: [
+          { id: 'msg-u1', type: 'user', content: 'first prompt' },
+          { id: 'msg-g1', type: 'gemini', content: 'response 1' },
+          { id: 'msg-u2', type: 'user', content: 'second prompt' },
+          { id: 'msg-g2', type: 'gemini', content: 'response 2' },
+          { id: 'msg-u3', type: 'user', content: 'third prompt' },
+          { id: 'msg-g3', type: 'gemini', content: 'response 3' },
+        ],
+        sessionId: 'test-session',
+      });
+    });
+
+    it('should rewind to the first user message with /rewind 0', async () => {
+      const result = await rewindCommand.action!(mockContext, '0');
+
+      expect(mockRewindTo).toHaveBeenCalledWith('msg-u1');
+      expect(mockSetHistory).toHaveBeenCalled();
+      expect(mockLoadHistory).toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Rewound to before user message 0.',
+      });
+    });
+
+    it('should rewind to the second user message with /rewind 1', async () => {
+      const result = await rewindCommand.action!(mockContext, '1');
+
+      expect(mockRewindTo).toHaveBeenCalledWith('msg-u2');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Rewound to before user message 1.',
+      });
+    });
+
+    it('should resolve negative index: /rewind -1 targets last user message', async () => {
+      const result = await rewindCommand.action!(mockContext, '-1');
+
+      expect(mockRewindTo).toHaveBeenCalledWith('msg-u3');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Rewound to before user message 2.',
+      });
+    });
+
+    it('should resolve negative index: /rewind -2 targets second-to-last', async () => {
+      const result = await rewindCommand.action!(mockContext, '-2');
+
+      expect(mockRewindTo).toHaveBeenCalledWith('msg-u2');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Rewound to before user message 1.',
+      });
+    });
+
+    it('should return error for non-integer argument', async () => {
+      const result = await rewindCommand.action!(mockContext, 'abc');
+
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Invalid argument. Usage: /rewind <index> (integer, supports negative indexing)',
+      });
+    });
+
+    it('should return error for out-of-range positive index', async () => {
+      const result = await rewindCommand.action!(mockContext, '999');
+
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Invalid index. Valid range: 0 to 2 (or -3 to -1).',
+      });
+    });
+
+    it('should return error for out-of-range negative index', async () => {
+      const result = await rewindCommand.action!(mockContext, '-999');
+
+      expect(mockRewindTo).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Invalid index. Valid range: 0 to 2 (or -3 to -1).',
+      });
+    });
+
+    it('should not return success message when rewind fails', async () => {
+      mockRewindTo.mockReturnValue(null);
+
+      const result = await rewindCommand.action!(mockContext, '0');
+
+      expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+        'error',
+        'Could not fetch conversation file',
+      );
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -20,11 +20,26 @@ import {
   coreEvents,
   debugLogger,
   logRewind,
+  partToString,
   RewindEvent,
   type ChatRecordingService,
   type GeminiClient,
+  type MessageRecord,
   convertSessionToClientHistory,
 } from '@google/gemini-cli-core';
+import { stripReferenceContent } from '../utils/formatters.js';
+
+/**
+ * Extracts the cleaned prompt text from a user message, matching the logic
+ * used by the RewindViewer TUI to restore the input buffer after a rewind.
+ */
+function getCleanedRewindText(userMessage: MessageRecord): string {
+  const contentToUse = userMessage.displayContent || userMessage.content;
+  const originalUserText = contentToUse ? partToString(contentToUse) : '';
+  return userMessage.displayContent
+    ? originalUserText
+    : stripReferenceContent(originalUserText);
+}
 
 /**
  * Helper function to handle the core logic of rewinding a conversation.
@@ -36,6 +51,7 @@ import {
  * @param recordingService The chat recording service.
  * @param messageId The ID of the message to rewind to.
  * @param newText The new text for the input field after rewinding.
+ * @returns true if the rewind was successful, false otherwise.
  */
 async function rewindConversation(
   context: CommandContext,
@@ -43,7 +59,7 @@ async function rewindConversation(
   recordingService: ChatRecordingService,
   messageId: string,
   newText: string,
-) {
+): Promise<boolean> {
   try {
     const conversation = recordingService.rewindTo(messageId);
     if (!conversation) {
@@ -51,7 +67,7 @@ async function rewindConversation(
       debugLogger.error(errorMsg);
       context.ui.removeComponent();
       coreEvents.emitFeedback('error', errorMsg);
-      return;
+      return false;
     }
 
     // Convert to UI and Client formats
@@ -81,6 +97,7 @@ async function rewindConversation(
 
     // 2. Load the rewound history and set the input
     context.ui.loadHistory(historyWithIds, newText);
+    return true;
   } catch (error) {
     // If an error occurs, we still want to remove the component if possible
     context.ui.removeComponent();
@@ -88,6 +105,7 @@ async function rewindConversation(
       'error',
       error instanceof Error ? error.message : 'Unknown error during rewind',
     );
+    return false;
   }
 }
 
@@ -95,7 +113,7 @@ export const rewindCommand: SlashCommand = {
   name: 'rewind',
   description: 'Jump back to a specific message and restart the conversation',
   kind: CommandKind.BUILT_IN,
-  action: (context) => {
+  action: async (context, args) => {
     const agentContext = context.services.agentContext;
     const config = agentContext?.config;
     if (!config)
@@ -138,6 +156,60 @@ export const rewindCommand: SlashCommand = {
         messageType: 'info',
         content: 'Nothing to rewind to.',
       };
+    }
+
+    // Non-interactive index-based rewind: /rewind <N>
+    const argTrimmed = args?.trim() ?? '';
+    if (argTrimmed) {
+      if (!/^-?\d+$/.test(argTrimmed)) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content:
+            'Invalid argument. Usage: /rewind <index> (integer, supports negative indexing)',
+        };
+      }
+
+      const userMessages = conversation.messages.filter(
+        (msg) => msg.type === 'user',
+      );
+      let index = parseInt(argTrimmed, 10);
+
+      // Resolve negative index (Python-style: -1 = last)
+      if (index < 0) {
+        index += userMessages.length;
+      }
+
+      if (index < 0 || index >= userMessages.length) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Invalid index. Valid range: 0 to ${userMessages.length - 1} (or -${userMessages.length} to -1).`,
+        };
+      }
+
+      const targetMessage = userMessages[index];
+      const cleanedText = getCleanedRewindText(targetMessage);
+
+      logRewind(config, new RewindEvent(RewindOutcome.RewindOnly));
+
+      const success = await rewindConversation(
+        context,
+        client,
+        recordingService,
+        targetMessage.id,
+        cleanedText,
+      );
+
+      if (success) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: `Rewound to before user message ${index}.`,
+        };
+      }
+      // Error already emitted by rewindConversation via coreEvents
+      return;
     }
 
     return {

--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -20,27 +20,12 @@ import {
   coreEvents,
   debugLogger,
   logRewind,
-  partToString,
   RewindEvent,
   type ChatRecordingService,
   type GeminiClient,
-  type MessageRecord,
   convertSessionToClientHistory,
 } from '@google/gemini-cli-core';
-import { stripReferenceContent } from '../utils/formatters.js';
-
-/**
- * Extracts the cleaned prompt text from a user message, matching the logic
- * used by the RewindViewer TUI to restore the input buffer after a rewind.
- */
-function getCleanedRewindText(userMessage: MessageRecord): string {
-  const contentToUse = userMessage.displayContent || userMessage.content;
-  const originalUserText = contentToUse ? partToString(contentToUse) : '';
-  return userMessage.displayContent
-    ? originalUserText
-    : stripReferenceContent(originalUserText);
-}
-
+import { getCleanedRewindText } from '../utils/formatters.js';
 /**
  * Helper function to handle the core logic of rewinding a conversation.
  * This function encapsulates the steps needed to rewind the conversation,

--- a/packages/cli/src/ui/components/RewindViewer.tsx
+++ b/packages/cli/src/ui/components/RewindViewer.tsx
@@ -18,7 +18,7 @@ import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { useRewind } from '../hooks/useRewind.js';
 import { RewindConfirmation, RewindOutcome } from './RewindConfirmation.js';
-import { stripReferenceContent } from '../utils/formatters.js';
+import { getCleanedRewindText } from '../utils/formatters.js';
 import { Command } from '../key/keyMatchers.js';
 import { CliSpinner } from './CliSpinner.js';
 import { ExpandableText } from './shared/ExpandableText.js';
@@ -35,14 +35,6 @@ interface RewindViewerProps {
 }
 
 const MAX_LINES_PER_BOX = 2;
-
-const getCleanedRewindText = (userPrompt: MessageRecord): string => {
-  const contentToUse = userPrompt.displayContent || userPrompt.content;
-  const originalUserText = contentToUse ? partToString(contentToUse) : '';
-  return userPrompt.displayContent
-    ? originalUserText
-    : stripReferenceContent(originalUserText);
-};
 
 export const RewindViewer: React.FC<RewindViewerProps> = ({
   conversation,

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -7,6 +7,8 @@
 import {
   REFERENCE_CONTENT_START,
   REFERENCE_CONTENT_END,
+  type MessageRecord,
+  partToString,
 } from '@google/gemini-cli-core';
 
 export const formatBytes = (bytes: number): string => {
@@ -152,4 +154,15 @@ export const formatResetTime = (
   }).format(resetDate);
 
   return `${duration} at ${timeStr}`;
+};
+
+/**
+ * Extracts the cleaned prompt text from a user message.
+ */
+export const getCleanedRewindText = (userMessage: MessageRecord): string => {
+  const contentToUse = userMessage.displayContent || userMessage.content;
+  const originalUserText = contentToUse ? partToString(contentToUse) : '';
+  return userMessage.displayContent
+    ? originalUserText
+    : stripReferenceContent(originalUserText);
 };


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

Adds support for an optional `[index]` argument to the `/rewind` command. This allows external tools orchestrating the CLI to trim conversation history programmatically, maintaining prompt cache efficiency without needing to navigate the TUI. This PR also addresses internal code duplication by centralizing string manipulation utilities.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

- **Indexing:** Supports 0-based indexing and Python-style negative indexing (e.g., `/rewind -1` for the last message).
- **Buffer handling:** Properly restores the cleaned prompt text back into the input buffer.
- **Refactoring:** Centralized `getCleanedRewindText()` in `formatters.ts` to ensure consistent string padding across all rewind paths.
- **Error handling:** `rewindConversation()` now returns a boolean to prevent displaying a success message when rewind fails.
- **Files Modified**:
  - `packages/cli/src/ui/commands/rewindCommand.tsx`
  - `packages/cli/src/ui/commands/rewindCommand.test.tsx`
  - `packages/cli/src/ui/components/RewindViewer.tsx`
  - `packages/cli/src/ui/utils/formatters.ts`
  - `docs/cli/rewind.md`


## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Closes #24933

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

1. Start Gemini CLI and send a few prompts.
2. Enter `/rewind -1` to delete the last user message and its response.
3. Verify the chat history trims successfully and your input prompt restores the rewound text.
4. Run the unit tests locally:
   ```bash
   npm test -w @google/gemini-cli -- src/ui/commands/rewindCommand.test.tsx
   ```
5. Verify the full preflight suite passes:
   ```bash
   npm run preflight
   ```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
