### PR TITLE
fix(core): use close event instead of exit for child_process

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -772,7 +772,7 @@ export class ShellExecutionService {
 
       abortSignal.addEventListener('abort', abortHandler, { once: true });
 
-      child.on('exit', (code, signal) => {
+      child.on('close', (code, signal) => {
         handleExit(code, signal);
       });
 


### PR DESCRIPTION
Fixes #24923 by changing child.on(`exit`) to child.on(`close`) to prevent truncating short commands.