### PR TITLE
fix: support clipboard image paste in WSL2 environments

### DIFF
--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -190,6 +190,70 @@ describe('clipboardUtils', () => {
     });
   });
 
+  describe('clipboardHasImage (WSL2)', () => {
+    beforeEach(() => {
+      mockPlatform('linux');
+      process.env['WSL_DISTRO_NAME'] = 'Ubuntu';
+    });
+
+    afterEach(() => {
+      delete process.env['WSL_DISTRO_NAME'];
+    });
+
+    it('should return true when PowerShell reports image in clipboard', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'True\n',
+        stderr: '',
+      });
+
+      const result = await clipboardUtils.clipboardHasImage();
+
+      expect(result).toBe(true);
+      expect(spawnAsync).toHaveBeenCalledWith('powershell.exe', [
+        '-NoProfile',
+        '-Command',
+        'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
+      ]);
+    });
+
+    it('should return false when PowerShell reports no image', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'False\n',
+        stderr: '',
+      });
+
+      const result = await clipboardUtils.clipboardHasImage();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when powershell.exe is not available', async () => {
+      vi.mocked(spawnAsync).mockRejectedValueOnce(
+        new Error('spawn powershell.exe ENOENT'),
+      );
+
+      const result = await clipboardUtils.clipboardHasImage();
+
+      expect(result).toBe(false);
+    });
+
+    it('should not fall through to native Linux clipboard tools', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'False\n',
+        stderr: '',
+      });
+
+      await clipboardUtils.clipboardHasImage();
+
+      // Should only call powershell.exe, never wl-paste or xclip
+      expect(spawnAsync).toHaveBeenCalledTimes(1);
+      expect(spawnAsync).toHaveBeenCalledWith(
+        'powershell.exe',
+        expect.any(Array),
+      );
+    });
+  });
+
   describe('saveClipboardImage (Linux)', () => {
     const mockTargetDir = '/tmp/target';
     const mockTempDir = path.join('/tmp/global', 'images');
@@ -343,6 +407,117 @@ describe('clipboardUtils', () => {
       const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
       expect(result).toBe(null);
       expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveClipboardImage (WSL2)', () => {
+    const mockTargetDir = '/tmp/target';
+    const mockTempDir = path.join('/tmp/global', 'images');
+
+    beforeEach(() => {
+      mockPlatform('linux');
+      process.env['WSL_DISTRO_NAME'] = 'Ubuntu';
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      delete process.env['WSL_DISTRO_NAME'];
+    });
+
+    it('should save image via PowerShell interop with wslpath conversion', async () => {
+      // Mock wslpath conversion
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout:
+          '\\\\wsl.localhost\\Ubuntu\\tmp\\global\\images\\clipboard-123.png\n',
+        stderr: '',
+      });
+      // Mock PowerShell save
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'success\n',
+        stderr: '',
+      });
+      // Mock fs.stat
+      vi.mocked(fs.stat).mockResolvedValue({
+        size: 100,
+      } as unknown as import('node:fs').Stats);
+
+      const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
+
+      expect(result).toContain(mockTempDir);
+      expect(result).toMatch(/clipboard-\d+\.png$/);
+      expect(spawnAsync).toHaveBeenCalledWith('wslpath', [
+        '-w',
+        expect.stringContaining('clipboard-'),
+      ]);
+      expect(spawnAsync).toHaveBeenCalledWith('powershell.exe', [
+        '-NoProfile',
+        '-Command',
+        expect.stringContaining('Save'),
+      ]);
+    });
+
+    it('should return null when PowerShell does not output success', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: '\\\\wsl.localhost\\Ubuntu\\tmp\\test.png\n',
+        stderr: '',
+      });
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: '',
+        stderr: '',
+      });
+
+      const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when wslpath fails', async () => {
+      vi.mocked(spawnAsync).mockRejectedValueOnce(
+        new Error('spawn wslpath ENOENT'),
+      );
+
+      const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null when saved file is empty', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: '\\\\wsl.localhost\\Ubuntu\\tmp\\test.png\n',
+        stderr: '',
+      });
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'success\n',
+        stderr: '',
+      });
+      vi.mocked(fs.stat).mockResolvedValue({
+        size: 0,
+      } as unknown as import('node:fs').Stats);
+
+      const result = await clipboardUtils.saveClipboardImage(mockTargetDir);
+
+      expect(result).toBe(null);
+    });
+
+    it('should escape single quotes in Windows path for PowerShell', async () => {
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: "\\\\wsl.localhost\\Ubuntu\\tmp\\User's Files\\test.png\n",
+        stderr: '',
+      });
+      vi.mocked(spawnAsync).mockResolvedValueOnce({
+        stdout: 'success\n',
+        stderr: '',
+      });
+      vi.mocked(fs.stat).mockResolvedValue({
+        size: 100,
+      } as unknown as import('node:fs').Stats);
+
+      await clipboardUtils.saveClipboardImage(mockTargetDir);
+
+      const psCall = vi.mocked(spawnAsync).mock.calls[1];
+      const script = psCall[1][2];
+      // Single quotes should be doubled for PowerShell escaping
+      expect(script).toContain("User''s Files");
     });
   });
 

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -31,6 +31,14 @@ export const IMAGE_EXTENSIONS = [
 /** Matches strings that start with a path prefix (/, ~, ., Windows drive letter, or UNC path) */
 const PATH_PREFIX_PATTERN = /^([/~.]|[a-zA-Z]:|\\\\)/;
 
+// Detect WSL2 via environment variables set by the WSL2 init system.
+const isWSL = (): boolean =>
+  Boolean(
+    process.env['WSL_DISTRO_NAME'] ||
+      process.env['WSLENV'] ||
+      process.env['WSL_INTEROP'],
+  );
+
 // Track which tool works on Linux to avoid redundant checks/failures
 let linuxClipboardTool: 'wl-paste' | 'xclip' | null = null;
 
@@ -163,6 +171,21 @@ async function checkXclipForImage() {
  */
 export async function clipboardHasImage(): Promise<boolean> {
   if (process.platform === 'linux') {
+    // WSL2: use Windows clipboard via PowerShell interop
+    if (isWSL()) {
+      try {
+        const { stdout } = await spawnAsync('powershell.exe', [
+          '-NoProfile',
+          '-Command',
+          'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
+        ]);
+        return stdout.trim() === 'True';
+      } catch (error) {
+        debugLogger.warn('Error checking WSL clipboard for image:', error);
+        return false;
+      }
+    }
+
     const tool = getUserLinuxClipboardTool();
     if (tool === 'wl-paste') {
       if (await checkWlPasteForImage()) return true;
@@ -281,6 +304,45 @@ export async function saveClipboardImage(
 
     if (process.platform === 'linux') {
       const tempFilePath = path.join(tempDir, `clipboard-${timestamp}.png`);
+
+      // WSL2: save via PowerShell interop
+      if (isWSL()) {
+        try {
+          // Convert Linux path to Windows path for PowerShell
+          const { stdout: winPath } = await spawnAsync('wslpath', [
+            '-w',
+            tempFilePath,
+          ]);
+          const psPath = winPath.trim().replace(/'/g, "''");
+
+          const script = `
+            Add-Type -AssemblyName System.Windows.Forms
+            Add-Type -AssemblyName System.Drawing
+            if ([System.Windows.Forms.Clipboard]::ContainsImage()) {
+              $image = [System.Windows.Forms.Clipboard]::GetImage()
+              $image.Save('${psPath}', [System.Drawing.Imaging.ImageFormat]::Png)
+              Write-Output "success"
+            }
+          `;
+
+          const { stdout } = await spawnAsync('powershell.exe', [
+            '-NoProfile',
+            '-Command',
+            script,
+          ]);
+
+          if (stdout.trim() === 'success') {
+            const stats = await fs.stat(tempFilePath);
+            if (stats.size > 0) {
+              return tempFilePath;
+            }
+          }
+        } catch (error) {
+          debugLogger.warn('Error saving WSL clipboard image:', error);
+        }
+        return null;
+      }
+
       const tool = getUserLinuxClipboardTool();
 
       if (tool === 'wl-paste') {


### PR DESCRIPTION
## Summary

Clipboard image paste (`Ctrl+V` with an image) silently fails on WSL2 because `getUserLinuxClipboardTool()` checks `XDG_SESSION_TYPE` to pick between `wl-paste` (Wayland) and `xclip` (X11). WSL2 sets neither env var, so the function returns `null` and both `clipboardHasImage()` and `saveClipboardImage()` bail early.

This PR detects WSL2 via environment variables (`WSL_DISTRO_NAME`, `WSLENV`, `WSL_INTEROP`) and routes clipboard operations through `powershell.exe` using Windows interop — the same PowerShell scripts already used by the win32 code path. Path conversion uses the built-in `wslpath` utility.

**Changes:**
- Add `isWSL()` helper using the same env var pattern as `commandUtils.ts`
- Add WSL2 branch in `clipboardHasImage()` before existing Linux tool check
- Add WSL2 branch in `saveClipboardImage()` with `wslpath -w` path conversion
- Add 9 test cases covering all WSL2 branches (happy path, errors, edge cases)

**What's NOT changed:**
- Native Linux clipboard paths (wl-paste/xclip) — untouched
- macOS and Windows paths — untouched
- No new dependencies — `powershell.exe` and `wslpath` are WSL2 builtins

## Test plan

- [x] All 53 tests pass (`npx vitest run packages/cli/src/ui/utils/clipboardUtils.test.ts`)
- [x] Existing 44 tests unaffected (verified by stashing changes)
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [ ] Manual: Copy image to Windows clipboard → paste in gemini-cli on WSL2

Fixes #22274