### PR TITLE
fix(cli): use ansi-derived semantic colors for ansi themes

### DIFF
--- a/packages/cli/src/ui/themes/builtin/dark/ansi-dark.ts
+++ b/packages/cli/src/ui/themes/builtin/dark/ansi-dark.ts
@@ -5,7 +5,7 @@
  */
 
 import { type ColorsTheme, Theme } from '../../theme.js';
-import { darkSemanticColors } from '../../semantic-tokens.js';
+import type { SemanticColors } from '../../semantic-tokens.js';
 
 const ansiColors: ColorsTheme = {
   type: 'dark',
@@ -27,9 +27,46 @@ const ansiColors: ColorsTheme = {
   GradientColors: ['cyan', 'green'],
 };
 
+// semantic colors derived from ansi color names instead of hex values
+const ansiDarkSemanticColors: SemanticColors = {
+  text: {
+    primary: ansiColors.Foreground,
+    secondary: ansiColors.Gray,
+    link: ansiColors.AccentBlue,
+    accent: ansiColors.AccentPurple,
+    response: ansiColors.Foreground,
+  },
+  background: {
+    primary: ansiColors.Background,
+    message: ansiColors.Background,
+    input: ansiColors.Background,
+    focus: ansiColors.FocusBackground ?? ansiColors.Background,
+    diff: {
+      added: ansiColors.DiffAdded,
+      removed: ansiColors.DiffRemoved,
+    },
+  },
+  border: {
+    default: ansiColors.DarkGray,
+  },
+  ui: {
+    comment: ansiColors.Comment,
+    symbol: ansiColors.Gray,
+    active: ansiColors.AccentBlue,
+    dark: ansiColors.DarkGray,
+    focus: ansiColors.AccentGreen,
+    gradient: ansiColors.GradientColors,
+  },
+  status: {
+    error: ansiColors.AccentRed,
+    success: ansiColors.AccentGreen,
+    warning: ansiColors.AccentYellow,
+  },
+};
+
 export const ANSI: Theme = new Theme(
   'ANSI',
-  'dark', // Consistent with its color palette base
+  'dark',
   {
     hljs: {
       display: 'block',
@@ -157,5 +194,5 @@ export const ANSI: Theme = new Theme(
     },
   },
   ansiColors,
-  darkSemanticColors,
+  ansiDarkSemanticColors,
 );

--- a/packages/cli/src/ui/themes/builtin/light/ansi-light.ts
+++ b/packages/cli/src/ui/themes/builtin/light/ansi-light.ts
@@ -5,7 +5,7 @@
  */
 
 import { type ColorsTheme, Theme } from '../../theme.js';
-import { lightSemanticColors } from '../../semantic-tokens.js';
+import type { SemanticColors } from '../../semantic-tokens.js';
 
 const ansiLightColors: ColorsTheme = {
   type: 'light',
@@ -24,6 +24,43 @@ const ansiLightColors: ColorsTheme = {
   Gray: 'gray',
   DarkGray: 'gray',
   GradientColors: ['blue', 'green'],
+};
+
+// semantic colors derived from ansi color names instead of hex values
+const ansiLightSemanticColors: SemanticColors = {
+  text: {
+    primary: ansiLightColors.Foreground,
+    secondary: ansiLightColors.Gray,
+    link: ansiLightColors.AccentBlue,
+    accent: ansiLightColors.AccentPurple,
+    response: ansiLightColors.Foreground,
+  },
+  background: {
+    primary: ansiLightColors.Background,
+    message: ansiLightColors.Background,
+    input: ansiLightColors.Background,
+    focus: ansiLightColors.FocusBackground ?? ansiLightColors.Background,
+    diff: {
+      added: ansiLightColors.DiffAdded,
+      removed: ansiLightColors.DiffRemoved,
+    },
+  },
+  border: {
+    default: ansiLightColors.DarkGray,
+  },
+  ui: {
+    comment: ansiLightColors.Comment,
+    symbol: ansiLightColors.Gray,
+    active: ansiLightColors.AccentBlue,
+    dark: ansiLightColors.DarkGray,
+    focus: ansiLightColors.AccentGreen,
+    gradient: ansiLightColors.GradientColors,
+  },
+  status: {
+    error: ansiLightColors.AccentRed,
+    success: ansiLightColors.AccentGreen,
+    warning: ansiLightColors.AccentYellow,
+  },
 };
 
 export const ANSILight: Theme = new Theme(
@@ -147,5 +184,5 @@ export const ANSILight: Theme = new Theme(
     },
   },
   ansiLightColors,
-  lightSemanticColors,
+  ansiLightSemanticColors,
 );


### PR DESCRIPTION
## Summary

Fix ANSI themes using hardcoded hex colors from `darkSemanticColors`/`lightSemanticColors` instead of their own ANSI color names, causing low contrast on certain terminal configurations.

## Details

The ANSI dark theme was using `darkSemanticColors` which maps to hex values from `darkTheme` (e.g., `#FFFFFF` for `text.primary`). This ignores the terminal's actual foreground color and causes readability issues on semi-transparent or custom-colored terminals.

Both ANSI dark and ANSI light themes now derive their semantic colors directly from their own ANSI color palettes. For example, `text.primary` now maps to the terminal default foreground (`''`) instead of a hardcoded hex value, allowing the terminal's native colors to be used.

## Related Issues

Fixes #18152

## Screenshots

<img width="1294" height="623" alt="Screenshot 2026-04-12 at 11 32 30 PM" src="https://github.com/user-attachments/assets/a568cd30-4a5b-4979-a7f6-57c38ef4023c" />

## How to Validate

1. Set the theme to ANSI: select ANSI from the `/theme` command
2. Send a prompt and observe the previous prompt color
3. Previous prompts should now use the terminal's default foreground color instead of hardcoded `#FFFFFF`
4. Test with different terminal backgrounds (dark, light, semi-transparent) to verify contrast

```bash
npm run build
npm start
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker