### PR TITLE
fix(extensions): fix unbounded redirects in fetchJson

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -56,6 +56,24 @@ describe('fetchJson', () => {
     });
   });
 
+  it('should reject when there are too many redirects', async () => {
+    // Mock 11 consecutive 302 redirects
+    for (let i = 0; i < 11; i++) {
+      getMock.mockImplementationOnce((_url, _options, callback) => {
+        const res = new EventEmitter() as IncomingMessage;
+        res.statusCode = 302;
+        res.headers = { location: `https://example.com/redirect-${i + 1}` };
+        (callback as (res: IncomingMessage) => void)(res);
+        res.emit('end');
+        return new EventEmitter() as ClientRequest;
+      });
+    }
+
+    await expect(
+      fetchJson('https://example.com/start-redirect'),
+    ).rejects.toThrow('Too many redirects');
+  });
+
   it('should handle redirects (301 and 302)', async () => {
     // Test 302
     getMock.mockImplementationOnce((_url, _options, callback) => {

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -31,7 +31,7 @@ export async function fetchJson<T>(
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          fetchJson<T>(res.headers.location, redirectCount++)
+          fetchJson<T>(res.headers.location, redirectCount + 1)
             .then(resolve)
             .catch(reject);
           return;


### PR DESCRIPTION
Hi there! 👋

I was looking through the GitHub fetch extension and noticed a subtle but important bug in how  handles redirects.

**The issue:** The recursive call was passing  (post-increment), which evaluates to the original value before incrementing. Because of this, the counter never actually increases, so  will follow redirects indefinitely instead of stopping after the intended 10-hop limit.

**The fix:** Changed it to , which is consistent with how  handles the same scenario in .

I also added a test case that mocks 11 consecutive redirects to make sure the limit is properly enforced going forward.

This fixes #24893. Let me know if you'd like me to tweak anything! 😊