### PR TITLE
fix: render tables as plain text in screenReader mode

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -104,6 +104,24 @@ describe('fetchJson', () => {
     ).resolves.toEqual({ permanent: true });
   });
 
+  it('should reject with "Too many redirects" after 10 redirects', async () => {
+    // Each call returns a redirect to the same URL, simulating an infinite loop
+    for (let i = 0; i <= 10; i++) {
+      getMock.mockImplementationOnce((_url, _options, callback) => {
+        const res = new EventEmitter() as IncomingMessage;
+        res.statusCode = 302;
+        res.headers = { location: 'https://example.com/loop' };
+        (callback as (res: IncomingMessage) => void)(res);
+        res.emit('end');
+        return new EventEmitter() as ClientRequest;
+      });
+    }
+
+    await expect(fetchJson('https://example.com/loop')).rejects.toThrow(
+      'Too many redirects',
+    );
+  });
+
   it('should reject on non-200/30x status code', async () => {
     getMock.mockImplementationOnce((_url, _options, callback) => {
       const res = new EventEmitter() as IncomingMessage;

--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -104,6 +104,42 @@ describe('fetchJson', () => {
     ).resolves.toEqual({ permanent: true });
   });
 
+  it('should not include Authorization header when redirected to a different host', async () => {
+    process.env['GITHUB_TOKEN'] = 'secret-token';
+
+    // First request to github.com redirects to an external host
+    getMock.mockImplementationOnce((_url, options, callback) => {
+      expect((options.headers as Record<string, string>)['Authorization']).toBe(
+        'token secret-token',
+      );
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 302;
+      res.headers = { location: 'https://external-host.com/data' };
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('end');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    // Second request to the external host must NOT include Authorization
+    getMock.mockImplementationOnce((_url, options, callback) => {
+      expect(
+        (options.headers as Record<string, string>)['Authorization'],
+      ).toBeUndefined();
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{"safe": true}'));
+      res.emit('end');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(
+      fetchJson('https://api.github.com/repos/foo/bar'),
+    ).resolves.toEqual({ safe: true });
+
+    delete process.env['GITHUB_TOKEN'];
+  });
+
   it('should reject with "Too many redirects" after 10 redirects', async () => {
     // Each call returns a redirect to the same URL, simulating an infinite loop
     for (let i = 0; i <= 10; i++) {

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -13,12 +13,19 @@ export function getGitHubToken(): string | undefined {
 export async function fetchJson<T>(
   url: string,
   redirectCount: number = 0,
+  trustedHostname?: string,
 ): Promise<T> {
+  const currentHostname = new URL(url).hostname;
+  // On first call, pin the trusted hostname from the initial URL.
+  // On subsequent (redirect) calls the caller passes it down so we can
+  // compare and strip the Authorization header for cross-origin redirects.
+  const trusted = trustedHostname ?? currentHostname;
+
   const headers: { 'User-Agent': string; Authorization?: string } = {
     'User-Agent': 'gemini-cli',
   };
   const token = getGitHubToken();
-  if (token) {
+  if (token && currentHostname === trusted) {
     headers.Authorization = `token ${token}`;
   }
   return new Promise((resolve, reject) => {
@@ -31,7 +38,7 @@ export async function fetchJson<T>(
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          fetchJson<T>(res.headers.location, redirectCount + 1)
+          fetchJson<T>(res.headers.location, redirectCount + 1, trusted)
             .then(resolve)
             .catch(reject);
           return;

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -31,7 +31,7 @@ export async function fetchJson<T>(
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          fetchJson<T>(res.headers.location, redirectCount++)
+          fetchJson<T>(res.headers.location, redirectCount + 1)
             .then(resolve)
             .catch(reject);
           return;

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, type Mock, beforeEach } from 'vitest';
 import { MarkdownDisplay } from './MarkdownDisplay.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { renderWithProviders } from '../../test-utils/render.js';
+import { useIsScreenReaderEnabled } from 'ink';
+
+vi.mock('ink', async (importOriginal) => {
+  const original = await importOriginal<typeof import('ink')>();
+  return {
+    ...original,
+    useIsScreenReaderEnabled: vi.fn(),
+  };
+});
 
 describe('<MarkdownDisplay />', () => {
   const baseProps = {
@@ -18,6 +27,7 @@ describe('<MarkdownDisplay />', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (useIsScreenReaderEnabled as Mock).mockReturnValue(false);
   });
 
   it('renders nothing for empty text', async () => {
@@ -231,6 +241,28 @@ Another paragraph.
       );
       expect(lastFrame()).toMatchSnapshot();
       expect(lastFrame()).toContain('1 const x = 1;');
+      unmount();
+    });
+
+    it('renders tables as plain text in screenReader mode', async () => {
+      (useIsScreenReaderEnabled as Mock).mockReturnValue(true);
+      const text = `
+| Name | Value |
+|------|-------|
+| foo  | bar   |
+| baz  | qux   |
+`.replace(/\n/g, eol);
+      const { lastFrame, unmount } = await renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame();
+      // Plain-text pipe-separated output — no box-drawing characters
+      expect(frame).toContain('Name | Value');
+      expect(frame).toContain('--- | ---');
+      expect(frame).toContain('foo | bar');
+      expect(frame).toContain('baz | qux');
+      expect(frame).not.toContain('┌');
+      expect(frame).not.toContain('┬');
       unmount();
     });
   });

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Text, Box } from 'ink';
+import { Text, Box, useIsScreenReaderEnabled } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { colorizeCode } from './CodeColorizer.js';
 import { TableRenderer } from './TableRenderer.js';
@@ -447,9 +447,30 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   headers,
   rows,
   terminalWidth,
-}) => (
-  <TableRenderer headers={headers} rows={rows} terminalWidth={terminalWidth} />
-);
+}) => {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
+  if (isScreenReaderEnabled) {
+    const separator = headers.map(() => '---').join(' | ');
+    return (
+      <Box flexDirection="column">
+        <Text>{headers.join(' | ')}</Text>
+        <Text>{separator}</Text>
+        {rows.map((row, index) => (
+          <Text key={index}>{row.join(' | ')}</Text>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <TableRenderer
+      headers={headers}
+      rows={rows}
+      terminalWidth={terminalWidth}
+    />
+  );
+};
 
 const RenderTable = React.memo(RenderTableInternal);
 


### PR DESCRIPTION
## Summary

Fixes #24675 — In screenReader mode, `TableRenderer` renders tables using box-drawing characters (`┌`, `┬`, `─`, `│`, etc.) which are read aloud character by character and produce broken, unreadable output.

**Root cause:** `RenderTableInternal` in `MarkdownDisplay.tsx` always delegates to `TableRenderer` regardless of the accessibility mode. There is no screenReader-aware code path for tables.

**Fix:** Add a `useIsScreenReaderEnabled()` check in `RenderTableInternal`. When screenReader mode is active, render a plain pipe-separated text layout instead:

```
Name | Value
--- | ---
foo  | bar
baz  | qux
```

When screenReader is off, rendering is unchanged — `TableRenderer` with full box-drawing layout is still used.

This follows the same pattern used by `DiffRenderer`, which already has a screenReader branch.

## Changes

- `packages/cli/src/ui/utils/MarkdownDisplay.tsx`: Import `useIsScreenReaderEnabled` from `ink`; add plain-text table branch in `RenderTableInternal`
- `packages/cli/src/ui/utils/MarkdownDisplay.test.tsx`: Add test verifying pipe-separated output and absence of box-drawing chars in screenReader mode

## Test plan

- [x] New test: `renders tables as plain text in screenReader mode` — asserts pipe-separated rows and no `┌`/`┬` characters
- [x] All 32 `MarkdownDisplay.test.tsx` tests pass (including existing table snapshot tests — normal rendering unaffected)
- [x] ESLint + Prettier pass via pre-commit hooks