### PR TITLE
feat(cli): add /export-logs command and keybinding for log export

### DIFF
--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -115,6 +115,7 @@ available combinations.
 | `app.restart`                 | Restart the application.                                                                                                                           | `R`<br />`Shift+R` |
 | `app.suspend`                 | Suspend the CLI and move it to the background.                                                                                                     | `Ctrl+Z`           |
 | `app.showShellUnfocusWarning` | Show warning when trying to move focus away from shell input.                                                                                      | `Tab`              |
+| `app.exportLogs`              | Export debug console logs to a file.                                                                                                               | `Ctrl+Shift+L`     |
 
 #### Background Shell Controls
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -115,7 +115,7 @@ available combinations.
 | `app.restart`                 | Restart the application.                                                                                                                           | `R`<br />`Shift+R` |
 | `app.suspend`                 | Suspend the CLI and move it to the background.                                                                                                     | `Ctrl+Z`           |
 | `app.showShellUnfocusWarning` | Show warning when trying to move focus away from shell input.                                                                                      | `Tab`              |
-| `app.exportLogs`              | Export debug console logs to a file.                                                                                                               | `Ctrl+Shift+L`     |
+| `app.exportLogs`              | Export debug console logs to a file.                                                                                                               | `F10`              |
 
 #### Background Shell Controls
 

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -31,6 +31,7 @@ import { corgiCommand } from '../ui/commands/corgiCommand.js';
 import { docsCommand } from '../ui/commands/docsCommand.js';
 import { directoryCommand } from '../ui/commands/directoryCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
+import { exportLogsCommand } from '../ui/commands/exportLogsCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { footerCommand } from '../ui/commands/footerCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
@@ -133,6 +134,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       docsCommand,
       directoryCommand,
       editorCommand,
+      exportLogsCommand,
       ...(this.config?.getExtensionsEnabled() === false
         ? [
             {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1892,6 +1892,12 @@ Logging in with Google... Restarting Gemini CLI to continue.
         }
       }
 
+      if (keyMatchers[Command.EXPORT_LOGS](key)) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        handleSlashCommand('/export-logs');
+        return true;
+      }
+
       if (keyMatchers[Command.SHOW_ERROR_DETAILS](key)) {
         if (settings.merged.general.devtools) {
           void (async () => {

--- a/packages/cli/src/ui/commands/exportLogsCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportLogsCommand.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { exportLogsCommand } from './exportLogsCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { CommandContext } from './types.js';
+
+vi.mock('../hooks/useConsoleMessages.js', () => ({
+  getConsoleMessages: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getConsoleMessages } from '../hooks/useConsoleMessages.js';
+import * as fsPromises from 'node:fs/promises';
+
+describe('exportLogsCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockContext = createMockCommandContext({});
+  });
+
+  it('should return error when no console logs exist', async () => {
+    vi.mocked(getConsoleMessages).mockReturnValue([]);
+
+    const result = await exportLogsCommand.action!(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'No console logs to export.',
+    });
+  });
+
+  it('should export logs to default filename', async () => {
+    vi.mocked(getConsoleMessages).mockReturnValue([
+      { type: 'log', content: 'test message', count: 1 },
+    ]);
+
+    const result = await exportLogsCommand.action!(mockContext, '');
+
+    expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+    });
+  });
+
+  it('should export logs to custom filename', async () => {
+    vi.mocked(getConsoleMessages).mockReturnValue([
+      { type: 'error', content: 'error message', count: 1 },
+    ]);
+
+    const result = await exportLogsCommand.action!(mockContext, 'my-logs.json');
+
+    expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('my-logs.json'),
+    });
+  });
+
+  it('should reject non-json file extension', async () => {
+    vi.mocked(getConsoleMessages).mockReturnValue([
+      { type: 'log', content: 'test', count: 1 },
+    ]);
+
+    const result = await exportLogsCommand.action!(mockContext, 'logs.txt');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Only .json format is supported for log export.',
+    });
+    expect(fsPromises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle write errors', async () => {
+    vi.mocked(getConsoleMessages).mockReturnValue([
+      { type: 'log', content: 'test', count: 1 },
+    ]);
+    vi.mocked(fsPromises.writeFile).mockRejectedValue(
+      new Error('permission denied'),
+    );
+
+    const result = await exportLogsCommand.action!(mockContext, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+      content: expect.stringContaining('permission denied'),
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/exportLogsCommand.ts
+++ b/packages/cli/src/ui/commands/exportLogsCommand.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import type { MessageActionReturn } from '@google/gemini-cli-core';
+import type { SlashCommand } from './types.js';
+import { CommandKind } from './types.js';
+import { getConsoleMessages } from '../hooks/useConsoleMessages.js';
+
+export const exportLogsCommand: SlashCommand = {
+  name: 'export-logs',
+  description: 'Export debug console logs to a JSON file',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  action: async (_context, args): Promise<MessageActionReturn> => {
+    const messages = getConsoleMessages();
+
+    if (messages.length === 0) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'No console logs to export.',
+      };
+    }
+
+    const filename = args.trim() || `gemini-logs-${Date.now()}.json`;
+    const filePath = path.resolve(filename);
+
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext !== '.json') {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Only .json format is supported for log export.',
+      };
+    }
+
+    try {
+      await fsPromises.writeFile(
+        filePath,
+        JSON.stringify(messages, null, 2),
+        'utf-8',
+      );
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Exported ${messages.length} log entries to ${filename}`,
+      };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Error exporting logs: ${errorMessage}`,
+      };
+    }
+  },
+};

