### PR TITLE
fix: handle RangeError when conversation exceeds JSON serializable size

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -956,6 +956,55 @@ describe('ChatRecordingService', () => {
     });
   });
 
+  describe('RangeError (conversation too large) graceful degradation - issue #24902', () => {
+    it('should disable recording and not throw when RangeError occurs during appendRecord', async () => {
+      await chatRecordingService.initialize();
+
+      vi.mocked(fs.appendFileSync).mockImplementation(() => {
+        throw new RangeError('Invalid string length');
+      });
+
+      expect(() =>
+        chatRecordingService.recordMessage({
+          type: 'user',
+          content: 'Hello',
+          model: 'gemini-pro',
+        }),
+      ).not.toThrow();
+
+      expect(chatRecordingService.getConversationFilePath()).toBeNull();
+    });
+
+    it('should skip recording operations after RangeError disables recording', async () => {
+      await chatRecordingService.initialize();
+
+      vi.mocked(fs.appendFileSync)
+        .mockImplementationOnce(() => {
+          throw new RangeError('Invalid string length');
+        })
+        .mockImplementation(() => {});
+
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'Hello',
+        model: 'gemini-pro',
+      });
+
+      // Recording should be disabled after RangeError
+      expect(chatRecordingService.getConversationFilePath()).toBeNull();
+
+      // Subsequent records should silently no-op
+      const appendSpy = vi.mocked(fs.appendFileSync);
+      const callsBefore = appendSpy.mock.calls.length;
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'Second message',
+        model: 'gemini-pro',
+      });
+      expect(appendSpy.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
   describe('updateMessagesFromHistory', () => {
     beforeEach(async () => {
       await chatRecordingService.initialize();

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -47,6 +47,14 @@ const ENOSPC_WARNING_MESSAGE =
   'The conversation will continue but will not be saved to disk. ' +
   'Free up disk space and restart to enable recording.';
 
+/**
+ * Warning message shown when recording is disabled due to conversation exceeding
+ * the maximum serializable size.
+ */
+const RANGE_WARNING_MESSAGE =
+  'Chat recording disabled: Conversation exceeded maximum serializable size. ' +
+  'The conversation will continue but will not be saved to disk.';
+
 function hasProperty<T extends string>(
   obj: unknown,
   prop: T,
@@ -397,6 +405,9 @@ export class ChatRecordingService {
       if (isNodeError(error) && error.code === 'ENOSPC') {
         this.conversationFile = null;
         debugLogger.warn(ENOSPC_WARNING_MESSAGE);
+      } else if (error instanceof RangeError) {
+        this.conversationFile = null;
+        debugLogger.warn(RANGE_WARNING_MESSAGE);
       } else {
         throw error;
       }


### PR DESCRIPTION
## Problem

When `JSON.stringify` is called on a very large conversation object, V8 throws a `RangeError: Invalid string length`. This was not caught by the existing error handler in `appendRecord`, causing an unhandled rejection that crashed the CLI.

Fixes #24902

## Solution

Mirror the existing `ENOSPC` pattern in `appendRecord`:
- Catch `RangeError` alongside `ENOSPC`
- Disable chat recording (`this.conversationFile = null`)
- Emit a warning via `debugLogger.warn`
- Allow the conversation to continue uninterrupted

## Changes

- `chatRecordingService.ts`: Add `RANGE_WARNING_MESSAGE` constant and `RangeError` branch in `appendRecord` catch block
- `chatRecordingService.test.ts`: Add two tests covering graceful degradation and subsequent no-op behaviour