### PR TITLE
fix(core): ensure output streams flush before teardown

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -772,7 +772,7 @@ export class ShellExecutionService {
 
       abortSignal.addEventListener('abort', abortHandler, { once: true });
 
-      child.on('exit', (code, signal) => {
+      child.on('close', (code, signal) => {
         handleExit(code, signal);
       });
 


### PR DESCRIPTION
Fixes #24923. Fast commands lost stdout because we exited on \exit\ instead of \close\.