### PR TITLE
fix(core): prevent YOLO mode from being downgraded

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1762,6 +1762,39 @@ describe('PolicyEngine', () => {
   });
 
   describe('shell command parsing failure', () => {
+    it('should return ALLOW in YOLO mode for dangerous commands due to heuristics override', async () => {
+      // Create an engine with YOLO mode and a sandbox manager that flags a command as dangerous
+      const rules: PolicyRule[] = [
+        {
+          toolName: '*',
+          decision: PolicyDecision.ALLOW,
+          priority: 999,
+          modes: [ApprovalMode.YOLO],
+        },
+      ];
+
+      const mockSandboxManager = new NoopSandboxManager();
+      mockSandboxManager.isDangerousCommand = vi.fn().mockReturnValue(true);
+      mockSandboxManager.isKnownSafeCommand = vi.fn().mockReturnValue(false);
+
+      engine = new PolicyEngine({
+        rules,
+        approvalMode: ApprovalMode.YOLO,
+        sandboxManager: mockSandboxManager,
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'powershell echo "dangerous"' },
+        },
+        undefined,
+      );
+
+      // Even though the command is flagged as dangerous, YOLO mode should preserve the ALLOW decision
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
     it('should return ALLOW in YOLO mode even if shell command parsing fails', async () => {
       const { splitCommands } = await import('../utils/shell-utils.js');
       const rules: PolicyRule[] = [

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -312,6 +312,13 @@ export class PolicyEngine {
       const parsedArgs = parsedObjArgs.map(extractStringFromParseEntry);
 
       if (this.sandboxManager.isDangerousCommand(parsedArgs)) {
+        if (this.approvalMode === ApprovalMode.YOLO) {
+          debugLogger.debug(
+            `[PolicyEngine.check] Command evaluated as dangerous, but YOLO mode is active. Preserving decision: ${command}`,
+          );
+          return decision;
+        }
+
         debugLogger.debug(
           `[PolicyEngine.check] Command evaluated as dangerous, forcing ASK_USER: ${command}`,
         );

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -48,6 +48,7 @@ import {
 } from '../utils/shell-utils.js';
 import { SHELL_TOOL_NAME } from './tool-names.js';
 import { PARAM_ADDITIONAL_PERMISSIONS } from './definitions/base-declarations.js';
+import { ApprovalMode } from '../policy/types.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { getShellDefinition } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
@@ -252,6 +253,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
     abortSignal: AbortSignal,
     forcedDecision?: ForcedToolDecision,
   ): Promise<ToolCallConfirmationDetails | false> {
+    if (this.context.config.getApprovalMode() === ApprovalMode.YOLO) {
+      return super.shouldConfirmExecute(abortSignal, forcedDecision);
+    }
+
     if (this.params[PARAM_ADDITIONAL_PERMISSIONS]) {
       return this.getConfirmationDetails(abortSignal);
     }


### PR DESCRIPTION
## Summary

Prevents YOLO mode decisions from being downgraded to `ASK_USER` when a shell command is evaluated as dangerous by heuristics.

## Details

In `packages/core/src/policy/policy-engine.ts`, the policy engine previously overrode decisions to `ASK_USER` if `this.sandboxManager.isDangerousCommand(parsedArgs)` returned true, even when YOLO mode was active. This change ensures that YOLO mode (where the user expects autonomous execution) preserves the `ALLOW` decision for dangerous commands. Added a test case `should return ALLOW in YOLO mode for dangerous commands due to heuristics override`.

## Related Issues

#25015

## How to Validate

1. Run the test suite: `npm run test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts`
2. Start the CLI in YOLO mode and attempt to run a command that triggers the dangerous command heuristics. Verify it runs autonomously without asking the user.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
