### PR TITLE
fix(core): use UTF-8 decoder for PTY output to fix CJK character garbling on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -25,6 +25,7 @@ import {
 import { NoopSandboxManager } from './sandboxManager.js';
 import { ExecutionLifecycleService } from './executionLifecycleService.js';
 import type { AnsiOutput, AnsiToken } from '../utils/terminalSerializer.js';
+import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 
 // Hoisted Mocks
 const mockPtySpawn = vi.hoisted(() => vi.fn());
@@ -336,6 +337,23 @@ describe('ShellExecutionService', () => {
         pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
       });
       expect(result.output.trim()).toBe('你好');
+    });
+
+    it('should decode PTY output as UTF-8 regardless of system encoding', async () => {
+      // Simulate a Japanese Windows system where chcp returns code page 932 (Shift-JIS).
+      // The PTY decoder should be pre-initialized to UTF-8, so this mock override
+      // should have no effect on PTY output decoding. Regression test for #12468.
+      vi.mocked(getCachedEncodingForBuffer).mockReturnValue('shift_jis');
+
+      const { result } = await simulateExecution('echo "こんにちは"', (pty) => {
+        pty.onData.mock.calls[0][0]('こんにちは\r\n');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.output).toContain('こんにちは');
+
+      // Restore default mock for subsequent tests
+      vi.mocked(getCachedEncodingForBuffer).mockReturnValue('utf-8');
     });
 
     it('should handle commands with no output', async () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -990,7 +990,7 @@ export class ShellExecutionService {
       // the decoder to UTF-8 prevents getCachedEncodingForBuffer() from
       // using the system code page (e.g. Shift-JIS on Japanese Windows)
       // to decode what is already UTF-8 data. Fixes #12468.
-      const decoder = new TextDecoder('utf-8');
+      let decoder: TextDecoder | null = new TextDecoder('utf-8');
       let output: string | AnsiOutput | null = null;
       const sniffChunks: Buffer[] = [];
       let binaryBytesReceived = 0;

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -984,7 +984,13 @@ export class ShellExecutionService {
       }).result;
 
       let processingChain = Promise.resolve();
-      let decoder: TextDecoder | null = null;
+      // node-pty delivers data as JavaScript strings via onData().
+      // Buffer.from(data, 'utf-8') in the onData handler always produces
+      // UTF-8 bytes, regardless of the system code page. Pre-initializing
+      // the decoder to UTF-8 prevents getCachedEncodingForBuffer() from
+      // using the system code page (e.g. Shift-JIS on Japanese Windows)
+      // to decode what is already UTF-8 data. Fixes #12468.
+      const decoder = new TextDecoder('utf-8');
       let output: string | AnsiOutput | null = null;
       const sniffChunks: Buffer[] = [];
       let binaryBytesReceived = 0;


### PR DESCRIPTION
## Summary

Fixes #12468 — Japanese/CJK characters garbled (mojibake) when using the interactive shell on Windows systems with non-UTF-8 code pages (e.g. code page 932 for Japanese).

**Root cause:** `node-pty` delivers data as JavaScript strings via `onData()`. The handler converts these to UTF-8 buffers with `Buffer.from(data, 'utf-8')`, but the `TextDecoder` was lazily initialized using the system code page (e.g. Shift-JIS on Japanese Windows). This caused a double-decode: UTF-8 bytes decoded as Shift-JIS = garbled text.

**Fix:** Pre-initialize the PTY `TextDecoder` to UTF-8 since `Buffer.from(data, 'utf-8')` always produces UTF-8 bytes regardless of system locale. The `childProcessFallback` path is unaffected — its encoding detection is correct because it receives raw binary bytes, not pre-decoded strings.

**Evidence:**
- The garbled pattern (`縺薙ｓ縺ｫ縺｡縺ｯ` for `こんにちは`) is characteristic of UTF-8 bytes decoded as Shift-JIS
- Maintainer-confirmed workaround (`enableInteractiveShell: false`) bypasses the PTY path entirely, confirming the bug is PTY-specific
- 3 prior PRs (#12523, #20769, #21624) attempted workarounds; this fixes the actual root cause

## Test Coverage

All new code paths have test coverage.

```
CODE PATH COVERAGE
===========================
[~] packages/core/src/services/shellExecutionService.ts
    │
    ├── decoder initialization (line 993)
    │   └── [★★★ TESTED] Pre-initialized to UTF-8 — regression test with shift_jis mock
    │
    └── decoder.decode(data, { stream: true }) (line 1147)
        ├── [★★★ TESTED] CJK characters (こんにちは) — new regression test
        ├── [★★★ TESTED] Multi-byte split chunks (你好) — existing test
        └── [★★★ TESTED] ASCII output — existing test

COVERAGE: 4/4 live paths tested (100%)
```

## Pre-Landing Review

No issues found.

## Test plan

- [x] All 67 shellExecutionService tests pass (including new CJK regression test)
- [x] All 38 systemEncoding tests pass (no changes to this file)
- [x] Pre-commit hooks pass (prettier + eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)