### PR TITLE
feat(cli): add search and filter to debug console

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -2129,6 +2129,22 @@ describe('AppContainer State Management', () => {
 
         pressKey('\x03'); // Ctrl+C
         expect(mockHandleSlashCommand).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger IDE context detail while debug console is open', async () => {
+        mockConfig.getIdeMode = vi.fn().mockReturnValue(true);
+        await setupKeypressTest();
+
+        act(() => {
+          capturedUIActions.setQueueErrorMessage('debug');
+        });
+        rerender();
+
+        pressKey('\x1b[24~'); // F12 opens debug console
+        expect(capturedUIState.showErrorDetails).toBe(true);
+
+        pressKey('\x1bOS'); // F4
+        expect(mockHandleSlashCommand).not.toHaveBeenCalledWith('/ide status');
         unmount();
       });
     });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1922,6 +1922,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         return true;
       } else if (
         keyMatchers[Command.SHOW_IDE_CONTEXT_DETAIL](key) &&
+        !showErrorDetails &&
         config.getIdeMode() &&
         ideContextState
       ) {

--- a/packages/cli/src/ui/components/ColorsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/ColorsDisplay.test.tsx
@@ -47,6 +47,13 @@ describe('ColorsDisplay', () => {
         success: '#00ff00',
         warning: '#ffff00',
       },
+      logLevels: {
+        log: '#ffffff',
+        info: '#0000ff',
+        warn: '#ffff00',
+        error: '#ff0000',
+        debug: '#cccccc',
+      },
     });
 
     vi.spyOn(themeManager, 'getActiveTheme').mockReturnValue({
@@ -85,6 +92,13 @@ describe('ColorsDisplay', () => {
           error: '#ff0000',
           success: '#00ff00',
           warning: '#ffff00',
+        },
+        logLevels: {
+          log: '#ffffff',
+          info: '#0000ff',
+          warning: '#ffff00',
+          error: '#ff0000',
+          debug: '#cccccc',
         },
       } as unknown as SemanticColors,
     } as unknown as Theme);

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -93,8 +93,15 @@ vi.mock('./ShortcutsHelp.js', () => ({
   ShortcutsHelp: () => <Text>ShortcutsHelp</Text>,
 }));
 
