### PR TITLE
fix(core): merge process.env into shadow repo environment

### DIFF
--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,6 +58,7 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
+      ...process.env,
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,


### PR DESCRIPTION
Fixes #25034. The checkpointing git service would override process.env entirely, dropping the user's PATH.