### PR TITLE
feat: support MCP channel chat injection (#25208)

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -71,6 +71,7 @@ import {
   CoreEvent,
   refreshServerHierarchicalMemory,
   flattenMemory,
+  type ChatInjectPayload,
   type MemoryChangedPayload,
   writeToStdout,
   disableMouseEvents,
@@ -2356,6 +2357,18 @@ Logging in with Google... Restarting Gemini CLI to continue.
       coreEvents.off(CoreEvent.MemoryChanged, handleMemoryChanged);
     };
   }, []);
+
+  useEffect(() => {
+    const handleChatInject = (payload: ChatInjectPayload) => {
+      debugLogger.log(`AppContainer handleChatInject received payload: ${JSON.stringify(payload)}`);
+      // Use the message queue to handle queuing when not idle
+      addMessage(payload.message);
+    };
+    coreEvents.on(CoreEvent.ChatInject, handleChatInject);
+    return () => {
+      coreEvents.off(CoreEvent.ChatInject, handleChatInject);
+    };
+  }, [addMessage]);
 
   useEffect(() => {
     let isMounted = true;

--- a/packages/cli/src/ui/hooks/useMessageQueue.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { StreamingState } from '../types.js';
+import { debugLogger } from '@google/gemini-cli-core';
 
 export interface UseMessageQueueOptions {
   isConfigInitialized: boolean;
@@ -39,7 +40,10 @@ export function useMessageQueue({
   const addMessage = useCallback((message: string) => {
     const trimmedMessage = message.trim();
     if (trimmedMessage.length > 0) {
+      debugLogger.log(`useMessageQueue: adding message to queue: ${trimmedMessage.substring(0, 50)}...`);
       setMessageQueue((prev) => [...prev, trimmedMessage]);
+    } else {
+      debugLogger.log('useMessageQueue: ignored empty message');
     }
   }, []);
 
@@ -66,12 +70,14 @@ export function useMessageQueue({
 
   // Process queued messages when streaming becomes idle
   useEffect(() => {
+    debugLogger.log(`useMessageQueue effect trigger: config=${isConfigInitialized}, state=${streamingState}, mcpReady=${isMcpReady}, queueLen=${messageQueue.length}`);
     if (
       isConfigInitialized &&
       streamingState === StreamingState.Idle &&
       isMcpReady &&
       messageQueue.length > 0
     ) {
+      debugLogger.log('useMessageQueue: submitting queued message!');
       // Combine all messages with double newlines for clarity
       const combinedMessage = messageQueue.join('\n\n');
       // Clear the queue and submit

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -35,6 +35,7 @@ import {
   type Resource,
   type Tool as McpTool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import { parse } from 'shell-quote';
 import {
   AuthProviderType,
@@ -135,6 +136,14 @@ export interface RegistrySet {
   promptRegistry: PromptRegistry;
   resourceRegistry: ResourceRegistry;
 }
+
+const ChatInjectNotificationSchema = z.object({
+  method: z.literal('notifications/chat/channel'),
+  params: z.object({
+    message: z.string().optional(),
+    content: z.string().optional(),
+  }).passthrough().optional()
+});
 
 /**
  * A client for a single MCP server.
@@ -386,6 +395,27 @@ export class McpClient implements McpProgressReporter {
     if (!this.client) {
       return;
     }
+
+    this.client.setNotificationHandler(
+      ChatInjectNotificationSchema,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (notification: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        let message = notification.params?.message || notification.params?.content;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        const meta = notification.params?.meta;
+        
+        if (typeof message === 'string') {
+          const sanitizedMessage = message.replace(/\u003c/g, '\u0026lt;').replace(/\u003e/g, '\u0026gt;');
+          const attrs = (meta && typeof meta === 'object' && Object.keys(meta).length > 0)
+            ? ' ' + Object.entries(meta).map(([k, v]) => k + '="' + String(v) + '"').join(' ')
+            : '';
+          message = '\u003cchannel source="plugin:' + this.serverName + ':agentchat"' + attrs + '\u003e\n' + sanitizedMessage + '\n\u003c/channel\u003e';
+          debugLogger.log('🔔 Received chat channel notification from ' + this.serverName);
+          coreEvents.emitChatInject(message);
+        }
+      }
+    );
 
     const capabilities = this.client.getServerCapabilities();
 

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -178,6 +178,13 @@ export interface QuotaChangedPayload {
   resetTime?: string;
 }
 
+/**
+ * Payload for the 'chat-inject' event.
+ */
+export interface ChatInjectPayload {
+  message: string;
+}
+
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
   ModelChanged = 'model-changed',
@@ -201,6 +208,7 @@ export enum CoreEvent {
   EditorSelected = 'editor-selected',
   SlashCommandConflicts = 'slash-command-conflicts',
   QuotaChanged = 'quota-changed',
+  ChatInject = 'chat-inject',
   TelemetryKeychainAvailability = 'telemetry-keychain-availability',
   TelemetryTokenStorageType = 'telemetry-token-storage-type',
 }
@@ -219,6 +227,7 @@ export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.Output]: [OutputPayload];
   [CoreEvent.MemoryChanged]: [MemoryChangedPayload];
   [CoreEvent.QuotaChanged]: [QuotaChangedPayload];
+  [CoreEvent.ChatInject]: [ChatInjectPayload];
   [CoreEvent.ExternalEditorClosed]: never[];
   [CoreEvent.McpClientUpdate]: Array<Map<string, McpClient> | never>;
   [CoreEvent.OauthDisplayMessage]: string[];
@@ -417,6 +426,14 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   ): void {
     const payload: QuotaChangedPayload = { remaining, limit, resetTime };
     this.emit(CoreEvent.QuotaChanged, payload);
+  }
+
+  /**
+   * Notifies subscribers to inject a chat message.
+   */
+  emitChatInject(message: string): void {
+    const payload: ChatInjectPayload = { message };
+    this._emitOrQueue(CoreEvent.ChatInject, payload);
   }
 
   /**


### PR DESCRIPTION
Currently, the Gemini CLI only supports a request-response architecture via MCP. There is no native mechanism for an MCP server to proactively push real-time events or messages directly into the user's active CLI chat session.

This commit implements a full end-to-end pipeline allowing MCP servers to inject messages directly into the Gemini CLI chat stream using JSON-RPC notifications:

1. Protocol Implementation: Introduced ChatInjectNotificationSchema to listen for the notifications/chat/channel MCP notification method, extracting the meta payload and wrapping it in <channel> tags.
2. Event Bus: Added CoreEvent.ChatInject and ChatInjectPayload to securely pass the injected messages from the background MCP transport layer.
3. UI Integration: The CLI UI now actively listens to the event and pushes injected messages into the user's prompt queue via addMessage(), ensuring they are processed safely.

Fixes #25208

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
