### PR TITLE
fix(shell): force UTF-8 output encoding for PowerShell on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -68,7 +68,21 @@ export const SCROLLBACK_LIMIT = 300000;
 const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
 const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
 
+// PowerShell preamble that forces UTF-8 output encoding so that non-ASCII
+// characters (e.g. Chinese, Japanese, Cyrillic) are not garbled when captured
+// through Node.js pipes on Windows systems whose default code page is not 65001.
+const POWERSHELL_UTF8_GUARD =
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;';
+
 function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
+  if (shell === 'powershell') {
+    const trimmed = command.trimStart();
+    if (trimmed.startsWith(POWERSHELL_UTF8_GUARD)) {
+      return command;
+    }
+    return `${POWERSHELL_UTF8_GUARD} ${command}`;
+  }
+
   if (shell !== 'bash') {
     return command;
   }


### PR DESCRIPTION
## Summary

Fixes #20661

On Windows systems whose default code page is not 65001 (e.g. CP936 on Chinese-locale machines), PowerShell streams shell command output using the system code page. This causes non-ASCII characters (Chinese, Japanese, Cyrillic, etc.) to be garbled when captured via `run_shell_command`.

- Introduce a `POWERSHELL_UTF8_GUARD` preamble (`[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;`) that is prepended to every PowerShell command before execution.
- This is analogous to the existing `BASH_SHOPT_GUARD` that is prepended to bash commands.
- The guard is idempotent — if the command already starts with it (e.g. from a retry), it is not prepended again.

## Root cause

`ensurePromptvarsDisabled()` in `shellExecutionService.ts` only handled the `bash` shell type. For `powershell`, commands were passed through unchanged, so PowerShell used the Windows system code page for `[Console]::OutputEncoding`, corrupting non-ASCII output captured through Node.js pipes.

## Test plan

- [ ] On a Windows machine with a non-UTF-8 default code page (e.g. CP936), run `run_shell_command` with a command that outputs Chinese characters (e.g. `Get-Content file-with-chinese.md`). Verify the output is no longer garbled.
- [ ] Verify existing tests pass: `npm test` in `packages/core`.
- [ ] Verify no regression on ASCII-only output on Windows/Linux/macOS.