### PR TITLE
fix(core): handle ENAMETOOLONG gracefully in robustRealpath

### DIFF
--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -424,7 +424,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       e &&
       typeof e === 'object' &&
       'code' in e &&
-      (e.code === 'ENOENT' || e.code === 'EISDIR')
+      (e.code === 'ENOENT' || e.code === 'EISDIR' || e.code === 'ENAMETOOLONG')
     ) {
       try {
         const stat = fs.lstatSync(p);
@@ -441,7 +441,9 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
             lstatError &&
             typeof lstatError === 'object' &&
             'code' in lstatError &&
-            (lstatError.code === 'ENOENT' || lstatError.code === 'EISDIR')
+            (lstatError.code === 'ENOENT' ||
+              lstatError.code === 'EISDIR' ||
+              lstatError.code === 'ENAMETOOLONG')
           )
         ) {
           throw lstatError;


### PR DESCRIPTION
Fixes #24898. Avoids a crash when massive SQL strings accidentally get processed as system paths.