### PR TITLE
fix: correct API key empty validation logic

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -873,10 +873,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
     async (apiKey: string) => {
       try {
         onAuthError(null);
-        if (!apiKey.trim() && apiKey.length > 1) {
-          onAuthError(
-            'API key cannot be empty string with length greater than 1.',
-          );
+        if (!apiKey.trim()) {
+          onAuthError('API key cannot be empty.');
           return;
         }
 


### PR DESCRIPTION
## Summary
- Fixed invalid validation condition that was always false: `!apiKey.trim() && apiKey.length > 1`
- The original condition was logically impossible because if `apiKey.trim()` is falsy (empty string), then `apiKey.length` is 0, which is not greater than 1
- Simplified to `!apiKey.trim()` to properly validate that API key is not empty or whitespace-only

## Bug Details
**File:** `packages/cli/src/ui/AppContainer.tsx:876`

**Before:**
```typescript
if (!apiKey.trim() && apiKey.length > 1) {
  onAuthError('API key cannot be empty string with length greater than 1.');
  return;
}
```

**After:**
```typescript
if (!apiKey.trim()) {
  onAuthError('API key cannot be empty.');
  return;
}
```