### PR TITLE
fix(cli): make extension install/link idempotent for same source

### DIFF
--- a/packages/cli/src/commands/extensions/link.test.ts
+++ b/packages/cli/src/commands/extensions/link.test.ts
@@ -13,7 +13,12 @@ import {
   afterEach,
   type Mock,
 } from 'vitest';
-import { coreEvents, getErrorMessage } from '@google/gemini-cli-core';
+import chalk from 'chalk';
+import {
+  coreEvents,
+  getErrorMessage,
+  type GeminiCLIExtension,
+} from '@google/gemini-cli-core';
 import { type Argv } from 'yargs';
 import { handleLink, linkCommand } from './link.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
@@ -106,6 +111,40 @@ describe('extensions link command', () => {
         'Link failed message',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+      mockProcessExit.mockRestore();
+    });
+
+    it('should reuse existing extension without reinstalling', async () => {
+      const mockProcessExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as (
+          code?: string | number | null | undefined,
+        ) => never);
+
+      // ExtensionManager.installOrUpdateExtension will now resolve even if already installed
+      vi.mocked(
+        mockExtensionManager.prototype.installOrUpdateExtension,
+      ).mockImplementation(async () => {
+        coreEvents.emitConsoleLog(
+          'log',
+          chalk.blue(
+            'Extension "my-linked-extension" is already installed. Skipping re-installation.',
+          ),
+        );
+        return {
+          name: 'my-linked-extension',
+        } as GeminiCLIExtension;
+      });
+
+      await handleLink({ path: '/local/path/to/extension' });
+
+      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        chalk.blue(
+          'Extension "my-linked-extension" is already installed. Skipping re-installation.',
+        ),
+      );
+      expect(mockProcessExit).not.toHaveBeenCalled();
       mockProcessExit.mockRestore();
     });
   });

--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -11,7 +11,10 @@ import * as path from 'node:path';
 import { ExtensionManager } from './extension-manager.js';
 import { createTestMergedSettings, type MergedSettings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
-import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
+import {
+  EXTENSIONS_DIRECTORY_NAME,
+  INSTALL_METADATA_FILENAME,
+} from './extensions/variables.js';
 import { themeManager } from '../ui/themes/theme-manager.js';
 import {
   TrustLevel,
@@ -22,7 +25,9 @@ import {
   getRealPath,
   type CustomTheme,
   IntegrityDataStatus,
+  coreEvents,
 } from '@google/gemini-cli-core';
+import chalk from 'chalk';
 
 const mockHomedir = vi.hoisted(() => vi.fn(() => '/tmp/mock-home'));
 const mockIntegrityManager = vi.hoisted(() => ({
@@ -520,6 +525,39 @@ describe('ExtensionManager', () => {
           { name: 'ext1', version: '1.0.0' },
         ),
       ).rejects.toThrow(/already installed/);
+    });
+
+    it('should be idempotent if the extension is already installed from the same source', async () => {
+      const extDir = path.join(userExtensionsDir, 'idempotent-ext');
+      fs.mkdirSync(extDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(extDir, 'gemini-extension.json'),
+        JSON.stringify({ name: 'idempotent-ext', version: '1.0.0' }),
+      );
+      const installMetadata = { type: 'local' as const, source: extDir };
+      fs.writeFileSync(
+        path.join(extDir, INSTALL_METADATA_FILENAME),
+        JSON.stringify(installMetadata),
+      );
+
+      const logSpy = vi.spyOn(coreEvents, 'emitConsoleLog');
+
+      await extensionManager.loadExtensions();
+      const first =
+        await extensionManager.installOrUpdateExtension(installMetadata);
+      const second =
+        await extensionManager.installOrUpdateExtension(installMetadata);
+
+      expect(first.name).toBe('idempotent-ext');
+      expect(second.name).toBe('idempotent-ext');
+      expect(first.id).toBe(second.id);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'log',
+        chalk.blue(
+          'Extension "idempotent-ext" is already installed. Skipping re-installation.',
+        ),
+      );
     });
   });
 

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -292,6 +292,7 @@ Would you like to attempt to install via "git clone" instead?`,
 
       try {
         newExtensionConfig = await this.loadExtensionConfig(localSourcePath);
+        const extensionId = getExtensionId(newExtensionConfig, installMetadata);
 
         const newExtensionName = newExtensionConfig.name;
         const previousName = previousExtensionConfig?.name ?? newExtensionName;
@@ -309,6 +310,15 @@ Would you like to attempt to install via "git clone" instead?`,
             `Extension "${previousName}" was not already installed, cannot update it.`,
           );
         } else if (!isUpdate && previous) {
+          if (extensionId === previous.id) {
+            coreEvents.emitConsoleLog(
+              'log',
+              chalk.blue(
+                `Extension "${newExtensionName}" is already installed. Skipping re-installation.`,
+              ),
+            );
+            return previous;
+          }
           throw new Error(
             `Extension "${newExtensionName}" is already installed. Please uninstall it first.`,
           );
@@ -348,7 +358,6 @@ Would you like to attempt to install via "git clone" instead?`,
           previousSkills,
           isMigrating,
         );
-        const extensionId = getExtensionId(newExtensionConfig, installMetadata);
         const destinationPath = new ExtensionStorage(
           newExtensionName,
         ).getExtensionDir();

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -1171,25 +1171,23 @@ name = "yolo-checker"
       fs.rmSync(targetExtDir, { recursive: true, force: true });
     });
 
-    it('should throw an error if the extension already exists', async () => {
+    it('should be idempotent if the extension already exists from the same source', async () => {
       const sourceExtDir = createExtension({
         extensionsDir: tempHomeDir,
         name: 'my-local-extension',
         version: '1.0.0',
       });
       await extensionManager.loadExtensions();
-      await extensionManager.installOrUpdateExtension({
+      const first = await extensionManager.installOrUpdateExtension({
         source: sourceExtDir,
         type: 'local',
       });
-      await expect(
-        extensionManager.installOrUpdateExtension({
-          source: sourceExtDir,
-          type: 'local',
-        }),
-      ).rejects.toThrow(
-        'Extension "my-local-extension" is already installed. Please uninstall it first.',
-      );
+      const second = await extensionManager.installOrUpdateExtension({
+        source: sourceExtDir,
+        type: 'local',
+      });
+      expect(first.id).toBe(second.id);
+      expect(second.name).toBe('my-local-extension');
     });
 
     it('should throw an error and cleanup if gemini-extension.json is missing', async () => {


### PR DESCRIPTION
## Summary

- Refactored `ExtensionManager.installOrUpdateExtension` to check for matching extension IDs (source-based) before throwing name conflict errors.
- If the source/ID matches an existing extension, it returns the existing instance gracefully with a blue informative message emitted via `coreEvents`.
- Ensures name conflicts from different sources still throw an error requiring uninstallation first.
- Added/Updated test cases to verify idempotency, log emission, and exit code handling.

## Details

This centralized fix ensures idempotency across all interfaces (CLI, UI, ACP), preventing redundant installation errors when a user tries to link or install an extension they already have. It maintains strict safety against accidental name shadowing while providing proper user feedback.

## Related Issues

Fixes #22125 

## How to Validate

1. Manual CLI Verification

   1. Initial Link: Link a local extension that isn't installed yet.
      npm start -- extensions link packages/cli/test-assets/test-extension
      Expected: Successful installation message in green.
   2. Idempotent Link: Run the exact same command again.
      npm start -- extensions link packages/cli/test-assets/test-extension
      Expected: A blue message: Extension "test-extension" is already installed. Skipping re-installation. and the process should exit with code 0 (no error).
   3. Name Conflict: Try to link a different local directory that uses the same extension name.
      Expected: An error message stating the extension is already installed and requires uninstallation first, exiting with code 1.

2. Automated Tests

   Run the updated unit tests to ensure logic and log emission are correctly verified:

   ```
   # Run targeted tests for the link command and extension manager
   npx vitest run packages/cli/src/commands/extensions/link.test.ts \
                  packages/cli/src/config/extension-manager.test.ts \
                  packages/cli/src/config/extension.test.ts
   ```
   Expected: All tests pass, including the new assertions for coreEvents.emitConsoleLog and chalk.blue.

3. Preflight Check

   Run the full suite to ensure no regressions were introduced:

   ```
   npm run preflight
   ```
   Expected: Overall success.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
  - Status: No user-facing documentation changes were required as this fix corrects the visibility of an existing message.
- [x] Added/updated tests (if needed)
  - Status: Updated link.test.ts, extension-manager.test.ts, and extension.test.ts to include color-sensitive assertions and verify coreEvents emission.
- [x] Noted breaking changes (if any)
  -  Status: None. This is a bug fix that restores intended idempotent behavior.
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
