### PR TITLE
fix(shell): force UTF-8 encoding for PowerShell commands on Windows

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -406,6 +406,7 @@ export class ShellExecutionService {
     args: string[];
     env: NodeJS.ProcessEnv;
     cwd: string;
+    shell: ShellType;
     cleanup?: () => void;
   }> {
     const sandboxManager =
@@ -512,6 +513,7 @@ export class ShellExecutionService {
       args: sandboxedCommand.args,
       env: sandboxedCommand.env,
       cwd: sandboxedCommand.cwd ?? cwd,
+      shell,
       cleanup: sandboxedCommand.cleanup,
     };
   }
@@ -541,6 +543,7 @@ export class ShellExecutionService {
         args: finalArgs,
         env: finalEnv,
         cwd: finalCwd,
+        shell,
       } = prepared;
 
       const child = cpSpawn(finalExecutable, finalArgs, {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -68,17 +68,29 @@ export const SCROLLBACK_LIMIT = 300000;
 const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
 const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
 
-function ensurePromptvarsDisabled(command: string, shell: ShellType): string {
-  if (shell !== 'bash') {
-    return command;
-  }
+// Forces UTF-8 output encoding in PowerShell so non-ASCII output is correctly
+// captured through Node.js pipes regardless of the system code page.
+const POWERSHELL_UTF8_GUARD =
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;';
 
+function applyShellPreamble(command: string, shell: ShellType): string {
   const trimmed = command.trimStart();
-  if (trimmed.startsWith(BASH_SHOPT_GUARD)) {
-    return command;
+
+  if (shell === 'bash') {
+    if (trimmed.startsWith(BASH_SHOPT_GUARD)) {
+      return command;
+    }
+    return `${BASH_SHOPT_GUARD} ${command}`;
   }
 
-  return `${BASH_SHOPT_GUARD} ${command}`;
+  if (shell === 'powershell') {
+    if (trimmed.startsWith(POWERSHELL_UTF8_GUARD)) {
+      return command;
+    }
+    return `${POWERSHELL_UTF8_GUARD} ${command}`;
+  }
+
+  return command;
 }
 
 /** A structured result from a shell command execution. */
@@ -417,7 +429,7 @@ export class ShellExecutionService {
     const resolvedExecutable =
       (await resolveExecutable(executable)) ?? executable;
 
-    const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+    const guardedCommand = applyShellPreamble(commandToExecute, shell);
     const spawnArgs = [...argsPrefix, guardedCommand];
 
     // 2. Prepare Environment
@@ -615,7 +627,9 @@ export class ShellExecutionService {
 
       const handleOutput = (data: Buffer, stream: 'stdout' | 'stderr') => {
         if (!stdoutDecoder || !stderrDecoder) {
-          const encoding = getCachedEncodingForBuffer(data);
+          // PowerShell preamble forces UTF-8 output; skip system encoding detection.
+          const encoding =
+            shell === 'powershell' ? 'utf-8' : getCachedEncodingForBuffer(data);
           try {
             stdoutDecoder = new TextDecoder(encoding);
             stderrDecoder = new TextDecoder(encoding);


### PR DESCRIPTION
Fixes #20661

## Problem

On Windows with a non-UTF-8 system code page (e.g. CP936 for Chinese locale), PowerShell uses the system default encoding for console output. When gemini-cli captures this output through Node.js pipes, non-ASCII characters (e.g. Chinese text) are decoded incorrectly and appear garbled.

Two issues combine to cause this:
1. PowerShell's `[Console]::OutputEncoding` defaults to the system code page, so bytes written to stdout use that encoding.
2. `getCachedEncodingForBuffer` detects the system code page via `chcp` and uses it for the `TextDecoder`, but since we now force UTF-8 output, using the system code page decoder produces garbled text.

## Fix

- Add a `POWERSHELL_UTF8_GUARD` preamble prepended to every PowerShell command:
  ```powershell
  [Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8;
  ```
  This forces PowerShell to write UTF-8 bytes to stdout/stderr before the user's command runs.

- Rename `ensurePromptvarsDisabled` → `applyShellPreamble` to reflect its broader responsibility (it now handles both bash shopt options and PowerShell UTF-8 setup).

- In `handleOutput`, skip `getCachedEncodingForBuffer` when `shell === 'powershell'` and always construct the `TextDecoder` with `'utf-8'`, ensuring the forced UTF-8 output is decoded correctly regardless of the system code page.

The guard is idempotent — if the command already starts with it, it is not prepended again.