### PR TITLE
fix(cli): add paste submit guard to TextInput for Windows terminals

### DIFF
--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -428,7 +428,7 @@ describe('TextInput', () => {
         sequence: 'line1\nline2\nline3\nline4\nline5\nline6',
       });
     });
-    // Enter arrives in the same tick (before the 40ms guard clears)
+    // Enter arrives in the same tick (within the 40ms guard window)
     await act(async () => {
       keypressHandler({
         name: 'enter',

--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -408,4 +408,96 @@ describe('TextInput', () => {
     expect(lastFrame()).toContain('line2');
     unmount();
   });
+
+  it('treats Enter as newline when it immediately follows a paste event', async () => {
+    vi.useFakeTimers();
+    const { waitUntilReady, unmount } = await render(
+      <TextInput buffer={mockBuffer} onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+    const keypressHandler = mockedUseKeypress.mock.calls[0][0];
+
+    // Simulate a paste event followed immediately by Enter (same tick)
+    await act(async () => {
+      keypressHandler({
+        name: 'paste',
+        shift: false,
+        alt: false,
+        ctrl: false,
+        cmd: false,
+        insertable: true,
+        sequence: 'line1\nline2\nline3\nline4\nline5\nline6',
+      });
+    });
+    // Enter arrives in the same tick (before the 40ms guard clears)
+    await act(async () => {
+      keypressHandler({
+        name: 'enter',
+        shift: false,
+        alt: false,
+        ctrl: false,
+        cmd: false,
+        sequence: '',
+      });
+    });
+    await waitUntilReady();
+
+    // onSubmit should NOT have been called — Enter was converted to newline
+    expect(onSubmit).not.toHaveBeenCalled();
+    // handleInput should have been called with a shift+enter (newline)
+    expect(mockBuffer.handleInput).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'enter', shift: true }),
+    );
+
+    vi.useRealTimers();
+    unmount();
+  });
+
+  it('allows normal submit after paste guard timeout expires', async () => {
+    vi.useFakeTimers();
+    const placeholder = '[Pasted Text: 6 lines]';
+    const realContent = 'line1\nline2\nline3\nline4\nline5\nline6';
+    mockBuffer.setText(placeholder);
+    mockBuffer.pastedContent = { [placeholder]: realContent };
+
+    const { waitUntilReady, unmount } = await render(
+      <TextInput buffer={mockBuffer} onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+    const keypressHandler = mockedUseKeypress.mock.calls[0][0];
+
+    // Simulate paste event
+    await act(async () => {
+      keypressHandler({
+        name: 'paste',
+        shift: false,
+        alt: false,
+        ctrl: false,
+        cmd: false,
+        insertable: true,
+        sequence: realContent,
+      });
+    });
+
+    // Advance past the 40ms guard window
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+
+    // Now Enter should trigger a normal submit with expanded content
+    await act(async () => {
+      keypressHandler({
+        name: 'enter',
+        shift: false,
+        alt: false,
+        ctrl: false,
+        cmd: false,
+        sequence: '',
+      });
+    });
+    await waitUntilReady();
+
+    expect(onSubmit).toHaveBeenCalledWith(realContent);
+
+    vi.useRealTimers();
+    unmount();
+  });
 });

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -50,10 +50,9 @@ export function TextInput({
   const [cursorVisualRowAbsolute, cursorVisualColAbsolute] = visualCursor;
 
   // Track recent paste events to prevent accidental auto-submission.
-  // Uses refs (not state) so the value is always current inside the
+  // Uses a ref (not state) so the value is always current inside the
   // keypress callback regardless of React's render cycle.
   const recentPasteTimeRef = useRef<number | null>(null);
-  const pasteGuardTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleKeyPress = useCallback(
     (key: Key) => {
@@ -63,7 +62,10 @@ export function TextInput({
       }
 
       if (keyMatchers[Command.SUBMIT](key) && onSubmit) {
-        if (recentPasteTimeRef.current !== null) {
+        if (
+          recentPasteTimeRef.current !== null &&
+          Date.now() - recentPasteTimeRef.current < PASTE_SUBMIT_GUARD_MS
+        ) {
           // A paste just occurred — treat this Enter as a newline to avoid
           // submitting stale content from the pre-paste render closure.
           handleInput({
@@ -74,6 +76,7 @@ export function TextInput({
           });
           return true;
         }
+        recentPasteTimeRef.current = null;
         onSubmit(expandPastePlaceholders(text, buffer.pastedContent));
         return true;
       }
@@ -81,13 +84,6 @@ export function TextInput({
       // Record paste events so the SUBMIT guard above can detect them.
       if (key.name === 'paste') {
         recentPasteTimeRef.current = Date.now();
-        if (pasteGuardTimerRef.current) {
-          clearTimeout(pasteGuardTimerRef.current);
-        }
-        pasteGuardTimerRef.current = setTimeout(() => {
-          recentPasteTimeRef.current = null;
-          pasteGuardTimerRef.current = null;
-        }, PASTE_SUBMIT_GUARD_MS);
       }
 
       const handled = handleInput(key);

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { Text, Box } from 'ink';
 import { useKeypress, type Key } from '../../hooks/useKeypress.js';
 import chalk from 'chalk';
@@ -22,6 +22,15 @@ export interface TextInputProps {
   onCancel?: () => void;
   focus?: boolean;
 }
+
+/**
+ * Guard window (ms) after a paste event during which Enter is treated as a
+ * newline rather than a submit.  This mirrors the protection in InputPrompt
+ * and prevents accidental auto-submission on terminals that deliver a trailing
+ * Return in the same data chunk as the bracketed-paste end sequence.  40 ms is
+ * well below human reaction time yet long enough to cover same-tick delivery.
+ */
+const PASTE_SUBMIT_GUARD_MS = 40;
 
 export function TextInput({
   buffer,
@@ -40,6 +49,12 @@ export function TextInput({
   } = buffer;
   const [cursorVisualRowAbsolute, cursorVisualColAbsolute] = visualCursor;
 
+  // Track recent paste events to prevent accidental auto-submission.
+  // Uses refs (not state) so the value is always current inside the
+  // keypress callback regardless of React's render cycle.
+  const recentPasteTimeRef = useRef<number | null>(null);
+  const pasteGuardTimerRef = useRef<NodeJS.Timeout | null>(null);
+
   const handleKeyPress = useCallback(
     (key: Key) => {
       if (key.name === 'escape' && onCancel) {
@@ -48,8 +63,31 @@ export function TextInput({
       }
 
       if (keyMatchers[Command.SUBMIT](key) && onSubmit) {
+        if (recentPasteTimeRef.current !== null) {
+          // A paste just occurred — treat this Enter as a newline to avoid
+          // submitting stale content from the pre-paste render closure.
+          handleInput({
+            ...key,
+            name: 'enter',
+            shift: true,
+            sequence: '\r',
+          });
+          return true;
+        }
         onSubmit(expandPastePlaceholders(text, buffer.pastedContent));
         return true;
+      }
+
+      // Record paste events so the SUBMIT guard above can detect them.
+      if (key.name === 'paste') {
+        recentPasteTimeRef.current = Date.now();
+        if (pasteGuardTimerRef.current) {
+          clearTimeout(pasteGuardTimerRef.current);
+        }
+        pasteGuardTimerRef.current = setTimeout(() => {
+          recentPasteTimeRef.current = null;
+          pasteGuardTimerRef.current = null;
+        }, PASTE_SUBMIT_GUARD_MS);
       }
 
       const handled = handleInput(key);


### PR DESCRIPTION
## Summary

`TextInput` is missing the paste-submit guard that `InputPrompt` already has (added in PR #9284). On Windows terminals where `isTerminalPasteTrusted()` returns `false`, Enter can arrive before React finishes the post-paste re-render, causing `onSubmit` to receive stale closure values (empty string) instead of the pasted content. This adds a 40 ms `useRef`-based guard that converts Enter to a newline immediately after a paste event.

PR #19946 fixed the `[Pasted Text: X lines]` placeholder submission by adding `expandPastePlaceholders` to `TextInput`, but that only covers the case where React has already re-rendered before Enter arrives. This PR covers the remaining race.

## Details

**Why `useRef` instead of `useState`:** `InputPrompt` uses `useState` for its `recentUnsafePasteTime`, which has the same stale-closure limitation — if Enter arrives before React re-renders, the old closure still sees `null`. `InputPrompt` gets away with it because `bufferFastReturn` (30 ms in `KeypressContext`) catches most same-chunk Enter events first. `useRef` eliminates the render-cycle dependency entirely — the value written during the paste event is immediately visible to the Enter handler regardless of render state.

**What changed:**
- `TextInput.tsx`: Two refs (`recentPasteTimeRef`, `pasteGuardTimerRef`), paste detection stamps the ref, SUBMIT check converts Enter to shift+Enter when ref is active, 40 ms timeout clears it.
- `TextInput.test.tsx`: Two new tests — guard blocks Enter within 40 ms of paste; normal submit works after guard expires.

No changes to `text-buffer.ts`, `KeypressContext.tsx`, or any shared infrastructure. `TextInput`'s props and behavioural contract are unchanged.

## Related Issues

Fixes #21406

## How to Validate

1. `npm run build && npm start`
2. Trigger an AskUser dialog (e.g., request Gemini to edit a file, choose "suggest changes")
3. On a Windows terminal, paste 5+ lines into the TextInput — Enter arriving immediately after paste should insert a newline, not submit
4. Wait a moment, then press Enter — should submit with the real pasted content

Unit tests:
```
cd packages/cli
npx vitest run src/ui/components/shared/TextInput.test.tsx    # 15/15 passing (13 existing + 2 new)
npx vitest run src/ui/auth/ApiAuthDialog.test.tsx              # 6/6 passing
```
TypeScript, ESLint, and Prettier clean on modified files.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
