### PR TITLE
feat(cli): Add support for OSC 777 terminal notifications (#25202)

### DIFF
--- a/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.test.ts
@@ -330,31 +330,31 @@ describe('TerminalCapabilityManager', () => {
         name: 'Ghostty (terminal name)',
         terminalName: 'Ghostty',
         env: {},
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'ghostty (TERM_PROGRAM)',
         terminalName: undefined,
         env: { TERM_PROGRAM: 'ghostty' },
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'xterm-ghostty (TERM)',
         terminalName: undefined,
         env: { TERM: 'xterm-ghostty' },
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'iTerm.app (TERM_PROGRAM)',
         terminalName: undefined,
         env: { TERM_PROGRAM: 'iTerm.app' },
-        expected: false,
+        expected: 'osc777',
       },
       {
         name: 'undefined env',
         terminalName: undefined,
         env: {},
-        expected: false,
+        expected: 'osc777',
       },
     ])(
       'should return $expected for $name',
@@ -365,7 +365,7 @@ describe('TerminalCapabilityManager', () => {
     );
   });
 
-  describe('supportsOsc9Notifications', () => {
+  describe('getNotificationBackend', () => {
     const manager = TerminalCapabilityManager.getInstance();
 
     it.each([
@@ -373,67 +373,67 @@ describe('TerminalCapabilityManager', () => {
         name: 'WezTerm (terminal name)',
         terminalName: 'WezTerm',
         env: {},
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'iTerm.app (terminal name)',
         terminalName: 'iTerm.app',
         env: {},
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'ghostty (terminal name)',
         terminalName: 'ghostty',
         env: {},
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'kitty (terminal name)',
         terminalName: 'kitty',
         env: {},
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'some-other-term (terminal name)',
         terminalName: 'some-other-term',
         env: {},
-        expected: false,
+        expected: 'osc777',
       },
       {
         name: 'iTerm.app (TERM_PROGRAM)',
         terminalName: undefined,
         env: { TERM_PROGRAM: 'iTerm.app' },
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'vscode (TERM_PROGRAM)',
         terminalName: undefined,
         env: { TERM_PROGRAM: 'vscode' },
-        expected: false,
+        expected: 'osc777',
       },
       {
         name: 'xterm-kitty (TERM)',
         terminalName: undefined,
         env: { TERM: 'xterm-kitty' },
-        expected: true,
+        expected: 'osc9',
       },
       {
         name: 'xterm-256color (TERM)',
         terminalName: undefined,
         env: { TERM: 'xterm-256color' },
-        expected: false,
+        expected: 'osc777',
       },
       {
         name: 'Windows Terminal (WT_SESSION)',
         terminalName: 'iTerm.app',
         env: { WT_SESSION: 'some-guid' },
-        expected: false,
+        expected: 'bel',
       },
     ])(
       'should return $expected for $name',
       ({ terminalName, env, expected }) => {
         vi.spyOn(manager, 'getTerminalName').mockReturnValue(terminalName);
-        expect(manager.supportsOsc9Notifications(env)).toBe(expected);
+        expect(manager.getNotificationBackend(env)).toBe(expected);
       },
     );
   });

--- a/packages/cli/src/ui/utils/terminalCapabilityManager.ts
+++ b/packages/cli/src/ui/utils/terminalCapabilityManager.ts
@@ -284,16 +284,20 @@ export class TerminalCapabilityManager {
     );
   }
 
-  supportsOsc9Notifications(env: NodeJS.ProcessEnv = process.env): boolean {
+  getNotificationBackend(env: NodeJS.ProcessEnv = process.env): 'osc9' | 'osc777' | 'bel' {
     if (env['WT_SESSION']) {
-      return false;
+      return 'bel';
     }
 
-    return (
+    if (
       this.hasOsc9TerminalSignature(this.getTerminalName()) ||
       this.hasOsc9TerminalSignature(env['TERM_PROGRAM']) ||
       this.hasOsc9TerminalSignature(env['TERM'])
-    );
+    ) {
+      return 'osc9';
+    }
+
+    return 'osc777';
   }
 
   private hasOsc9TerminalSignature(value: string | undefined): boolean {

--- a/packages/cli/src/utils/terminalNotifications.test.ts
+++ b/packages/cli/src/utils/terminalNotifications.test.ts
@@ -85,9 +85,25 @@ describe('terminal notifications', () => {
     expect(emitted.endsWith('\x07')).toBe(true);
   });
 
-  it('emits BEL fallback when OSC 9 is not supported', async () => {
+  it('emits OSC 777 fallback when OSC 9 is not supported', async () => {
     vi.stubEnv('TERM_PROGRAM', '');
     vi.stubEnv('TERM', '');
+
+    const shown = await notifyViaTerminal(true, {
+      title: 'Title',
+      subtitle: 'Subtitle',
+      body: 'Body',
+    });
+
+    expect(shown).toBe(true);
+    const emitted = String(writeToStdout.mock.calls[0][0]);
+    expect(emitted.startsWith('\x1b]777;')).toBe(true);
+  });
+
+  it('emits BEL fallback on Windows Terminal', async () => {
+    vi.stubEnv('TERM_PROGRAM', '');
+    vi.stubEnv('TERM', '');
+    vi.stubEnv('WT_SESSION', 'some-id');
 
     const shown = await notifyViaTerminal(true, {
       title: 'Title',

--- a/packages/cli/src/utils/terminalNotifications.ts
+++ b/packages/cli/src/utils/terminalNotifications.ts
@@ -91,14 +91,27 @@ function buildTerminalNotificationMessage(
   return sanitizeForDisplay(combined, MAX_OSC9_MESSAGE_CHARS);
 }
 
-function emitOsc9Notification(content: RunEventNotificationContent): void {
-  const message = buildTerminalNotificationMessage(content);
-  if (!TerminalCapabilityManager.getInstance().supportsOsc9Notifications()) {
+function emitTerminalNotification(content: RunEventNotificationContent): void {
+  const backend = TerminalCapabilityManager.getInstance().getNotificationBackend();
+
+  if (backend === 'bel') {
     writeToStdout(BEL);
     return;
   }
 
-  writeToStdout(`${OSC9_PREFIX}${message}${BEL}`);
+  if (backend === 'osc9') {
+    const message = buildTerminalNotificationMessage(content);
+    writeToStdout(`${OSC9_PREFIX}${message}${BEL}`);
+    return;
+  }
+
+  if (backend === 'osc777') {
+    const titlePiece = [content.title, content.subtitle].filter(Boolean).join(' - ');
+    const safeTitle = sanitizeForDisplay(titlePiece, MAX_NOTIFICATION_TITLE_CHARS + MAX_NOTIFICATION_SUBTITLE_CHARS);
+    const safeBody = sanitizeForDisplay(content.body, MAX_NOTIFICATION_BODY_CHARS);
+    writeToStdout(`\x1b]777;notify;${safeTitle};${safeBody}${BEL}`);
+    return;
+  }
 }
 
 export async function notifyViaTerminal(
@@ -110,7 +123,7 @@ export async function notifyViaTerminal(
   }
 
   try {
-    emitOsc9Notification(sanitizeNotificationContent(content));
+    emitTerminalNotification(sanitizeNotificationContent(content));
     return true;
   } catch (error) {
     debugLogger.debug('Failed to emit terminal notification:', error);

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,6 +58,7 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
+      ...process.env,
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,


### PR DESCRIPTION
Fixes #25202. By default, gemini-cli now uses OSC 777 notifications on Linux terminals which do not identify as macOS-style (like iTerm2 or Kitty) or WT_SESSION. This helps terminal apps natively show system notifications.