### PR TITLE
fix: skip directory entries in getIgnoreFilePaths to prevent EISDIR crash

### DIFF
--- a/packages/core/src/utils/filesearch/ignore.ts
+++ b/packages/core/src/utils/filesearch/ignore.ts
@@ -20,7 +20,13 @@ export function loadIgnoreRules(
 
   for (const filePath of ignoreFiles) {
     if (fs.existsSync(filePath)) {
-      ignorer.add(fs.readFileSync(filePath, 'utf8'));
+      try {
+        ignorer.add(fs.readFileSync(filePath, 'utf8'));
+      } catch {
+        // Skip paths that cannot be read as text files (e.g., directories).
+        // This can happen if customIgnoreFilePaths contains directory-like
+        // entries such as "node_modules/" that exist on disk.
+      }
     }
   }
 

--- a/packages/core/src/utils/ignoreFileParser.test.ts
+++ b/packages/core/src/utils/ignoreFileParser.test.ts
@@ -75,6 +75,21 @@ describe('IgnoreFileParser', () => {
       expect(paths[0]).toBe(path.join(projectRoot, secondary));
       expect(paths[1]).toBe(path.join(projectRoot, primary));
     });
+
+    it('should not return directory paths from getIgnoreFilePaths()', async () => {
+      // When customIgnoreFilePaths contains entries like "node_modules/" the
+      // resolved path is a directory. Including it caused EISDIR when
+      // loadIgnoreRules() tried to readFileSync the directory, which silently
+      // broke @ file completion in the UI.
+      await fs.mkdir(path.join(projectRoot, 'node_modules'), {
+        recursive: true,
+      });
+
+      const parser = new IgnoreFileParser(projectRoot, ['node_modules/']);
+      const paths = parser.getIgnoreFilePaths();
+
+      expect(paths).toHaveLength(0);
+    });
   });
 
   describe('Direct Pattern Input (isPatterns = true)', () => {

--- a/packages/core/src/utils/ignoreFileParser.ts
+++ b/packages/core/src/utils/ignoreFileParser.ts
@@ -105,7 +105,16 @@ export class IgnoreFileParser implements IgnoreFileFilter {
       .slice()
       .reverse()
       .map((fileName) => path.join(this.projectRoot, fileName))
-      .filter((filePath) => fs.existsSync(filePath));
+      .filter((filePath) => {
+        try {
+          // Only return paths that are actual files, not directories.
+          // customIgnoreFilePaths entries like "node_modules/" resolve to a
+          // directory, causing EISDIR when later read as an ignore file.
+          return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+        } catch {
+          return false;
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #19868 — `@` file completion breaks entirely when `context.fileFiltering.customIgnoreFilePaths` is set in `settings.json`.

### Root cause

`IgnoreFileParser.getIgnoreFilePaths()` filtered entries only by `existsSync`, so entries like `"node_modules/"` resolved to an existing **directory** path and were included. `loadIgnoreRules()` in the file search engine then called `readFileSync` on that directory, throwing `EISDIR`. This error propagated out of `RecursiveFileSearch.initialize()`, causing `useAtCompletion` to enter its `ERROR` state — silently disabling all `@` path completions.

### Fix

- **`IgnoreFileParser.getIgnoreFilePaths()`** — add `statSync(filePath).isFile()` check so only actual files are returned, not directories.
- **`loadIgnoreRules()`** — add a defensive `try/catch` around `readFileSync` as a belt-and-suspenders guard against any unreadable path.

### Test

Added a test in `ignoreFileParser.test.ts` that creates a `node_modules/` directory in the project root, constructs an `IgnoreFileParser` with `['node_modules/']`, and asserts that `getIgnoreFilePaths()` returns an empty array.

### Repro

Add to `~/.gemini/settings.json`:
```json
{
  "context": {
    "fileFiltering": {
      "customIgnoreFilePaths": ["node_modules/"]
    }
  }
}
```
Type `@` in the prompt — no suggestions appear. After this fix, suggestions return normally.