+const detailedMessagesDisplayMock = vi.hoisted(() => ({
+  props: [] as Array<Record<string, unknown>>,
+}));
+
 vi.mock('./DetailedMessagesDisplay.js', () => ({
-  DetailedMessagesDisplay: () => <Text>DetailedMessagesDisplay</Text>,
+  DetailedMessagesDisplay: (props: Record<string, unknown>) => {
+    detailedMessagesDisplayMock.props.push(props);
+    return <Text>DetailedMessagesDisplay</Text>;
+  },
 }));
 
 vi.mock('./InputPrompt.js', () => ({
@@ -295,6 +302,7 @@ describe('Composer', () => {
     vi.useFakeTimers();
     composerTestControls.suggestionsVisible = false;
     composerTestControls.isAlternateBuffer = false;
+    detailedMessagesDisplayMock.props = [];
   });
 
   afterEach(() => {
@@ -800,6 +808,23 @@ describe('Composer', () => {
 
       expect(lastFrame()).toContain('DetailedMessagesDisplay');
       expect(lastFrame()).toContain('ShowMoreLines');
+    });
+
+    it('passes an isolated search buffer to DetailedMessagesDisplay', async () => {
+      const promptBuffer = { text: 'real prompt' } as unknown as TextBuffer;
+      const uiState = createMockUIState({
+        showErrorDetails: true,
+      });
+
+      await renderComposer(uiState, undefined, undefined, undefined, {
+        buffer: promptBuffer,
+      });
+
+      const props = detailedMessagesDisplayMock.props.at(-1);
+      expect(props).toBeTruthy();
+      expect(props?.['searchBuffer']).toBeDefined();
+      expect(props?.['searchBuffer']).not.toBe(promptBuffer);
+      expect((props?.['searchBuffer'] as TextBuffer).text).toBe('');
     });
 
     it('does not show error details when showErrorDetails is false', async () => {

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -28,6 +28,7 @@ import { ConfigInitDisplay } from './ConfigInitDisplay.js';
 import { TodoTray } from './messages/Todo.js';
 import { useComposerStatus } from '../hooks/useComposerStatus.js';
 import { appEvents, AppEvent } from '../../utils/events.js';
+import { useTextBuffer } from './shared/text-buffer.js';
 
 export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
   const uiState = useUIState();
@@ -41,6 +42,11 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
   const isNarrow = isNarrowWidth(terminalWidth);
   const debugConsoleMaxHeight = Math.floor(Math.max(terminalWidth * 0.2, 5));
   const [suggestionsVisible, setSuggestionsVisible] = useState(false);
+  const debugConsoleSearchBuffer = useTextBuffer({
+    initialText: '',
+    viewport: { height: 1, width: Math.max(uiState.terminalWidth - 4, 1) },
+    singleLine: true,
+  });
 
   const isAlternateBuffer = useAlternateBuffer();
   const showUiDetails = uiState.cleanUiDetailsVisible;
@@ -135,6 +141,7 @@ export const Composer = ({ isFocused = true }: { isFocused?: boolean }) => {
               }
               width={uiState.terminalWidth}
               hasFocus={uiState.showErrorDetails}
+              searchBuffer={debugConsoleSearchBuffer}
             />
             <ShowMoreLines constrainHeight={uiState.constrainHeight} />
           </Box>

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
@@ -5,13 +5,17 @@
  */
 
 import { renderWithProviders } from '../../test-utils/render.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { waitFor } from '../../test-utils/async.js';
 import { DetailedMessagesDisplay } from './DetailedMessagesDisplay.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ConsoleMessageItem } from '../types.js';
-import { Box } from 'ink';
-import type React from 'react';
+import { Box, Text } from 'ink';
+import React from 'react';
 import { createMockSettings } from '../../test-utils/settings.js';
 import { useConsoleMessages } from '../hooks/useConsoleMessages.js';
+import type { TextBuffer } from './shared/text-buffer.js';
+import { useTextBuffer } from './shared/text-buffer.js';
 
 vi.mock('../hooks/useConsoleMessages.js', () => ({
   useConsoleMessages: vi.fn(),
@@ -34,9 +38,25 @@ vi.mock('./shared/ScrollableList.js', () => ({
 }));
 
 describe('DetailedMessagesDisplay', () => {
+  const renderDisplay = async (
+    props: Partial<React.ComponentProps<typeof DetailedMessagesDisplay>> = {},
+  ) =>
+    renderWithProviders(
+      <DetailedMessagesDisplay
+        maxHeight={20}
+        width={80}
+        hasFocus={true}
+        {...props}
+      />,
+      {
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
+      },
+    );
+
   beforeEach(() => {
     vi.mocked(useConsoleMessages).mockReturnValue([]);
   });
+
   it('renders nothing when messages are empty', async () => {
     const { lastFrame, unmount } = await renderWithProviders(
       <DetailedMessagesDisplay maxHeight={10} width={80} hasFocus={false} />,
@@ -50,28 +70,33 @@ describe('DetailedMessagesDisplay', () => {
 
   it('renders messages correctly', async () => {
     const messages: ConsoleMessageItem[] = [
-      { type: 'log', content: 'Log message', count: 1 },
-      { type: 'warn', content: 'Warning message', count: 1 },
-      { type: 'error', content: 'Error message', count: 1 },
-      { type: 'debug', content: 'Debug message', count: 1 },
+      { id: '1', type: 'log', content: 'Log message', count: 1 },
+      { id: '2', type: 'info', content: 'Info message', count: 1 },
+      { id: '3', type: 'warn', content: 'Warning message', count: 1 },
+      { id: '4', type: 'error', content: 'Error message', count: 1 },
+      { id: '5', type: 'debug', content: 'Debug message', count: 1 },
     ];
     vi.mocked(useConsoleMessages).mockReturnValue(messages);
 
-    const { lastFrame, unmount } = await renderWithProviders(
-      <DetailedMessagesDisplay maxHeight={20} width={80} hasFocus={true} />,
-      {
-        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
-      },
-    );
+    const { lastFrame, unmount } = await renderDisplay();
     const output = lastFrame();
 
+    expect(output).toContain('Debug Console');
+    expect(output).toContain('F4 to search');
+    expect(output).toContain('All(4)*');
+    expect(output).toContain('Log(1)');
+    expect(output).toContain('Info(1)');
+    expect(output).toContain('Warn(1)');
+    expect(output).toContain('Error(1)');
+    expect(output).toContain('Info message');
+    expect(output).not.toContain('Debug message');
     expect(output).toMatchSnapshot();
     unmount();
   });
 
   it('shows the F12 hint even in low error verbosity mode', async () => {
     const messages: ConsoleMessageItem[] = [
-      { type: 'error', content: 'Error message', count: 1 },
+      { id: '5', type: 'error', content: 'Error message', count: 1 },
     ];
     vi.mocked(useConsoleMessages).mockReturnValue(messages);
 
@@ -81,13 +106,15 @@ describe('DetailedMessagesDisplay', () => {
         settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
       },
     );
-    expect(lastFrame()).toContain('(F12 to close)');
+    expect(lastFrame()).toContain(
+      'Debug Console (F12 to close | F4 to search)',
+    );
     unmount();
   });
 
   it('shows the F12 hint in full error verbosity mode', async () => {
     const messages: ConsoleMessageItem[] = [
-      { type: 'error', content: 'Error message', count: 1 },
+      { id: '6', type: 'error', content: 'Error message', count: 1 },
     ];
     vi.mocked(useConsoleMessages).mockReturnValue(messages);
 
@@ -97,25 +124,197 @@ describe('DetailedMessagesDisplay', () => {
         settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
-    expect(lastFrame()).toContain('(F12 to close)');
+    expect(lastFrame()).toContain(
+      'Debug Console (F12 to close | F4 to search)',
+    );
     unmount();
   });
 
   it('renders message counts', async () => {
     const messages: ConsoleMessageItem[] = [
-      { type: 'log', content: 'Repeated message', count: 5 },
+      { id: '7', type: 'log', content: 'Repeated message', count: 5 },
     ];
     vi.mocked(useConsoleMessages).mockReturnValue(messages);
 
-    const { lastFrame, unmount } = await renderWithProviders(
-      <DetailedMessagesDisplay maxHeight={10} width={80} hasFocus={false} />,
+    const { lastFrame, unmount } = await renderDisplay({
+      maxHeight: 10,
+      hasFocus: false,
+    });
+    const output = lastFrame();
+
+    expect(output).toContain('Repeated message');
+    expect(output).toContain('(x5)');
+    expect(output).toMatchSnapshot();
+    unmount();
+  });
+
+  it('does not filter messages from search text until search mode is active', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'info', content: 'alpha match', count: 1 },
+      { id: '2', type: 'warn', content: 'beta only', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+    const searchBuffer = { text: 'alpha' } as TextBuffer;
+
+    const { lastFrame, unmount } = await renderDisplay({ searchBuffer });
+
+    const output = lastFrame();
+    expect(output).toContain('alpha match');
+    expect(output).toContain('beta only');
+    expect(output).not.toContain('Search: alpha');
+    unmount();
+  });
+
+  it('renders info messages with info-level color', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'info', content: 'Info message', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+    const searchBuffer = { text: '' } as TextBuffer;
+
+    const { lastFrame, unmount } = await renderDisplay({ searchBuffer });
+
+    expect(lastFrame()).toContain('Info message');
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+
+  it('filters messages after entering search mode with F4 and typing a keyword', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'info', content: 'alpha match', count: 1 },
+      { id: '2', type: 'warn', content: 'beta only', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+
+    const SearchHarness = () => {
+      const searchBuffer = useTextBuffer({
+        initialText: '',
+        viewport: { width: 30, height: 1 },
+        singleLine: true,
+      });
+
+      return (
+        <DetailedMessagesDisplay
+          maxHeight={20}
+          width={80}
+          hasFocus={true}
+          searchBuffer={searchBuffer}
+        />
+      );
+    };
+
+    const { lastFrame, stdin, unmount } = await renderWithProviders(
+      <SearchHarness />,
       {
         settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
       },
     );
-    const output = lastFrame();
 
-    expect(output).toMatchSnapshot();
+    await React.act(async () => {
+      stdin.write('\u001bOS');
+    });
+
+    await waitFor(() => {
+      const output = lastFrame();
+      expect(output).toContain('F4 esc search');
+      expect(output).toContain('Search:');
+      expect(output).toContain('Filter logs');
+      expect(output).toContain('╭');
+      expect(output).toContain('╮');
+    });
+
+    await React.act(async () => {
+      stdin.write('alpha');
+    });
+
+    await waitFor(() => {
+      const output = lastFrame();
+      expect(output).toContain('alpha match');
+      expect(output).not.toContain('beta only');
+      expect(output).toContain('alpha');
+      expect(output).toContain('[results: 1]');
+      expect(output).not.toContain('F\ni\nl\nt\ne\nr\n \nl\no\ng\ns');
+    });
+
+    unmount();
+  });
+
+  it('keeps search input active for consecutive typing instead of bubbling to lower inputs', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'info', content: 'alpha match', count: 1 },
+      { id: '2', type: 'warn', content: 'beta only', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+
+    const LowerPriorityInput = () => {
+      const [value, setValue] = React.useState('');
+
+      useKeypress(
+        (key: Key) => {
+          if (key.sequence.length === 1 && !key.ctrl && !key.alt && !key.cmd) {
+            setValue((current) => current + key.sequence);
+            return true;
+          }
+          return false;
+        },
+        { isActive: true, priority: true },
+      );
+
+      return <Text>Composer mirror: {value || '(empty)'}</Text>;
+    };
+
+    const SearchHarness = () => {
+      const searchBuffer = useTextBuffer({
+        initialText: '',
+        viewport: { width: 30, height: 1 },
+        singleLine: true,
+      });
+
+      return (
+        <Box flexDirection="column">
+          <DetailedMessagesDisplay
+            maxHeight={20}
+            width={80}
+            hasFocus={true}
+            searchBuffer={searchBuffer}
+          />
+          <LowerPriorityInput />
+        </Box>
+      );
+    };
+
+    const { lastFrame, stdin, unmount } = await renderWithProviders(
+      <SearchHarness />,
+      {
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
+      },
+    );
+
+    await React.act(async () => {
+      stdin.write('\u001bOS');
+    });
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('F4 esc search');
+      expect(lastFrame()).toContain('Search:');
+      expect(lastFrame()).toContain('Composer mirror: (empty)');
+    });
+
+    await React.act(async () => {
+      stdin.write('alpha');
+    });
+
+    await waitFor(() => {
+      const output = lastFrame();
+      expect(output).toContain('Composer mirror: (empty)');
+      expect(output).toContain('alpha match');
+      expect(output).not.toContain('beta only');
+      expect(output).toContain('a');
+      expect(output).toContain('l');
+      expect(output).toContain('p');
+      expect(output).toContain('h');
+    });
+
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx
@@ -7,7 +7,10 @@
 import { renderWithProviders } from '../../test-utils/render.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
 import { waitFor } from '../../test-utils/async.js';
-import { DetailedMessagesDisplay } from './DetailedMessagesDisplay.js';
+import {
+  DetailedMessagesDisplay,
+  getLevelFilterShortcut,
+} from './DetailedMessagesDisplay.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ConsoleMessageItem } from '../types.js';
 import { Box, Text } from 'ink';
@@ -57,6 +60,93 @@ describe('DetailedMessagesDisplay', () => {
     vi.mocked(useConsoleMessages).mockReturnValue([]);
   });
 
+  describe('getLevelFilterShortcut', () => {
+    const shortcuts: Parameters<typeof getLevelFilterShortcut>[1] = {
+      '1': 'all',
+      '2': 'log',
+      '3': 'info',
+      '4': 'warn',
+      '5': 'error',
+      '6': 'debug',
+    };
+
+    it('maps Alt+number shortcuts using key.name', () => {
+      expect(
+        getLevelFilterShortcut(
+          {
+            name: '1',
+            sequence: '\u001b1',
+            alt: true,
+            ctrl: false,
+            cmd: false,
+            shift: false,
+            insertable: true,
+          },
+          shortcuts,
+        ),
+      ).toBe('all');
+      expect(
+        getLevelFilterShortcut(
+          {
+            name: '4',
+            sequence: '\u001b4',
+            alt: true,
+            ctrl: false,
+            cmd: false,
+            shift: false,
+            insertable: true,
+          },
+          shortcuts,
+        ),
+      ).toBe('warn');
+    });
+
+    it('ignores non-Alt or modified shortcuts', () => {
+      expect(
+        getLevelFilterShortcut(
+          {
+            name: '4',
+            sequence: '4',
+            alt: false,
+            ctrl: false,
+            cmd: false,
+            shift: false,
+            insertable: true,
+          },
+          shortcuts,
+        ),
+      ).toBeUndefined();
+      expect(
+        getLevelFilterShortcut(
+          {
+            name: '4',
+            sequence: '\u001b4',
+            alt: true,
+            ctrl: true,
+            cmd: false,
+            shift: false,
+            insertable: false,
+          },
+          shortcuts,
+        ),
+      ).toBeUndefined();
+      expect(
+        getLevelFilterShortcut(
+          {
+            name: '4',
+            sequence: '\u001b4',
+            alt: true,
+            ctrl: false,
+            cmd: true,
+            shift: false,
+            insertable: false,
+          },
+          shortcuts,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
   it('renders nothing when messages are empty', async () => {
     const { lastFrame, unmount } = await renderWithProviders(
       <DetailedMessagesDisplay maxHeight={10} width={80} hasFocus={false} />,
@@ -83,11 +173,14 @@ describe('DetailedMessagesDisplay', () => {
 
     expect(output).toContain('Debug Console');
     expect(output).toContain('F4 to search');
-    expect(output).toContain('All(4)*');
+    expect(output).toContain('Alt+1-6 to filter by level');
+    expect(output).toContain('All(4)');
     expect(output).toContain('Log(1)');
     expect(output).toContain('Info(1)');
     expect(output).toContain('Warn(1)');
     expect(output).toContain('Error(1)');
+    expect(output).not.toContain('Alt+1:All');
+    expect(output).not.toContain('Alt+4:Warn');
     expect(output).toContain('Info message');
     expect(output).not.toContain('Debug message');
     expect(output).toMatchSnapshot();
@@ -148,7 +241,7 @@ describe('DetailedMessagesDisplay', () => {
     unmount();
   });
 
-  it('does not filter messages from search text until search mode is active', async () => {
+  it('filters messages whenever search text is present', async () => {
     const messages: ConsoleMessageItem[] = [
       { id: '1', type: 'info', content: 'alpha match', count: 1 },
       { id: '2', type: 'warn', content: 'beta only', count: 1 },
@@ -160,7 +253,7 @@ describe('DetailedMessagesDisplay', () => {
 
     const output = lastFrame();
     expect(output).toContain('alpha match');
-    expect(output).toContain('beta only');
+    expect(output).not.toContain('beta only');
     expect(output).not.toContain('Search: alpha');
     unmount();
   });
@@ -217,7 +310,6 @@ describe('DetailedMessagesDisplay', () => {
     await waitFor(() => {
       const output = lastFrame();
       expect(output).toContain('F4 esc search');
-      expect(output).toContain('Search:');
       expect(output).toContain('Filter logs');
       expect(output).toContain('╭');
       expect(output).toContain('╮');
@@ -232,8 +324,18 @@ describe('DetailedMessagesDisplay', () => {
       expect(output).toContain('alpha match');
       expect(output).not.toContain('beta only');
       expect(output).toContain('alpha');
-      expect(output).toContain('[results: 1]');
       expect(output).not.toContain('F\ni\nl\nt\ne\nr\n \nl\no\ng\ns');
+    });
+
+    await React.act(async () => {
+      stdin.write('\u001b');
+    });
+
+    await waitFor(() => {
+      const output = lastFrame();
+      expect(output).toContain('alpha match');
+      expect(output).not.toContain('beta only');
+      expect(output).not.toContain('Filter logs');
     });
 
     unmount();
@@ -296,7 +398,7 @@ describe('DetailedMessagesDisplay', () => {
 
     await waitFor(() => {
       expect(lastFrame()).toContain('F4 esc search');
-      expect(lastFrame()).toContain('Search:');
+      expect(lastFrame()).toContain('Filter logs');
       expect(lastFrame()).toContain('Composer mirror: (empty)');
     });
 
@@ -313,6 +415,83 @@ describe('DetailedMessagesDisplay', () => {
       expect(output).toContain('l');
       expect(output).toContain('p');
       expect(output).toContain('h');
+    });
+
+    unmount();
+  });
+
+  it('renders compact level filter labels and shortcut hint', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'log', content: 'log message', count: 1 },
+      { id: '2', type: 'warn', content: 'warn message', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+
+    const { lastFrame, unmount } = await renderDisplay();
+
+    const output = lastFrame();
+    expect(output).toContain('Alt+1-6 to filter by level');
+    expect(output).toContain('All(2)');
+    expect(output).toContain('Log(1)');
+    expect(output).toContain('Warn(1)');
+    expect(output).not.toContain('Alt+1:All');
+    expect(output).not.toContain('Alt+4:Warn');
+    expect(output).toContain('log message');
+    expect(output).toContain('warn message');
+
+    unmount();
+  });
+
+  it('does not intercept plain number input while the debug console is visible', async () => {
+    const messages: ConsoleMessageItem[] = [
+      { id: '1', type: 'log', content: 'alpha match', count: 1 },
+    ];
+    vi.mocked(useConsoleMessages).mockReturnValue(messages);
+
+    const LowerPriorityInput = () => {
+      const [value, setValue] = React.useState('');
+
+      useKeypress(
+        (key: Key) => {
+          if (key.sequence.length === 1 && !key.ctrl && !key.alt && !key.cmd) {
+            setValue((current) => current + key.sequence);
+            return true;
+          }
+          return false;
+        },
+        { isActive: true, priority: true },
+      );
+
+      return <Text>Composer mirror: {value || '(empty)'}</Text>;
+    };
+
+    const InputHarness = () => (
+      <Box flexDirection="column">
+        <DetailedMessagesDisplay maxHeight={20} width={80} hasFocus={true} />
+        <LowerPriorityInput />
+      </Box>
+    );
+
+    const { lastFrame, stdin, unmount } = await renderWithProviders(
+      <InputHarness />,
+      {
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('Composer mirror: (empty)');
+    });
+
+    await React.act(async () => {
+      stdin.write('4');
+    });
+
+    await waitFor(() => {
+      const output = lastFrame();
+      expect(output).toContain('Composer mirror: 4');
+      expect(output).toContain('Alt+1-6 to filter by level');
+      expect(output).toContain('alpha match');
     });
 
     unmount();

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
@@ -5,29 +5,143 @@
  */
 
 import type React from 'react';
-import { useRef, useCallback, useMemo } from 'react';
+import { useRef, useCallback, useState, useMemo, useEffect } from 'react';
 import { Box, Text } from 'ink';
+import { TextInput } from './shared/TextInput.js';
 import { theme } from '../semantic-colors.js';
 import type { ConsoleMessageItem } from '../types.js';
 import {
   ScrollableList,
   type ScrollableListRef,
 } from './shared/ScrollableList.js';
+import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { KeypressPriority } from '../contexts/KeypressContext.js';
 import { useConsoleMessages } from '../hooks/useConsoleMessages.js';
 import { useConfig } from '../contexts/ConfigContext.js';
+import type { TextBuffer } from './shared/text-buffer.js';
 
 interface DetailedMessagesDisplayProps {
   maxHeight: number | undefined;
   width: number;
   hasFocus: boolean;
+  searchBuffer?: TextBuffer;
 }
 
+enum LogLevelLabels {
+  all = 'all',
+  log = 'log',
+  info = 'info',
+  warn = 'warn',
+  error = 'error',
+  debug = 'debug',
+}
+
+type DisplayedLogLevel = Exclude<ConsoleMessageItem['type'], 'group'>;
+type MessagePresentation = {
+  color: string;
+  icon: string;
+};
+type FilterButtonConfig = {
+  key: LogLevelLabels;
+  label: string;
+  color: string;
+  shortcut: string;
+};
+
 const iconBoxWidth = 3;
+const DEFAULT_MESSAGE_PRESENTATION: MessagePresentation = {
+  color: theme.logLevels.info,
+  icon: 'ℹ',
+};
+const LEVEL_COUNTS_INITIAL_STATE: Record<LogLevelLabels, number> = {
+  [LogLevelLabels.all]: 0,
+  [LogLevelLabels.log]: 0,
+  [LogLevelLabels.info]: 0,
+  [LogLevelLabels.warn]: 0,
+  [LogLevelLabels.error]: 0,
+  [LogLevelLabels.debug]: 0,
+};
+const FILTER_BUTTONS: readonly FilterButtonConfig[] = [
+  {
+    key: LogLevelLabels.all,
+    label: 'All',
+    color: theme.text.primary,
+    shortcut: '1',
+  },
+  {
+    key: LogLevelLabels.log,
+    label: 'Log',
+    color: theme.logLevels.log,
+    shortcut: '2',
+  },
+  {
+    key: LogLevelLabels.info,
+    label: 'Info',
+    color: theme.logLevels.info,
+    shortcut: '3',
+  },
+  {
+    key: LogLevelLabels.warn,
+    label: 'Warn',
+    color: theme.logLevels.warn,
+    shortcut: '4',
+  },
+  {
+    key: LogLevelLabels.error,
+    label: 'Error',
+    color: theme.logLevels.error,
+    shortcut: '5',
+  },
+  {
+    key: LogLevelLabels.debug,
+    label: 'Debug',
+    color: theme.logLevels.debug,
+    shortcut: '6',
+  },
+] as const;
+const FILTER_SHORTCUTS: Record<string, LogLevelLabels> = Object.fromEntries(
+  FILTER_BUTTONS.map(({ shortcut, key }) => [shortcut, key]),
+) as Record<string, LogLevelLabels>;
+const MESSAGE_PRESENTATIONS: Record<DisplayedLogLevel, MessagePresentation> = {
+  log: {
+    color: theme.logLevels.log,
+    icon: 'ℹ',
+  },
+  info: {
+    color: theme.logLevels.info,
+    icon: 'ℹ',
+  },
+  warn: {
+    color: theme.logLevels.warn,
+    icon: '⚠',
+  },
+  error: {
+    color: theme.logLevels.error,
+    icon: '✖',
+  },
+  debug: {
+    color: theme.logLevels.debug,
+    icon: '🔍',
+  },
+};
+
+function getMessagePresentation(type: DisplayedLogLevel): MessagePresentation {
+  return MESSAGE_PRESENTATIONS[type] ?? DEFAULT_MESSAGE_PRESENTATION;
+}
 
 export const DetailedMessagesDisplay: React.FC<
   DetailedMessagesDisplayProps
-> = ({ maxHeight, width, hasFocus }) => {
+> = ({ maxHeight, width, hasFocus, searchBuffer }) => {
   const scrollableListRef = useRef<ScrollableListRef<ConsoleMessageItem>>(null);
+  const [levelFilter, setLevelFilter] = useState<LogLevelLabels>(
+    LogLevelLabels.all,
+  );
+  const [activeSection, setActiveSection] = useState<'list' | 'search'>('list');
+  const activeSectionRef = useRef(activeSection);
+
+  useEffect(() => {
+    activeSectionRef.current = activeSection;
+  }, [activeSection]);
 
   const consoleMessages = useConsoleMessages();
   const config = useConfig();
@@ -40,10 +154,70 @@ export const DetailedMessagesDisplay: React.FC<
   }, [consoleMessages, config]);
 
   const borderAndPadding = 3;
+  const filteredMessages = useMemo(
+    () =>
+      messages.filter((msg) => {
+        if (levelFilter !== LogLevelLabels.all && msg.type !== levelFilter) {
+          return false;
+        }
+
+        if (activeSection === 'search' && searchBuffer?.text) {
+          return msg.content
+            .toLowerCase()
+            .includes(searchBuffer.text.toLowerCase());
+        }
+
+        return true;
+      }),
+    [messages, activeSection, levelFilter, searchBuffer?.text],
+  );
+
+  const levelCounts = useMemo(() => {
+    const counts = { ...LEVEL_COUNTS_INITIAL_STATE };
+
+    for (const msg of messages) {
+      counts[msg.type]++;
+    }
+
+    counts[LogLevelLabels.all] = messages.length;
+
+    return counts;
+  }, [messages]);
+
+  const handleKeypress = useCallback((key: Key): boolean | void => {
+    const input = key.sequence;
+    const section = activeSectionRef.current;
+
+    if (key.name === 'f4' && !key.ctrl && !key.alt) {
+      setActiveSection(section === 'list' ? 'search' : 'list');
+      return true;
+    }
+
+    if (key.name === 'escape' && section === 'search') {
+      setActiveSection('list');
+      return true;
+    }
+
+    if (
+      !key.ctrl &&
+      !key.alt &&
+      input &&
+      FILTER_SHORTCUTS[input] &&
+      section === 'list'
+    ) {
+      setLevelFilter(FILTER_SHORTCUTS[input]);
+      return true;
+    }
+  }, []);
+
+  useKeypress(handleKeypress, {
+    isActive: hasFocus,
+    priority: KeypressPriority.Critical,
+  });
 
   const estimatedItemHeight = useCallback(
     (index: number) => {
-      const msg = messages[index];
+      const msg = filteredMessages[index];
       if (!msg) {
         return 1;
       }
@@ -54,12 +228,13 @@ export const DetailedMessagesDisplay: React.FC<
       const lines = Math.ceil((msg.content?.length || 1) / textWidth);
       return Math.max(1, lines);
     },
-    [width, messages],
+    [width, filteredMessages],
   );
 
   if (messages.length === 0) {
     return null;
   }
+  const listHeight = maxHeight ?? 3;
 
   return (
     <Box
@@ -76,55 +251,93 @@ export const DetailedMessagesDisplay: React.FC<
     >
       <Box marginBottom={1}>
         <Text bold color={theme.text.primary}>
-          Debug Console <Text color={theme.text.secondary}>(F12 to close)</Text>
+          Debug Console{' '}
+          <Text color={theme.text.secondary}>
+            (F12 to close |{' '}
+            <Text
+              color={
+                activeSection !== 'list'
+                  ? theme.status.success
+                  : theme.text.secondary
+              }
+            >
+              F4 {activeSection === 'list' ? 'to search' : 'esc search'}
+            </Text>
+            )
+          </Text>
         </Text>
       </Box>
-      <Box height={maxHeight} width={width - borderAndPadding}>
-        <ScrollableList
-          ref={scrollableListRef}
-          data={messages}
-          renderItem={({ item: msg }: { item: ConsoleMessageItem }) => {
-            let textColor = theme.text.primary;
-            let icon = 'ℹ'; // Information source (ℹ)
+      <Box flexDirection="row" marginBottom={1}>
+        {FILTER_BUTTONS.map(({ key, label, color, shortcut }) => (
+          <Box key={key} marginRight={1}>
+            <Text
+              color={color}
+              bold={levelFilter === key}
+              underline={levelFilter === key}
+            >
+              {shortcut}:{label}({levelCounts[key]})
+              {levelFilter === key ? '* ' : ' '}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+      {searchBuffer && activeSection === 'search' && (
+        <Box flexDirection="row" alignItems="center" marginBottom={1}>
+          <Box
+            flexGrow={1}
+            minWidth={0}
+            borderStyle="round"
+            borderColor={theme.border.default}
+            paddingX={1}
+            height={3}
+          >
+            <TextInput
+              buffer={searchBuffer}
+              placeholder="Filter logs"
+              focus={hasFocus && activeSection === 'search'}
+              priority={KeypressPriority.Critical}
+            />
+          </Box>
+        </Box>
+      )}
+      <Box height={listHeight} width={width - borderAndPadding}>
+        {filteredMessages.length > 0 ? (
+          <ScrollableList
+            ref={scrollableListRef}
+            data={filteredMessages}
+            renderItem={({ item: msg }: { item: ConsoleMessageItem }) => {
+              const { color: textColor, icon } = getMessagePresentation(
+                msg.type,
+              );
 
-            switch (msg.type) {
-              case 'warn':
-                textColor = theme.status.warning;
-                icon = '⚠'; // Warning sign (⚠)
-                break;
-              case 'error':
-                textColor = theme.status.error;
-                icon = '✖'; // Heavy multiplication x (✖)
-                break;
-              case 'debug':
-                textColor = theme.text.secondary; // Or theme.text.secondary
-                icon = '🔍'; // Left-pointing magnifying glass (🔍)
-                break;
-              case 'log':
-              default:
-                // Default textColor and icon are already set
-                break;
-            }
-
-            return (
-              <Box flexDirection="row">
-                <Box minWidth={iconBoxWidth} flexShrink={0}>
-                  <Text color={textColor}>{icon}</Text>
+              return (
+                <Box flexDirection="row">
+                  <Box minWidth={iconBoxWidth} flexShrink={0}>
+                    <Text color={textColor}>{icon}</Text>
+                  </Box>
+                  <Text color={textColor} wrap="wrap">
+                    {msg.content}
+                    {msg.count && msg.count > 1 && (
+                      <Text color={theme.text.secondary}> (x{msg.count})</Text>
+                    )}
+                  </Text>
                 </Box>
-                <Text color={textColor} wrap="wrap">
-                  {msg.content}
-                  {msg.count && msg.count > 1 && (
-                    <Text color={theme.text.secondary}> (x{msg.count})</Text>
-                  )}
-                </Text>
-              </Box>
-            );
-          }}
-          keyExtractor={(item, index) => `${item.content}-${index}`}
-          estimatedItemHeight={estimatedItemHeight}
-          hasFocus={hasFocus}
-          initialScrollIndex={Number.MAX_SAFE_INTEGER}
-        />
+              );
+            }}
+            keyExtractor={(item) => item.id}
+            estimatedItemHeight={estimatedItemHeight}
+            hasFocus={hasFocus && activeSection === 'list'}
+            initialScrollIndex={Number.MAX_SAFE_INTEGER}
+          />
+        ) : (
+          <Box>
+            <Text color={theme.text.secondary}>
+              {searchBuffer?.text || levelFilter !== LogLevelLabels.all
+                ? 'No messages match the filter'
+                : 'No messages'}
+            </Text>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
+++ b/packages/cli/src/ui/components/DetailedMessagesDisplay.tsx
@@ -45,14 +45,9 @@ type FilterButtonConfig = {
   key: LogLevelLabels;
   label: string;
   color: string;
-  shortcut: string;
 };
 
 const iconBoxWidth = 3;
-const DEFAULT_MESSAGE_PRESENTATION: MessagePresentation = {
-  color: theme.logLevels.info,
-  icon: 'ℹ',
-};
 const LEVEL_COUNTS_INITIAL_STATE: Record<LogLevelLabels, number> = {
   [LogLevelLabels.all]: 0,
   [LogLevelLabels.log]: 0,
@@ -61,72 +56,94 @@ const LEVEL_COUNTS_INITIAL_STATE: Record<LogLevelLabels, number> = {
   [LogLevelLabels.error]: 0,
   [LogLevelLabels.debug]: 0,
 };
-const FILTER_BUTTONS: readonly FilterButtonConfig[] = [
-  {
-    key: LogLevelLabels.all,
-    label: 'All',
-    color: theme.text.primary,
-    shortcut: '1',
-  },
-  {
-    key: LogLevelLabels.log,
-    label: 'Log',
-    color: theme.logLevels.log,
-    shortcut: '2',
-  },
-  {
-    key: LogLevelLabels.info,
-    label: 'Info',
-    color: theme.logLevels.info,
-    shortcut: '3',
-  },
-  {
-    key: LogLevelLabels.warn,
-    label: 'Warn',
-    color: theme.logLevels.warn,
-    shortcut: '4',
-  },
-  {
-    key: LogLevelLabels.error,
-    label: 'Error',
-    color: theme.logLevels.error,
-    shortcut: '5',
-  },
-  {
-    key: LogLevelLabels.debug,
-    label: 'Debug',
-    color: theme.logLevels.debug,
-    shortcut: '6',
-  },
-] as const;
-const FILTER_SHORTCUTS: Record<string, LogLevelLabels> = Object.fromEntries(
-  FILTER_BUTTONS.map(({ shortcut, key }) => [shortcut, key]),
-) as Record<string, LogLevelLabels>;
-const MESSAGE_PRESENTATIONS: Record<DisplayedLogLevel, MessagePresentation> = {
-  log: {
-    color: theme.logLevels.log,
-    icon: 'ℹ',
-  },
-  info: {
-    color: theme.logLevels.info,
-    icon: 'ℹ',
-  },
-  warn: {
-    color: theme.logLevels.warn,
-    icon: '⚠',
-  },
-  error: {
-    color: theme.logLevels.error,
-    icon: '✖',
-  },
-  debug: {
-    color: theme.logLevels.debug,
-    icon: '🔍',
-  },
-};
+
+function getFilterButtons(): readonly FilterButtonConfig[] {
+  return [
+    {
+      key: LogLevelLabels.all,
+      label: 'All',
+      color: theme.text.primary,
+    },
+    {
+      key: LogLevelLabels.log,
+      label: 'Log',
+      color: theme.logLevels.log,
+    },
+    {
+      key: LogLevelLabels.info,
+      label: 'Info',
+      color: theme.logLevels.info,
+    },
+    {
+      key: LogLevelLabels.warn,
+      label: 'Warn',
+      color: theme.logLevels.warn,
+    },
+    {
+      key: LogLevelLabels.error,
+      label: 'Error',
+      color: theme.logLevels.error,
+    },
+    {
+      key: LogLevelLabels.debug,
+      label: 'Debug',
+      color: theme.logLevels.debug,
+    },
+  ] as const;
+}
+
+function getFilterShortcuts(): Record<string, LogLevelLabels> {
+  return {
+    '1': LogLevelLabels.all,
+    '2': LogLevelLabels.log,
+    '3': LogLevelLabels.info,
+    '4': LogLevelLabels.warn,
+    '5': LogLevelLabels.error,
+    '6': LogLevelLabels.debug,
+  };
+}
 
 function getMessagePresentation(type: DisplayedLogLevel): MessagePresentation {
-  return MESSAGE_PRESENTATIONS[type] ?? DEFAULT_MESSAGE_PRESENTATION;
+  const messagePresentations: Record<DisplayedLogLevel, MessagePresentation> = {
+    log: {
+      color: theme.logLevels.log,
+      icon: 'ℹ',
+    },
+    info: {
+      color: theme.logLevels.info,
+      icon: 'ℹ',
+    },
+    warn: {
+      color: theme.logLevels.warn,
+      icon: '⚠',
+    },
+    error: {
+      color: theme.logLevels.error,
+      icon: '✖',
+    },
+    debug: {
+      color: theme.logLevels.debug,
+      icon: '🔍',
+    },
+  };
+
+  return (
+    messagePresentations[type] ?? {
+      color: theme.logLevels.info,
+      icon: 'ℹ',
+    }
+  );
+}
+
+export function getLevelFilterShortcut<T extends string>(
+  key: Key,
+  filterShortcuts: Record<string, T>,
+): T | undefined {
+  if (!key.alt || key.ctrl || key.cmd) {
+    return undefined;
+  }
+
+  return filterShortcuts[key.name];
 }
 
 export const DetailedMessagesDisplay: React.FC<
@@ -143,6 +160,9 @@ export const DetailedMessagesDisplay: React.FC<
     activeSectionRef.current = activeSection;
   }, [activeSection]);
 
+  const filterButtons = useMemo(() => getFilterButtons(), []);
+  const filterShortcuts = useMemo(() => getFilterShortcuts(), []);
+
   const consoleMessages = useConsoleMessages();
   const config = useConfig();
 
@@ -154,6 +174,7 @@ export const DetailedMessagesDisplay: React.FC<
   }, [consoleMessages, config]);
 
   const borderAndPadding = 3;
+  const normalizedSearchText = searchBuffer?.text.trim().toLowerCase() ?? '';
   const filteredMessages = useMemo(
     () =>
       messages.filter((msg) => {
@@ -161,15 +182,13 @@ export const DetailedMessagesDisplay: React.FC<
           return false;
         }
 
-        if (activeSection === 'search' && searchBuffer?.text) {
-          return msg.content
-            .toLowerCase()
-            .includes(searchBuffer.text.toLowerCase());
+        if (normalizedSearchText) {
+          return msg.content.toLowerCase().includes(normalizedSearchText);
         }
 
         return true;
       }),
-    [messages, activeSection, levelFilter, searchBuffer?.text],
+    [messages, levelFilter, normalizedSearchText],
   );
 
   const levelCounts = useMemo(() => {
@@ -184,31 +203,28 @@ export const DetailedMessagesDisplay: React.FC<
     return counts;
   }, [messages]);
 
-  const handleKeypress = useCallback((key: Key): boolean | void => {
-    const input = key.sequence;
-    const section = activeSectionRef.current;
+  const handleKeypress = useCallback(
+    (key: Key): boolean | void => {
+      const section = activeSectionRef.current;
 
-    if (key.name === 'f4' && !key.ctrl && !key.alt) {
-      setActiveSection(section === 'list' ? 'search' : 'list');
-      return true;
-    }
+      if (key.name === 'f4' && !key.ctrl && !key.alt) {
+        setActiveSection(section === 'list' ? 'search' : 'list');
+        return true;
+      }
 
-    if (key.name === 'escape' && section === 'search') {
-      setActiveSection('list');
-      return true;
-    }
+      if (key.name === 'escape' && section === 'search') {
+        setActiveSection('list');
+        return true;
+      }
 
-    if (
-      !key.ctrl &&
-      !key.alt &&
-      input &&
-      FILTER_SHORTCUTS[input] &&
-      section === 'list'
-    ) {
-      setLevelFilter(FILTER_SHORTCUTS[input]);
-      return true;
-    }
-  }, []);
+      const shortcutTarget = getLevelFilterShortcut(key, filterShortcuts);
+      if (shortcutTarget) {
+        setLevelFilter(shortcutTarget);
+        return true;
+      }
+    },
+    [filterShortcuts],
+  );
 
   useKeypress(handleKeypress, {
     isActive: hasFocus,
@@ -234,7 +250,6 @@ export const DetailedMessagesDisplay: React.FC<
   if (messages.length === 0) {
     return null;
   }
-  const listHeight = maxHeight ?? 3;
 
   return (
     <Box
@@ -268,18 +283,20 @@ export const DetailedMessagesDisplay: React.FC<
         </Text>
       </Box>
       <Box flexDirection="row" marginBottom={1}>
-        {FILTER_BUTTONS.map(({ key, label, color, shortcut }) => (
+        {filterButtons.map(({ key, label, color }) => (
           <Box key={key} marginRight={1}>
             <Text
               color={color}
               bold={levelFilter === key}
               underline={levelFilter === key}
             >
-              {shortcut}:{label}({levelCounts[key]})
-              {levelFilter === key ? '* ' : ' '}
+              {label}({levelCounts[key]}){levelFilter === key ? '* ' : ' '}
             </Text>
           </Box>
         ))}
+      </Box>
+      <Box marginBottom={1}>
+        <Text color={theme.text.secondary}>Alt+1-6 to filter by level</Text>
       </Box>
       {searchBuffer && activeSection === 'search' && (
         <Box flexDirection="row" alignItems="center" marginBottom={1}>
@@ -300,7 +317,7 @@ export const DetailedMessagesDisplay: React.FC<
           </Box>
         </Box>
       )}
-      <Box height={listHeight} width={width - borderAndPadding}>
+      <Box height={maxHeight} width={width - borderAndPadding}>
         {filteredMessages.length > 0 ? (
           <ScrollableList
             ref={scrollableListRef}
@@ -332,7 +349,7 @@ export const DetailedMessagesDisplay: React.FC<
         ) : (
           <Box>
             <Text color={theme.text.secondary}>
-              {searchBuffer?.text || levelFilter !== LogLevelLabels.all
+              {normalizedSearchText || levelFilter !== LogLevelLabels.all
                 ? 'No messages match the filter'
                 : 'No messages'}
             </Text>

--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -117,6 +117,13 @@ describe('<Header />', () => {
         success: '',
         warning: '',
       },
+      logLevels: {
+        log: '',
+        info: '',
+        warn: '',
+        error: '',
+        debug: '',
+      },
     });
     const Gradient = await import('ink-gradient');
     await render(<Header version="1.0.0" nightly={false} />);

--- a/packages/cli/src/ui/components/__snapshots__/DetailedMessagesDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/DetailedMessagesDisplay.test.tsx.snap
@@ -1,12 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`DetailedMessagesDisplay > renders info messages with info-level color 1`] = `
+"
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ Debug Console (F12 to close | F4 to search)                                  │
+│                                                                              │
+│ 1:All(1)*  2:Log(0)  3:Info(1)  4:Warn(0)  5:Error(0)  6:Debug(0)            │
+│ ℹ  Info message                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
 exports[`DetailedMessagesDisplay > renders message counts 1`] = `
 "
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│ Debug Console (F12 to close)                                                 │
+│ Debug Console (F12 to close | F4 to search)                                  │
 │                                                                              │
+│ 1:All(1)*  2:Log(1)  3:Info(0)  4:Warn(0)  5:Error(0)  6:Debug(0)            │
 │ ℹ  Repeated message (x5)                                                     │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -18,13 +43,13 @@ exports[`DetailedMessagesDisplay > renders message counts 1`] = `
 exports[`DetailedMessagesDisplay > renders messages correctly 1`] = `
 "
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│ Debug Console (F12 to close)                                                 │
+│ Debug Console (F12 to close | F4 to search)                                  │
 │                                                                              │
+│ 1:All(4)*  2:Log(1)  3:Info(1)  4:Warn(1)  5:Error(1)  6:Debug(0)            │
 │ ℹ  Log message                                                               │
+│ ℹ  Info message                                                              │
 │ ⚠  Warning message                                                           │
 │ ✖  Error message                                                             │
-│                                                                              │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/packages/cli/src/ui/components/__snapshots__/DetailedMessagesDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/DetailedMessagesDisplay.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`DetailedMessagesDisplay > renders info messages with info-level color 1
 ╭──────────────────────────────────────────────────────────────────────────────╮
 │ Debug Console (F12 to close | F4 to search)                                  │
 │                                                                              │
-│ 1:All(1)*  2:Log(0)  3:Info(1)  4:Warn(0)  5:Error(0)  6:Debug(0)            │
+│ All(1)*  Log(0)  Info(1)  Warn(0)  Error(0)  Debug(0)                        │
+│ Alt+1-6 to filter by level                                                   │
+│                                                                              │
 │ ℹ  Info message                                                              │
-│                                                                              │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -28,11 +28,11 @@ exports[`DetailedMessagesDisplay > renders info messages with info-level color 1
 exports[`DetailedMessagesDisplay > renders message counts 1`] = `
 "
 ╭──────────────────────────────────────────────────────────────────────────────╮
-│ Debug Console (F12 to close | F4 to search)                                  │
 │                                                                              │
-│ 1:All(1)*  2:Log(1)  3:Info(0)  4:Warn(0)  5:Error(0)  6:Debug(0)            │
+│ All(1)*  Log(1)  Info(0)  Warn(0)  Error(0)  Debug(0)                        │
+│                                                                              │
+│ Alt+1-6 to filter by level                                                   │
 │ ℹ  Repeated message (x5)                                                     │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -45,13 +45,13 @@ exports[`DetailedMessagesDisplay > renders messages correctly 1`] = `
 ╭──────────────────────────────────────────────────────────────────────────────╮
 │ Debug Console (F12 to close | F4 to search)                                  │
 │                                                                              │
-│ 1:All(4)*  2:Log(1)  3:Info(1)  4:Warn(1)  5:Error(1)  6:Debug(0)            │
+│ All(4)*  Log(1)  Info(1)  Warn(1)  Error(1)  Debug(0)                        │
+│ Alt+1-6 to filter by level                                                   │
+│                                                                              │
 │ ℹ  Log message                                                               │
 │ ℹ  Info message                                                              │
 │ ⚠  Warning message                                                           │
 │ ✖  Error message                                                             │
-│                                                                              │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ThemeDialog.test.tsx.snap
@@ -190,6 +190,16 @@ exports[`ThemeDialog Snapshots > should render correctly in theme selection mode
 │                                              │         cess       and positive status          │ │
 │                                              │  #FFFFA status.wa Color for warnings and        │ │
 │                                              │  F      rning     cautionary status             │ │
+│                                              │  #FFFFFF   logLevels.                           │ │
+│                                              │            log                                  │ │
+│                                              │  #87AFFF   logLevels.                           │ │
+│                                              │            info                                 │ │
+│                                              │  #FFFFAF   logLevels.                           │ │
+│                                              │            warn                                 │ │
+│                                              │  #FF87AF   logLevels.                           │ │
+│                                              │            error                                │ │
+│                                              │  #20B2AA   logLevels.                           │ │
+│                                              │            debug                                │ │
 │                                              │  #4796E4   ui.gradien                           │ │
 │                                              │  #847ACE   t                                    │ │
 │                                              │  #C3677F                                        │ │

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -21,6 +21,7 @@ export interface TextInputProps {
   onSubmit?: (value: string) => void;
   onCancel?: () => void;
   focus?: boolean;
+  priority?: boolean | number;
 }
 
 export function TextInput({
@@ -29,6 +30,7 @@ export function TextInput({
   onSubmit,
   onCancel,
   focus = true,
+  priority,
 }: TextInputProps): React.JSX.Element {
   const keyMatchers = useKeyMatchers();
   const {
@@ -58,7 +60,10 @@ export function TextInput({
     [handleInput, onCancel, onSubmit, text, buffer.pastedContent, keyMatchers],
   );
 
-  useKeypress(handleKeyPress, { isActive: focus, priority: true });
+  useKeypress(handleKeyPress, {
+    isActive: focus,
+    priority: priority ?? true,
+  });
 
   const showPlaceholder = text.length === 0 && placeholder;
 

--- a/packages/cli/src/ui/hooks/useConsoleMessages.test.tsx
+++ b/packages/cli/src/ui/hooks/useConsoleMessages.test.tsx
@@ -113,9 +113,13 @@ describe('useConsoleMessages', () => {
       vi.runAllTimers();
     });
 
-    expect(result.current.consoleMessages).toEqual([
-      { type: 'log', content: 'Test message', count: 1 },
-    ]);
+    expect(result.current.consoleMessages).toHaveLength(1);
+    expect(result.current.consoleMessages[0]).toMatchObject({
+      type: 'log',
+      content: 'Test message',
+      count: 1,
+    });
+    expect(result.current.consoleMessages[0]?.id).toEqual(expect.any(String));
   });
 
   it('should batch and count identical consecutive messages', async () => {
@@ -128,9 +132,13 @@ describe('useConsoleMessages', () => {
       vi.runAllTimers();
     });
 
-    expect(result.current.consoleMessages).toEqual([
-      { type: 'log', content: 'Test message', count: 3 },
-    ]);
+    expect(result.current.consoleMessages).toHaveLength(1);
+    expect(result.current.consoleMessages[0]).toMatchObject({
+      type: 'log',
+      content: 'Test message',
+      count: 3,
+    });
+    expect(result.current.consoleMessages[0]?.id).toEqual(expect.any(String));
   });
 
   it('should not batch different messages', async () => {
@@ -142,10 +150,19 @@ describe('useConsoleMessages', () => {
       vi.runAllTimers();
     });
 
-    expect(result.current.consoleMessages).toEqual([
-      { type: 'log', content: 'First message', count: 1 },
-      { type: 'error', content: 'Second message', count: 1 },
-    ]);
+    expect(result.current.consoleMessages).toHaveLength(2);
+    expect(result.current.consoleMessages[0]).toMatchObject({
+      type: 'log',
+      content: 'First message',
+      count: 1,
+    });
+    expect(result.current.consoleMessages[1]).toMatchObject({
+      type: 'error',
+      content: 'Second message',
+      count: 1,
+    });
+    expect(result.current.consoleMessages[0]?.id).toEqual(expect.any(String));
+    expect(result.current.consoleMessages[1]?.id).toEqual(expect.any(String));
   });
 });
 

--- a/packages/cli/src/ui/hooks/useConsoleMessages.ts
+++ b/packages/cli/src/ui/hooks/useConsoleMessages.ts
@@ -12,6 +12,10 @@ import {
   type ConsoleLogPayload,
 } from '@google/gemini-cli-core';
 
+function nextMessageId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
 export interface UseErrorCountReturn {
   errorCount: number;
   clearErrorCount: () => void;
@@ -79,7 +83,7 @@ function processQueue() {
         count: prev.count + 1,
       };
     } else {
-      newMessages.push({ ...queuedMessage, count: 1 });
+      newMessages.push({ ...queuedMessage, id: nextMessageId(), count: 1 });
     }
   }
 
@@ -132,6 +136,7 @@ const handleConsoleLog = (payload: ConsoleLogPayload) => {
   }
 
   handleNewMessage({
+    id: nextMessageId(),
     type: payload.type,
     content,
     count: 1,
@@ -154,7 +159,7 @@ const handleOutput = (payload: {
       `... [Truncated ${content.length - MAX_OUTPUT_CHUNK_LENGTH} characters]`;
   }
 
-  handleNewMessage({ type: 'log', content, count: 1 });
+  handleNewMessage({ id: nextMessageId(), type: 'log', content, count: 1 });
 };
 
 /**

--- a/packages/cli/src/ui/hooks/useConsoleMessages.ts
+++ b/packages/cli/src/ui/hooks/useConsoleMessages.ts
@@ -83,7 +83,7 @@ function processQueue() {
         count: prev.count + 1,
       };
     } else {
-      newMessages.push({ ...queuedMessage, id: nextMessageId(), count: 1 });
+      newMessages.push(structuredClone(queuedMessage));
     }
   }
 

--- a/packages/cli/src/ui/semantic-colors.ts
+++ b/packages/cli/src/ui/semantic-colors.ts
@@ -23,4 +23,7 @@ export const theme: SemanticColors = {
   get status() {
     return themeManager.getSemanticColors().status;
   },
+  get logLevels() {
+    return themeManager.getSemanticColors().logLevels;
+  },
 };

--- a/packages/cli/src/ui/themes/builtin/dark/solarized-dark.ts
+++ b/packages/cli/src/ui/themes/builtin/dark/solarized-dark.ts
@@ -61,6 +61,13 @@ const semanticColors: SemanticColors = {
     warning: '#d0b000',
     error: '#dc322f',
   },
+  logLevels: {
+    log: '#839496',
+    info: '#268bd2',
+    warn: '#d0b000',
+    error: '#dc322f',
+    debug: '#20B2AA',
+  },
 };
 
 export const SolarizedDark: Theme = new Theme(

--- a/packages/cli/src/ui/themes/builtin/light/solarized-light.ts
+++ b/packages/cli/src/ui/themes/builtin/light/solarized-light.ts
@@ -61,6 +61,13 @@ const semanticColors: SemanticColors = {
     warning: '#d0b000',
     error: '#dc322f',
   },
+  logLevels: {
+    log: '#657b83',
+    info: '#268bd2',
+    warn: '#d0b000',
+    error: '#dc322f',
+    debug: '#008B8B',
+  },
 };
 
 export const SolarizedLight: Theme = new Theme(

--- a/packages/cli/src/ui/themes/builtin/no-color.ts
+++ b/packages/cli/src/ui/themes/builtin/no-color.ts
@@ -62,6 +62,13 @@ const noColorSemanticColors: SemanticColors = {
     success: '',
     warning: '',
   },
+  logLevels: {
+    log: '',
+    info: '',
+    warn: '',
+    error: '',
+    debug: '',
+  },
 };
 
 export const NoColorTheme: Theme = new Theme(

--- a/packages/cli/src/ui/themes/semantic-tokens.ts
+++ b/packages/cli/src/ui/themes/semantic-tokens.ts
@@ -40,6 +40,13 @@ export interface SemanticColors {
     success: string;
     warning: string;
   };
+  logLevels: {
+    log: string;
+    info: string;
+    warn: string;
+    error: string;
+    debug: string;
+  };
 }
 
 export const lightSemanticColors: SemanticColors = {
@@ -76,6 +83,13 @@ export const lightSemanticColors: SemanticColors = {
     success: lightTheme.AccentGreen,
     warning: lightTheme.AccentYellow,
   },
+  logLevels: {
+    log: lightTheme.Foreground,
+    info: lightTheme.AccentBlue,
+    warn: lightTheme.AccentYellow,
+    error: lightTheme.AccentRed,
+    debug: '#008B8B',
+  },
 };
 
 export const darkSemanticColors: SemanticColors = {
@@ -111,5 +125,12 @@ export const darkSemanticColors: SemanticColors = {
     error: darkTheme.AccentRed,
     success: darkTheme.AccentGreen,
     warning: darkTheme.AccentYellow,
+  },
+  logLevels: {
+    log: darkTheme.Foreground,
+    info: darkTheme.AccentBlue,
+    warn: darkTheme.AccentYellow,
+    error: darkTheme.AccentRed,
+    debug: '#20B2AA',
   },
 };

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -427,6 +427,13 @@ class ThemeManager {
           dark: colors.DarkGray,
           focus: colors.FocusColor ?? colors.AccentGreen,
         },
+        logLevels: {
+          log: colors.Foreground,
+          info: colors.AccentBlue,
+          warn: colors.AccentYellow,
+          error: colors.AccentRed,
+          debug: semanticColors.logLevels.debug,
+        },
       };
     } else {
       this.cachedSemanticColors = semanticColors;

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -325,6 +325,13 @@ export class Theme {
         success: this.colors.AccentGreen,
         warning: this.colors.AccentYellow,
       },
+      logLevels: {
+        log: this.colors.Foreground,
+        info: this.colors.AccentBlue,
+        warn: this.colors.AccentYellow,
+        error: this.colors.AccentRed,
+        debug: this.colors.AccentPurple,
+      },
     };
     this._colorMap = Object.freeze(this._buildColorMap(rawMappings)); // Build and freeze the map
 
@@ -609,6 +616,13 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
       error: customTheme.status?.error ?? colors.AccentRed,
       success: customTheme.status?.success ?? colors.AccentGreen,
       warning: customTheme.status?.warning ?? colors.AccentYellow,
+    },
+    logLevels: {
+      log: customTheme.logLevels?.log ?? colors.Foreground,
+      info: customTheme.logLevels?.info ?? colors.AccentBlue,
+      warn: customTheme.logLevels?.warn ?? colors.AccentYellow,
+      error: customTheme.logLevels?.error ?? colors.AccentRed,
+      debug: customTheme.logLevels?.debug ?? colors.AccentPurple,
     },
   };
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -486,6 +486,7 @@ export type Message =
     };
 
 export interface ConsoleMessageItem {
+  id: string;
   type: 'log' | 'warn' | 'error' | 'debug' | 'info';
   content: string;
   count: number;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -318,6 +318,13 @@ export interface CustomTheme {
     success?: string;
     warning?: string;
   };
+  logLevels?: {
+    log?: string;
+    info?: string;
+    warn?: string;
+    error?: string;
+    debug?: string;
+  };
 
   // Legacy properties (all optional)
   Background?: string;

--- a/packages/devtools/client/src/App.test.ts
+++ b/packages/devtools/client/src/App.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterConsoleLogs,
+  getConsoleLevelCounts,
+  normalizeConsoleSearchText,
+} from './App.js';
+
+describe('devtools console filtering helpers', () => {
+  const logs = [
+    { type: 'log' as const, content: 'startup complete' },
+    { type: 'info' as const, content: 'session registered' },
+    { type: 'warn' as const, content: 'retry scheduled' },
+    { type: 'error' as const, content: 'request failed' },
+    { type: 'debug' as const, content: 'socket connected' },
+    { type: 'debug' as const, content: 'network logging enabled' },
+  ];
+
+  it('computes per-level counts for the toolbar', () => {
+    expect(getConsoleLevelCounts(logs as never[])).toEqual({
+      all: 6,
+      log: 1,
+      info: 1,
+      warn: 1,
+      error: 1,
+      debug: 2,
+    });
+  });
+
+  it('filters by level only when a specific level is active', () => {
+    expect(filterConsoleLogs(logs as never[], 'debug', '')).toEqual([
+      { type: 'debug', content: 'socket connected' },
+      { type: 'debug', content: 'network logging enabled' },
+    ]);
+  });
+
+  it('filters by search text case-insensitively', () => {
+    expect(filterConsoleLogs(logs as never[], 'all', 'SESSION')).toEqual([
+      { type: 'info', content: 'session registered' },
+    ]);
+  });
+
+  it('combines level and search filters', () => {
+    expect(filterConsoleLogs(logs as never[], 'debug', 'network')).toEqual([
+      { type: 'debug', content: 'network logging enabled' },
+    ]);
+  });
+
+  it('returns an empty list when no logs match the active filters', () => {
+    expect(filterConsoleLogs(logs as never[], 'error', 'socket')).toEqual([]);
+  });
+
+  it('normalizes search text by trimming surrounding whitespace', () => {
+    expect(normalizeConsoleSearchText('  SESSION  ')).toBe('session');
+    expect(filterConsoleLogs(logs as never[], 'all', '  SESSION  ')).toEqual([
+      { type: 'info', content: 'session registered' },
+    ]);
+  });
+});

--- a/packages/devtools/client/src/App.tsx
+++ b/packages/devtools/client/src/App.tsx
@@ -9,6 +9,67 @@ import { useDevToolsData, type ConsoleLog, type NetworkLog } from './hooks';
 
 type ThemeMode = 'light' | 'dark' | null; // null means follow system
 
+export type ConsoleLevelFilter =
+  | 'all'
+  | 'log'
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'debug';
+
+const CONSOLE_LEVEL_BUTTONS: ReadonlyArray<{
+  key: ConsoleLevelFilter;
+  label: string;
+  activeColor: string;
+}> = [
+  { key: 'all', label: 'All', activeColor: 'var(--console-level-all-color)' },
+  { key: 'log', label: 'Log', activeColor: '#8ab4f8' },
+  { key: 'info', label: 'Info', activeColor: '#81c995' },
+  { key: 'warn', label: 'Warn', activeColor: '#fdd663' },
+  { key: 'error', label: 'Error', activeColor: '#f28b82' },
+  { key: 'debug', label: 'Debug', activeColor: '#c792ea' },
+];
+
+export function normalizeConsoleSearchText(searchText: string): string {
+  return searchText.trim().toLowerCase();
+}
+
+export function filterConsoleLogs(
+  logs: ConsoleLog[],
+  levelFilter: ConsoleLevelFilter,
+  searchText: string,
+): ConsoleLog[] {
+  const normalizedSearchText = normalizeConsoleSearchText(searchText);
+
+  return logs.filter((log) => {
+    if (levelFilter !== 'all' && log.type !== levelFilter) {
+      return false;
+    }
+
+    if (normalizedSearchText) {
+      const content = (log.content || '').toLowerCase();
+      if (!content.includes(normalizedSearchText)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function getConsoleLevelCounts(
+  logs: ConsoleLog[],
+): Record<ConsoleLevelFilter, number> {
+  return {
+    all: logs.length,
+    log: logs.filter((l) => l.type === 'log').length,
+    info: logs.filter((l) => l.type === 'info').length,
+    warn: logs.filter((l) => l.type === 'warn').length,
+    error: logs.filter((l) => l.type === 'error').length,
+    debug: logs.filter((l) => l.type === 'debug').length,
+  };
+}
+
 interface ThemeColors {
   bg: string;
   bgSecondary: string;
@@ -777,23 +838,28 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
 
 function ConsoleView({ logs, t }: { logs: ConsoleLog[]; t: ThemeColors }) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const [levelFilter, setLevelFilter] = useState<ConsoleLevelFilter>('all');
+  const [searchText, setSearchText] = useState('');
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [logs.length]);
+
+  const filteredLogs = useMemo(
+    () => filterConsoleLogs(logs, levelFilter, searchText),
+    [logs, levelFilter, searchText],
+  );
+
+  const levelCounts = useMemo(() => getConsoleLevelCounts(logs), [logs]);
 
   if (logs.length === 0) {
     return (
       <div
         style={{
           padding: '20px',
-
           color: t.textSecondary,
-
           fontSize: '11px',
-
           textAlign: 'center',
-
           flex: 1,
         }}
       >
@@ -805,23 +871,134 @@ function ConsoleView({ logs, t }: { logs: ConsoleLog[]; t: ThemeColors }) {
   return (
     <div
       style={{
+        display: 'flex',
+        flexDirection: 'column',
         flex: 1,
-
-        overflowY: 'auto',
-
-        fontFamily:
-          'SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace',
-
-        background: t.consoleBg,
-
-        fontSize: '12px',
+        height: '100%',
       }}
     >
-      {logs.map((log) => (
-        <ConsoleLogEntry key={log.id} log={log} t={t} />
-      ))}
+      <div
+        style={{
+          padding: '8px 12px',
+          background: t.bgSecondary,
+          borderBottom: `1px solid ${t.border}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div style={{ display: 'flex', gap: '4px' }}>
+          {CONSOLE_LEVEL_BUTTONS.map(({ key, label, activeColor }) => {
+            const isActive = levelFilter === key;
+            const buttonColor = key === 'all' ? t.textSecondary : activeColor;
 
-      <div ref={bottomRef} />
+            return (
+              <button
+                key={key}
+                onClick={() => setLevelFilter(key)}
+                style={{
+                  padding: '4px 10px',
+                  fontSize: '11px',
+                  border: 'none',
+                  borderRadius: '3px',
+                  cursor: 'pointer',
+                  background: isActive ? buttonColor : t.bg,
+                  color: isActive ? '#000' : t.text,
+                  opacity: isActive ? 1 : 0.7,
+                  transition: 'all 0.15s',
+                  fontWeight: isActive ? '600' : '400',
+                }}
+                title={`${label} (${levelCounts[key]})`}
+              >
+                {label} ({levelCounts[key]})
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{ width: '1px', height: '20px', background: t.border }} />
+
+        <input
+          type="text"
+          placeholder="Filter logs..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          style={{
+            flex: 1,
+            minWidth: '150px',
+            maxWidth: '300px',
+            padding: '4px 10px',
+            background: t.bg,
+            color: t.text,
+            border: `1px solid ${t.border}`,
+            borderRadius: '4px',
+            fontSize: '12px',
+            outline: 'none',
+          }}
+        />
+
+        {(levelFilter !== 'all' || searchText) && (
+          <button
+            onClick={() => {
+              setLevelFilter('all');
+              setSearchText('');
+            }}
+            style={{
+              padding: '4px 10px',
+              fontSize: '11px',
+              border: `1px solid ${t.border}`,
+              borderRadius: '3px',
+              cursor: 'pointer',
+              background: t.bg,
+              color: t.textSecondary,
+            }}
+            title="Clear filters"
+          >
+            ✕ Clear
+          </button>
+        )}
+
+        <span
+          style={{
+            fontSize: '11px',
+            color: t.textSecondary,
+            marginLeft: 'auto',
+          }}
+        >
+          Showing {filteredLogs.length} of {logs.length}
+        </span>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          fontFamily:
+            'SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace',
+          background: t.consoleBg,
+          fontSize: '12px',
+        }}
+      >
+        {filteredLogs.length === 0 ? (
+          <div
+            style={{
+              padding: '40px 20px',
+              color: t.textSecondary,
+              fontSize: '12px',
+              textAlign: 'center',
+            }}
+          >
+            No logs match the current filter
+          </div>
+        ) : (
+          filteredLogs.map((log) => (
+            <ConsoleLogEntry key={log.id} log={log} t={t} />
+          ))
+        )}
+
+        <div ref={bottomRef} />
+      </div>
     </div>
   );
 }

--- a/packages/devtools/client/src/App.tsx
+++ b/packages/devtools/client/src/App.tsx
@@ -60,14 +60,28 @@ export function filterConsoleLogs(
 export function getConsoleLevelCounts(
   logs: ConsoleLog[],
 ): Record<ConsoleLevelFilter, number> {
-  return {
+  const counts: Record<ConsoleLevelFilter, number> = {
     all: logs.length,
-    log: logs.filter((l) => l.type === 'log').length,
-    info: logs.filter((l) => l.type === 'info').length,
-    warn: logs.filter((l) => l.type === 'warn').length,
-    error: logs.filter((l) => l.type === 'error').length,
-    debug: logs.filter((l) => l.type === 'debug').length,
+    log: 0,
+    info: 0,
+    warn: 0,
+    error: 0,
+    debug: 0,
   };
+
+  for (const log of logs) {
+    switch (log.type) {
+      case 'log':
+      case 'info':
+      case 'warn':
+      case 'error':
+      case 'debug':
+        counts[log.type] += 1;
+        break;
+    }
+  }
+
+  return counts;
 }
 
 interface ThemeColors {


### PR DESCRIPTION
## Summary

Add search and level-based filtering to the debug console so users can narrow console output faster when troubleshooting. This improves both the CLI debug console experience and the devtools client by making high-volume logs easier to inspect.

[录屏 2026-04-13 16-58-32.webm](https://github.com/user-attachments/assets/4090c612-d590-4028-9bae-da1efae9cbcc)

[录屏 2026-04-13 16-05-36.webm](https://github.com/user-attachments/assets/e3130bd1-2f79-446a-a729-9bc0fd96ca13)

## Details

- Adds console log filtering by level (`All`, `Log`, `Info`, `Warn`, `Error`, `Debug`) and free-text search in the devtools client.
- Introduces reusable filtering helpers and test coverage for count calculation, level filtering, text filtering, combined filters, and empty-result behavior.
- Extends console message data with stable `id` support to improve list rendering and filtering behavior.
- Adds theme support for per-log-level colors across CLI themes, semantic tokens, and custom theme configuration.
- Prevents IDE context detail from being triggered while the debug console is open, avoiding shortcut conflicts during debugging.
- Updates CLI UI tests and snapshots to cover the new debug console behavior and theme changes.

## Related Issues

N/A

## How to Validate

1. Run the relevant test suites:
   - `npm test -- packages/devtools/client/src/App.test.ts`
   - `npm test -- packages/cli/src/ui/components/DetailedMessagesDisplay.test.tsx`
   - `npm test -- packages/cli/src/ui/hooks/useConsoleMessages.test.tsx`
2. Start the devtools client and open the console view.
3. Verify level filter buttons show counts for each log type and correctly filter displayed logs.
4. Enter search text and confirm matching is case-insensitive and trims surrounding whitespace.
5. Combine a level filter with search text and confirm only matching logs remain.
6. Clear filters and confirm the full log list returns.
7. In CLI debug console flow, verify F12 opens error/debug details and F4 does not trigger IDE context detail while the debug console is open.
8. Optionally switch themes or use a custom theme and confirm log levels render with distinct colors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker