### PR TITLE
Stop showing scrollbar unless we are in terminalBuffer mode

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1836,7 +1836,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 height={Math.min(buffer.viewportHeight, scrollableData.length)}
                 width="100%"
               >
-                {isAlternateBuffer ? (
+                {config.getUseTerminalBuffer() ? (
                   <ScrollableList
                     ref={listRef}
                     hasFocus={focus}


### PR DESCRIPTION
This works around rendering artifcats in alternate buffer mode while not in
terminalBuffer mode.

## Summary

Fixes #25316