--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -190,6 +190,12 @@ export const Help: React.FC<Help> = ({ commands }) => (
       </Text>{' '}
       - Cycle through your prompt history
     </Text>
+    <Text color={theme.text.primary}>
+      <Text bold color={theme.text.accent}>
+        {formatCommand(Command.EXPORT_LOGS)}
+      </Text>{' '}
+      - Export debug console logs
+    </Text>
     <Box height={1} />
     <Text color={theme.text.primary}>
       For a full list of shortcuts, see{' '}

--- a/packages/cli/src/ui/components/ShortcutsHelp.tsx
+++ b/packages/cli/src/ui/components/ShortcutsHelp.tsx
@@ -44,6 +44,10 @@ const buildShortcutItems = (): ShortcutItem[] => [
     key: formatCommand(Command.OPEN_EXTERNAL_EDITOR),
     description: 'open external editor',
   },
+  {
+    key: formatCommand(Command.EXPORT_LOGS),
+    description: 'export logs',
+  },
 ];
 
 const Shortcut: React.FC<{ item: ShortcutItem }> = ({ item }) => (
@@ -75,6 +79,7 @@ export const ShortcutsHelp: React.FC = () => {
         items[8],
         items[9],
         items[3],
+        items[10],
       ];
 
   return (

--- a/packages/cli/src/ui/components/__snapshots__/ShortcutsHelp.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ShortcutsHelp.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'linux' 1`] = `
  Alt+M raw markdown mode
  Ctrl+R reverse-search history
  Ctrl+G open external editor
+ F10 export logs
 "
 `;
 
@@ -29,6 +30,7 @@ exports[`ShortcutsHelp > renders correctly in 'narrow' mode on 'mac' 1`] = `
  Option+M raw markdown mode
  Ctrl+R reverse-search history
  Ctrl+G open external editor
+ F10 export logs
 "
 `;
 
@@ -38,7 +40,7 @@ exports[`ShortcutsHelp > renders correctly in 'wide' mode on 'linux' 1`] = `
  ! shell mode                    Shift+Tab cycle mode            Ctrl+V paste images
  @ select file or folder         Ctrl+Y YOLO mode                Alt+M raw markdown mode
  Double Esc clear & rewind       Ctrl+R reverse-search history   Ctrl+G open external editor
- Tab focus UI
+ Tab focus UI                    F10 export logs
 "
 `;
 
@@ -48,6 +50,6 @@ exports[`ShortcutsHelp > renders correctly in 'wide' mode on 'mac' 1`] = `
  ! shell mode                    Shift+Tab cycle mode            Ctrl+V paste images
  @ select file or folder         Ctrl+Y YOLO mode                Option+M raw markdown mode
  Double Esc clear & rewind       Ctrl+R reverse-search history   Ctrl+G open external editor
- Tab focus UI
+ Tab focus UI                    F10 export logs
 "
 `;

--- a/packages/cli/src/ui/hooks/useConsoleMessages.ts
+++ b/packages/cli/src/ui/hooks/useConsoleMessages.ts
@@ -158,6 +158,14 @@ const handleOutput = (payload: {
 };
 
 /**
+ * Returns the current console messages without requiring a React hook.
+ * Useful for non-component code like slash commands.
+ */
+export function getConsoleMessages(): ConsoleMessageItem[] {
+  return globalConsoleMessages;
+}
+
+/**
  * Hook to access the global console message history.
  * Decoupled from any component lifecycle to ensure history is preserved even
  * when the UI is unmounted.

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -408,7 +408,7 @@ export const defaultKeyBindingConfig: KeyBindingConfig = new Map([
   [Command.RESTART_APP, [new KeyBinding('r'), new KeyBinding('shift+r')]],
   [Command.SUSPEND_APP, [new KeyBinding('ctrl+z')]],
   [Command.SHOW_SHELL_INPUT_UNFOCUS_WARNING, [new KeyBinding('tab')]],
-  [Command.EXPORT_LOGS, [new KeyBinding('ctrl+shift+l')]],
+  [Command.EXPORT_LOGS, [new KeyBinding('f10')]],
   [Command.DUMP_FRAME, [new KeyBinding('f8')]],
   [Command.START_RECORDING, [new KeyBinding('f6')]],
   [Command.STOP_RECORDING, [new KeyBinding('f7')]],

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -112,6 +112,7 @@ export enum Command {
   UPDATE_EXTENSION = 'extension.update',
   LINK_EXTENSION = 'extension.link',
 
+  EXPORT_LOGS = 'app.exportLogs',
   DUMP_FRAME = 'app.dumpFrame',
   START_RECORDING = 'app.startRecording',
   STOP_RECORDING = 'app.stopRecording',
@@ -407,6 +408,7 @@ export const defaultKeyBindingConfig: KeyBindingConfig = new Map([
   [Command.RESTART_APP, [new KeyBinding('r'), new KeyBinding('shift+r')]],
   [Command.SUSPEND_APP, [new KeyBinding('ctrl+z')]],
   [Command.SHOW_SHELL_INPUT_UNFOCUS_WARNING, [new KeyBinding('tab')]],
+  [Command.EXPORT_LOGS, [new KeyBinding('ctrl+shift+l')]],
   [Command.DUMP_FRAME, [new KeyBinding('f8')]],
   [Command.START_RECORDING, [new KeyBinding('f6')]],
   [Command.STOP_RECORDING, [new KeyBinding('f7')]],
@@ -538,6 +540,7 @@ export const commandCategories: readonly CommandCategory[] = [
       Command.RESTART_APP,
       Command.SUSPEND_APP,
       Command.SHOW_SHELL_INPUT_UNFOCUS_WARNING,
+      Command.EXPORT_LOGS,
     ],
   },
   {
@@ -678,6 +681,7 @@ export const commandDescriptions: Readonly<Record<Command, string>> = {
   [Command.UPDATE_EXTENSION]: 'Update the current extension if available.',
   [Command.LINK_EXTENSION]: 'Link the current extension to a local path.',
 
+  [Command.EXPORT_LOGS]: 'Export debug console logs to a file.',
   [Command.DUMP_FRAME]: 'Dump the current frame as a snapshot.',
   [Command.START_RECORDING]: 'Start recording the session.',
   [Command.STOP_RECORDING]: 'Stop recording the session.',


### PR DESCRIPTION
## Summary

Add `/export-logs` slash command and `Ctrl+Shift+L` keybinding to export debug console logs to a JSON file.

## Details

- Add new `/export-logs` command that exports console messages to a `.json` file in the current directory
- Add `EXPORT_LOGS` (`app.exportLogs`) to the `Command` enum with default keybinding `Ctrl+Shift+L`
- Export a `getConsoleMessages()` getter from `useConsoleMessages.ts` for non-hook access to the global console store
- Register the command in `BuiltinCommandLoader`
- Update keyboard shortcuts documentation

Usage: `/export-logs` or `/export-logs custom-filename.json`

## Related Issues

Fixes #20404

## How to Validate

1. Start the CLI: `npm start`
2. Send a few prompts to generate console activity
3. Run `/export-logs` — should create `gemini-logs-<timestamp>.json` in the current directory
4. Run `/export-logs my-logs.json` — should create `my-logs.json`
5. Verify the JSON file contains the console message entries
6. Check `/shortcuts` shows `app.exportLogs` with `Ctrl+Shift+L`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker