### PR TITLE
fix(core): handle floating promises in message bus and schedule

### DIFF
--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -238,9 +238,11 @@ export class MessageBus extends EventEmitter {
       // Subscribe to responses
       this.subscribe<TResponse>(responseType, responseHandler);
 
-      // Publish the request with correlation ID
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-type-assertion
-      this.publish({ ...request, correlationId } as TRequest);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      this.publish({ ...request, correlationId } as TRequest).catch((err) => {
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
     });
   }
 }

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -335,8 +335,7 @@ async function waitForConfirmation(
       )
       .catch((error) => {
         debugLogger.warn('Error waiting for confirmation via IDE', error);
-        // Return a never-resolving promise so the race continues with the bus
-        return new Promise<ConfirmationResult>(() => {});
+        throw error;
       });
 
     return await Promise.race([busPromise, idePromise]);

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -163,15 +163,19 @@ export class Scheduler {
     });
   };
 
-  private readonly handleToolConfirmationRequest = async (
+  private readonly handleToolConfirmationRequest = (
     request: ToolConfirmationRequest,
   ) => {
-    await this.messageBus.publish({
-      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-      correlationId: request.correlationId,
-      confirmed: false,
-      requiresUserConfirmation: true,
-    });
+    this.messageBus
+      .publish({
+        type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        correlationId: request.correlationId,
+        confirmed: false,
+        requiresUserConfirmation: true,
+      })
+      .catch(() => {
+        // Error updating confirmation response, swallowed intentionally
+      });
   };
 
   private setupMessageBusListener(messageBus: MessageBus): void {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -362,7 +362,10 @@ export abstract class BaseToolInvocation<
       };
 
       try {
-        void this.messageBus.publish(request);
+        this.messageBus.publish(request).catch(() => {
+          cleanup();
+          resolve('allow');
+        });
       } catch {
         cleanup();
         resolve('allow');


### PR DESCRIPTION
## Summary

Audit of ESLint suppressions that masked bugs, specifically addressing the items from Issue #16220. This PR adds explicit error handling to floating promises in the `MessageBus`, `ToolInvocation`, and `Scheduler` to prevent unnecessary 30s timeouts and improve system responsiveness when asynchronous message publishing fails.

## Details

- **`message-bus.ts`**: Replaced a floating `publish()` call in the `request()` method with a promise chain that includes a `.catch()` block. This ensures that failures in publishing result in an immediate rejection instead of hanging for a 30-second timeout.
- **`tools.ts`**: Wrapped the `publish()` call in `getMessageBusDecision` with both a synchronous `try-catch` and an asynchronous `.catch()`. This allows the tool to gracefully resolve with a default decision (`'allow'`) if the message bus fails, avoiding potential system hangs.
- **`scheduler.ts`**: Refactored `handleToolConfirmationRequest` from an `async` function to a regular function with an explicit `.catch()` on the `publish()` call. This prevents unhandled promise rejections within the event listener cycle.
- **`confirmation.ts`**: Updated the IDE confirmation catch block to `throw error` instead of returning a never-resolving promise. This allows the `Promise.race` in the confirmation logic to terminate immediately upon failure.

## Related Issues

Fixes #16220

## How to Validate

1. Run the targeted unit tests for the affected components to ensure core logic and integration remain intact:
   ```bash
   npm test -w @google/gemini-cli-core -- src/tools/message-bus-integration.test.ts src/confirmation-bus/message-bus.test.ts src/scheduler/scheduler.test.ts src/scheduler/confirmation.test.ts

2. Verify that all 72 tests pass.
3. Run npm run lint and npm run typecheck to ensure no regressions in code quality or types.