### PR TITLE
refactor(core): replace unsafe type assertions with zod runtime validation

### DIFF
--- a/packages/core/src/utils/safeJsonStringify.test.ts
+++ b/packages/core/src/utils/safeJsonStringify.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { safeJsonStringify } from './safeJsonStringify.js';
+import {
+  safeJsonStringify,
+  safeJsonStringifyBooleanValuesOnly,
+} from './safeJsonStringify.js';
 
 describe('safeJsonStringify', () => {
   it('should stringify normal objects without issues', () => {
@@ -69,5 +72,29 @@ describe('safeJsonStringify', () => {
     expect(safeJsonStringify('test')).toBe('"test"');
     expect(safeJsonStringify(42)).toBe('42');
     expect(safeJsonStringify(true)).toBe('true');
+  });
+});
+
+describe('safeJsonStringifyBooleanValuesOnly', () => {
+  it('should retain only boolean values', () => {
+    const obj = { enabled: true, disabled: false, name: 'test', count: 42 };
+    const result = JSON.parse(safeJsonStringifyBooleanValuesOnly(obj));
+    expect(result).toEqual({ enabled: true, disabled: false });
+  });
+
+  it('should return empty object for non-object input', () => {
+    const result = safeJsonStringifyBooleanValuesOnly(null);
+    expect(result).toBe('{}');
+  });
+
+  it('should handle object with no boolean values', () => {
+    const obj = { name: 'test', count: 42 };
+    const result = JSON.parse(safeJsonStringifyBooleanValuesOnly(obj));
+    expect(result).toEqual({});
+  });
+
+  it('should handle empty object', () => {
+    const result = JSON.parse(safeJsonStringifyBooleanValuesOnly({}));
+    expect(result).toEqual({});
   });
 });

--- a/packages/core/src/utils/safeJsonStringify.ts
+++ b/packages/core/src/utils/safeJsonStringify.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { z } from 'zod';
+
+const BooleanRecordSchema = z.record(z.unknown());
+
 /**
  * Safely stringifies an object to JSON, handling circular references by replacing them with [Circular].
  *
@@ -11,8 +15,6 @@
  * @param space - Optional space parameter for formatting (defaults to no formatting)
  * @returns JSON string with circular references replaced by [Circular]
  */
-import type { Config } from '../config/config.js';
-
 export function safeJsonStringify(
   obj: unknown,
   space?: string | number,
@@ -34,17 +36,17 @@ export function safeJsonStringify(
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function removeEmptyObjects(data: any): object {
+function removeEmptyObjects(data: unknown): object {
+  const result = BooleanRecordSchema.safeParse(data);
+  if (!result.success) {
+    return {};
+  }
   const cleanedObject: { [key: string]: unknown } = {};
-  for (const k in data) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const v = data[k];
+  for (const [k, v] of Object.entries(result.data)) {
     if (v !== null && v !== undefined && typeof v === 'boolean') {
       cleanedObject[k] = v;
     }
   }
-
   return cleanedObject;
 }
 
@@ -54,12 +56,10 @@ function removeEmptyObjects(data: any): object {
  * @param obj - The object to stringify
  * @returns JSON string with circular references skipped and only non-null, Boolean member values retained.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function safeJsonStringifyBooleanValuesOnly(obj: any): string {
+export function safeJsonStringifyBooleanValuesOnly(obj: unknown): string {
   let configSeen = false;
   return JSON.stringify(removeEmptyObjects(obj), (key, value) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((value as Config) !== null && !configSeen) {
+    if (value !== null && !configSeen) {
       configSeen = true;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return value;

--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -211,4 +211,25 @@ describe('SchemaValidator', () => {
       ).not.toBeNull();
     });
   });
+
+  describe('schema validation error handling', () => {
+    it('gracefully handles schema with invalid $ref', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: { $ref: '#/definitions/nonexistent' },
+        },
+      };
+      // should skip validation rather than throw
+      expect(SchemaValidator.validate(schema, { name: 'test' })).toBeNull();
+    });
+
+    it('validates schema without $schema field', () => {
+      const result = SchemaValidator.validateSchema({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      });
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -9,13 +9,24 @@ import AjvPkg, { type AnySchema, type Ajv } from 'ajv';
 
 import Ajv2020Pkg from 'ajv/dist/2020.js';
 import * as addFormats from 'ajv-formats';
+import { z } from 'zod';
 import { debugLogger } from './debugLogger.js';
 
-// Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const AjvClass = (AjvPkg as any).default || AjvPkg;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+// zod schema for esm/cjs module interop resolution
+const EsmModuleSchema = z.object({ default: z.unknown() }).passthrough();
+
+// zod schema for extracting $schema identifier
+const SchemaWithIdSchema = z.object({ $schema: z.string() }).passthrough();
+
+function resolveEsmDefault(mod: unknown): unknown {
+  const result = EsmModuleSchema.safeParse(mod);
+  return result.success ? result.data.default : mod;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AjvClass: any = resolveEsmDefault(AjvPkg);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Ajv2020Class: any = resolveEsmDefault(Ajv2020Pkg);
 
 const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
@@ -36,13 +47,18 @@ const ajvDefault: Ajv = new AjvClass(ajvOptions);
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-assignment
-const addFormatsFunc = (addFormats as any).default || addFormats;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const addFormatsFunc: any = resolveEsmDefault(addFormats);
 addFormatsFunc(ajvDefault);
 addFormatsFunc(ajv2020);
 
 // Canonical draft-2020-12 meta-schema URI (used by rmcp MCP servers)
 const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
+
+function getSchemaId(schema: unknown): string {
+  const result = SchemaWithIdSchema.safeParse(schema);
+  return result.success ? result.data.$schema : '<no $schema>';
+}
 
 /**
  * Returns the appropriate validator based on schema's $schema field.
@@ -91,10 +107,9 @@ export class SchemaValidator {
       // Skip validation rather than blocking tool usage.
       // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
       debugLogger.warn(
-        `Failed to compile schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
+        `Failed to compile schema (${getSchemaId(
+          schema,
+        )}): ${error instanceof Error ? error.message : String(error)}. ` +
           'Skipping parameter validation.',
       );
       return null;
@@ -123,10 +138,9 @@ export class SchemaValidator {
       // Schema validation failed (unsupported version, etc.)
       // Skip validation rather than blocking tool usage.
       debugLogger.warn(
-        `Failed to validate schema (${
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
-        }): ${error instanceof Error ? error.message : String(error)}. ` +
+        `Failed to validate schema (${getSchemaId(
+          schema,
+        )}): ${error instanceof Error ? error.message : String(error)}. ` +
           'Skipping schema validation.',
       );
       return null;

--- a/packages/core/src/utils/userAccountManager.test.ts
+++ b/packages/core/src/utils/userAccountManager.test.ts
@@ -140,6 +140,60 @@ describe('UserAccountManager', () => {
         old: [],
       });
     });
+
+    it('should handle JSON array by starting fresh via zod validation', async () => {
+      fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
+      fs.writeFileSync(accountsFile(), JSON.stringify([1, 2, 3]));
+      const consoleLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
+
+      await userAccountManager.cacheGoogleAccount('test1@google.com');
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'))).toEqual({
+        active: 'test1@google.com',
+        old: [],
+      });
+    });
+
+    it('should handle non-string active field via zod validation', async () => {
+      fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
+      fs.writeFileSync(
+        accountsFile(),
+        JSON.stringify({ active: 123, old: [] }),
+      );
+      const consoleLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
+
+      await userAccountManager.cacheGoogleAccount('test1@google.com');
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'))).toEqual({
+        active: 'test1@google.com',
+        old: [],
+      });
+    });
+
+    it('should handle old array with non-string items via zod validation', async () => {
+      fs.mkdirSync(path.dirname(accountsFile()), { recursive: true });
+      fs.writeFileSync(
+        accountsFile(),
+        JSON.stringify({ active: null, old: [1, 2, 3] }),
+      );
+      const consoleLogSpy = vi
+        .spyOn(debugLogger, 'log')
+        .mockImplementation(() => {});
+
+      await userAccountManager.cacheGoogleAccount('test1@google.com');
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(JSON.parse(fs.readFileSync(accountsFile(), 'utf-8'))).toEqual({
+        active: 'test1@google.com',
+        old: [],
+      });
+    });
   });
 
   describe('getCachedGoogleAccount', () => {

--- a/packages/core/src/utils/userAccountManager.ts
+++ b/packages/core/src/utils/userAccountManager.ts
@@ -6,13 +6,19 @@
 
 import path from 'node:path';
 import { promises as fsp, readFileSync } from 'node:fs';
+import { z } from 'zod';
 import { Storage } from '../config/storage.js';
 import { debugLogger } from './debugLogger.js';
 
-interface UserAccounts {
+const UserAccountsSchema = z.object({
+  active: z.string().nullable().optional(),
+  old: z.array(z.string()).optional(),
+});
+
+type UserAccounts = {
   active: string | null;
   old: string[];
-}
+};
 
 export class UserAccountManager {
   private getGoogleAccountsCachePath(): string {
@@ -30,31 +36,17 @@ export class UserAccountManager {
       return defaultState;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const parsed = JSON.parse(content);
+    const parsed: unknown = JSON.parse(content);
+    const result = UserAccountsSchema.safeParse(parsed);
 
-    // Inlined validation logic
-    if (typeof parsed !== 'object' || parsed === null) {
-      debugLogger.log('Invalid accounts file schema, starting fresh.');
-      return defaultState;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const { active, old } = parsed as Partial<UserAccounts>;
-    const isValid =
-      (active === undefined || active === null || typeof active === 'string') &&
-      (old === undefined ||
-        (Array.isArray(old) && old.every((i) => typeof i === 'string')));
-
-    if (!isValid) {
+    if (!result.success) {
       debugLogger.log('Invalid accounts file schema, starting fresh.');
       return defaultState;
     }
 
     return {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      active: parsed.active ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      old: parsed.old ?? [],
+      active: result.data.active ?? null,
+      old: result.data.old ?? [],
     };
   }
 


### PR DESCRIPTION
## Summary

Replace unsafe type assertions (`as`) with zod runtime schema validation in `packages/core/src/utils/` to improve type safety and eliminate `no-unsafe-type-assertion` lint suppressions.

## Details

- Import `z` from `zod` in `safeJsonStringify.ts`, `schemaValidator.ts`, and `userAccountManager.ts`
- Define zod schemas (`BooleanRecordSchema`, `EsmModuleSchema`, `SchemaWithIdSchema`, `UserAccountsSchema`) for data structures handled in each file
- Replace all unsafe type assertions with `safeParse()` validation
- Add 9 new unit tests covering the zod validation logic
- Remove all `no-unsafe-type-assertion` eslint suppressions from the three files
- Follows existing patterns in the codebase (e.g., `checkpointUtils.ts` already uses zod)

## Related Issues

Fixes #19758

## How to Validate

```bash
# type-check (no new errors)
npx tsc --noEmit --project packages/core/tsconfig.json

# lint (no errors on changed files)
node node_modules/.bin/eslint packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts

# unit tests (52 tests, all pass)
npx vitest run packages/core/src/utils/safeJsonStringify.test.ts packages/core/src/utils/schemaValidator.test.ts packages/core/src/utils/userAccountManager.test.ts

# verify no suppressions remain
grep -rn "no-unsafe-type-assertion" packages/core/src/utils/safeJsonStringify.ts packages/core/src/utils/schemaValidator.ts packages/core/src/utils/userAccountManager.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker