### PR TITLE
fix: resolve shell status indicator sticking after command completion

### DIFF
--- a/packages/cli/src/ui/hooks/usePhraseCycler.ts
+++ b/packages/cli/src/ui/hooks/usePhraseCycler.ts
@@ -174,9 +174,13 @@ export const usePhraseCycler = (
 
   if (shouldShowFocusHint) {
     currentTip = INTERACTIVE_SHELL_WAITING_PHRASE;
-  } else if (isWaiting) {
+  }
+
+  if (!currentTip && isWaiting) {
     currentTip = 'Waiting for user confirmation...';
-  } else if (isActive) {
+  }
+
+  if (!currentTip && isActive) {
     currentTip = currentTipState;
     currentWittyPhrase = currentWittyPhraseState;
   }

--- a/packages/cli/src/ui/hooks/useShellInactivityStatus.ts
+++ b/packages/cli/src/ui/hooks/useShellInactivityStatus.ts
@@ -51,7 +51,10 @@ export const useShellInactivityStatus = ({
   );
 
   const isAwaitingFocus =
-    !!activePtyId && !embeddedShellFocused && isInteractiveShellEnabled;
+    !!activePtyId &&
+    !embeddedShellFocused &&
+    isInteractiveShellEnabled &&
+    streamingState !== StreamingState.Idle;
 
   // Derive whether output was produced by comparing the last output time to when the operation started.
   const hasProducedOutput = lastOutputTime > operationStartTime;


### PR DESCRIPTION
This PR fixes a bug where the 'Shell awaiting input' message would linger in the UI after a shell command had already finished. It ensures that shell focuses hints are only shown when the system is not Idle. Fixes #25166.