### PR TITLE
fix: drain redirect response and resolve relative URLs in downloadFile

### DIFF
--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -543,7 +543,9 @@ export async function downloadFile(
               new Error('Redirect response missing Location header'),
             );
           }
-          downloadFile(res.headers.location, dest, options, redirectCount + 1)
+          res.resume(); // Drain response body to free the socket
+          const redirectUrl = new URL(res.headers.location, url).toString();
+          downloadFile(redirectUrl, dest, options, redirectCount + 1)
             .then(resolve)
             .catch(reject);
           return;


### PR DESCRIPTION
Follow-up to #24896 — applies the same two fixes to the sibling function `downloadFile` in `github.ts`.

## Problem

`downloadFile` has the same redirect handling issues that were fixed in `fetchJson` (#24896):

1. **Socket leak**: The redirect response body is not consumed. Node.js keeps the underlying TCP socket open until the response stream is drained or garbage collected, which can cause socket exhaustion under repeated redirects.

2. **Relative redirect URLs**: `res.headers.location` is passed directly to the recursive call without resolving against the current URL. Relative `Location` headers (e.g. `/path/to/file`) would fail since `https.get` expects an absolute URL.

## Changes

- Add `res.resume()` before following redirect to drain the response body and release the socket
- Use `new URL(res.headers.location, url).toString()` to resolve relative `Location` headers against the current URL

Both fixes mirror the approach already applied to `fetchJson` in #24896.

## Test plan

- [x] Verified the fix matches the pattern from #24896
- [x] `downloadFile` is used for extension downloads (GitHub release assets), which commonly return 302 redirects to CDN URLs