### PR TITLE
feat(core): shell inference for file operations under sandboxing

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,16 +1,11 @@
 {
   "experimental": {
+    "plan": true,
     "extensionReloading": true,
     "modelSteering": true,
     "memoryManager": true
   },
   "general": {
-    "devtools": true,
-    "plan": {
-      "enabled": true
-    }
-  },
-  "agents": {
-    "overrides": {}
+    "devtools": true
   }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,11 +1,16 @@
 {
   "experimental": {
-    "plan": true,
     "extensionReloading": true,
     "modelSteering": true,
     "memoryManager": true
   },
   "general": {
-    "devtools": true
+    "devtools": true,
+    "plan": {
+      "enabled": true
+    }
+  },
+  "agents": {
+    "overrides": {}
   }
 }

--- a/integration-tests/shell-parity.test.ts
+++ b/integration-tests/shell-parity.test.ts
@@ -5,9 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import {
-  TestRig,
-} from './test-helper.js';
+import { TestRig } from './test-helper.js';
 
 describe('shell-parity', () => {
   let rig: TestRig;
@@ -19,20 +17,29 @@ describe('shell-parity', () => {
   afterEach(async () => await rig.cleanup());
 
   it('should use run_shell_command for replace when sandboxing is enabled', async () => {
-    await rig.setup('should use run_shell_command for replace when sandboxing is enabled', {
-      settings: {
-        security: { toolSandboxing: true },
+    await rig.setup(
+      'should use run_shell_command for replace when sandboxing is enabled',
+      {
+        settings: {
+          security: { toolSandboxing: true },
+        },
       },
-    });
+    );
     rig.createFile('test.ts', 'const foo = "bar";');
 
     // We expect the model to use run_shell_command because edit/replace/write_file are filtered out.
-    const result = await rig.run({
+    await rig.run({
       args: `Replace "bar" with "baz" in test.ts`,
     });
 
     // Verify forbidden tools were NOT used
-    const forbiddenTools = ['grep_search', 'replace', 'write_file', 'edit', 'read_file'];
+    const forbiddenTools = [
+      'grep_search',
+      'replace',
+      'write_file',
+      'edit',
+      'read_file',
+    ];
     const toolLogs = rig.readToolLogs();
     const usedForbidden = toolLogs.filter((t) =>
       forbiddenTools.includes(t.toolRequest.name),
@@ -55,11 +62,14 @@ describe('shell-parity', () => {
   });
 
   it('should use run_shell_command for search when sandboxing is enabled', async () => {
-    await rig.setup('should use run_shell_command for search when sandboxing is enabled', {
-      settings: {
-        security: { toolSandboxing: true },
+    await rig.setup(
+      'should use run_shell_command for search when sandboxing is enabled',
+      {
+        settings: {
+          security: { toolSandboxing: true },
+        },
       },
-    });
+    );
     rig.createFile('search-me.txt', 'target-string');
 
     await rig.run({
@@ -68,7 +78,9 @@ describe('shell-parity', () => {
 
     // Verify grep_search was NOT used
     const toolLogs = rig.readToolLogs();
-    const usedGrep = toolLogs.filter((t) => t.toolRequest.name === 'grep_search');
+    const usedGrep = toolLogs.filter(
+      (t) => t.toolRequest.name === 'grep_search',
+    );
     expect(usedGrep).toHaveLength(0);
 
     // Verify run_shell_command was used
@@ -80,11 +92,14 @@ describe('shell-parity', () => {
   });
 
   it('should use run_shell_command for read when sandboxing is enabled', async () => {
-    await rig.setup('should use run_shell_command for read when sandboxing is enabled', {
-      settings: {
-        security: { toolSandboxing: true },
+    await rig.setup(
+      'should use run_shell_command for read when sandboxing is enabled',
+      {
+        settings: {
+          security: { toolSandboxing: true },
+        },
       },
-    });
+    );
     rig.createFile('read-me.txt', 'hello world');
 
     const result = await rig.run({

--- a/integration-tests/shell-parity.test.ts
+++ b/integration-tests/shell-parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  TestRig,
+} from './test-helper.js';
+
+describe('shell-parity', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => await rig.cleanup());
+
+  it('should use run_shell_command for replace when sandboxing is enabled', async () => {
+    await rig.setup('should use run_shell_command for replace when sandboxing is enabled', {
+      settings: {
+        security: { toolSandboxing: true },
+      },
+    });
+    rig.createFile('test.ts', 'const foo = "bar";');
+
+    // We expect the model to use run_shell_command because edit/replace/write_file are filtered out.
+    const result = await rig.run({
+      args: `Replace "bar" with "baz" in test.ts`,
+    });
+
+    // Verify forbidden tools were NOT used
+    const forbiddenTools = ['grep_search', 'replace', 'write_file', 'edit', 'read_file'];
+    const toolLogs = rig.readToolLogs();
+    const usedForbidden = toolLogs.filter((t) =>
+      forbiddenTools.includes(t.toolRequest.name),
+    );
+    expect(usedForbidden).toHaveLength(0);
+
+    // Verify run_shell_command was used
+    const shellCall = await rig.waitForToolCall('run_shell_command');
+    expect(shellCall).toBeTruthy();
+
+    // Verify the command looks like a replace operation
+    const command = shellCall!.args.command as string;
+    // It should contain some form of replacement (sed, perl, or powershell -replace)
+    expect(command).toMatch(/sed|replace|Set-Content|perl/i);
+
+    // Verify file content changed
+    const content = rig.readFile('test.ts');
+    expect(content).toContain('baz');
+    expect(content).not.toContain('"bar"');
+  });
+
+  it('should use run_shell_command for search when sandboxing is enabled', async () => {
+    await rig.setup('should use run_shell_command for search when sandboxing is enabled', {
+      settings: {
+        security: { toolSandboxing: true },
+      },
+    });
+    rig.createFile('search-me.txt', 'target-string');
+
+    await rig.run({
+      args: `Search for "target-string" in search-me.txt`,
+    });
+
+    // Verify grep_search was NOT used
+    const toolLogs = rig.readToolLogs();
+    const usedGrep = toolLogs.filter((t) => t.toolRequest.name === 'grep_search');
+    expect(usedGrep).toHaveLength(0);
+
+    // Verify run_shell_command was used
+    const shellCall = await rig.waitForToolCall('run_shell_command');
+    expect(shellCall).toBeTruthy();
+
+    const command = shellCall!.args.command as string;
+    expect(command).toMatch(/grep|rg|ripgrep|Select-String|findstr/i);
+  });
+
+  it('should use run_shell_command for read when sandboxing is enabled', async () => {
+    await rig.setup('should use run_shell_command for read when sandboxing is enabled', {
+      settings: {
+        security: { toolSandboxing: true },
+      },
+    });
+    rig.createFile('read-me.txt', 'hello world');
+
+    const result = await rig.run({
+      args: `Read the file read-me.txt and tell me what it says`,
+    });
+
+    // Verify read_file was NOT used
+    const toolLogs = rig.readToolLogs();
+    const usedRead = toolLogs.filter((t) => t.toolRequest.name === 'read_file');
+    expect(usedRead).toHaveLength(0);
+
+    // Verify run_shell_command was used
+    const shellCall = await rig.waitForToolCall('run_shell_command');
+    expect(shellCall).toBeTruthy();
+
+    const command = shellCall!.args.command as string;
+    expect(command).toMatch(/cat|head|tail|less|more|Get-Content|type/i);
+
+    expect(result).toContain('hello world');
+  });
+});

--- a/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/SectionHeader.test.tsx.snap
@@ -6,6 +6,12 @@ Narrow Container
 "
 `;
 
+exports[`<SectionHeader /> > 'renders correctly in a narrow contain…' 2`] = `
+"─────────────────────────
+Narrow Container
+"
+`;
+
 exports[`<SectionHeader /> > 'renders correctly when title is trunc…' 1`] = `
 "────────────────────
 Very Long Header Ti…

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -42,7 +42,7 @@ export function mapToDisplay(
     if (call.status === CoreToolCallStatus.Error) {
       description = JSON.stringify(call.request.args);
     } else {
-      description = call.invocation.getDescription();
+      description = typeof call.invocation.getDisplayTitle === 'function' ? call.invocation.getDisplayTitle() : call.invocation.getDescription();
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;
     }
 

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -42,10 +42,9 @@ export function mapToDisplay(
     if (call.status === CoreToolCallStatus.Error) {
       description = JSON.stringify(call.request.args);
     } else {
-      description =
-        typeof call.invocation.getDisplayTitle === 'function'
-          ? call.invocation.getDisplayTitle()
-          : call.invocation.getDescription();
+      description = call.invocation.getDisplayTitle
+        ? call.invocation.getDisplayTitle()
+        : call.invocation.getDescription();
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;
     }
 

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -42,7 +42,10 @@ export function mapToDisplay(
     if (call.status === CoreToolCallStatus.Error) {
       description = JSON.stringify(call.request.args);
     } else {
-      description = typeof call.invocation.getDisplayTitle === 'function' ? call.invocation.getDisplayTitle() : call.invocation.getDescription();
+      description =
+        typeof call.invocation.getDisplayTitle === 'function'
+          ? call.invocation.getDisplayTitle()
+          : call.invocation.getDescription();
       renderOutputAsMarkdown = call.tool.isOutputMarkdown;
     }
 

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1026,7 +1026,10 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           const invocation = tool.build(args);
           // Prefer getDisplayTitle if it differs, otherwise fallback to getDescription.
           // This ensures the timeline ("Shell (Replace)") matches the confirmation dialog.
-          description = typeof invocation.getDisplayTitle === 'function' ? invocation.getDisplayTitle() : invocation.getDescription();
+          description =
+            typeof invocation.getDisplayTitle === 'function'
+              ? invocation.getDisplayTitle()
+              : invocation.getDescription();
         }
       } catch {
         // Ignore errors during formatting for activity emission

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1024,7 +1024,9 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
         if (tool) {
           displayName = tool.displayName ?? toolName;
           const invocation = tool.build(args);
-          description = invocation.getDescription();
+          // Prefer getDisplayTitle if it differs, otherwise fallback to getDescription.
+          // This ensures the timeline ("Shell (Replace)") matches the confirmation dialog.
+          description = typeof invocation.getDisplayTitle === 'function' ? invocation.getDisplayTitle() : invocation.getDescription();
         }
       } catch {
         // Ignore errors during formatting for activity emission

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1026,10 +1026,9 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           const invocation = tool.build(args);
           // Prefer getDisplayTitle if it differs, otherwise fallback to getDescription.
           // This ensures the timeline ("Shell (Replace)") matches the confirmation dialog.
-          description =
-            typeof invocation.getDisplayTitle === 'function'
-              ? invocation.getDisplayTitle()
-              : invocation.getDescription();
+          description = invocation.getDisplayTitle
+            ? invocation.getDisplayTitle()
+            : invocation.getDescription();
         }
       } catch {
         // Ignore errors during formatting for activity emission

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1032,7 +1032,10 @@ export class GeminiChat {
 
       let description: string | undefined = undefined;
       if ('invocation' in call && call.invocation) {
-        description = typeof call.invocation.getDisplayTitle === 'function' ? call.invocation.getDisplayTitle() : call.invocation.getDescription();
+        description =
+          typeof call.invocation.getDisplayTitle === 'function'
+            ? call.invocation.getDisplayTitle()
+            : call.invocation.getDescription();
       }
 
       return {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1030,6 +1030,11 @@ export class GeminiChat {
           ? resultDisplayRaw
           : undefined;
 
+      let description: string | undefined = undefined;
+      if ('invocation' in call && call.invocation) {
+        description = typeof call.invocation.getDisplayTitle === 'function' ? call.invocation.getDisplayTitle() : call.invocation.getDescription();
+      }
+
       return {
         id: call.request.callId,
         name: call.request.originalRequestName ?? call.request.name,
@@ -1038,8 +1043,7 @@ export class GeminiChat {
         status: call.status,
         timestamp: new Date().toISOString(),
         resultDisplay,
-        description:
-          'invocation' in call ? call.invocation?.getDescription() : undefined,
+        description,
       };
     });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -30,9 +30,12 @@ import {
   isGemini2Model,
   supportsModernFeatures,
 } from '../config/models.js';
-import { hasCycleInSchema } from '../tools/tools.js';
+import { hasCycleInSchema, hasDisplayTitle } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
-import type { CompletedToolCall } from '../scheduler/types.js';
+import {
+  type CompletedToolCall,
+  isInvocationCall,
+} from '../scheduler/types.js';
 import {
   logContentRetry,
   logContentRetryFailure,
@@ -1031,11 +1034,10 @@ export class GeminiChat {
           : undefined;
 
       let description: string | undefined = undefined;
-      if ('invocation' in call && call.invocation) {
-        description =
-          typeof call.invocation.getDisplayTitle === 'function'
-            ? call.invocation.getDisplayTitle()
-            : call.invocation.getDescription();
+      if (isInvocationCall(call)) {
+        description = hasDisplayTitle(call.invocation)
+          ? call.invocation.getDisplayTitle()
+          : call.invocation.getDescription();
       }
 
       return {

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -5,13 +5,14 @@
  */
 
 import type { Part } from '@google/genai';
-import type {
-  AnyDeclarativeTool,
-  AnyToolInvocation,
-  ToolCallConfirmationDetails,
-  ToolConfirmationOutcome,
-  ToolResultDisplay,
-  ToolLiveOutput,
+import {
+  isAnyToolInvocation,
+  type AnyDeclarativeTool,
+  type AnyToolInvocation,
+  type ToolCallConfirmationDetails,
+  type ToolConfirmationOutcome,
+  type ToolResultDisplay,
+  type ToolLiveOutput,
 } from '../tools/tools.js';
 import type { ToolErrorType } from '../tools/tool-error.js';
 import type { SerializableConfirmationDetails } from '../confirmation-bus/types.js';
@@ -194,6 +195,12 @@ export type CompletedToolCall =
   | SuccessfulToolCall
   | CancelledToolCall
   | ErroredToolCall;
+
+export function isInvocationCall(
+  call: CompletedToolCall,
+): call is CompletedToolCall & { invocation: AnyToolInvocation } {
+  return 'invocation' in call && isAnyToolInvocation(call.invocation);
+}
 
 export type ConfirmHandler = (
   toolCall: WaitingToolCall,

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -139,6 +139,7 @@ describe('ShellTool', () => {
       getShellBackgroundCompletionBehavior: vi.fn().mockReturnValue('silent'),
       getEnableShellOutputEfficiency: vi.fn().mockReturnValue(true),
       getSandboxEnabled: vi.fn().mockReturnValue(false),
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
       sanitizationConfig: {},
       sandboxManager: new NoopSandboxManager(),
     } as unknown as Config;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -151,6 +151,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
           return `Shell (Write File)`;
         case FileOperationType.READ:
           return `Shell (Read File)`;
+        default:
+          break;
       }
     }
     return this.params.command;
@@ -218,7 +220,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
   }
 
   protected override async getConfirmationDetails(
-    abortSignal: AbortSignal,
+    _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     const command = stripShellWrapper(this.params.command);
     const inferred = inferFileOperation(this.params.command);
@@ -244,25 +246,29 @@ export class ShellToolInvocation extends BaseToolInvocation<
         inferred.type === FileOperationType.EDIT &&
         originalContent !== null
       ) {
-        if (inferred.metadata?.['sedExpression']) {
+        if (typeof inferred.metadata?.['sedExpression'] === 'string') {
           newContent = this.simulateSed(
             originalContent,
-            inferred.metadata['sedExpression'] as string,
+            inferred.metadata['sedExpression'],
           );
         } else if (
-          inferred.metadata?.['oldString'] &&
-          inferred.metadata?.['newString']
+          typeof inferred.metadata?.['oldString'] === 'string' &&
+          typeof inferred.metadata?.['newString'] === 'string'
         ) {
           newContent = this.simulatePsReplace(
             originalContent,
-            inferred.metadata['oldString'] as string,
-            inferred.metadata['newString'] as string,
+            inferred.metadata['oldString'],
+            inferred.metadata['newString'],
           );
         }
       }
 
       if (newContent !== undefined && originalContent !== null) {
-        const fileDiff = Diff.createPatch(filePath, originalContent, newContent);
+        const fileDiff = Diff.createPatch(
+          filePath,
+          originalContent,
+          newContent,
+        );
         const editDetails: ToolEditConfirmationDetails = {
           type: 'edit',
           title: this.getDisplayTitle(),
@@ -510,6 +516,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
           case FileOperationType.WRITE:
             operation = FileOperation.UPDATE;
             canonicalToolName = WRITE_FILE_TOOL_NAME;
+            break;
+          default:
             break;
         }
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -12,6 +12,7 @@ import crypto from 'node:crypto';
 import { debugLogger } from '../index.js';
 import type { SandboxPermissions } from '../services/sandboxManager.js';
 import { ToolErrorType } from './tool-error.js';
+import * as Diff from 'diff';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -22,6 +23,7 @@ import {
   type BackgroundExecutionData,
   type ToolCallConfirmationDetails,
   type ToolExecuteConfirmationDetails,
+  type ToolEditConfirmationDetails,
   type PolicyUpdateOptions,
   type ToolLiveOutput,
   type ExecuteOptions,
@@ -41,8 +43,19 @@ import {
   stripShellWrapper,
   parseCommandDetails,
   hasRedirection,
+  inferFileOperation,
+  FileOperationType,
 } from '../utils/shell-utils.js';
-import { SHELL_TOOL_NAME } from './tool-names.js';
+import { logFileOperation } from '../telemetry/loggers.js';
+import { FileOperationEvent } from '../telemetry/types.js';
+import { FileOperation } from '../telemetry/metrics.js';
+import {
+  SHELL_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+  GREP_TOOL_NAME,
+  READ_FILE_TOOL_NAME,
+} from './tool-names.js';
 import { PARAM_ADDITIONAL_PERMISSIONS } from './definitions/base-declarations.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { getShellDefinition } from './definitions/coreTools.js';
@@ -127,6 +140,19 @@ export class ShellToolInvocation extends BaseToolInvocation<
   }
 
   override getDisplayTitle(): string {
+    const inferred = inferFileOperation(this.params.command);
+    if (inferred) {
+      switch (inferred.type) {
+        case FileOperationType.SEARCH:
+          return `Shell (Search)`;
+        case FileOperationType.EDIT:
+          return `Shell (Replace)`;
+        case FileOperationType.WRITE:
+          return `Shell (Write File)`;
+        case FileOperationType.READ:
+          return `Shell (Read File)`;
+      }
+    }
     return this.params.command;
   }
 
@@ -162,10 +188,96 @@ export class ShellToolInvocation extends BaseToolInvocation<
     return super.shouldConfirmExecute(abortSignal);
   }
 
+  private simulateSed(
+    content: string,
+    sedExpression: string,
+  ): string | undefined {
+    const match = sedExpression.match(/^s\/(.+)\/(.+)\/([g]*)?$/);
+    if (!match) return undefined;
+    const [_, oldStr, newStr, flags] = match;
+    try {
+      const regex = new RegExp(oldStr, flags?.includes('g') ? 'g' : '');
+      return content.replace(regex, newStr);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private simulatePsReplace(
+    content: string,
+    oldString: string,
+    newString: string,
+  ): string {
+    try {
+      // PowerShell -replace is regex-based and case-insensitive by default.
+      const regex = new RegExp(oldString, 'gi');
+      return content.replace(regex, newString);
+    } catch {
+      return content;
+    }
+  }
+
   protected override async getConfirmationDetails(
-    _abortSignal: AbortSignal,
+    abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
     const command = stripShellWrapper(this.params.command);
+    const inferred = inferFileOperation(this.params.command);
+
+    if (
+      inferred &&
+      (inferred.type === FileOperationType.EDIT ||
+        inferred.type === FileOperationType.WRITE)
+    ) {
+      const filePath = path.resolve(
+        this.context.config.getTargetDir(),
+        inferred.filePath,
+      );
+      let originalContent: string | null = null;
+      try {
+        originalContent = await fsPromises.readFile(filePath, 'utf-8');
+      } catch {
+        // file might not exist yet if it's a WRITE
+      }
+
+      let newContent: string | undefined;
+      if (
+        inferred.type === FileOperationType.EDIT &&
+        originalContent !== null
+      ) {
+        if (inferred.metadata?.['sedExpression']) {
+          newContent = this.simulateSed(
+            originalContent,
+            inferred.metadata['sedExpression'] as string,
+          );
+        } else if (
+          inferred.metadata?.['oldString'] &&
+          inferred.metadata?.['newString']
+        ) {
+          newContent = this.simulatePsReplace(
+            originalContent,
+            inferred.metadata['oldString'] as string,
+            inferred.metadata['newString'] as string,
+          );
+        }
+      }
+
+      if (newContent !== undefined && originalContent !== null) {
+        const fileDiff = Diff.createPatch(filePath, originalContent, newContent);
+        const editDetails: ToolEditConfirmationDetails = {
+          type: 'edit',
+          title: this.getDisplayTitle(),
+          fileName: path.basename(filePath),
+          filePath: inferred.filePath,
+          fileDiff,
+          originalContent,
+          newContent,
+          onConfirm: async (_outcome: ToolConfirmationOutcome) => {
+            // Policy updates are now handled centrally by the scheduler
+          },
+        };
+        return editDetails;
+      }
+    }
 
     const parsed = parseCommandDetails(command);
     let rootCommandDisplay = '';
@@ -216,7 +328,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
     const confirmationDetails: ToolExecuteConfirmationDetails = {
       type: 'exec',
-      title: 'Confirm Shell Command',
+      title: this.getDisplayTitle(),
       command: this.params.command,
       rootCommand: rootCommandDisplay,
       rootCommands,
@@ -376,6 +488,46 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       const result = await resultPromise;
+
+      // Telemetry parity
+      const inferred = inferFileOperation(this.params.command);
+      if (inferred && result.exitCode === 0) {
+        let operation: FileOperation | undefined;
+        let canonicalToolName = SHELL_TOOL_NAME;
+        switch (inferred.type) {
+          case FileOperationType.SEARCH:
+            operation = FileOperation.READ;
+            canonicalToolName = GREP_TOOL_NAME;
+            break;
+          case FileOperationType.READ:
+            operation = FileOperation.READ;
+            canonicalToolName = READ_FILE_TOOL_NAME;
+            break;
+          case FileOperationType.EDIT:
+            operation = FileOperation.UPDATE;
+            canonicalToolName = EDIT_TOOL_NAME;
+            break;
+          case FileOperationType.WRITE:
+            operation = FileOperation.UPDATE;
+            canonicalToolName = WRITE_FILE_TOOL_NAME;
+            break;
+        }
+
+        if (operation) {
+          const extension = path.extname(inferred.filePath);
+          logFileOperation(
+            this.context.config,
+            new FileOperationEvent(
+              canonicalToolName,
+              operation,
+              0, // Lines changed not easily available
+              '', // mimetype
+              extension,
+              '', // programming language
+            ),
+          );
+        }
+      }
 
       const backgroundPIDs: number[] = [];
       if (os.platform() !== 'win32') {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -45,6 +45,12 @@ import {
   hasRedirection,
   inferFileOperation,
 } from '../utils/shell-utils.js';
+import {
+  getSpecificMimeType,
+  readFileWithEncoding,
+  detectFileType,
+} from '../utils/fileUtils.js';
+import { getLanguageFromFilePath } from '../utils/language-detection.js';
 import { logFileOperation } from '../telemetry/loggers.js';
 import { FileOperationEvent } from '../telemetry/types.js';
 import { FileOperation } from '../telemetry/metrics.js';
@@ -518,16 +524,33 @@ export class ShellToolInvocation extends BaseToolInvocation<
         }
 
         if (operation) {
-          const extension = path.extname(inferred.filePath);
+          const absolutePath = path.resolve(cwd, inferred.filePath);
+          const extension = path.extname(absolutePath);
+
+          let lines = 0;
+          const mimetype = getSpecificMimeType(absolutePath) || '';
+          const programmingLanguage =
+            getLanguageFromFilePath(absolutePath) || '';
+
+          try {
+            const fileType = await detectFileType(absolutePath);
+            if (fileType === 'text' || fileType === 'svg') {
+              const content = await readFileWithEncoding(absolutePath);
+              lines = content.split('\n').length;
+            }
+          } catch {
+            // Best effort line counting
+          }
+
           logFileOperation(
             this.context.config,
             new FileOperationEvent(
               canonicalToolName,
               operation,
-              0, // Lines changed not easily available
-              '', // mimetype
+              lines,
+              mimetype,
               extension,
-              '', // programming language
+              programmingLanguage,
             ),
           );
         }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -44,7 +44,6 @@ import {
   parseCommandDetails,
   hasRedirection,
   inferFileOperation,
-  FileOperationType,
 } from '../utils/shell-utils.js';
 import { logFileOperation } from '../telemetry/loggers.js';
 import { FileOperationEvent } from '../telemetry/types.js';
@@ -143,13 +142,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const inferred = inferFileOperation(this.params.command);
     if (inferred) {
       switch (inferred.type) {
-        case FileOperationType.SEARCH:
+        case 'search':
           return `Shell (Search)`;
-        case FileOperationType.EDIT:
+        case 'edit':
           return `Shell (Replace)`;
-        case FileOperationType.WRITE:
+        case 'write':
           return `Shell (Write File)`;
-        case FileOperationType.READ:
+        case 'read':
           return `Shell (Read File)`;
         default:
           break;
@@ -225,11 +224,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const command = stripShellWrapper(this.params.command);
     const inferred = inferFileOperation(this.params.command);
 
-    if (
-      inferred &&
-      (inferred.type === FileOperationType.EDIT ||
-        inferred.type === FileOperationType.WRITE)
-    ) {
+    if (inferred && (inferred.type === 'edit' || inferred.type === 'write')) {
       const filePath = path.resolve(
         this.context.config.getTargetDir(),
         inferred.filePath,
@@ -242,23 +237,24 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       let newContent: string | undefined;
-      if (
-        inferred.type === FileOperationType.EDIT &&
-        originalContent !== null
-      ) {
-        if (typeof inferred.metadata?.['sedExpression'] === 'string') {
+      if (inferred.type === 'edit' && originalContent !== null) {
+        if (
+          inferred.metadata?.type === 'edit' &&
+          inferred.metadata.sedExpression
+        ) {
           newContent = this.simulateSed(
             originalContent,
-            inferred.metadata['sedExpression'],
+            inferred.metadata.sedExpression,
           );
         } else if (
-          typeof inferred.metadata?.['oldString'] === 'string' &&
-          typeof inferred.metadata?.['newString'] === 'string'
+          inferred.metadata?.type === 'edit' &&
+          inferred.metadata.oldString &&
+          inferred.metadata.newString
         ) {
           newContent = this.simulatePsReplace(
             originalContent,
-            inferred.metadata['oldString'],
-            inferred.metadata['newString'],
+            inferred.metadata.oldString,
+            inferred.metadata.newString,
           );
         }
       }
@@ -501,19 +497,19 @@ export class ShellToolInvocation extends BaseToolInvocation<
         let operation: FileOperation | undefined;
         let canonicalToolName = SHELL_TOOL_NAME;
         switch (inferred.type) {
-          case FileOperationType.SEARCH:
+          case 'search':
             operation = FileOperation.READ;
             canonicalToolName = GREP_TOOL_NAME;
             break;
-          case FileOperationType.READ:
+          case 'read':
             operation = FileOperation.READ;
             canonicalToolName = READ_FILE_TOOL_NAME;
             break;
-          case FileOperationType.EDIT:
+          case 'edit':
             operation = FileOperation.UPDATE;
             canonicalToolName = EDIT_TOOL_NAME;
             break;
-          case FileOperationType.WRITE:
+          case 'write':
             operation = FileOperation.UPDATE;
             canonicalToolName = WRITE_FILE_TOOL_NAME;
             break;

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -22,6 +22,11 @@ import { ToolRegistry, DiscoveredTool } from './tool-registry.js';
 import {
   DISCOVERED_TOOL_PREFIX,
   UPDATE_TOPIC_TOOL_NAME,
+  GREP_TOOL_NAME,
+  EDIT_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+  READ_FILE_TOOL_NAME,
+  SHELL_TOOL_NAME,
 } from './tool-names.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import {
@@ -732,6 +737,33 @@ describe('ToolRegistry', () => {
       const declarations = toolRegistry.getFunctionDeclarations();
       expect(declarations).toHaveLength(1);
       expect(declarations[0].name).toBe(`mcp_${serverName}_${toolName}`);
+    });
+
+    it('should exclude lower fidelity tools when sandboxing is enabled for the main agent', () => {
+      vi.spyOn(config, 'getSandboxEnabled').mockReturnValue(true);
+      (toolRegistry as any).isMainRegistry = true;
+
+      // Register the tools that should be excluded
+      const grepTool = new MockTool({ name: GREP_TOOL_NAME });
+      const editTool = new MockTool({ name: EDIT_TOOL_NAME });
+      const writeTool = new MockTool({ name: WRITE_FILE_TOOL_NAME });
+      const readTool = new MockTool({ name: READ_FILE_TOOL_NAME });
+      const shellTool = new MockTool({ name: SHELL_TOOL_NAME });
+
+      toolRegistry.registerTool(grepTool);
+      toolRegistry.registerTool(editTool);
+      toolRegistry.registerTool(writeTool);
+      toolRegistry.registerTool(readTool);
+      toolRegistry.registerTool(shellTool);
+
+      const declarations = toolRegistry.getFunctionDeclarations();
+      const names = declarations.map((d) => d.name);
+
+      expect(names).not.toContain(GREP_TOOL_NAME);
+      expect(names).not.toContain(EDIT_TOOL_NAME);
+      expect(names).not.toContain(WRITE_FILE_TOOL_NAME);
+      expect(names).not.toContain(READ_FILE_TOOL_NAME);
+      expect(names).toContain(SHELL_TOOL_NAME);
     });
   });
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -30,6 +30,8 @@ import {
   getToolAliases,
   WRITE_FILE_TOOL_NAME,
   EDIT_TOOL_NAME,
+  GREP_TOOL_NAME,
+  READ_FILE_TOOL_NAME,
   UPDATE_TOPIC_TOOL_NAME,
 } from './tool-names.js';
 
@@ -631,6 +633,17 @@ export class ToolRegistry {
         !mainAgentTools.includes(toolName) &&
         !mainAgentTools.includes(tool.constructor.name) &&
         !mainAgentTools.some((t) => t.startsWith(`${tool.constructor.name}(`))
+      ) {
+        return;
+      }
+
+      if (
+        this.isMainRegistry &&
+        this.config.getSandboxEnabled() &&
+        (toolName === GREP_TOOL_NAME ||
+          toolName === EDIT_TOOL_NAME ||
+          toolName === WRITE_FILE_TOOL_NAME ||
+          toolName === READ_FILE_TOOL_NAME)
       ) {
         return;
       }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -393,6 +393,32 @@ export abstract class BaseToolInvocation<
 export type AnyToolInvocation = ToolInvocation<object, ToolResult>;
 
 /**
+ * Type guard to check if an object is an AnyToolInvocation.
+ */
+export function isAnyToolInvocation(
+  invocation: unknown,
+): invocation is AnyToolInvocation {
+  if (typeof invocation !== 'object' || invocation === null) {
+    return false;
+  }
+
+  return (
+    'execute' in invocation &&
+    typeof invocation.execute === 'function' &&
+    'getDescription' in invocation &&
+    typeof invocation.getDescription === 'function' &&
+    'params' in invocation &&
+    isRecord(invocation.params)
+  );
+}
+
+export function hasDisplayTitle(
+  invocation: AnyToolInvocation,
+): invocation is AnyToolInvocation & { getDisplayTitle(): string } {
+  return typeof invocation.getDisplayTitle === 'function';
+}
+
+/**
  * Interface for a tool builder that validates parameters and creates invocations.
  */
 export interface ToolBuilder<

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -606,40 +606,42 @@ describe('resolveExecutable', () => {
   });
 });
 
-  describe('inferFileOperation', () => {
-    it('should infer sed -i as an EDIT operation', () => {
-      mockPlatform.mockReturnValue('linux');
-      const result = inferFileOperation("sed -i 's/foo/bar/g' test.ts");
-      expect(result).toBeDefined();
-      expect(result?.type).toBe(FileOperationType.EDIT);
-      expect(result?.filePath).toBe('test.ts');
-      expect(result?.metadata?.['sedExpression']).toBe('s/foo/bar/g');
-    });
-
-    it('should infer echo redirection as a WRITE operation', () => {
-      mockPlatform.mockReturnValue('linux');
-      const result = inferFileOperation("echo 'hello' > hello.txt");
-      expect(result).toBeDefined();
-      expect(result?.type).toBe(FileOperationType.WRITE);
-      expect(result?.filePath).toBe('hello.txt');
-    });
-
-    it('should infer grep as a SEARCH operation', () => {
-      mockPlatform.mockReturnValue('linux');
-      const result = inferFileOperation("grep 'pattern' file.txt");
-      expect(result).toBeDefined();
-      expect(result?.type).toBe(FileOperationType.SEARCH);
-      expect(result?.filePath).toBe('file.txt');
-      expect(result?.metadata?.['pattern']).toBe('pattern');
-    });
-
-    it('should infer PowerShell -replace as an EDIT operation', () => {
-      mockPlatform.mockReturnValue('win32');
-      const result = inferFileOperation("(Get-Content file.txt) -replace 'a', 'b' | Set-Content file.txt");
-      expect(result).toBeDefined();
-      expect(result?.type).toBe(FileOperationType.EDIT);
-      expect(result?.filePath).toBe('file.txt');
-      expect(result?.metadata?.['oldString']).toBe('a');
-      expect(result?.metadata?.['newString']).toBe('b');
-    });
+describe('inferFileOperation', () => {
+  it('should infer sed -i as an EDIT operation', () => {
+    mockPlatform.mockReturnValue('linux');
+    const result = inferFileOperation("sed -i 's/foo/bar/g' test.ts");
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(FileOperationType.EDIT);
+    expect(result?.filePath).toBe('test.ts');
+    expect(result?.metadata?.['sedExpression']).toBe('s/foo/bar/g');
   });
+
+  it('should infer echo redirection as a WRITE operation', () => {
+    mockPlatform.mockReturnValue('linux');
+    const result = inferFileOperation("echo 'hello' > hello.txt");
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(FileOperationType.WRITE);
+    expect(result?.filePath).toBe('hello.txt');
+  });
+
+  it('should infer grep as a SEARCH operation', () => {
+    mockPlatform.mockReturnValue('linux');
+    const result = inferFileOperation("grep 'pattern' file.txt");
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(FileOperationType.SEARCH);
+    expect(result?.filePath).toBe('file.txt');
+    expect(result?.metadata?.['pattern']).toBe('pattern');
+  });
+
+  it('should infer PowerShell -replace as an EDIT operation', () => {
+    mockPlatform.mockReturnValue('win32');
+    const result = inferFileOperation(
+      "(Get-Content file.txt) -replace 'a', 'b' | Set-Content file.txt",
+    );
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(FileOperationType.EDIT);
+    expect(result?.filePath).toBe('file.txt');
+    expect(result?.metadata?.['oldString']).toBe('a');
+    expect(result?.metadata?.['newString']).toBe('b');
+  });
+});

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -23,6 +23,8 @@ import {
   stripShellWrapper,
   hasRedirection,
   resolveExecutable,
+  inferFileOperation,
+  FileOperationType,
 } from './shell-utils.js';
 import path from 'node:path';
 
@@ -603,3 +605,41 @@ describe('resolveExecutable', () => {
     expect(await resolveExecutable('unknown')).toBeUndefined();
   });
 });
+
+  describe('inferFileOperation', () => {
+    it('should infer sed -i as an EDIT operation', () => {
+      mockPlatform.mockReturnValue('linux');
+      const result = inferFileOperation("sed -i 's/foo/bar/g' test.ts");
+      expect(result).toBeDefined();
+      expect(result?.type).toBe(FileOperationType.EDIT);
+      expect(result?.filePath).toBe('test.ts');
+      expect(result?.metadata?.['sedExpression']).toBe('s/foo/bar/g');
+    });
+
+    it('should infer echo redirection as a WRITE operation', () => {
+      mockPlatform.mockReturnValue('linux');
+      const result = inferFileOperation("echo 'hello' > hello.txt");
+      expect(result).toBeDefined();
+      expect(result?.type).toBe(FileOperationType.WRITE);
+      expect(result?.filePath).toBe('hello.txt');
+    });
+
+    it('should infer grep as a SEARCH operation', () => {
+      mockPlatform.mockReturnValue('linux');
+      const result = inferFileOperation("grep 'pattern' file.txt");
+      expect(result).toBeDefined();
+      expect(result?.type).toBe(FileOperationType.SEARCH);
+      expect(result?.filePath).toBe('file.txt');
+      expect(result?.metadata?.['pattern']).toBe('pattern');
+    });
+
+    it('should infer PowerShell -replace as an EDIT operation', () => {
+      mockPlatform.mockReturnValue('win32');
+      const result = inferFileOperation("(Get-Content file.txt) -replace 'a', 'b' | Set-Content file.txt");
+      expect(result).toBeDefined();
+      expect(result?.type).toBe(FileOperationType.EDIT);
+      expect(result?.filePath).toBe('file.txt');
+      expect(result?.metadata?.['oldString']).toBe('a');
+      expect(result?.metadata?.['newString']).toBe('b');
+    });
+  });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -24,7 +24,6 @@ import {
   hasRedirection,
   resolveExecutable,
   inferFileOperation,
-  FileOperationType,
 } from './shell-utils.js';
 import path from 'node:path';
 
@@ -611,16 +610,19 @@ describe('inferFileOperation', () => {
     mockPlatform.mockReturnValue('linux');
     const result = inferFileOperation("sed -i 's/foo/bar/g' test.ts");
     expect(result).toBeDefined();
-    expect(result?.type).toBe(FileOperationType.EDIT);
+    expect(result?.type).toBe('edit');
     expect(result?.filePath).toBe('test.ts');
-    expect(result?.metadata?.['sedExpression']).toBe('s/foo/bar/g');
+    expect(result?.metadata?.type).toBe('edit');
+    if (result?.metadata?.type === 'edit') {
+      expect(result.metadata.sedExpression).toBe('s/foo/bar/g');
+    }
   });
 
   it('should infer echo redirection as a WRITE operation', () => {
     mockPlatform.mockReturnValue('linux');
     const result = inferFileOperation("echo 'hello' > hello.txt");
     expect(result).toBeDefined();
-    expect(result?.type).toBe(FileOperationType.WRITE);
+    expect(result?.type).toBe('write');
     expect(result?.filePath).toBe('hello.txt');
   });
 
@@ -628,9 +630,12 @@ describe('inferFileOperation', () => {
     mockPlatform.mockReturnValue('linux');
     const result = inferFileOperation("grep 'pattern' file.txt");
     expect(result).toBeDefined();
-    expect(result?.type).toBe(FileOperationType.SEARCH);
+    expect(result?.type).toBe('search');
     expect(result?.filePath).toBe('file.txt');
-    expect(result?.metadata?.['pattern']).toBe('pattern');
+    expect(result?.metadata?.type).toBe('search');
+    if (result?.metadata?.type === 'search') {
+      expect(result.metadata.pattern).toBe('pattern');
+    }
   });
 
   it('should infer PowerShell -replace as an EDIT operation', () => {
@@ -639,9 +644,12 @@ describe('inferFileOperation', () => {
       "(Get-Content file.txt) -replace 'a', 'b' | Set-Content file.txt",
     );
     expect(result).toBeDefined();
-    expect(result?.type).toBe(FileOperationType.EDIT);
+    expect(result?.type).toBe('edit');
     expect(result?.filePath).toBe('file.txt');
-    expect(result?.metadata?.['oldString']).toBe('a');
-    expect(result?.metadata?.['newString']).toBe('b');
+    expect(result?.metadata?.type).toBe('edit');
+    if (result?.metadata?.type === 'edit') {
+      expect(result.metadata.oldString).toBe('a');
+      expect(result.metadata.newString).toBe('b');
+    }
   });
 });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -835,7 +835,9 @@ export function inferFileOperation(
     }
 
     // ... | tee file
-    const teeMatch = stripped.match(/\|\s*tee\s+(?:-a\s+)?['"]?([^'"]+)['"]?\s*$/);
+    const teeMatch = stripped.match(
+      /\|\s*tee\s+(?:-a\s+)?['"]?([^'"]+)['"]?\s*$/,
+    );
     if (teeMatch) {
       return {
         type: FileOperationType.WRITE,
@@ -874,7 +876,10 @@ export function inferFileOperation(
       return {
         type: FileOperationType.EDIT,
         filePath: psReplaceMatch[1].trim(),
-        metadata: { oldString: psReplaceMatch[2], newString: psReplaceMatch[3] },
+        metadata: {
+          oldString: psReplaceMatch[2],
+          newString: psReplaceMatch[3],
+        },
       };
     }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -623,6 +623,20 @@ export function getShellConfiguration(): ShellConfiguration {
  */
 export const isWindows = () => os.platform() === 'win32';
 
+export enum FileOperationType {
+  SEARCH = 'SEARCH',
+  EDIT = 'EDIT',
+  WRITE = 'WRITE',
+  READ = 'READ',
+}
+
+export interface InferredFileOperation {
+  type: FileOperationType;
+  filePath: string;
+  /** Inferred details (e.g., the sed expression or replacement string) */
+  metadata?: Record<string, unknown>;
+}
+
 /**
  * Escapes a string so that it can be safely used as a single argument
  * in a shell command, preventing command injection.
@@ -749,6 +763,157 @@ export function getCommandRoots(command: string): string[] {
     .map((detail) => detail.name)
     .filter((name) => !REDIRECTION_NAMES.has(name))
     .filter(Boolean);
+}
+
+/**
+ * Attempts to infer if a shell command is performing a common file operation
+ * like search, edit, or write.
+ */
+export function inferFileOperation(
+  command: string,
+): InferredFileOperation | undefined {
+  const stripped = stripShellWrapper(command);
+  const shellType = getShellConfiguration().shell;
+
+  if (shellType === 'bash') {
+    // sed -i 's/foo/bar/g' file
+    // Handle both -i and --in-place, and optional space after -i
+    const sedMatch = stripped.match(
+      /^sed\s+(?:-i|--in-place)(?:\s*['"]?\.?['"]?)?\s+['"]?([^'"]+)['"]?\s+['"]?([^'"]+)['"]?\s*$/,
+    );
+    if (sedMatch) {
+      return {
+        type: FileOperationType.EDIT,
+        filePath: sedMatch[2].trim(),
+        metadata: { sedExpression: sedMatch[1] },
+      };
+    }
+
+    // echo "content" > file
+    // Simple redirection check
+    const redirectionMatch = stripped.match(
+      /(?:^|&&|\|\||;)\s*(?:echo|printf)\s+.*?\s*>\s*(\S+)\s*$/,
+    );
+    if (redirectionMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: redirectionMatch[1].trim(),
+      };
+    }
+
+    // cat > file <<EOF ...
+    const heredocMatch = stripped.match(
+      /(?:^|&&|\|\||;)\s*cat\s*>\s*(\S+)\s*<<\s*(\S+)/,
+    );
+    if (heredocMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: heredocMatch[1].trim(),
+      };
+    }
+
+    // cp src dest
+    const cpMatch = stripped.match(
+      /^(?:cp)\s+(?:-[^ ]+\s+)*['"]?([^'"]+)['"]?\s+['"]?([^'"]+)['"]?\s*$/,
+    );
+    if (cpMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: cpMatch[2].trim(),
+      };
+    }
+
+    // mv src dest
+    const mvMatch = stripped.match(
+      /^(?:mv)\s+(?:-[^ ]+\s+)*['"]?([^'"]+)['"]?\s+['"]?([^'"]+)['"]?\s*$/,
+    );
+    if (mvMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: mvMatch[2].trim(),
+      };
+    }
+
+    // ... | tee file
+    const teeMatch = stripped.match(/\|\s*tee\s+(?:-a\s+)?['"]?([^'"]+)['"]?\s*$/);
+    if (teeMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: teeMatch[1].trim(),
+      };
+    }
+
+    // grep "pattern" file
+    const grepMatch = stripped.match(
+      /^(?:grep|rg|ripgrep)\s+(?:-[^ ]+\s+)*['"]?([^'"]+)['"]?\s+['"]?([^'"]+)['"]?\s*$/,
+    );
+    if (grepMatch) {
+      return {
+        type: FileOperationType.SEARCH,
+        filePath: grepMatch[2].trim(),
+        metadata: { pattern: grepMatch[1] },
+      };
+    }
+
+    // cat file, head file, tail file
+    const readMatch = stripped.match(
+      /^(?:cat|head|tail|less|more)\s+(?:-[^ ]+\s+)*['"]?([^'"]+)['"]?\s*$/,
+    );
+    if (readMatch) {
+      return {
+        type: FileOperationType.READ,
+        filePath: readMatch[1].trim(),
+      };
+    }
+  } else if (shellType === 'powershell') {
+    // (Get-Content file) -replace 'a', 'b' | Set-Content file
+    const psReplaceMatch = stripped.match(
+      /\(Get-Content\s+['"]?([^'"]+)['"]?\)\s+-replace\s+['"]?([^'"]+)['"]?,\s*['"]?([^'"]+)['"]?\s*\|\s*Set-Content\s+['"]?([^'"]+)['"]?/i,
+    );
+    if (psReplaceMatch) {
+      return {
+        type: FileOperationType.EDIT,
+        filePath: psReplaceMatch[1].trim(),
+        metadata: { oldString: psReplaceMatch[2], newString: psReplaceMatch[3] },
+      };
+    }
+
+    // Set-Content -Path file -Value "..."
+    const psSetContentMatch = stripped.match(
+      /Set-Content\s+-(?:Path|LiteralPath)\s+['"]?([^'"]+)['"]?/i,
+    );
+    if (psSetContentMatch) {
+      return {
+        type: FileOperationType.WRITE,
+        filePath: psSetContentMatch[1].trim(),
+      };
+    }
+
+    // Select-String -Path file -Pattern "..."
+    const psSearchMatch = stripped.match(
+      /Select-String\s+-(?:Path|LiteralPath)\s+['"]?([^'"]+)['"]?\s+-Pattern\s+['"]?([^'"]+)['"]?/i,
+    );
+    if (psSearchMatch) {
+      return {
+        type: FileOperationType.SEARCH,
+        filePath: psSearchMatch[1].trim(),
+        metadata: { pattern: psSearchMatch[2] },
+      };
+    }
+
+    // Get-Content file, type file, cat file
+    const psReadMatch = stripped.match(
+      /^(?:Get-Content|type|cat)\s+(?:-(?:Path|LiteralPath|Tail|Head|TotalCount|Wait)\s+[^ ]+\s+)*['"]?([^'"]+)['"]?\s*$/i,
+    );
+    if (psReadMatch) {
+      return {
+        type: FileOperationType.READ,
+        filePath: psReadMatch[1].trim(),
+      };
+    }
+  }
+
+  return undefined;
 }
 
 export function stripShellWrapper(command: string): string {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -623,18 +623,39 @@ export function getShellConfiguration(): ShellConfiguration {
  */
 export const isWindows = () => os.platform() === 'win32';
 
-export enum FileOperationType {
-  SEARCH = 'SEARCH',
-  EDIT = 'EDIT',
-  WRITE = 'WRITE',
-  READ = 'READ',
-}
+export type FileOperationType = 'search' | 'edit' | 'write' | 'read';
+
+export type SearchFileMetadata = {
+  type: 'search';
+  pattern: string;
+};
+
+export type EditFileMetadata = {
+  type: 'edit';
+  sedExpression?: string;
+  oldString?: string;
+  newString?: string;
+};
+
+export type WriteFileMetadata = {
+  type: 'write';
+};
+
+export type ReadFileMetadata = {
+  type: 'read';
+};
+
+export type InferredFileMetadata =
+  | SearchFileMetadata
+  | EditFileMetadata
+  | WriteFileMetadata
+  | ReadFileMetadata;
 
 export interface InferredFileOperation {
   type: FileOperationType;
   filePath: string;
   /** Inferred details (e.g., the sed expression or replacement string) */
-  metadata?: Record<string, unknown>;
+  metadata?: InferredFileMetadata;
 }
 
 /**
@@ -783,9 +804,9 @@ export function inferFileOperation(
     );
     if (sedMatch) {
       return {
-        type: FileOperationType.EDIT,
+        type: 'edit',
         filePath: sedMatch[2].trim(),
-        metadata: { sedExpression: sedMatch[1] },
+        metadata: { type: 'edit', sedExpression: sedMatch[1] },
       };
     }
 
@@ -796,7 +817,7 @@ export function inferFileOperation(
     );
     if (redirectionMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: redirectionMatch[1].trim(),
       };
     }
@@ -807,7 +828,7 @@ export function inferFileOperation(
     );
     if (heredocMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: heredocMatch[1].trim(),
       };
     }
@@ -818,7 +839,7 @@ export function inferFileOperation(
     );
     if (cpMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: cpMatch[2].trim(),
       };
     }
@@ -829,7 +850,7 @@ export function inferFileOperation(
     );
     if (mvMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: mvMatch[2].trim(),
       };
     }
@@ -840,7 +861,7 @@ export function inferFileOperation(
     );
     if (teeMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: teeMatch[1].trim(),
       };
     }
@@ -851,9 +872,9 @@ export function inferFileOperation(
     );
     if (grepMatch) {
       return {
-        type: FileOperationType.SEARCH,
+        type: 'search',
         filePath: grepMatch[2].trim(),
-        metadata: { pattern: grepMatch[1] },
+        metadata: { type: 'search', pattern: grepMatch[1] },
       };
     }
 
@@ -863,7 +884,7 @@ export function inferFileOperation(
     );
     if (readMatch) {
       return {
-        type: FileOperationType.READ,
+        type: 'read',
         filePath: readMatch[1].trim(),
       };
     }
@@ -874,9 +895,10 @@ export function inferFileOperation(
     );
     if (psReplaceMatch) {
       return {
-        type: FileOperationType.EDIT,
+        type: 'edit',
         filePath: psReplaceMatch[1].trim(),
         metadata: {
+          type: 'edit',
           oldString: psReplaceMatch[2],
           newString: psReplaceMatch[3],
         },
@@ -889,7 +911,7 @@ export function inferFileOperation(
     );
     if (psSetContentMatch) {
       return {
-        type: FileOperationType.WRITE,
+        type: 'write',
         filePath: psSetContentMatch[1].trim(),
       };
     }
@@ -900,9 +922,9 @@ export function inferFileOperation(
     );
     if (psSearchMatch) {
       return {
-        type: FileOperationType.SEARCH,
+        type: 'search',
         filePath: psSearchMatch[1].trim(),
-        metadata: { pattern: psSearchMatch[2] },
+        metadata: { type: 'search', pattern: psSearchMatch[2] },
       };
     }
 
@@ -912,7 +934,7 @@ export function inferFileOperation(
     );
     if (psReadMatch) {
       return {
-        type: FileOperationType.READ,
+        type: 'read',
         filePath: psReadMatch[1].trim(),
       };
     }


### PR DESCRIPTION
Title: feat(core): shell inference for file operations under sandboxing

## Description
When `security.toolSandboxing` is enabled, the CLI now excludes the lower-fidelity tools (`grep_search`, `replace`, `write_file`, `read_file`) from the main agent, relying on `run_shell_command` (e.g. `sed`, `grep`, `cat`, `echo >`) to perform these actions safely.

To maintain UX and telemetry parity, `run_shell_command` now infers common file operations. When detected:
- The UI title is updated to a high-fidelity display (e.g., "Shell (Read File)", "Shell (Replace)").
- File editing/writing commands (like `sed -i` or `echo >`) generate a predicted diff view for the user during confirmation.
- The execution emits standard `FileOperationEvent` telemetry using canonical tool names to ensure metrics consistency across setups.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [X] Added unit tests for inference logic in `shell-utils.test.ts`
- [X] Added `shell-parity.test.ts` integration test
- [X] Verified UI locally.
