### PR TITLE
feat(cli): provide default post-submit prompt for skill command

### DIFF
--- a/packages/cli/src/services/SkillCommandLoader.test.ts
+++ b/packages/cli/src/services/SkillCommandLoader.test.ts
@@ -88,7 +88,7 @@ describe('SkillCommandLoader', () => {
       type: 'tool',
       toolName: ACTIVATE_SKILL_TOOL_NAME,
       toolArgs: { name: 'test-skill' },
-      postSubmitPrompt: undefined,
+      postSubmitPrompt: 'Use the skill test-skill',
     });
   });
 

--- a/packages/cli/src/services/SkillCommandLoader.ts
+++ b/packages/cli/src/services/SkillCommandLoader.ts
@@ -46,7 +46,10 @@ export class SkillCommandLoader implements ICommandLoader {
           type: 'tool',
           toolName: ACTIVATE_SKILL_TOOL_NAME,
           toolArgs: { name: skill.name },
-          postSubmitPrompt: args.trim().length > 0 ? args.trim() : undefined,
+          postSubmitPrompt:
+            args.trim().length > 0
+              ? args.trim()
+              : `Use the skill ${skill.name}`,
         }),
       };
     });


### PR DESCRIPTION
## Summary

Provide a default post-submit prompt "Use the skill [name]" for skill commands if no extra arguments are provided.

## Details

This ensures that when a user runs a skill command (e.g., `/pr-creator`), the agent is immediately prompted to use the skill, reducing the need for an extra user turn to manually type "use the skill pr-creator".

## Related Issues

Related to #25318

## How to Validate

Run the relevant test:
`npm test -w @google/gemini-cli -- src/services/SkillCommandLoader.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
