### PR TITLE
feat: add UserCancel hook event

### DIFF
--- a/issue_25166.md
+++ b/issue_25166.md
@@ -1,0 +1,39 @@
+### What happened?
+
+Repeatedly, after Gemini executes a simple CLI command, it hangs, while still showing the shell command as active and "Awaiting user input".  The shell command has already finished.  This happens for extremely simple shell commands that will not await or ask for user input.
+
+### What did you expect to happen?
+
+Gemini CLI be able to run shell commands reliably.
+
+### Client information
+
+<details>
+<summary>Client Information</summary>
+
+Run `gemini` to enter the interactive CLI, then run the `/about` command.
+
+```console
+> /about
+╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  │
+│ About Gemini CLI                                                                                                                                                                                                                                                                                                                                                                                                                                                                 │
+│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  │
+│ CLI Version                                                                                                                                                       0.37.1                                                                                                                                                                                                                                                                                                         │
+│ Git Commit                                                                                                                                                        3b2d4f100                                                                                                                                                                                                                                                                                                      │
+│ Model                                                                                                                                                             Auto (Gemini 3)                                                                                                                                                                                                                                                                                                │
+│ Sandbox                                                                                                                                                           no sandbox                                                                                                                                                                                                                                                                                                     │
+│ OS                                                                                                                                                                win32                                                                                                                                                                                                                                                                                                          │
+│ Auth Method                                                                                                                                                       Signed in with Google (jnett96@gmail.com)                                                                                                                                                                                                                                                                      │
+│ Tier                                                                                                                                                              Gemini Code Assist in Google One AI Pro      
+```
+
+</details>
+
+### Login information
+
+_No response_
+
+### Anything else we need to know?
+
+_No response_

--- a/issue_25172.md
+++ b/issue_25172.md
@@ -1,0 +1,76 @@
+## Problem
+
+There is currently no hook event that fires when a user cancels an ongoing agent execution. This creates a gap in the hook lifecycle:
+
+### CLI Context (Ctrl+C / SIGINT)
+When a user presses Ctrl+C during agent execution:
+1. The abort signal causes `processTurn()` to exit via the catch block (`client.ts` ~line 1009)
+2. A `UserCancelled` event is yielded and the function returns immediately
+3. **Neither `AfterAgent` nor `SessionEnd` hooks fire** — the catch block exits before the AfterAgent hook check at lines 945-1007
+
+### A2A Server Context (`tasks/cancel` JSON-RPC)
+When a task is canceled via the A2A protocol:
+1. `CoderAgentExecutor.cancelTask()` aborts execution, cancels pending tools, and sets state to `canceled`
+2. **No hooks fire at all** — the cancellation flow in `executor.ts` has no hook integration
+3. External systems (e.g., orchestrators, schedulers) that rely on hooks for completion notifications are never notified
+
+### Impact
+- External orchestration systems cannot react to cancellations
+- Queued/pending tasks waiting on the cancelled agent's completion hang indefinitely
+- Cleanup logic that should run on cancellation (e.g., resource release, state sync) has no hook point
+- Cancellation is a terminal state, but the hook system has no awareness of it
+
+## Proposed Solution
+
+Add a new `UserCancel` hook event to the `HookEventName` enum. Unlike Before/After pairs, cancellation is a single instantaneous event — there is no meaningful "before cancel" phase, so a standalone `UserCancel` event is the right abstraction (similar to `Notification` or `SessionEnd`).
+
+### 1. New Types (`packages/core/src/hooks/types.ts`)
+
+```typescript
+// Add to HookEventName enum
+UserCancel = 'UserCancel'
+
+// New input type
+interface UserCancelInput extends HookInput {
+  reason: string;       // e.g., "user_request", "sigint", "timeout"
+  task_id?: string;     // Available in A2A server context
+}
+```
+
+### 2. Hook Event Handler (`packages/core/src/hooks/hookEventHandler.ts`)
+
+Add `fireUserCancelEvent(reason, taskId?)` — follows the same pattern as `fireSessionEndEvent`.
+
+### 3. Hook System Facade (`packages/core/src/hooks/hookSystem.ts`)
+
+Expose `fireUserCancelEvent()` delegating to the event handler.
+
+### 4. Integration Points
+
+**CLI** — In the cancellation catch block of `processTurn()` (`client.ts` ~line 1009), fire `UserCancel` before yielding `UserCancelled`.
+
+**A2A Server** — In `CoderAgentExecutor.cancelTask()` (`executor.ts`), fire `UserCancel` after setting state to `canceled` but before `task.dispose()`.
+
+### 5. User Configuration
+
+Users would configure it in `settings.json` like any other hook:
+```json
+{
+  "hooks": {
+    "UserCancel": [{
+      "hooks": [{ "type": "command", "command": "notify-orchestrator.sh" }]
+    }]
+  }
+}
+```
+
+## Use Case
+
+In multi-agent orchestration setups, a coordinator/scheduler needs to be notified when a coding agent's task is cancelled — not just when it completes successfully. Without a `UserCancel` hook, the coordinator sees the agent as still running, and any downstream tasks waiting on it will hang indefinitely.
+
+## Alternatives Considered
+
+- **Firing `AfterAgent` on cancellation**: Conflates successful completion with cancellation. Hooks that only care about successful completions would need to filter, and the semantic meaning of "AfterAgent" becomes unclear.
+- **Firing `SessionEnd` on cancellation**: SessionEnd has different semantics (session lifecycle, not task lifecycle). In the A2A server context, a cancel doesn't end the session.
+- **Naming it `AfterCancel`**: There is no corresponding `BeforeCancel` — cancellation is instantaneous, not a two-phase operation. A standalone `UserCancel` event is more accurate.
+- **Handling it purely in A2A server without hooks**: Works for the A2A case but doesn't solve CLI cancellation. A hook-based approach is more general and consistent with the existing architecture.

--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -40,47 +40,57 @@ vi.mock('../http/requestStorage.js', () => ({
 }));
 
 vi.mock('./task.js', () => {
-  const mockTaskInstance = (taskId: string, contextId: string) => ({
-    id: taskId,
-    contextId,
-    taskState: 'working',
-    acceptUserMessage: vi
-      .fn()
-      .mockImplementation(async function* (context, aborted) {
-        const isConfirmation = (
-          context.userMessage.parts as Array<{ kind: string }>
-        ).some((p) => p.kind === 'confirmation');
-        // Hang only for main user messages (text), allow confirmations to finish quickly
-        if (!isConfirmation && aborted) {
-          await new Promise((resolve) => {
-            aborted.addEventListener('abort', resolve, { once: true });
-          });
-        }
-        yield { type: 'content', value: 'hello' };
-      }),
-    acceptAgentMessage: vi.fn().mockResolvedValue(undefined),
-    scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
-    waitForPendingTools: vi.fn().mockResolvedValue(undefined),
-    getAndClearCompletedTools: vi.fn().mockReturnValue([]),
-    addToolResponsesToHistory: vi.fn(),
-    sendCompletedToolsToLlm: vi.fn().mockImplementation(async function* () {}),
-    cancelPendingTools: vi.fn(),
-    setTaskStateAndPublishUpdate: vi.fn(),
-    dispose: vi.fn(),
-    getMetadata: vi.fn().mockResolvedValue({}),
-    geminiClient: {
-      initialize: vi.fn().mockResolvedValue(undefined),
-    },
-    toSDKTask: () => ({
+  const mockTaskInstance = (taskId: string, contextId: string) => {
+    const task = {
       id: taskId,
       contextId,
-      kind: 'task',
-      status: { state: 'working', timestamp: new Date().toISOString() },
-      metadata: {},
-      history: [],
-      artifacts: [],
-    }),
-  });
+      taskState: 'working',
+      acceptUserMessage: vi
+        .fn()
+        .mockImplementation(async function* (context, aborted) {
+          const isConfirmation = (
+            context.userMessage.parts as Array<{ kind: string }>
+          ).some((p) => p.kind === 'confirmation');
+          // Hang only for main user messages (text), allow confirmations to finish quickly
+          if (!isConfirmation && aborted) {
+            await new Promise((resolve) => {
+              aborted.addEventListener('abort', resolve, { once: true });
+            });
+          }
+          yield { type: 'content', value: 'hello' };
+        }),
+      acceptAgentMessage: vi.fn().mockResolvedValue(undefined),
+      scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
+      waitForPendingTools: vi.fn().mockResolvedValue(undefined),
+      getAndClearCompletedTools: vi.fn().mockReturnValue([]),
+      addToolResponsesToHistory: vi.fn(),
+      sendCompletedToolsToLlm: vi
+        .fn()
+        .mockImplementation(async function* () {}),
+      cancelPendingTools: vi.fn(),
+      setTaskStateAndPublishUpdate: vi.fn(),
+      dispose: vi.fn(),
+      getMetadata: vi.fn().mockResolvedValue({}),
+      config: {
+        getEnableHooks: vi.fn().mockReturnValue(false),
+        getHookSystem: vi.fn().mockReturnValue(undefined),
+      },
+      geminiClient: {
+        initialize: vi.fn().mockResolvedValue(undefined),
+      },
+      toSDKTask: () => ({
+        id: taskId,
+        contextId,
+        kind: 'task',
+        status: { state: task.taskState, timestamp: new Date().toISOString() },
+        metadata: {},
+        history: [],
+        artifacts: [],
+      }),
+    };
+
+    return task;
+  };
 
   const MockTask = vi.fn().mockImplementation(mockTaskInstance);
   (MockTask as unknown as { create: Mock }).create = vi
@@ -244,5 +254,64 @@ describe('CoderAgentExecutor', () => {
 
     expect(executor.getTask(taskId)).toBeUndefined();
     expect(wrapper.task.dispose).toHaveBeenCalled();
+  });
+
+  it('fires the user cancel hook after the task state is updated', async () => {
+    const taskId = 'test-task-cancel';
+    const contextId = 'test-context';
+    const callOrder: string[] = [];
+    const fireUserCancelEvent = vi.fn().mockImplementation(async () => {
+      callOrder.push('hook');
+      expect(mockTask.taskState).toBe('canceled');
+    });
+    const mockTask = {
+      id: taskId,
+      contextId,
+      taskState: 'working',
+      cancelPendingTools: vi.fn(),
+      setTaskStateAndPublishUpdate: vi.fn((state: string) => {
+        callOrder.push('state');
+        mockTask.taskState = state;
+      }),
+      dispose: vi.fn(),
+      config: {
+        getEnableHooks: vi.fn().mockReturnValue(true),
+        getHookSystem: vi.fn().mockReturnValue({
+          fireUserCancelEvent,
+        }),
+      },
+    };
+    const wrapper = {
+      task: mockTask,
+      toSDKTask: vi.fn().mockReturnValue({
+        id: taskId,
+        contextId,
+        kind: 'task',
+        status: {
+          state: 'canceled',
+          timestamp: new Date().toISOString(),
+        },
+        metadata: {},
+        history: [],
+        artifacts: [],
+      }),
+    };
+
+    (
+      executor as unknown as {
+        tasks: Map<string, typeof wrapper>;
+      }
+    ).tasks.set(taskId, wrapper);
+
+    await executor.cancelTask(taskId, mockEventBus);
+
+    expect(callOrder).toEqual(['state', 'hook']);
+    expect(mockTask.cancelPendingTools).toHaveBeenCalledWith(
+      'Task canceled by user request.',
+    );
+    expect(fireUserCancelEvent).toHaveBeenCalledWith('user_request', taskId);
+    expect(mockTask.dispose).toHaveBeenCalled();
+    expect(mockTaskStore.save).toHaveBeenCalledTimes(1);
+    expect(executor.getTask(taskId)).toBeUndefined();
   });
 });

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -237,13 +237,6 @@ export class CoderAgentExecutor implements AgentExecutor {
       );
       task.cancelPendingTools('Task canceled by user request.');
 
-      if (task.config.getEnableHooks()) {
-        await task.config
-          .getHookSystem()
-          ?.getEventHandler()
-          .fireUserCancelEvent('user_request', taskId);
-      }
-
       const stateChange: StateChange = {
         kind: CoderAgentEvent.StateChangeEvent,
       };
@@ -254,6 +247,13 @@ export class CoderAgentExecutor implements AgentExecutor {
         undefined,
         true,
       );
+
+      if (task.config.getEnableHooks()) {
+        await task.config
+          .getHookSystem()
+          ?.fireUserCancelEvent('user_request', taskId);
+      }
+
       logger.info(
         `[CoderAgentExecutor] Task ${taskId} cancellation processed. Saving state.`,
       );

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -237,6 +237,13 @@ export class CoderAgentExecutor implements AgentExecutor {
       );
       task.cancelPendingTools('Task canceled by user request.');
 
+      if (task.config.getEnableHooks()) {
+        await task.config
+          .getHookSystem()
+          ?.getEventHandler()
+          .fireUserCancelEvent('user_request', taskId);
+      }
+
       const stateChange: StateChange = {
         kind: CoderAgentEvent.StateChangeEvent,
       };

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -147,6 +147,7 @@ const mockHookSystem = {
   fireBeforeAgentEvent: vi.fn().mockResolvedValue(undefined),
   fireAfterAgentEvent: vi.fn().mockResolvedValue(undefined),
   firePreCompressEvent: vi.fn().mockResolvedValue(undefined),
+  fireUserCancelEvent: vi.fn().mockResolvedValue(undefined),
 };
 
 /**
@@ -816,6 +817,7 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     it('yields UserCancelled when processTurn throws AbortError', async () => {
+      vi.mocked(mockConfig.getEnableHooks).mockReturnValue(true);
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
       vi.spyOn(client['loopDetector'], 'turnStarted').mockRejectedValueOnce(
@@ -830,6 +832,9 @@ describe('Gemini Client (client.ts)', () => {
       const events = await fromAsync(stream);
 
       expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
+      expect(mockHookSystem.fireUserCancelEvent).toHaveBeenCalledWith(
+        'user_request',
+      );
     });
 
     it.each([

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1014,9 +1014,9 @@ export class GeminiClient {
     } catch (error) {
       if (signal?.aborted || isAbortError(error)) {
         if (hooksEnabled) {
-          await this.context.hookSystem
-            .getEventHandler()
-            .fireUserCancelEvent('user_request');
+          await this.config
+            .getHookSystem()
+            ?.fireUserCancelEvent('user_request');
         }
         yield { type: GeminiEventType.UserCancelled };
         return turn;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1013,6 +1013,11 @@ export class GeminiClient {
       }
     } catch (error) {
       if (signal?.aborted || isAbortError(error)) {
+        if (hooksEnabled) {
+          await this.context.hookSystem
+            .getEventHandler()
+            .fireUserCancelEvent('user_request');
+        }
         yield { type: GeminiEventType.UserCancelled };
         return turn;
       }

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -23,6 +23,7 @@ import {
   type BeforeModelInput,
   type AfterModelInput,
   type BeforeToolSelectionInput,
+  type UserCancelInput,
   type NotificationType,
   type SessionStartSource,
   type SessionEndReason,
@@ -197,6 +198,23 @@ export class HookEventHandler {
 
     const context: HookEventContext = { trigger: reason };
     return this.executeHooks(HookEventName.SessionEnd, input, context);
+  }
+
+  /**
+   * Fire a UserCancel event
+   */
+  async fireUserCancelEvent(
+    reason: string,
+    taskId?: string,
+  ): Promise<AggregatedHookResult> {
+    const input: UserCancelInput = {
+      ...this.createBaseInput(HookEventName.UserCancel),
+      reason,
+      ...(taskId && { task_id: taskId }),
+    };
+
+    const context: HookEventContext = { trigger: reason };
+    return this.executeHooks(HookEventName.UserCancel, input, context);
   }
 
   /**

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -232,6 +232,13 @@ export class HookSystem {
     return this.hookEventHandler.fireSessionEndEvent(reason);
   }
 
+  async fireUserCancelEvent(
+    reason: string,
+    taskId?: string,
+  ): Promise<AggregatedHookResult | undefined> {
+    return this.hookEventHandler.fireUserCancelEvent(reason, taskId);
+  }
+
   async firePreCompressEvent(
     trigger: PreCompressTrigger,
   ): Promise<AggregatedHookResult | undefined> {

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -52,6 +52,7 @@ export enum HookEventName {
   BeforeModel = 'BeforeModel',
   AfterModel = 'AfterModel',
   BeforeToolSelection = 'BeforeToolSelection',
+  UserCancel = 'UserCancel',
 }
 
 /**
@@ -643,6 +644,14 @@ export enum SessionEndReason {
  */
 export interface SessionEndInput extends HookInput {
   reason: SessionEndReason;
+}
+
+/**
+ * UserCancel hook input
+ */
+export interface UserCancelInput extends HookInput {
+  reason: string;
+  task_id?: string;
 }
 
 /**


### PR DESCRIPTION
This PR adds a UserCancel hook event to properly notify orchestration systems or downstream tasks when an agent execution is cancelled. Fixes #25172.