### PR TITLE
a2a-server: harden HTTP auth for custom endpoints

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -107,11 +107,15 @@ vi.mock('@google/gemini-cli-core', async () => {
   };
 });
 
+const TEST_BEARER_TOKEN = 'test-bearer-token';
+const AUTH_HEADER = `Bearer ${TEST_BEARER_TOKEN}`;
+
 describe('E2E Tests', () => {
   let app: express.Express;
   let server: Server;
 
   beforeAll(async () => {
+    process.env['CODER_AGENT_BEARER_TOKEN'] = TEST_BEARER_TOKEN;
     app = await createApp();
     server = app.listen(0); // Listen on a random available port
   });
@@ -123,6 +127,7 @@ describe('E2E Tests', () => {
   afterAll(
     () =>
       new Promise<void>((resolve) => {
+        delete process.env['CODER_AGENT_BEARER_TOKEN'];
         server.close(() => {
           resolve();
         });
@@ -873,7 +878,10 @@ describe('E2E Tests', () => {
         .mockReturnValue(mockCommands);
 
       const agent = request.agent(app);
-      const res = await agent.get('/listCommands').expect(200);
+      const res = await agent
+        .get('/listCommands')
+        .set('Authorization', AUTH_HEADER)
+        .expect(200);
 
       expect(res.body).toEqual({
         commands: [
@@ -920,7 +928,10 @@ describe('E2E Tests', () => {
         .mockReturnValue([cyclicCommand]);
 
       const agent = request.agent(app);
-      const res = await agent.get('/listCommands').expect(200);
+      const res = await agent
+        .get('/listCommands')
+        .set('Authorization', AUTH_HEADER)
+        .expect(200);
 
       expect(res.body.commands[0].name).toBe('cyclic-command');
       expect(res.body.commands[0].subCommands).toEqual([]);
@@ -962,6 +973,7 @@ describe('E2E Tests', () => {
         .post('/executeCommand')
         .send({ command: 'extensions list', args: [] })
         .set('Content-Type', 'application/json')
+        .set('Authorization', AUTH_HEADER)
         .expect(200);
 
       expect(res.body).toEqual({
@@ -979,6 +991,7 @@ describe('E2E Tests', () => {
         .post('/executeCommand')
         .send({ command: 'invalid command' })
         .set('Content-Type', 'application/json')
+        .set('Authorization', AUTH_HEADER)
         .expect(404);
 
       expect(res.body.error).toBe('Command not found: invalid command');
@@ -991,6 +1004,7 @@ describe('E2E Tests', () => {
         .post('/executeCommand')
         .send({ args: [] })
         .set('Content-Type', 'application/json')
+        .set('Authorization', AUTH_HEADER)
         .expect(400);
       expect(getExtensionsSpy).not.toHaveBeenCalled();
     });
@@ -1001,6 +1015,7 @@ describe('E2E Tests', () => {
         .post('/executeCommand')
         .send({ command: 'extensions.list', args: 'not-an-array' })
         .set('Content-Type', 'application/json')
+        .set('Authorization', AUTH_HEADER)
         .expect(400);
 
       expect(res.body.error).toBe('"args" field must be an array.');
@@ -1020,6 +1035,7 @@ describe('E2E Tests', () => {
       delete process.env['CODER_AGENT_WORKSPACE_PATH'];
       const response = await request(app)
         .post('/executeCommand')
+        .set('Authorization', AUTH_HEADER)
         .send({ command: 'test-command', args: [] });
 
       expect(response.status).toBe(200);
@@ -1040,6 +1056,7 @@ describe('E2E Tests', () => {
       delete process.env['CODER_AGENT_WORKSPACE_PATH'];
       const response = await request(app)
         .post('/executeCommand')
+        .set('Authorization', AUTH_HEADER)
         .send({ command: 'workspace-command', args: [] });
 
       expect(response.status).toBe(400);
@@ -1062,6 +1079,7 @@ describe('E2E Tests', () => {
       process.env['CODER_AGENT_WORKSPACE_PATH'] = '/tmp/test-workspace';
       const response = await request(app)
         .post('/executeCommand')
+        .set('Authorization', AUTH_HEADER)
         .send({ command: 'workspace-command', args: [] });
 
       expect(response.status).toBe(200);
@@ -1086,6 +1104,7 @@ describe('E2E Tests', () => {
         .post('/executeCommand')
         .send({ command: 'context-check-command', args: [] })
         .set('Content-Type', 'application/json')
+        .set('Authorization', AUTH_HEADER)
         .expect(200);
 
       expect(res.body.data).toBe('success');
@@ -1127,6 +1146,7 @@ describe('E2E Tests', () => {
           .send({ command: 'stream-test', args: [] })
           .set('Content-Type', 'application/json')
           .set('Accept', 'text/event-stream')
+          .set('Authorization', AUTH_HEADER)
           .on('response', (res) => {
             let data = '';
             res.on('data', (chunk: Buffer) => {
@@ -1175,6 +1195,7 @@ describe('E2E Tests', () => {
           .post('/executeCommand')
           .send({ command: 'non-stream-test', args: [] })
           .set('Content-Type', 'application/json')
+          .set('Authorization', AUTH_HEADER)
           .expect(200);
 
         expect(res.body).toEqual({ name: 'non-stream-test', data: 'done' });

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import express, { type Request } from 'express';
+import express from 'express';
 
 import type { AgentCard, Message } from '@a2a-js/sdk';
 import {
@@ -13,15 +13,19 @@ import {
   InMemoryTaskStore,
   DefaultExecutionEventBus,
   type AgentExecutionEvent,
-  UnauthenticatedUser,
 } from '@a2a-js/sdk/server';
-import { A2AExpressApp, type UserBuilder } from '@a2a-js/sdk/server/express'; // Import server components
+import { A2AExpressApp } from '@a2a-js/sdk/server/express'; // Import server components
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger.js';
 import type { AgentSettings } from '../types.js';
 import { GCSTaskStore, NoOpTaskStore } from '../persistence/gcs.js';
 import { CoderAgentExecutor } from '../agent/executor.js';
 import { requestStorage } from './requestStorage.js';
+import {
+  buildAgentUserBuilder,
+  loadAgentServerCredentials,
+  requireAgentAuth,
+} from './auth.js';
 import { loadConfig, loadEnvironment, setTargetDir } from '../config/config.js';
 import { loadSettings } from '../config/settings.js';
 import { loadExtensions } from '../config/extension.js';
@@ -90,35 +94,6 @@ const coderAgentCard: AgentCard = {
 export function updateCoderAgentCardUrl(port: number) {
   coderAgentCard.url = `http://localhost:${port}/`;
 }
-
-const customUserBuilder: UserBuilder = async (req: Request) => {
-  const auth = req.headers['authorization'];
-  if (auth) {
-    const scheme = auth.split(' ')[0];
-    logger.info(
-      `[customUserBuilder] Received Authorization header with scheme: ${scheme}`,
-    );
-  }
-  if (!auth) return new UnauthenticatedUser();
-
-  // 1. Bearer Auth
-  if (auth.startsWith('Bearer ')) {
-    const token = auth.substring(7);
-    if (token === 'valid-token') {
-      return { userName: 'bearer-user', isAuthenticated: true };
-    }
-  }
-
-  // 2. Basic Auth
-  if (auth.startsWith('Basic ')) {
-    const credentials = Buffer.from(auth.substring(6), 'base64').toString();
-    if (credentials === 'admin:password') {
-      return { userName: 'basic-user', isAuthenticated: true };
-    }
-  }
-
-  return new UnauthenticatedUser();
-};
 
 async function handleExecuteCommand(
   req: express.Request,
@@ -232,6 +207,9 @@ export async function createApp() {
 
     const context = { config, git, agentExecutor };
 
+    const credentials = loadAgentServerCredentials();
+    const authMiddleware = requireAgentAuth(credentials);
+
     const requestHandler = new DefaultRequestHandler(
       coderAgentCard,
       taskStoreForHandler,
@@ -243,11 +221,14 @@ export async function createApp() {
       requestStorage.run({ req }, next);
     });
 
-    const appBuilder = new A2AExpressApp(requestHandler, customUserBuilder);
+    const appBuilder = new A2AExpressApp(
+      requestHandler,
+      buildAgentUserBuilder(credentials),
+    );
     expressApp = appBuilder.setupRoutes(expressApp, '');
     expressApp.use(express.json());
 
-    expressApp.post('/tasks', async (req, res) => {
+    expressApp.post('/tasks', authMiddleware, async (req, res) => {
       try {
         const taskId = uuidv4();
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -273,11 +254,11 @@ export async function createApp() {
       }
     });
 
-    expressApp.post('/executeCommand', (req, res) => {
+    expressApp.post('/executeCommand', authMiddleware, (req, res) => {
       void handleExecuteCommand(req, res, context);
     });
 
-    expressApp.get('/listCommands', (req, res) => {
+    expressApp.get('/listCommands', authMiddleware, (req, res) => {
       try {
         const transformCommand = (
           command: Command,
@@ -319,7 +300,7 @@ export async function createApp() {
       }
     });
 
-    expressApp.get('/tasks/metadata', async (req, res) => {
+    expressApp.get('/tasks/metadata', authMiddleware, async (req, res) => {
       // This endpoint is only meaningful if the task store is in-memory.
       if (!(taskStoreForExecutor instanceof InMemoryTaskStore)) {
         res.status(501).send({
@@ -347,7 +328,7 @@ export async function createApp() {
       }
     });
 
-    expressApp.get('/tasks/:taskId/metadata', async (req, res) => {
+    expressApp.get('/tasks/:taskId/metadata', authMiddleware, async (req, res) => {
       const taskId = req.params.taskId;
       let wrapper = agentExecutor.getTask(taskId);
       if (!wrapper) {

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -307,6 +307,7 @@ export async function createApp() {
           error:
             'Listing all task metadata is only supported when using InMemoryTaskStore.',
         });
+        return;
       }
       try {
         const wrappers = agentExecutor.getAllTasks();

--- a/packages/a2a-server/src/http/auth.ts
+++ b/packages/a2a-server/src/http/auth.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import type { NextFunction, Request, Response } from 'express';
+import type { UserBuilder } from '@a2a-js/sdk/server/express';
+import { UnauthenticatedUser } from '@a2a-js/sdk/server';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Credentials accepted by the a2a-server. Values are loaded from environment
+ * variables when provided, otherwise a random bearer token is generated at
+ * startup so the server never ships with well-known default credentials.
+ */
+export interface AgentServerCredentials {
+  bearerToken: string;
+  basicUsername?: string;
+  basicPassword?: string;
+}
+
+function generateRandomToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) {
+    // Still perform a comparison to keep timing uniform.
+    const pad = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, pad);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Loads the credentials used to authenticate requests against the
+ * a2a-server's custom HTTP endpoints and the A2A protocol routes.
+ *
+ * Environment variables:
+ *   CODER_AGENT_BEARER_TOKEN   - bearer token; auto-generated if unset
+ *   CODER_AGENT_BASIC_USERNAME - optional basic auth username
+ *   CODER_AGENT_BASIC_PASSWORD - optional basic auth password
+ */
+export function loadAgentServerCredentials(): AgentServerCredentials {
+  const envBearer = process.env['CODER_AGENT_BEARER_TOKEN'];
+  const bearerToken =
+    envBearer && envBearer.length > 0 ? envBearer : generateRandomToken();
+
+  if (!envBearer) {
+    logger.info(
+      '[a2a-server] Generated ephemeral bearer token for this process. ' +
+        'Set CODER_AGENT_BEARER_TOKEN to supply a stable value.',
+    );
+  }
+
+  const basicUsername = process.env['CODER_AGENT_BASIC_USERNAME'];
+  const basicPassword = process.env['CODER_AGENT_BASIC_PASSWORD'];
+  const hasBasic =
+    !!basicUsername &&
+    basicUsername.length > 0 &&
+    !!basicPassword &&
+    basicPassword.length > 0;
+
+  return {
+    bearerToken,
+    basicUsername: hasBasic ? basicUsername : undefined,
+    basicPassword: hasBasic ? basicPassword : undefined,
+  };
+}
+
+function verifyAuthorizationHeader(
+  header: string | undefined,
+  credentials: AgentServerCredentials,
+): { userName: string } | null {
+  if (!header) return null;
+
+  if (header.startsWith('Bearer ')) {
+    const token = header.substring('Bearer '.length);
+    if (constantTimeEquals(token, credentials.bearerToken)) {
+      return { userName: 'bearer-user' };
+    }
+    return null;
+  }
+
+  if (
+    header.startsWith('Basic ') &&
+    credentials.basicUsername &&
+    credentials.basicPassword
+  ) {
+    const decoded = Buffer.from(
+      header.substring('Basic '.length),
+      'base64',
+    ).toString('utf8');
+    const expected =
+      credentials.basicUsername + ':' + credentials.basicPassword;
+    if (constantTimeEquals(decoded, expected)) {
+      return { userName: 'basic-user' };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Builds the {@link UserBuilder} used by the A2A SDK to identify callers of
+ * the A2A protocol routes. Returns an unauthenticated user when the supplied
+ * credentials do not match.
+ */
+export function buildAgentUserBuilder(
+  credentials: AgentServerCredentials,
+): UserBuilder {
+  return async (req: Request) => {
+    const header = req.headers['authorization'];
+    if (header) {
+      const scheme = header.split(' ')[0];
+      logger.info(
+        `[a2a-server] Received Authorization header with scheme: ${scheme}`,
+      );
+    }
+    const verified = verifyAuthorizationHeader(header, credentials);
+    if (!verified) return new UnauthenticatedUser();
+    return { userName: verified.userName, isAuthenticated: true };
+  };
+}
+
+/**
+ * Express middleware that rejects requests whose Authorization header does
+ * not match the process's configured credentials. Applied to the custom
+ * (non-A2A-protocol) HTTP endpoints.
+ */
+export function requireAgentAuth(credentials: AgentServerCredentials) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const header = req.headers['authorization'];
+    const verified = verifyAuthorizationHeader(header, credentials);
+    if (!verified) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    next();
+  };
+}

--- a/packages/a2a-server/src/http/auth.ts
+++ b/packages/a2a-server/src/http/auth.ts
@@ -47,19 +47,19 @@ function constantTimeEquals(a: string, b: string): boolean {
  *   CODER_AGENT_BASIC_PASSWORD - optional basic auth password
  */
 export function loadAgentServerCredentials(): AgentServerCredentials {
-  const envBearer = process.env['CODER_AGENT_BEARER_TOKEN'];
+  const envBearer = process.env['CODER_AGENT_BEARER_TOKEN']?.trim();
   const bearerToken =
     envBearer && envBearer.length > 0 ? envBearer : generateRandomToken();
 
-  if (!envBearer) {
+  if (!envBearer || envBearer.length === 0) {
     logger.info(
       '[a2a-server] Generated ephemeral bearer token for this process. ' +
         'Set CODER_AGENT_BEARER_TOKEN to supply a stable value.',
     );
   }
 
-  const basicUsername = process.env['CODER_AGENT_BASIC_USERNAME'];
-  const basicPassword = process.env['CODER_AGENT_BASIC_PASSWORD'];
+  const basicUsername = process.env['CODER_AGENT_BASIC_USERNAME']?.trim();
+  const basicPassword = process.env['CODER_AGENT_BASIC_PASSWORD']?.trim();
   const hasBasic =
     !!basicUsername &&
     basicUsername.length > 0 &&

--- a/packages/a2a-server/src/http/endpoints.test.ts
+++ b/packages/a2a-server/src/http/endpoints.test.ts
@@ -73,10 +73,13 @@ describe('Agent Server Endpoints', () => {
   let app: express.Express;
   let server: Server;
   let testWorkspace: string;
+  const TEST_BEARER_TOKEN = 'test-bearer-token';
+  const authHeader = `Bearer ${TEST_BEARER_TOKEN}`;
 
   const createTask = (contextId: string) =>
     request(app)
       .post('/tasks')
+      .set('Authorization', authHeader)
       .send({
         contextId,
         agentSettings: {
@@ -87,6 +90,7 @@ describe('Agent Server Endpoints', () => {
       .set('Content-Type', 'application/json');
 
   beforeAll(async () => {
+    process.env['CODER_AGENT_BEARER_TOKEN'] = TEST_BEARER_TOKEN;
     // Create a unique temporary directory for the workspace to avoid conflicts
     testWorkspace = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-agent-test-'),
@@ -102,6 +106,7 @@ describe('Agent Server Endpoints', () => {
   });
 
   afterAll(async () => {
+    delete process.env['CODER_AGENT_BEARER_TOKEN'];
     if (server) {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => {
@@ -129,7 +134,9 @@ describe('Agent Server Endpoints', () => {
   it('should get metadata for a specific task via GET /tasks/:taskId/metadata', async () => {
     const createResponse = await createTask('test-context-2');
     const taskId = createResponse.body;
-    const response = await request(app).get(`/tasks/${taskId}/metadata`);
+    const response = await request(app)
+      .get(`/tasks/${taskId}/metadata`)
+      .set('Authorization', authHeader);
     expect(response.status).toBe(200);
     expect(response.body.metadata.id).toBe(taskId);
   }, 6000);
@@ -137,7 +144,9 @@ describe('Agent Server Endpoints', () => {
   it('should get metadata for all tasks via GET /tasks/metadata', async () => {
     const createResponse = await createTask('test-context-3');
     const taskId = createResponse.body;
-    const response = await request(app).get('/tasks/metadata');
+    const response = await request(app)
+      .get('/tasks/metadata')
+      .set('Authorization', authHeader);
     expect(response.status).toBe(200);
     expect(Array.isArray(response.body)).toBe(true);
     expect(response.body.length).toBeGreaterThan(0);
@@ -148,7 +157,9 @@ describe('Agent Server Endpoints', () => {
   });
 
   it('should return 404 for a non-existent task', async () => {
-    const response = await request(app).get('/tasks/fake-task/metadata');
+    const response = await request(app)
+      .get('/tasks/fake-task/metadata')
+      .set('Authorization', authHeader);
     expect(response.status).toBe(404);
   });
 
@@ -158,5 +169,26 @@ describe('Agent Server Endpoints', () => {
     expect(response.status).toBe(200);
     expect(response.body.name).toBe('Gemini SDLC Agent');
     expect(response.body.url).toBe(`http://localhost:${port}/`);
+  });
+
+  it('should reject custom endpoint requests without credentials', async () => {
+    const taskResponse = await request(app)
+      .post('/tasks')
+      .send({ contextId: 'noauth' })
+      .set('Content-Type', 'application/json');
+    expect(taskResponse.status).toBe(401);
+
+    const metadataResponse = await request(app).get('/tasks/metadata');
+    expect(metadataResponse.status).toBe(401);
+
+    const listResponse = await request(app).get('/listCommands');
+    expect(listResponse.status).toBe(401);
+  });
+
+  it('should reject custom endpoint requests with a wrong bearer token', async () => {
+    const response = await request(app)
+      .get('/tasks/metadata')
+      .set('Authorization', 'Bearer not-the-right-token');
+    expect(response.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

- Load the bearer token used by the a2a-server HTTP auth from `CODER_AGENT_BEARER_TOKEN`, and generate a fresh random token at startup when the variable is unset, instead of accepting a hard-coded literal.
- Apply the existing authentication middleware to the custom `/tasks`, `/executeCommand`, `/listCommands`, `/tasks/metadata`, and `/tasks/:taskId/metadata` endpoints so every route exposed by `createApp()` shares the same credential check.
- Add optional `CODER_AGENT_BASIC_USERNAME` / `CODER_AGENT_BASIC_PASSWORD` for operators who want to keep using basic auth.
- Use `crypto.timingSafeEqual` for credential comparisons.

## Motivation

Before this change, the custom endpoints registered in `packages/a2a-server/src/http/app.ts` were added without any middleware, and the shared `customUserBuilder` matched the literal strings `valid-token` and `admin:password`. That meant any local process (or a DNS-rebinding attacker targeting the loopback listener) could reach `/executeCommand` without knowing any secret specific to the running server.

This change keeps the existing behavior when `CODER_AGENT_BEARER_TOKEN` is provided, but makes the default configuration safe by generating a per-process random token and requiring it on every custom endpoint.

## Test plan

- [ ] `npm run test -w @google/gemini-cli-a2a-server` passes
- [ ] Requests to `/tasks`, `/executeCommand`, `/listCommands`, `/tasks/metadata`, and `/tasks/:taskId/metadata` without an `Authorization` header return `401`
- [ ] Same requests with `Authorization: Bearer $CODER_AGENT_BEARER_TOKEN` succeed
- [ ] `.well-known/agent-card.json` still reachable without credentials