### PR TITLE
fix(core): replace custom binary detection with isbinaryfile to correctly handle UTF-8 (U+FFFD)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10839,6 +10839,18 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -18187,6 +18199,7 @@
         "https-proxy-agent": "^7.0.6",
         "ignore": "^7.0.0",
         "ipaddr.js": "^1.9.1",
+        "isbinaryfile": "^5.0.7",
         "js-yaml": "^4.1.1",
         "json-stable-stringify": "^1.3.0",
         "marked": "^15.0.12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,7 @@
     "https-proxy-agent": "^7.0.6",
     "ignore": "^7.0.0",
     "ipaddr.js": "^1.9.1",
+    "isbinaryfile": "^5.0.7",
     "js-yaml": "^4.1.1",
     "json-stable-stringify": "^1.3.0",
     "marked": "^15.0.12",

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -286,6 +286,35 @@ describe('fileUtils', () => {
       }
       expect(await isBinaryFile(filePathForBinaryTest)).toBe(false);
     });
+
+    it('should return false for a source file containing literal U+FFFD (replacement character)', async () => {
+      // U+FFFD is a valid Unicode codepoint that legitimately appears in source
+      // files (for example Rust code declaring a UNICODE_REPLACEMENT_CHAR
+      // constant). Its UTF-8 encoding is EF BF BD; the binary detector must
+      // not treat these bytes as evidence of a binary file. Regression guard
+      // for issue #24547.
+      const content =
+        '// Rust-style source\npub const UNICODE_REPLACEMENT_CHAR: char = \'\uFFFD\';\nlet s = "\uFFFD\uFFFD\uFFFD";\n';
+      actualNodeFs.writeFileSync(filePathForBinaryTest, content, 'utf8');
+      expect(await isBinaryFile(filePathForBinaryTest)).toBe(false);
+    });
+
+    it('should return false for a file with mixed CJK, emoji, and U+FFFD content', async () => {
+      // Valid UTF-8 multibyte sequences (2/3/4-byte) must not trip the binary
+      // heuristic. This exercises 3-byte (CJK, U+FFFD) and 4-byte (emoji via
+      // surrogate pair) sequences together.
+      const content = '\uFFFD\uFFFD hello \u4e16\u754c \uD83D\uDE00\n';
+      actualNodeFs.writeFileSync(filePathForBinaryTest, content, 'utf8');
+      expect(await isBinaryFile(filePathForBinaryTest)).toBe(false);
+    });
+
+    it('should return true for a file with dense invalid UTF-8 byte sequences', async () => {
+      // Raw high bytes that do not form valid UTF-8 continuation sequences
+      // should still be detected as binary.
+      const binaryContent = Buffer.alloc(128, 0x80);
+      actualNodeFs.writeFileSync(filePathForBinaryTest, binaryContent);
+      expect(await isBinaryFile(filePathForBinaryTest)).toBe(true);
+    });
   });
 
   describe('BOM detection and encoding', () => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -288,11 +288,6 @@ describe('fileUtils', () => {
     });
 
     it('should return false for a source file containing literal U+FFFD (replacement character)', async () => {
-      // U+FFFD is a valid Unicode codepoint that legitimately appears in source
-      // files (for example Rust code declaring a UNICODE_REPLACEMENT_CHAR
-      // constant). Its UTF-8 encoding is EF BF BD; the binary detector must
-      // not treat these bytes as evidence of a binary file. Regression guard
-      // for issue #24547.
       const content =
         '// Rust-style source\npub const UNICODE_REPLACEMENT_CHAR: char = \'\uFFFD\';\nlet s = "\uFFFD\uFFFD\uFFFD";\n';
       actualNodeFs.writeFileSync(filePathForBinaryTest, content, 'utf8');
@@ -300,17 +295,12 @@ describe('fileUtils', () => {
     });
 
     it('should return false for a file with mixed CJK, emoji, and U+FFFD content', async () => {
-      // Valid UTF-8 multibyte sequences (2/3/4-byte) must not trip the binary
-      // heuristic. This exercises 3-byte (CJK, U+FFFD) and 4-byte (emoji via
-      // surrogate pair) sequences together.
       const content = '\uFFFD\uFFFD hello \u4e16\u754c \uD83D\uDE00\n';
       actualNodeFs.writeFileSync(filePathForBinaryTest, content, 'utf8');
       expect(await isBinaryFile(filePathForBinaryTest)).toBe(false);
     });
 
     it('should return true for a file with dense invalid UTF-8 byte sequences', async () => {
-      // Raw high bytes that do not form valid UTF-8 continuation sequences
-      // should still be detected as binary.
       const binaryContent = Buffer.alloc(128, 0x80);
       actualNodeFs.writeFileSync(filePathForBinaryTest, binaryContent);
       expect(await isBinaryFile(filePathForBinaryTest)).toBe(true);

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -346,20 +346,7 @@ export async function isEmpty(filePath: string): Promise<boolean> {
 
 /**
  * Heuristic: determine if a file is likely binary.
- *
- * Delegates to the well-established `isbinaryfile` package, which correctly
- * handles:
- *   - Unicode BOMs (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE, GB-18030) → text
- *   - PDF / common binary magic bytes → binary
- *   - NULL bytes → binary
- *   - Valid UTF-8 multibyte sequences (including U+FFFD encoded as EF BF BD,
- *     CJK characters, emojis, etc.) → skipped from the non-printable tally
- *   - Invalid high-byte sequences → counted toward a suspicious-byte ratio
- *
- * Fixes the false-positive binary detection for source files that legitimately
- * contain the Unicode replacement character U+FFFD (see issue #24547).
- * Returns `false` on I/O errors (e.g. ENOENT, path is a directory) to preserve
- * the prior lenient behavior — callers handle non-readable files elsewhere.
+ * Delegates to the `isbinaryfile` package for UTF-8-aware detection.
  */
 export async function isBinaryFile(filePath: string): Promise<boolean> {
   try {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import type { PartUnion } from '@google/genai';
+import { isBinaryFile as isBinaryFileCheck } from 'isbinaryfile';
 import mime from 'mime/lite';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
@@ -345,53 +346,30 @@ export async function isEmpty(filePath: string): Promise<boolean> {
 
 /**
  * Heuristic: determine if a file is likely binary.
- * Now BOM-aware: if a Unicode BOM is detected, we treat it as text.
- * For non-BOM files, retain the existing null-byte and non-printable ratio checks.
+ *
+ * Delegates to the well-established `isbinaryfile` package, which correctly
+ * handles:
+ *   - Unicode BOMs (UTF-8, UTF-16 LE/BE, UTF-32 LE/BE, GB-18030) → text
+ *   - PDF / common binary magic bytes → binary
+ *   - NULL bytes → binary
+ *   - Valid UTF-8 multibyte sequences (including U+FFFD encoded as EF BF BD,
+ *     CJK characters, emojis, etc.) → skipped from the non-printable tally
+ *   - Invalid high-byte sequences → counted toward a suspicious-byte ratio
+ *
+ * Fixes the false-positive binary detection for source files that legitimately
+ * contain the Unicode replacement character U+FFFD (see issue #24547).
+ * Returns `false` on I/O errors (e.g. ENOENT, path is a directory) to preserve
+ * the prior lenient behavior — callers handle non-readable files elsewhere.
  */
 export async function isBinaryFile(filePath: string): Promise<boolean> {
-  let fh: fs.promises.FileHandle | null = null;
   try {
-    fh = await fs.promises.open(filePath, 'r');
-    const stats = await fh.stat();
-    const fileSize = stats.size;
-    if (fileSize === 0) return false; // empty is not binary
-
-    // Sample up to 4KB from the head (previous behavior)
-    const sampleSize = Math.min(4096, fileSize);
-    const buf = Buffer.alloc(sampleSize);
-    const { bytesRead } = await fh.read(buf, 0, sampleSize, 0);
-    if (bytesRead === 0) return false;
-
-    // BOM → text (avoid false positives for UTF‑16/32 with nulls)
-    const bom = detectBOM(buf.subarray(0, Math.min(4, bytesRead)));
-    if (bom) return false;
-
-    let nonPrintableCount = 0;
-    for (let i = 0; i < bytesRead; i++) {
-      if (buf[i] === 0) return true; // strong indicator of binary when no BOM
-      if (buf[i] < 9 || (buf[i] > 13 && buf[i] < 32)) {
-        nonPrintableCount++;
-      }
-    }
-    // If >30% non-printable characters, consider it binary
-    return nonPrintableCount / bytesRead > 0.3;
+    return await isBinaryFileCheck(filePath);
   } catch (error) {
     debugLogger.warn(
       `Failed to check if file is binary: ${filePath}`,
       error instanceof Error ? error.message : String(error),
     );
     return false;
-  } finally {
-    if (fh) {
-      try {
-        await fh.close();
-      } catch (closeError) {
-        debugLogger.warn(
-          `Failed to close file handle for: ${filePath}`,
-          closeError instanceof Error ? closeError.message : String(closeError),
-        );
-      }
-    }
   }
 }
 


### PR DESCRIPTION

## Summary
Fixes #24547. Replaces the hand-rolled UTF-8 byte heuristic in `isBinaryFile()` with a delegation to the `isbinaryfile` npm package, so source files that legitimately contain the Unicode replacement character U+FFFD (`EF BF BD` in UTF-8) are no longer misclassified as binary.

## Details
- Adds `isbinaryfile@^5.0.7` as a `packages/core` dependency (Node ≥20 compatible, zero transitive deps, MIT-licensed, same library used by ESLint / Turborepo).
- `isBinaryFile()` in `packages/core/src/utils/fileUtils.ts` becomes a thin wrapper over `isbinaryfile`'s async API. Public signature is unchanged, so no call sites need updating.
- The library handles Unicode BOMs (UTF-8/16/32/GB-18030), PDF magic, NULL bytes, valid UTF-8 multibyte sequences, and an invalid-byte ratio (overlong encodings, post-U+10FFFF, DEL character).
- `detectBOM()` is kept in place because `readFileWithEncoding` and `isEmpty` still use it for BOM-aware decoding.
- Error semantics preserved: I/O errors (ENOENT, path-is-directory, etc.) still resolve to `false` with a `debugLogger.warn`, matching previous behavior for callers downstream.

## Related Issues
- Closes #24547

## How to Validate
1. `cd packages/core && npm run typecheck && npm run lint`
2. `cd packages/core && npx vitest run src/utils/fileUtils.test.ts` — 16 `isBinaryFile` tests pass (5 existing + 3 new regression tests for U+FFFD, mixed UTF-8, and invalid high-byte sequences, plus 8 BOM tests).
3. `cd packages/core && npx vitest run src/tools/read-file.test.ts src/tools/read-many-files.test.ts` — all downstream consumers clean.
4. Manual: create a file containing `'\uFFFD'`, run `read_file` / `replace` against it — content preserved, no hexdump corruption.

## Pre-Merge Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npx prettier --check` passes
- [x] Unit tests pass (including 3 new regression guards)
- [x] No behavior change for callers; function signature identical
