### PR TITLE
fix(models): route `auto-gemini-3` continuous prompts to PRO

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -484,7 +484,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         },
         {
           condition: {
-            requestedModels: ['auto-gemini-3', 'gemini-3-pro-preview'],
+            requestedModels: ['gemini-3-pro-preview'],
           },
           target: 'gemini-3-flash-preview',
         },


### PR DESCRIPTION
Resolves #18576. Previously, if `auto-gemini-3` was selected, the routing classified it downwards into the `gemini-3-flash-preview` bucket on subsequent contextual steps. Removing it from the flash classifier resolutions keeps it anchored to the intended PRO models for deeper research.