### PR TITLE
fix: render tables as plain text in screenReader mode

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, type Mock, beforeEach } from 'vitest';
 import { MarkdownDisplay } from './MarkdownDisplay.js';
 import { LoadedSettings } from '../../config/settings.js';
 import { renderWithProviders } from '../../test-utils/render.js';
+import { useIsScreenReaderEnabled } from 'ink';
+
+vi.mock('ink', async (importOriginal) => {
+  const original = await importOriginal<typeof import('ink')>();
+  return {
+    ...original,
+    useIsScreenReaderEnabled: vi.fn(),
+  };
+});
 
 describe('<MarkdownDisplay />', () => {
   const baseProps = {
@@ -18,6 +27,7 @@ describe('<MarkdownDisplay />', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (useIsScreenReaderEnabled as Mock).mockReturnValue(false);
   });
 
   it('renders nothing for empty text', async () => {
@@ -231,6 +241,28 @@ Another paragraph.
       );
       expect(lastFrame()).toMatchSnapshot();
       expect(lastFrame()).toContain('1 const x = 1;');
+      unmount();
+    });
+
+    it('renders tables as plain text in screenReader mode', async () => {
+      (useIsScreenReaderEnabled as Mock).mockReturnValue(true);
+      const text = `
+| Name | Value |
+|------|-------|
+| foo  | bar   |
+| baz  | qux   |
+`.replace(/\n/g, eol);
+      const { lastFrame, unmount } = await renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame();
+      // Plain-text pipe-separated output — no box-drawing characters
+      expect(frame).toContain('Name | Value');
+      expect(frame).toContain('--- | ---');
+      expect(frame).toContain('foo | bar');
+      expect(frame).toContain('baz | qux');
+      expect(frame).not.toContain('┌');
+      expect(frame).not.toContain('┬');
       unmount();
     });
   });

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -265,5 +265,27 @@ Another paragraph.
       expect(frame).not.toContain('┬');
       unmount();
     });
+
+    it('sanitizes ANSI escapes and markdown markers in screenReader table cells', async () => {
+      (useIsScreenReaderEnabled as Mock).mockReturnValue(true);
+      const ansiRed = '\u001b[31m';
+      const ansiReset = '\u001b[0m';
+      const text = [
+        `| **Header** | _Status_ |`,
+        `|------------|----------|`,
+        `| ${ansiRed}injected${ansiReset} | \`code\` |`,
+      ].join(eol);
+      const { lastFrame, unmount } = await renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame();
+      expect(frame).toContain('Header | Status');
+      expect(frame).toContain('injected | code');
+      expect(frame).not.toContain('\u001b[');
+      expect(frame).not.toContain('**');
+      expect(frame).not.toContain('_');
+      expect(frame).not.toContain('`');
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -451,13 +451,24 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   if (isScreenReaderEnabled) {
-    const separator = headers.map(() => '---').join(' | ');
+    // Strip ANSI escape sequences (ESC + '[' + params + letter) and markdown markers.
+    // eslint-disable-next-line no-control-regex
+    const ansiRegex = /\u001b\[[0-9;]*[a-zA-Z]/g;
+    const sanitizeCell = (cell: string): string =>
+      cell
+        .replace(ansiRegex, '')
+        .replace(/(\*\*|__)(.*?)\1/g, '$2')
+        .replace(/([*_`~])(.*?)\1/g, '$2')
+        .trim();
+
+    const sanitizedHeaders = headers.map(sanitizeCell);
+    const separator = sanitizedHeaders.map(() => '---').join(' | ');
     return (
       <Box flexDirection="column">
-        <Text>{headers.join(' | ')}</Text>
+        <Text>{sanitizedHeaders.join(' | ')}</Text>
         <Text>{separator}</Text>
         {rows.map((row, index) => (
-          <Text key={index}>{row.join(' | ')}</Text>
+          <Text key={index}>{row.map(sanitizeCell).join(' | ')}</Text>
         ))}
       </Box>
     );

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { Text, Box } from 'ink';
+import { Text, Box, useIsScreenReaderEnabled } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { colorizeCode } from './CodeColorizer.js';
 import { TableRenderer } from './TableRenderer.js';
@@ -447,9 +447,30 @@ const RenderTableInternal: React.FC<RenderTableProps> = ({
   headers,
   rows,
   terminalWidth,
-}) => (
-  <TableRenderer headers={headers} rows={rows} terminalWidth={terminalWidth} />
-);
+}) => {
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
+  if (isScreenReaderEnabled) {
+    const separator = headers.map(() => '---').join(' | ');
+    return (
+      <Box flexDirection="column">
+        <Text>{headers.join(' | ')}</Text>
+        <Text>{separator}</Text>
+        {rows.map((row, index) => (
+          <Text key={index}>{row.join(' | ')}</Text>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <TableRenderer
+      headers={headers}
+      rows={rows}
+      terminalWidth={terminalWidth}
+    />
+  );
+};
 
 const RenderTable = React.memo(RenderTableInternal);
 


### PR DESCRIPTION
## Summary

Fixes #24675 — In screenReader mode, `TableRenderer` renders tables using box-drawing characters (`┌`, `┬`, `─`, `│`, etc.) which are read aloud character by character and produce broken, unreadable output.

**Root cause:** `RenderTableInternal` in `MarkdownDisplay.tsx` always delegates to `TableRenderer` regardless of the accessibility mode. There is no screenReader-aware code path for tables.

**Fix:** Add a `useIsScreenReaderEnabled()` check in `RenderTableInternal`. When screenReader mode is active, render a plain pipe-separated text layout instead:

```
Name | Value
--- | ---
foo  | bar
baz  | qux
```

When screenReader is off, rendering is unchanged — `TableRenderer` with full box-drawing layout is still used.

This follows the same pattern used by `DiffRenderer`, which already has a screenReader branch.

## Changes

- `packages/cli/src/ui/utils/MarkdownDisplay.tsx`: Import `useIsScreenReaderEnabled` from `ink`; add plain-text table branch in `RenderTableInternal`
- `packages/cli/src/ui/utils/MarkdownDisplay.test.tsx`: Add test verifying pipe-separated output and absence of box-drawing chars in screenReader mode

## Test plan

- [x] New test: `renders tables as plain text in screenReader mode` — asserts pipe-separated rows and no `┌`/`┬` characters
- [x] All 32 `MarkdownDisplay.test.tsx` tests pass (including existing table snapshot tests — normal rendering unaffected)
- [x] ESLint + Prettier pass via pre-commit hooks