### PR TITLE
fix(cli): pass memory arguments via NODE_OPTIONS to support SEA binaries

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -77,14 +77,25 @@ async function run() {
     const nodeArgs: string[] = [...process.execArgv];
     const scriptArgs = process.argv.slice(2);
 
-    const memoryArgs = await getMemoryNodeArgs();
-    nodeArgs.push(...memoryArgs);
-
     const script = process.argv[1];
-    nodeArgs.push(script);
+    if (script !== undefined) {
+      nodeArgs.push(script);
+    }
     nodeArgs.push(...scriptArgs);
 
-    const newEnv = { ...process.env, GEMINI_CLI_NO_RELAUNCH: 'true' };
+    const newEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GEMINI_CLI_NO_RELAUNCH: 'true',
+    };
+    const memoryArgs = await getMemoryNodeArgs();
+    if (memoryArgs.length > 0) {
+      newEnv['NODE_OPTIONS'] = [
+        process.env['NODE_OPTIONS'] || '',
+        ...memoryArgs,
+      ]
+        .join(' ')
+        .trim();
+    }
     const RELAUNCH_EXIT_CODE = 199;
     let latestAdminSettings: unknown = undefined;
 


### PR DESCRIPTION
## Summary

Fixes the issue where running a compiled Node SEA (Single Executable Application) binary results in "Unknown arguments: max-old-space-size".

## Details

When the CLI relaunches itself to increase the memory limit, it was passing `--max-old-space-size` as a command-line argument. In a SEA binary, Node does not consume V8 flags from the command line; instead, it forwards them to the user script, causing yargs to fail.

This PR moves these memory arguments to the `NODE_OPTIONS` environment variable, which is supported by both regular Node and SEA binaries.

## Related Issues

Fixes #24591

## How to Validate

1. Run `npm run build:binary` to create a SEA binary.
2. Run the resulting binary (e.g., `./dist/linux-x64/gemini`).
3. Verify that it launches correctly without "Unknown arguments" errors.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
