### PR TITLE
fix: remove required check for optional 'status' field in isStructuredError

### DIFF
--- a/packages/core/src/agent/event-translator.ts
+++ b/packages/core/src/agent/event-translator.ts
@@ -432,7 +432,6 @@ function isStructuredError(error: unknown): error is StructuredError {
   return (
     typeof error === 'object' &&
     error !== null &&
-    'status' in error &&
     'message' in error &&
     typeof error.message === 'string'
   );


### PR DESCRIPTION
## Summary
- Fixed `isStructuredError` type guard in `event-translator.ts` to no longer require the optional `status` field
- The `StructuredError` interface defines `status?: number` as optional, but the type guard was incorrectly requiring it to be present
- This caused valid `StructuredError` objects without a status field to be misclassified

## Bug Details
**File:** `packages/core/src/agent/event-translator.ts:431-439`

**Before:**
```typescript
function isStructuredError(error: unknown): error is StructuredError {
  return (
    typeof error === 'object' &&
    error !== null &&
    'status' in error &&  // <-- BUG: 'status' is optional
    'message' in error &&
    typeof error.message === 'string'
  );
}
```

**After:**
```typescript
function isStructuredError(error: unknown): error is StructuredError {
  return (
    typeof error === 'object' &&
    error !== null &&
    'message' in error &&
    typeof error.message === 'string'
  );
}
```

**Reference:** `packages/core/src/core/turn.ts:112-115` defines the interface:
```typescript
export interface StructuredError {
  message: string;
  status?: number;  // <-- status is optional
}
```