### PR TITLE
fix(telemetry): remove duplicate VERTEX_API_ENABLED entries

### DIFF
--- a/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
+++ b/packages/core/src/telemetry/clearcut-logger/clearcut-logger.ts
@@ -646,18 +646,8 @@ export class ClearcutLogger {
         value: event.debug_enabled.toString(),
       },
       {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
-      },
-      {
         gemini_cli_key: EventMetadataKey.GEMINI_CLI_START_SESSION_MCP_SERVERS,
         value: event.mcp_servers,
-      },
-      {
-        gemini_cli_key:
-          EventMetadataKey.GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED,
-        value: event.vertex_ai_enabled.toString(),
       },
       {
         gemini_cli_key:


### PR DESCRIPTION
Resolves #22311. `logStartSessionEvent` was pushing `GEMINI_CLI_START_SESSION_VERTEX_API_ENABLED` 3 times into the telemetry data array. Refactored to keep only 1 instance.