### PR TITLE
fix(release): prefix git hash in nightly versions to prevent semver normalization

### DIFF
--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -285,7 +285,7 @@ function promoteNightlyVersion({ args } = {}) {
   const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
   const gitShortHash = execSync('git rev-parse --short HEAD').toString().trim();
   return {
-    releaseVersion: `${major}.${nextMinor}.0-nightly.${date}.${gitShortHash}`,
+    releaseVersion: `${major}.${nextMinor}.0-nightly.${date}.g${gitShortHash}`,
     npmTag: TAG_NIGHTLY,
     previousReleaseTag: previousNightlyTag,
   };
@@ -296,7 +296,7 @@ function getNightlyVersion() {
   const baseVersion = packageJson.version.split('-')[0];
   const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
   const gitShortHash = execSync('git rev-parse --short HEAD').toString().trim();
-  const releaseVersion = `${baseVersion}-nightly.${date}.${gitShortHash}`;
+  const releaseVersion = `${baseVersion}-nightly.${date}.g${gitShortHash}`;
   const previousReleaseTag = getLatestTag('v*-nightly*');
 
   return {

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -93,7 +93,7 @@ describe('getVersion', () => {
       vi.mocked(execSync).mockImplementation(mockExecSync);
       const result = getVersion({ type: 'nightly' });
       // Note: The base version now comes from package.json, not the previous nightly tag.
-      expect(result.releaseVersion).toBe('0.8.0-nightly.20250917.d3bf8a3d');
+      expect(result.releaseVersion).toBe('0.8.0-nightly.20250917.gd3bf8a3d');
       expect(result.npmTag).toBe('nightly');
       expect(result.previousReleaseTag).toBe('v0.8.0-nightly.20250916.abcdef');
     });
@@ -190,6 +190,20 @@ describe('getVersion', () => {
       });
       // Should have skipped preview.0 and landed on preview.1
       expect(result.releaseVersion).toBe('0.8.0-preview.1');
+    });
+
+    it('should preserve a git hash with a leading zero via the g prefix', () => {
+      const mockWithLeadingZeroHash = (command) => {
+        // Return an all-numeric hash with a leading zero
+        if (command.includes('git rev-parse --short HEAD')) return '017972622';
+        return mockExecSync(command);
+      };
+      vi.mocked(execSync).mockImplementation(mockWithLeadingZeroHash);
+
+      const result = getVersion({ type: 'nightly' });
+      // The 'g' prefix forces semver to treat this as an alphanumeric
+      // identifier, preventing it from stripping the leading zero.
+      expect(result.releaseVersion).toBe('0.8.0-nightly.20250917.g017972622');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes nightly release failures caused by `git rev-parse --short HEAD` producing an all-numeric hash with a leading zero (e.g., `017972622`). Semver treats purely numeric prerelease identifiers as integers, stripping the leading zero. This causes a version mismatch during post-publish verification (`017972622` vs `17972622`).

## Details

The nightly version is constructed as `X.Y.Z-nightly.YYYYMMDD.<git-short-hash>`. When the git short hash happens to be all-numeric and starts with `0`, npm/semver normalizes it by stripping the leading zero (per [semver spec §9](https://semver.org/#spec-item-9)). The verify-release action then compares the original string against `gemini --version` output and fails.

The fix prefixes the git hash with `g` (matching git's own convention from `git describe`) in both `getNightlyVersion()` and `promoteNightlyVersion()`. This forces semver to treat the segment as an alphanumeric identifier, which is never normalized.

Example: `0.39.0-nightly.20260413.g017972622` (preserved as-is by semver).

## Related Issues

Fixes #18007

## How to Validate

Run the release version tests:
```bash
npx vitest run scripts/tests/get-release-version.test.js
```

The new test case `should preserve a git hash with a leading zero via the g prefix` specifically validates this scenario by mocking a hash of `017972622` and asserting the version contains `g017972622`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
