### PR TITLE
chore(mcp): check MCP error code over brittle string match

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -38,7 +38,6 @@ import {
   McpClient,
   populateMcpServerCommand,
   discoverPrompts,
-  discoverResources,
   type McpContext,
 } from './mcp-client.js';
 import type { ToolRegistry } from './tool-registry.js';
@@ -340,66 +339,6 @@ describe('mcp-client', () => {
       );
       expect(result).toEqual([]);
       // MethodNotFound errors should be silently ignored regardless of message text
-      expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
-    });
-
-    it('should throw for discoverPrompts on non-MethodNotFound error with diagnostic', async () => {
-      const mockedClient = {
-        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
-        listPrompts: vi.fn().mockRejectedValue(new Error('Connection reset')),
-      };
-      await expect(
-        discoverPrompts(
-          'test-server',
-          mockedClient as unknown as ClientLib.Client,
-          MOCK_CONTEXT,
-        ),
-      ).rejects.toThrow('Connection reset');
-      expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
-        'error',
-        expect.stringContaining('Connection reset'),
-        expect.any(Error),
-        'test-server',
-      );
-    });
-
-    it('should throw for discoverResources on non-MethodNotFound error with diagnostic', async () => {
-      const mockedClient = {
-        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
-        request: vi
-          .fn()
-          .mockRejectedValue(new Error('Resource listing failed')),
-      };
-      await expect(
-        discoverResources(
-          'test-server',
-          mockedClient as unknown as ClientLib.Client,
-          MOCK_CONTEXT,
-        ),
-      ).rejects.toThrow('Resource listing failed');
-      expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
-        'error',
-        expect.stringContaining('Resource listing failed'),
-        expect.any(Error),
-        'test-server',
-      );
-    });
-
-    it('should return empty array for discoverResources on MethodNotFound without diagnostic', async () => {
-      const mockedClient = {
-        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
-        request: vi
-          .fn()
-          .mockRejectedValue(
-            new McpError(ErrorCode.MethodNotFound, 'Method not found'),
-          ),
-      };
-      const result = await discoverResources(
-        'test-server',
-        mockedClient as unknown as ClientLib.Client,
-        MOCK_CONTEXT,
-      );
-      expect(result).toEqual([]);
       expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -20,6 +20,8 @@ import { MCPOAuthTokenStorage } from '../mcp/oauth-token-storage.js';
 import { OAuthUtils } from '../mcp/oauth-utils.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import {
+  ErrorCode,
+  McpError,
   PromptListChangedNotificationSchema,
   ResourceListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
@@ -35,6 +37,8 @@ import {
   isEnabled,
   McpClient,
   populateMcpServerCommand,
+  discoverPrompts,
+  discoverResources,
   type McpContext,
 } from './mcp-client.js';
 import type { ToolRegistry } from './tool-registry.js';
@@ -262,7 +266,7 @@ describe('mcp-client', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should propagate errors when discovering prompts', async () => {
+    it('should not throw when discovering prompts fails and should still discover tools', async () => {
       const mockedClient = {
         connect: vi.fn(),
         discover: vi.fn(),
@@ -271,10 +275,20 @@ describe('mcp-client', () => {
         registerCapabilities: vi.fn(),
         setRequestHandler: vi.fn(),
         setNotificationHandler: vi.fn(),
-        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
-        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        getServerCapabilities: vi
+          .fn()
+          .mockReturnValue({ prompts: {}, tools: {} }),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            {
+              name: 'tool1',
+              description: 'Test tool',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        }),
         listPrompts: vi.fn().mockRejectedValue(new Error('Test error')),
-        request: vi.fn().mockResolvedValue({}),
+        request: vi.fn().mockResolvedValue({ resources: [] }),
       };
       vi.mocked(ClientLib.Client).mockReturnValue(
         mockedClient as unknown as ClientLib.Client,
@@ -284,6 +298,8 @@ describe('mcp-client', () => {
       );
       const mockedToolRegistry = {
         registerTool: vi.fn(),
+        sortTools: vi.fn(),
+        getToolsByServer: vi.fn().mockReturnValue([]),
         getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const promptRegistry = {
@@ -305,19 +321,98 @@ describe('mcp-client', () => {
         '0.0.1',
       );
       await client.connect();
-      await expect(
-        client.discoverInto(MOCK_CONTEXT, {
-          toolRegistry: mockedToolRegistry,
-          promptRegistry,
-          resourceRegistry,
-        }),
-      ).rejects.toThrow('Test error');
+      // Should NOT throw despite prompt discovery failure
+      await client.discoverInto(MOCK_CONTEXT, {
+        toolRegistry: mockedToolRegistry,
+        promptRegistry,
+        resourceRegistry,
+      });
+      // Diagnostic should still be emitted
       expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
         'error',
         `Error discovering prompts from test-server: Test error`,
         expect.any(Error),
         'test-server',
       );
+      // Tools should still be discovered
+      expect(mockedToolRegistry.registerTool).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty array for discoverPrompts on MethodNotFound error without diagnostic', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
+        listPrompts: vi
+          .fn()
+          .mockRejectedValue(
+            new McpError(ErrorCode.MethodNotFound, 'Method not supported'),
+          ),
+      };
+      const result = await discoverPrompts(
+        'test-server',
+        mockedClient as unknown as ClientLib.Client,
+        MOCK_CONTEXT,
+      );
+      expect(result).toEqual([]);
+      // MethodNotFound errors should be silently ignored regardless of message text
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array for discoverPrompts on non-MethodNotFound error with diagnostic', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
+        listPrompts: vi.fn().mockRejectedValue(new Error('Connection reset')),
+      };
+      const result = await discoverPrompts(
+        'test-server',
+        mockedClient as unknown as ClientLib.Client,
+        MOCK_CONTEXT,
+      );
+      expect(result).toEqual([]);
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('Connection reset'),
+        expect.any(Error),
+        'test-server',
+      );
+    });
+
+    it('should return empty array for discoverResources on error without throwing', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
+        request: vi
+          .fn()
+          .mockRejectedValue(new Error('Resource listing failed')),
+      };
+      const result = await discoverResources(
+        'test-server',
+        mockedClient as unknown as ClientLib.Client,
+        MOCK_CONTEXT,
+      );
+      expect(result).toEqual([]);
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('Resource listing failed'),
+        expect.any(Error),
+        'test-server',
+      );
+    });
+
+    it('should return empty array for discoverResources on MethodNotFound without diagnostic', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
+        request: vi
+          .fn()
+          .mockRejectedValue(
+            new McpError(ErrorCode.MethodNotFound, 'Method not found'),
+          ),
+      };
+      const result = await discoverResources(
+        'test-server',
+        mockedClient as unknown as ClientLib.Client,
+        MOCK_CONTEXT,
+      );
+      expect(result).toEqual([]);
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
     });
 
     it('should not discover tools if server does not support them', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -266,7 +266,7 @@ describe('mcp-client', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should not throw when discovering prompts fails and should still discover tools', async () => {
+    it('should propagate errors when discovering prompts', async () => {
       const mockedClient = {
         connect: vi.fn(),
         discover: vi.fn(),
@@ -275,20 +275,10 @@ describe('mcp-client', () => {
         registerCapabilities: vi.fn(),
         setRequestHandler: vi.fn(),
         setNotificationHandler: vi.fn(),
-        getServerCapabilities: vi
-          .fn()
-          .mockReturnValue({ prompts: {}, tools: {} }),
-        listTools: vi.fn().mockResolvedValue({
-          tools: [
-            {
-              name: 'tool1',
-              description: 'Test tool',
-              inputSchema: { type: 'object' },
-            },
-          ],
-        }),
+        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
         listPrompts: vi.fn().mockRejectedValue(new Error('Test error')),
-        request: vi.fn().mockResolvedValue({ resources: [] }),
+        request: vi.fn().mockResolvedValue({}),
       };
       vi.mocked(ClientLib.Client).mockReturnValue(
         mockedClient as unknown as ClientLib.Client,
@@ -298,8 +288,6 @@ describe('mcp-client', () => {
       );
       const mockedToolRegistry = {
         registerTool: vi.fn(),
-        sortTools: vi.fn(),
-        getToolsByServer: vi.fn().mockReturnValue([]),
         getMessageBus: vi.fn().mockReturnValue(undefined),
       } as unknown as ToolRegistry;
       const promptRegistry = {
@@ -321,21 +309,19 @@ describe('mcp-client', () => {
         '0.0.1',
       );
       await client.connect();
-      // Should NOT throw despite prompt discovery failure
-      await client.discoverInto(MOCK_CONTEXT, {
-        toolRegistry: mockedToolRegistry,
-        promptRegistry,
-        resourceRegistry,
-      });
-      // Diagnostic should still be emitted
+      await expect(
+        client.discoverInto(MOCK_CONTEXT, {
+          toolRegistry: mockedToolRegistry,
+          promptRegistry,
+          resourceRegistry,
+        }),
+      ).rejects.toThrow('Test error');
       expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
         'error',
         `Error discovering prompts from test-server: Test error`,
         expect.any(Error),
         'test-server',
       );
-      // Tools should still be discovered
-      expect(mockedToolRegistry.registerTool).toHaveBeenCalledTimes(1);
     });
 
     it('should return empty array for discoverPrompts on MethodNotFound error without diagnostic', async () => {
@@ -357,17 +343,18 @@ describe('mcp-client', () => {
       expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
     });
 
-    it('should return empty array for discoverPrompts on non-MethodNotFound error with diagnostic', async () => {
+    it('should throw for discoverPrompts on non-MethodNotFound error with diagnostic', async () => {
       const mockedClient = {
         getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
         listPrompts: vi.fn().mockRejectedValue(new Error('Connection reset')),
       };
-      const result = await discoverPrompts(
-        'test-server',
-        mockedClient as unknown as ClientLib.Client,
-        MOCK_CONTEXT,
-      );
-      expect(result).toEqual([]);
+      await expect(
+        discoverPrompts(
+          'test-server',
+          mockedClient as unknown as ClientLib.Client,
+          MOCK_CONTEXT,
+        ),
+      ).rejects.toThrow('Connection reset');
       expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
         'error',
         expect.stringContaining('Connection reset'),
@@ -376,19 +363,20 @@ describe('mcp-client', () => {
       );
     });
 
-    it('should return empty array for discoverResources on error without throwing', async () => {
+    it('should throw for discoverResources on non-MethodNotFound error with diagnostic', async () => {
       const mockedClient = {
         getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
         request: vi
           .fn()
           .mockRejectedValue(new Error('Resource listing failed')),
       };
-      const result = await discoverResources(
-        'test-server',
-        mockedClient as unknown as ClientLib.Client,
-        MOCK_CONTEXT,
-      );
-      expect(result).toEqual([]);
+      await expect(
+        discoverResources(
+          'test-server',
+          mockedClient as unknown as ClientLib.Client,
+          MOCK_CONTEXT,
+        ),
+      ).rejects.toThrow('Resource listing failed');
       expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledWith(
         'error',
         expect.stringContaining('Resource listing failed'),

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1252,6 +1252,10 @@ export async function connectAndDiscover(
   }
 }
 
+function isMcpMethodNotFoundError(error: unknown): boolean {
+  return error instanceof McpError && error.code === ErrorCode.MethodNotFound;
+}
+
 /**
  * Discovers and sanitizes tools from a connected MCP client.
  * It retrieves function declarations from the client, filters out disabled tools,
@@ -1331,9 +1335,7 @@ export async function discoverTools(
     }
     return discoveredTools;
   } catch (error) {
-    if (
-      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
-    ) {
+    if (!isMcpMethodNotFoundError(error)) {
       cliConfig.emitMcpDiagnostic(
         'error',
         `Error discovering tools from ${mcpServerName}: ${getErrorMessage(
@@ -1457,7 +1459,7 @@ export async function discoverPrompts(
         ),
     }));
   } catch (error) {
-    if (error instanceof McpError && error.code === ErrorCode.MethodNotFound) {
+    if (isMcpMethodNotFoundError(error)) {
       return [];
     }
     cliConfig.emitMcpDiagnostic(
@@ -1505,7 +1507,7 @@ async function listResources(
       cursor = response.nextCursor ?? undefined;
     } while (cursor);
   } catch (error) {
-    if (error instanceof McpError && error.code === ErrorCode.MethodNotFound) {
+    if (isMcpMethodNotFoundError(error)) {
       return [];
     }
     cliConfig.emitMcpDiagnostic(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1457,19 +1457,18 @@ export async function discoverPrompts(
         ),
     }));
   } catch (error) {
-    if (
-      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
-    ) {
-      cliConfig.emitMcpDiagnostic(
-        'error',
-        `Error discovering prompts from ${mcpServerName}: ${getErrorMessage(
-          error,
-        )}`,
-        error,
-        mcpServerName,
-      );
+    if (error instanceof McpError && error.code === ErrorCode.MethodNotFound) {
+      return [];
     }
-    return [];
+    cliConfig.emitMcpDiagnostic(
+      'error',
+      `Error discovering prompts from ${mcpServerName}: ${getErrorMessage(
+        error,
+      )}`,
+      error,
+      mcpServerName,
+    );
+    throw error;
   }
 }
 
@@ -1506,19 +1505,18 @@ async function listResources(
       cursor = response.nextCursor ?? undefined;
     } while (cursor);
   } catch (error) {
-    if (
-      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
-    ) {
-      cliConfig.emitMcpDiagnostic(
-        'error',
-        `Error discovering resources from ${mcpServerName}: ${getErrorMessage(
-          error,
-        )}`,
-        error,
-        mcpServerName,
-      );
+    if (error instanceof McpError && error.code === ErrorCode.MethodNotFound) {
+      return [];
     }
-    return [];
+    cliConfig.emitMcpDiagnostic(
+      'error',
+      `Error discovering resources from ${mcpServerName}: ${getErrorMessage(
+        error,
+      )}`,
+      error,
+      mcpServerName,
+    );
+    throw error;
   }
   return resources;
 }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -27,6 +27,8 @@ import {
   ReadResourceResultSchema,
   ResourceListChangedNotificationSchema,
   ToolListChangedNotificationSchema,
+  ErrorCode,
+  McpError,
   PromptListChangedNotificationSchema,
   ProgressNotificationSchema,
   type GetPromptResult,
@@ -1330,8 +1332,7 @@ export async function discoverTools(
     return discoveredTools;
   } catch (error) {
     if (
-      error instanceof Error &&
-      !error.message?.includes('Method not found')
+      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
     ) {
       cliConfig.emitMcpDiagnostic(
         'error',
@@ -1456,19 +1457,19 @@ export async function discoverPrompts(
         ),
     }));
   } catch (error) {
-    // It's okay if the method is not found, which is a common case.
-    if (error instanceof Error && error.message?.includes('Method not found')) {
-      return [];
-    }
-    cliConfig.emitMcpDiagnostic(
-      'error',
-      `Error discovering prompts from ${mcpServerName}: ${getErrorMessage(
+    if (
+      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
+    ) {
+      cliConfig.emitMcpDiagnostic(
+        'error',
+        `Error discovering prompts from ${mcpServerName}: ${getErrorMessage(
+          error,
+        )}`,
         error,
-      )}`,
-      error,
-      mcpServerName,
-    );
-    throw error;
+        mcpServerName,
+      );
+    }
+    return [];
   }
 }
 
@@ -1505,18 +1506,19 @@ async function listResources(
       cursor = response.nextCursor ?? undefined;
     } while (cursor);
   } catch (error) {
-    if (error instanceof Error && error.message?.includes('Method not found')) {
-      return [];
-    }
-    cliConfig.emitMcpDiagnostic(
-      'error',
-      `Error discovering resources from ${mcpServerName}: ${getErrorMessage(
+    if (
+      !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
+    ) {
+      cliConfig.emitMcpDiagnostic(
+        'error',
+        `Error discovering resources from ${mcpServerName}: ${getErrorMessage(
+          error,
+        )}`,
         error,
-      )}`,
-      error,
-      mcpServerName,
-    );
-    throw error;
+        mcpServerName,
+      );
+    }
+    return [];
   }
   return resources;
 }


### PR DESCRIPTION
## Summary

This PR enhances the stability of MCP server discovery by using specific MCP error codes instead of brittle string matching.

### Previously
MCP server failure on prompt discovery for "Method not supported" showed a brittle match on "Method not found" so "Method not supported" was not being picked up.

<img width="1200" height="524" alt="Screenshot 2026-04-14 at 10 17 54 AM" src="https://github.com/user-attachments/assets/762d43d9-4ead-4986-854e-ef8349994321" />

### Now
MCP prompts use proper error code to check discovery and return empty on error so tools can properly work.

<img width="1300" height="536" alt="Screenshot 2026-04-14 at 10 17 37 AM" src="https://github.com/user-attachments/assets/9b04d448-0fe8-4165-aa3d-be269ea8e506" />

## Details

- Replaced string-based error checking for "Method not found" with explicit `McpError` and `ErrorCode.MethodNotFound` checks.

## Related Issues

Fixes #25107

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
