### PR TITLE
fix(ci): add sdk package to CI shard and correct AgentLoopContext mock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
             npm run test:ci --workspace "@google/gemini-cli"
           else
             # Explicitly list non-cli packages to ensure they are sharded correctly
-            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --if-present -- --coverage.enabled=false
+            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --workspace "@google/gemini-cli-sdk" --if-present -- --coverage.enabled=false
             npm run test:scripts
           fi
 
@@ -266,7 +266,7 @@ jobs:
             npm run test:ci --workspace "@google/gemini-cli" -- --coverage.enabled=false
           else
             # Explicitly list non-cli packages to ensure they are sharded correctly
-            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --if-present -- --coverage.enabled=false
+            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --workspace "@google/gemini-cli-sdk" --if-present -- --coverage.enabled=false
             npm run test:scripts
           fi
 
@@ -433,7 +433,7 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           } else {
             # Explicitly list non-cli packages to ensure they are sharded correctly
-            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --if-present -- --coverage.enabled=false
+            npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --workspace "@google/gemini-cli-sdk" --if-present -- --coverage.enabled=false
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             npm run test:scripts
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -16,7 +16,18 @@ const mockClient = {
   updateSystemInstruction: vi.fn(),
 };
 
+// Mutable mock tool registry so AgentLoopContext property access works
+const mockToolRegistry = {
+  getTool: vi.fn().mockReturnValue(null),
+  registerTool: vi.fn(),
+  unregisterTool: vi.fn(),
+  clone: vi.fn(),
+};
+mockToolRegistry.clone.mockReturnValue(mockToolRegistry);
+
 // Mutable mock config so individual tests can spy on setUserMemory etc.
+// Must expose both getter methods (used by Config internals) AND plain properties
+// (accessed when Config is cast to AgentLoopContext in session.ts).
 const mockConfig = {
   initialize: vi.fn().mockResolvedValue(undefined),
   refreshAuth: vi.fn().mockResolvedValue(undefined),
@@ -24,11 +35,12 @@ const mockConfig = {
     getSkills: vi.fn().mockReturnValue([]),
     addSkills: vi.fn(),
   }),
-  getToolRegistry: vi.fn().mockReturnValue({
-    getTool: vi.fn().mockReturnValue(null),
-    registerTool: vi.fn(),
-    unregisterTool: vi.fn(),
-  }),
+  // Plain properties for AgentLoopContext cast
+  toolRegistry: mockToolRegistry,
+  messageBus: {},
+  geminiClient: mockClient,
+  // Getter methods retained for any internal Config usage
+  getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
   getMessageBus: vi.fn().mockReturnValue({}),
   getGeminiClient: vi.fn().mockReturnValue(mockClient),
   getSessionId: vi.fn().mockReturnValue('mock-session-id'),
@@ -181,8 +193,7 @@ describe('GeminiCliSession initialize()', () => {
   });
 });
 
-// TODO(#24999): Mock uses getGeminiClient() method but session.ts expects geminiClient property.
-describe.skip('GeminiCliSession sendStream()', () => {
+describe('GeminiCliSession sendStream()', () => {
   it('auto-initializes if not yet initialized', async () => {
     const session = new GeminiCliSession(
       baseOptions,


### PR DESCRIPTION
## Summary

Fixes #24999

### Root cause
Two issues prevented SDK tests from running in CI:
1. `.github/workflows/ci.yml` excluded `@google/gemini-cli-sdk` from the `others` shard, so its tests never ran in PR CI
2. `session.test.ts` used getter methods (`getGeminiClient()` etc.) on its mock where `AgentLoopContext` expects plain properties (`geminiClient`, `toolRegistry`, `messageBus`), causing the describe block to be skipped with a TODO comment

### Fix
- Added `@google/gemini-cli-sdk` to the `others` shard in all three OS test matrix entries (Linux, Mac, Windows)
- Updated `session.test.ts` mock to expose correct plain properties matching the `AgentLoopContext` interface in addition to the existing getter methods
- Removed `describe.skip` / TODO comment so the `sendStream()` tests now run

### Test
The previously skipped tests in `session.test.ts` now run and pass.