### PR TITLE
fix(core): prevent secondary crash in ModelRouterService finally block

### DIFF
--- a/packages/core/src/routing/modelRouterService.ts
+++ b/packages/core/src/routing/modelRouterService.ts
@@ -74,7 +74,7 @@ export class ModelRouterService {
    */
   async route(context: RoutingContext): Promise<RoutingDecision> {
     const startTime = Date.now();
-    let decision: RoutingDecision;
+    let decision: RoutingDecision | undefined;
 
     const [enableNumericalRouting, thresholdValue] = await Promise.all([
       this.config.getNumericalRoutingEnabled(),
@@ -117,10 +117,10 @@ export class ModelRouterService {
       );
     } finally {
       const event = new ModelRoutingEvent(
-        decision!.model,
-        decision!.metadata.source,
-        decision!.metadata.latencyMs,
-        decision!.metadata.reasoning,
+        decision?.model || 'unknown',
+        decision?.metadata?.source || 'unknown',
+        decision?.metadata?.latencyMs || 0,
+        decision?.metadata?.reasoning,
         failed,
         error_message,
         this.config.getApprovalMode(),


### PR DESCRIPTION
## Summary

This PR fixes a bug in `ModelRouterService` where an exception during routing could result in a secondary crash within the `finally` block, hiding the original error and aborting the chat turn with a misleading `TypeError`.

## Details

The `modelRouterService.route()` method executes the routing strategy within a `try...catch...finally` block. When an unexpected exception occurred during the actual model routing, execution jumped to the `catch` block. The `catch` block attempted to formulate a "fallback" decision. However, if something in this `catch` block also threw an exception before `decision` could be assigned, `decision` remained `undefined`. The `finally` block then attempted to access `decision!.model`, resulting in a `Cannot read properties of undefined (reading 'model')` error.

This fix replaces the non-null assertions (`!`) with optional chaining (`?`) and provides safe fallbacks in the `finally` block when constructing the `ModelRoutingEvent`. This ensures the `finally` block executes successfully, allowing the original error from the routing layer to bubble up correctly and be handled or logged.

## Related Issues

N/A

## How to Validate

1. Trigger a scenario where the `route` method's `catch` block fails to assign `decision` (e.g. forcing `config.getModel()` to throw an error while processing a fallback).
2. Observe that the original error is now properly reported instead of a generic `Cannot read properties of undefined (reading 'model')`.
3. Check the telemetry logs to ensure a `ModelRoutingEvent` with `failed=true` and `decision_model='unknown'` is still emitted.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
