### PR TITLE
feat(extensions): allow headless config and linking

### DIFF
--- a/packages/cli/src/commands/extensions/configure.ts
+++ b/packages/cli/src/commands/extensions/configure.ts
@@ -19,11 +19,12 @@ import { exitCli } from '../utils.js';
 interface ConfigureArgs {
   name?: string;
   setting?: string;
+  value?: string;
   scope: string;
 }
 
 export const configureCommand: CommandModule<object, ConfigureArgs> = {
-  command: 'config [name] [setting]',
+  command: 'config [name] [setting] [value]',
   describe: 'Configure extension settings.',
   builder: (yargs) =>
     yargs
@@ -35,6 +36,11 @@ export const configureCommand: CommandModule<object, ConfigureArgs> = {
         describe: 'The specific setting to configure (name or env var).',
         type: 'string',
       })
+      .positional('value', {
+        describe:
+          'The value to set for the setting. Bypasses the interactive prompt.',
+        type: 'string',
+      })
       .option('scope', {
         describe: 'The scope to set the setting in.',
         type: 'string',
@@ -42,7 +48,7 @@ export const configureCommand: CommandModule<object, ConfigureArgs> = {
         default: 'user',
       }),
   handler: async (args) => {
-    const { name, setting, scope } = args;
+    const { name, setting, value, scope } = args;
     const settings = loadSettings(process.cwd()).merged;
 
     if (!(settings.experimental?.extensionConfig ?? true)) {
@@ -73,6 +79,9 @@ export const configureCommand: CommandModule<object, ConfigureArgs> = {
         setting,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         scope as ExtensionSettingScope,
+        undefined,
+        undefined,
+        value,
       );
     }
     // Case 2: Configure all settings for an extension

--- a/packages/cli/src/commands/extensions/link.ts
+++ b/packages/cli/src/commands/extensions/link.ts
@@ -24,6 +24,7 @@ import { exitCli } from '../utils.js';
 interface InstallArgs {
   path: string;
   consent?: boolean;
+  skipSettings?: boolean;
 }
 
 export async function handleLink(args: InstallArgs) {
@@ -43,7 +44,7 @@ export async function handleLink(args: InstallArgs) {
     const extensionManager = new ExtensionManager({
       workspaceDir,
       requestConsent,
-      requestSetting: promptForSetting,
+      requestSetting: args.skipSettings ? null : promptForSetting,
       settings: loadSettings(workspaceDir).merged,
     });
     await extensionManager.loadExtensions();
@@ -76,6 +77,11 @@ export const linkCommand: CommandModule = {
         type: 'boolean',
         default: false,
       })
+      .option('skip-settings', {
+        describe: 'Skip the configuration on install process.',
+        type: 'boolean',
+        default: false,
+      })
       .check((_) => true),
   handler: async (argv) => {
     await handleLink({
@@ -83,6 +89,8 @@ export const linkCommand: CommandModule = {
       path: argv['path'] as string,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       consent: argv['consent'] as boolean | undefined,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      skipSettings: argv['skip-settings'] as boolean | undefined,
     });
     await exitCli();
   },

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -87,6 +87,7 @@ export async function configureSpecificSetting(
   scope: ExtensionSettingScope,
   logger: ConfigLogger = defaultLogger,
   requestSetting: RequestSettingCallback = defaultRequestSetting,
+  value?: string,
 ) {
   const { extension } = await getExtensionAndManager(
     extensionManager,
@@ -110,7 +111,7 @@ export async function configureSpecificSetting(
     extensionConfig,
     extension.id,
     settingKey,
-    requestSetting,
+    value !== undefined ? async () => value : requestSetting,
     scope,
     process.cwd(),
   );


### PR DESCRIPTION
## Summary

Adds headless configuration support for extensions to enable non-interactive setup in CI/CD
environments.

## Details

- Adds `--skip-settings` to `gemini extensions link`. This aligns it with the `install` command
and allows linking a local extension without being blocked by an interactive prompt for missing
settings.
- Adds an optional `[value]` positional argument to `gemini extensions config`. When provided, it
entirely bypasses the interactive prompt, securely encrypting the provided value exactly as if a user
had typed it in.

## How to Validate

1. Link an extension that has settings required: `gemini extensions link <path> --consent
--skip-settings`
2. Observe that it links without pausing for a prompt.
3. Configure the setting headlessly: `gemini extensions config <name> <setting_env_var> <value>`
4. Observe that the setting is updated securely without prompting.