### PR TITLE
fix: externalize https-proxy-agent to fix proxy support

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -64,6 +64,11 @@ const external = [
   '@lydell/node-pty-win32-x64',
   '@github/keytar',
   '@google/gemini-cli-devtools',
+  // https-proxy-agent is a CJS package. When bundled with esbuild code splitting,
+  // its named exports (HttpsProxyAgent) get lost in the CJS→ESM interop layer —
+  // they end up on `default` instead of as named exports. Marking it external lets
+  // Node.js's native CJS interop handle the import correctly.
+  'https-proxy-agent',
 ];
 
 const baseConfig = {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "node-fetch-native": "^1.6.7",
     "proper-lockfile": "^4.1.2",
     "punycode": "^2.3.1",
-    "simple-git": "^3.28.0"
+    "simple-git": "^3.28.0",
+    "https-proxy-agent": "^7.0.0"
   },
   "optionalDependencies": {
     "@github/keytar": "^7.10.6",


### PR DESCRIPTION
## Summary

Fixes #24471

- Mark `https-proxy-agent` as external in esbuild config
- Add it as a direct dependency so it ships with `node_modules`

## Problem

When proxy env vars (`https_proxy`, `HTTP_PROXY`) are set, gaxios does:

```js
this.#proxyAgent ||= (await import('https-proxy-agent')).HttpsProxyAgent;
```

This works in development (Node.js native CJS interop preserves named exports), but fails in the esbuild bundle. Code splitting puts the CJS package in a separate chunk as `export default require_dist()`, losing named exports — `.HttpsProxyAgent` becomes `undefined`.

## Fix

Externalizing `https-proxy-agent` follows the same pattern as other externalized packages (`@lydell/node-pty`, `@github/keytar`). Node.js resolves it from `node_modules` at runtime, where its native CJS interop correctly exposes `HttpsProxyAgent` as a named export.

## Test plan

- [ ] Set `https_proxy=http://127.0.0.1:7890` (or any proxy)
- [ ] Run `gemini --prompt "hello" --yolo`
- [ ] Verify no `HttpsProxyAgent is not a constructor` error
- [ ] Verify proxy is used for API requests