### PR TITLE
fix(core): don't invoke fallback dialog for non-quota 500 errors

### DIFF
--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -686,15 +686,41 @@ describe('retryWithBackoff', () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should trigger fallback for OAuth personal users on persistent 500 errors', async () => {
+  it('should throw after max attempts on persistent 500 without calling onPersistent429', async () => {
+    const fallbackCallback = vi.fn().mockResolvedValue('gemini-2.5-flash');
+
+    const mockFn = vi.fn().mockImplementation(async () => {
+      const error: HttpError = new Error('Internal Server Error');
+      error.status = 500;
+      throw error;
+    });
+
+    const promise = retryWithBackoff(mockFn, {
+      maxAttempts: 3,
+      initialDelayMs: 100,
+      onPersistent429: fallbackCallback,
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+    });
+
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toThrow('Internal Server Error');
+    // Fallback should NOT be called for generic 500 errors
+    expect(fallbackCallback).not.toHaveBeenCalled();
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('should still call onPersistent429 for RetryableQuotaError after max attempts', async () => {
     const fallbackCallback = vi.fn().mockResolvedValue('gemini-2.5-flash');
 
     let fallbackOccurred = false;
     const mockFn = vi.fn().mockImplementation(async () => {
       if (!fallbackOccurred) {
-        const error: HttpError = new Error('Internal Server Error');
-        error.status = 500;
-        throw error;
+        throw new RetryableQuotaError('Resource exhausted', {
+          code: 503,
+          message: 'Resource exhausted',
+          details: [],
+        });
       }
       return 'success';
     });
@@ -714,10 +740,8 @@ describe('retryWithBackoff', () => {
     await expect(promise).resolves.toBe('success');
     expect(fallbackCallback).toHaveBeenCalledWith(
       AuthType.LOGIN_WITH_GOOGLE,
-      expect.objectContaining({ status: 500 }),
+      expect.any(RetryableQuotaError),
     );
-    // 3 attempts (initial + 2 retries) fail with 500, then fallback triggers, then 1 success
-    expect(mockFn).toHaveBeenCalledTimes(4);
   });
 
   it('should trigger fallback for OAuth personal users on ModelNotFoundError', async () => {

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -742,6 +742,8 @@ describe('retryWithBackoff', () => {
       AuthType.LOGIN_WITH_GOOGLE,
       expect.any(RetryableQuotaError),
     );
+    // 3 attempts (initial + 2 retries) fail, then fallback triggers, then 1 success
+    expect(mockFn).toHaveBeenCalledTimes(4);
   });
 
   it('should trigger fallback for OAuth personal users on ModelNotFoundError', async () => {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -331,7 +331,10 @@ export async function retryWithBackoff<T>(
           debugLogger.warn(
             `Attempt ${attempt} failed${errorMessage ? `: ${errorMessage}` : ''}. Max attempts reached`,
           );
-          if (onPersistent429) {
+          if (
+            onPersistent429 &&
+            classifiedError instanceof RetryableQuotaError
+          ) {
             try {
               const fallbackModel = await onPersistent429(
                 authType,


### PR DESCRIPTION
## Summary

When users set `GOOGLE_GEMINI_BASE_URL` to a custom proxy and the proxy returns persistent 500 errors (e.g. invalid model name), the CLI hangs forever after exhausting retries.

**Root cause:** After 10 retry attempts, `retryWithBackoff` calls `onPersistent429` for ALL 500-class errors. For non-quota 500s, this triggers a UI fallback dialog that never renders, creating a Promise that never resolves.

**Fix:** Gate the `onPersistent429` call at `retry.ts:334` so it only fires when `classifiedError instanceof RetryableQuotaError`. Generic 500 errors now throw immediately after retry exhaustion instead of hanging.

- Retry behavior unchanged (still retries 10 times with exponential backoff for all 500s)
- Quota error fallback path unchanged (RetryableQuotaError still triggers the dialog)
- One condition added to one `if` statement

## Test Coverage

- Updated existing test: generic 500 errors now throw after max attempts without calling fallback
- Added regression test: `RetryableQuotaError` still correctly triggers `onPersistent429` after max attempts
- All 39 tests pass

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Test plan
- [x] All vitest tests pass (39 tests, 0 failures)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] Pre-commit hooks pass (prettier + eslint)

Fixes #25081