### PR TITLE
fix(gemma): resolve 404 errors and improve port resolution

### DIFF
--- a/packages/cli/src/commands/gemma/platform.ts
+++ b/packages/cli/src/commands/gemma/platform.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { loadSettings } from '../../config/settings.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -20,6 +21,34 @@ import {
 export interface PlatformInfo {
   key: string;
   binaryName: string;
+}
+
+export interface GemmaConfigStatus {
+  settingsEnabled: boolean;
+  configuredPort: number;
+}
+
+/**
+ * Resolves the Gemma configuration from the workspace settings.
+ */
+export function resolveGemmaConfig(fallbackPort: number): GemmaConfigStatus {
+  let settingsEnabled = false;
+  let configuredPort = fallbackPort;
+  try {
+    const settings = loadSettings(process.cwd());
+    const gemmaSettings = settings.merged.experimental?.gemmaModelRouter;
+    settingsEnabled = gemmaSettings?.enabled === true;
+    const hostStr = gemmaSettings?.classifier?.host;
+    if (hostStr) {
+      const match = hostStr.match(/:(\d+)/);
+      if (match) {
+        configuredPort = parseInt(match[1], 10);
+      }
+    }
+  } catch {
+    // Settings may fail to load in some contexts; treat as not enabled.
+  }
+  return { settingsEnabled, configuredPort };
 }
 
 /**

--- a/packages/cli/src/commands/gemma/start.ts
+++ b/packages/cli/src/commands/gemma/start.ts
@@ -78,11 +78,31 @@ export const startCommand: CommandModule = {
   builder: (yargs) =>
     yargs.option('port', {
       type: 'number',
-      default: DEFAULT_PORT,
       description: 'Port for the LiteRT server',
     }),
   handler: async (argv) => {
-    const port = Number(argv['port']);
+    let port: number | undefined;
+    if (argv['port'] !== undefined) {
+      port = Number(argv['port']);
+    }
+
+    if (!port) {
+      try {
+        const { loadSettings } = await import('../../config/settings.js');
+        const settings = loadSettings(process.cwd());
+        const hostStr =
+          settings.merged.experimental?.gemmaModelRouter?.classifier?.host;
+        if (hostStr) {
+          const match = hostStr.match(/:(\d+)/);
+          if (match) {
+            port = parseInt(match[1], 10);
+          }
+        }
+      } catch {
+        // Ignore
+      }
+      port = port ?? DEFAULT_PORT;
+    }
 
     if (!isBinaryInstalled()) {
       debugLogger.error(

--- a/packages/cli/src/commands/gemma/start.ts
+++ b/packages/cli/src/commands/gemma/start.ts
@@ -21,6 +21,7 @@ import {
   getBinaryPath,
   isBinaryInstalled,
   isServerRunning,
+  resolveGemmaConfig,
 } from './platform.js';
 
 /**
@@ -87,21 +88,8 @@ export const startCommand: CommandModule = {
     }
 
     if (!port) {
-      try {
-        const { loadSettings } = await import('../../config/settings.js');
-        const settings = loadSettings(process.cwd());
-        const hostStr =
-          settings.merged.experimental?.gemmaModelRouter?.classifier?.host;
-        if (hostStr) {
-          const match = hostStr.match(/:(\d+)/);
-          if (match) {
-            port = parseInt(match[1], 10);
-          }
-        }
-      } catch {
-        // Ignore
-      }
-      port = port ?? DEFAULT_PORT;
+      const { configuredPort } = resolveGemmaConfig(DEFAULT_PORT);
+      port = configuredPort;
     }
 
     if (!isBinaryInstalled()) {

--- a/packages/cli/src/commands/gemma/status.ts
+++ b/packages/cli/src/commands/gemma/status.ts
@@ -6,7 +6,6 @@
 
 import type { CommandModule } from 'yargs';
 import chalk from 'chalk';
-import { loadSettings } from '../../config/settings.js';
 import { DEFAULT_PORT, GEMMA_MODEL_NAME } from './constants.js';
 import {
   detectPlatform,
@@ -16,6 +15,7 @@ import {
   isServerRunning,
   readServerPid,
   isProcessRunning,
+  resolveGemmaConfig,
 } from './platform.js';
 import { exitCli } from '../utils.js';
 
@@ -38,22 +38,7 @@ export interface GemmaStatusResult {
 export async function checkGemmaStatus(
   port?: number,
 ): Promise<GemmaStatusResult> {
-  let settingsEnabled = false;
-  let configuredPort = DEFAULT_PORT;
-  try {
-    const settings = loadSettings(process.cwd());
-    const gemmaSettings = settings.merged.experimental?.gemmaModelRouter;
-    settingsEnabled = gemmaSettings?.enabled === true;
-    const hostStr = gemmaSettings?.classifier?.host;
-    if (hostStr) {
-      const match = hostStr.match(/:(\d+)/);
-      if (match) {
-        configuredPort = parseInt(match[1], 10);
-      }
-    }
-  } catch {
-    // Settings may fail to load in some contexts; treat as not enabled.
-  }
+  const { settingsEnabled, configuredPort } = resolveGemmaConfig(DEFAULT_PORT);
 
   const effectivePort = port ?? configuredPort;
   const binaryPath = getBinaryPath();
@@ -175,11 +160,13 @@ export const statusCommand: CommandModule = {
   builder: (yargs) =>
     yargs.option('port', {
       type: 'number',
-      default: DEFAULT_PORT,
       description: 'Port to check for the LiteRT server',
     }),
   handler: async (argv) => {
-    const port = Number(argv['port']);
+    let port: number | undefined;
+    if (argv['port'] !== undefined) {
+      port = Number(argv['port']);
+    }
     const status = await checkGemmaStatus(port);
     const output = formatGemmaStatus(status);
     // Use process.stdout directly for consistent output in non-interactive mode.

--- a/packages/cli/src/commands/gemma/status.ts
+++ b/packages/cli/src/commands/gemma/status.ts
@@ -38,7 +38,24 @@ export interface GemmaStatusResult {
 export async function checkGemmaStatus(
   port?: number,
 ): Promise<GemmaStatusResult> {
-  const effectivePort = port ?? DEFAULT_PORT;
+  let settingsEnabled = false;
+  let configuredPort = DEFAULT_PORT;
+  try {
+    const settings = loadSettings(process.cwd());
+    const gemmaSettings = settings.merged.experimental?.gemmaModelRouter;
+    settingsEnabled = gemmaSettings?.enabled === true;
+    const hostStr = gemmaSettings?.classifier?.host;
+    if (hostStr) {
+      const match = hostStr.match(/:(\d+)/);
+      if (match) {
+        configuredPort = parseInt(match[1], 10);
+      }
+    }
+  } catch {
+    // Settings may fail to load in some contexts; treat as not enabled.
+  }
+
+  const effectivePort = port ?? configuredPort;
   const binaryPath = getBinaryPath();
   const binaryInstalled = isBinaryInstalled();
   const modelDownloaded =
@@ -46,15 +63,6 @@ export async function checkGemmaStatus(
   const serverRunning = await isServerRunning(effectivePort);
   const pid = readServerPid();
   const serverPid = pid && isProcessRunning(pid) ? pid : null;
-
-  let settingsEnabled = false;
-  try {
-    const settings = loadSettings(process.cwd());
-    const gemmaSettings = settings.merged.experimental?.gemmaModelRouter;
-    settingsEnabled = gemmaSettings?.enabled === true;
-  } catch {
-    // Settings may fail to load in some contexts; treat as not enabled.
-  }
 
   const allPassing =
     binaryInstalled && modelDownloaded && serverRunning && settingsEnabled;

--- a/packages/cli/src/commands/gemma/stop.ts
+++ b/packages/cli/src/commands/gemma/stop.ts
@@ -14,6 +14,7 @@ import {
   readServerPid,
   isProcessRunning,
   isServerRunning,
+  resolveGemmaConfig,
 } from './platform.js';
 
 /**
@@ -81,21 +82,8 @@ export const stopCommand: CommandModule = {
     }
 
     if (!port) {
-      try {
-        const { loadSettings } = await import('../../config/settings.js');
-        const settings = loadSettings(process.cwd());
-        const hostStr =
-          settings.merged.experimental?.gemmaModelRouter?.classifier?.host;
-        if (hostStr) {
-          const match = hostStr.match(/:(\d+)/);
-          if (match) {
-            port = parseInt(match[1], 10);
-          }
-        }
-      } catch {
-        // Ignore
-      }
-      port = port ?? DEFAULT_PORT;
+      const { configuredPort } = resolveGemmaConfig(DEFAULT_PORT);
+      port = configuredPort;
     }
 
     const pid = readServerPid();

--- a/packages/cli/src/commands/gemma/stop.ts
+++ b/packages/cli/src/commands/gemma/stop.ts
@@ -66,18 +66,38 @@ export async function stopServer(): Promise<boolean> {
 
   return true;
 }
-
 export const stopCommand: CommandModule = {
   command: 'stop',
   describe: 'Stop the LiteRT-LM server',
   builder: (yargs) =>
     yargs.option('port', {
       type: 'number',
-      default: DEFAULT_PORT,
-      description: 'Port the server is running on',
+      description: 'Port where the LiteRT server is running',
     }),
   handler: async (argv) => {
-    const port = Number(argv['port']);
+    let port: number | undefined;
+    if (argv['port'] !== undefined) {
+      port = Number(argv['port']);
+    }
+
+    if (!port) {
+      try {
+        const { loadSettings } = await import('../../config/settings.js');
+        const settings = loadSettings(process.cwd());
+        const hostStr =
+          settings.merged.experimental?.gemmaModelRouter?.classifier?.host;
+        if (hostStr) {
+          const match = hostStr.match(/:(\d+)/);
+          if (match) {
+            port = parseInt(match[1], 10);
+          }
+        }
+      } catch {
+        // Ignore
+      }
+      port = port ?? DEFAULT_PORT;
+    }
+
     const pid = readServerPid();
 
     if (pid !== null && isProcessRunning(pid)) {

--- a/packages/core/src/core/localLiteRtLmClient.test.ts
+++ b/packages/core/src/core/localLiteRtLmClient.test.ts
@@ -7,6 +7,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalLiteRtLmClient } from './localLiteRtLmClient.js';
 import type { Config } from '../config/config.js';
+import { GoogleGenAI } from '@google/genai';
+
 const mockGenerateContent = vi.fn();
 
 vi.mock('@google/genai', () => {
@@ -44,6 +46,14 @@ describe('LocalLiteRtLmClient', () => {
     const result = await client.generateJson([], 'test-instruction');
 
     expect(result).toEqual({ key: 'value' });
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiVersion: 'v1beta',
+        httpOptions: expect.objectContaining({
+          baseUrl: 'http://test-host:1234',
+        }),
+      }),
+    );
     expect(mockGenerateContent).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'gemma:latest',

--- a/packages/core/src/core/localLiteRtLmClient.ts
+++ b/packages/core/src/core/localLiteRtLmClient.ts
@@ -25,6 +25,8 @@ export class LocalLiteRtLmClient {
     this.client = new GoogleGenAI({
       // The LiteRT-LM server does not require an API key, but the SDK requires one to be set even for local endpoints. This is a dummy value and is not used for authentication.
       apiKey: 'no-api-key-needed',
+      apiVersion: 'v1beta',
+      vertexai: false,
       httpOptions: {
         baseUrl: this.host,
         // If the LiteRT-LM server is started but the wrong port is set, there will be a lengthy TCP timeout (here fixed to be 10 seconds).


### PR DESCRIPTION
## Summary

This PR resolves 404 errors encountered when using the LiteRT-LM server with the Gemini SDK by ensuring the correct API version (`v1beta`) is used. It also improves the user experience by dynamically resolving the server port from project settings in the `gemma` CLI commands.

## Details

- **LocalLiteRtLmClient**: Explicitly set `apiVersion: 'v1beta'` and `vertexai: false` in the `GoogleGenAI` constructor. The local LiteRT-LM server follows the `v1beta` endpoint structure, and the SDK defaults to `v1`, causing 404s.
- **gemma CLI commands**: Updated `start`, `status`, and `stop` commands to read the port from `experimental.gemmaModelRouter.classifier.host` in the settings file if the `--port` flag is not provided.
- **Linting**: Fixed unsafe type assertions and restricted syntax (typeof on object properties) to comply with project standards.

## Related Issues

Related to `sameez/gemma-auto-setup`.

## How to Validate

1. Configure a custom port in your settings (e.g., `experimental.gemmaModelRouter.classifier.host: "http://localhost:1234"`).
2. Run `gemini gemma start` and verify it uses the configured port.
3. Verify that `LocalLiteRtLmClient` tests pass: `npm test -w @google/gemini-cli-core -- src/core/localLiteRtLmClient.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
