### PR TITLE
fix(shell): deduplicate command names in Action Required confirmation

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1030,6 +1030,22 @@ describe('ShellTool', () => {
         expect(details.rootCommand).toBe('ls, grep');
       }
     });
+
+    it('should deduplicate repeated command names in rootCommand display', async () => {
+      const shellTool = new ShellTool(mockConfig, createMockMessageBus());
+      const command = 'git status && git diff && git log';
+      const invocation = shellTool.build({ command });
+
+      // @ts-expect-error - getConfirmationDetails is protected
+      const details = await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      );
+
+      expect(details).not.toBe(false);
+      if (details && details.type === 'exec') {
+        expect(details.rootCommand).toBe('git');
+      }
+    });
   });
 
   describe('sandbox heuristics', () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -378,9 +378,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         rootCommandDisplay += ', redirection';
       }
     } else {
-      rootCommandDisplay = parsed.details
-        .map((detail) => detail.name)
-        .join(', ');
+      rootCommandDisplay = [
+        ...new Set(parsed.details.map((detail) => detail.name)),
+      ].join(', ');
     }
 
     const rootCommands = [...new Set(getCommandRoots(command))];


### PR DESCRIPTION
## Summary

Fixes #19768

When chained commands reuse the same binary (e.g. `git status && git diff && git log`), the "Action Required" confirmation prompt was displaying the command name multiple times (e.g. `git, git, git`).

**Root cause:** In `getConfirmationDetails` in `shell.ts`, `rootCommandDisplay` was built by mapping `parsed.details` to names and joining them directly — without deduplication.

**Fix:** Wrap the mapped names in a `Set` before joining, so only unique command names are shown (e.g. `git`).

## Changes

- `packages/core/src/tools/shell.ts`: Deduplicate command names using `Set` when building `rootCommandDisplay`.
- `packages/core/src/tools/shell.test.ts`: Add a test case verifying that `git status && git diff && git log` produces `rootCommand: 'git'` instead of `'git, git, git'`.

## Test plan

- [x] Existing `getConfirmationDetails` tests still pass
- [x] New test `should deduplicate repeated command names in rootCommand display` passes
- [x] All 57 shell tool tests pass (`npx vitest run packages/core/src/tools/shell.test.ts`)