### PR TITLE
fix(cli): correct Thai/Lao SARA AM width mismatch causing rendering bugs

### DIFF
--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { render } from 'ink';
+import { render, setStringWidthFunction } from 'ink';
 import { basename } from 'node:path';
 import { AppContainer } from './ui/AppContainer.js';
 import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
@@ -50,6 +50,7 @@ import { TerminalProvider } from './ui/contexts/TerminalContext.js';
 import { OverflowProvider } from './ui/contexts/OverflowContext.js';
 import { profiler } from './ui/components/DebugProfiler.js';
 import { initializeConsoleStore } from './ui/hooks/useConsoleMessages.js';
+import { getCachedStringWidth } from './ui/utils/textUtils.js';
 
 const SLOW_RENDER_MS = 200;
 
@@ -62,6 +63,11 @@ export async function startInteractiveUI(
   initializationResult: InitializationResult,
 ) {
   initializeConsoleStore();
+
+  // Override Ink's string width function with our corrected version that
+  // compensates for Thai/Lao SARA AM width mismatch in string-width@8.1.0.
+  // See: https://github.com/google-gemini/gemini-cli/issues/25369
+  setStringWidthFunction(getCachedStringWidth);
   // Never enter Ink alternate buffer mode when screen reader mode is enabled
   // as there is no benefit of alternate buffer mode when using a screen reader
   // and the Ink alternate buffer mode requires line wrapping harmful to

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -57,6 +57,37 @@ describe('textUtils', () => {
       expect(() => getCachedStringWidth(charWithAnsi)).not.toThrow();
       expect(typeof getCachedStringWidth(charWithAnsi)).toBe('number');
     });
+
+    it('should return width 2 for Thai Consonant + SARA AM (U+0E33)', () => {
+      // กำ = ก (1 col) + ำ (1 col) = 2 columns in terminal
+      // string-width@8.1.0 returns 1 due to Intl.Segmenter merging them
+      expect(getCachedStringWidth('\u0E01\u0E33')).toBe(2);
+    });
+
+    it('should return width 2 for Lao Consonant + SARA AM (U+0EB3)', () => {
+      // ກຳ = ກ (1 col) + ຳ (1 col) = 2 columns in terminal
+      expect(getCachedStringWidth('\u0E81\u0EB3')).toBe(2);
+    });
+
+    it('should return correct width for Thai text with multiple SARA AM', () => {
+      // กำหนด = ก+ำ(2) + ห(1) + น(1) + ด(1) = 5 columns
+      expect(getCachedStringWidth('\u0E01\u0E33\u0E2B\u0E19\u0E14')).toBe(5);
+    });
+
+    it('should return correct width for two consecutive SARA AM clusters', () => {
+      // กำคำ = ก+ำ(2) + ค+ำ(2) = 4 columns
+      expect(getCachedStringWidth('\u0E01\u0E33\u0E04\u0E33')).toBe(4);
+    });
+
+    it('should return width 1 for standalone SARA AM', () => {
+      // Standalone ำ at position 0 = 1 column (no preceding char to merge with)
+      expect(getCachedStringWidth('\u0E33')).toBe(1);
+    });
+
+    it('should return correct width for mixed Thai and ASCII text', () => {
+      // "Hi กำ" = H(1) + i(1) + space(1) + ก+ำ(2) = 5
+      expect(getCachedStringWidth('Hi \u0E01\u0E33')).toBe(5);
+    });
   });
 
   describe('stripUnsafeCharacters', () => {

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -216,12 +216,15 @@ export const getCachedStringWidth = (str: string): number => {
   }
 
   let width: number;
+  // TODO(#25369): Remove saraAmCompensation once string-width > 8.1.0
+  // fixes Intl.Segmenter-based width for Thai/Lao SARA AM clusters.
+  const compensation = saraAmCompensation(str);
   try {
-    width = stringWidth(str) + saraAmCompensation(str);
+    width = stringWidth(str) + compensation;
   } catch {
     // Fallback for characters that cause string-width to crash (e.g. U+0602)
     // See: https://github.com/google-gemini/gemini-cli/issues/16418
-    width = toCodePoints(stripAnsi(str)).length;
+    width = toCodePoints(stripAnsi(str)).length + compensation;
   }
 
   stringWidthCache.set(str, width);

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -174,7 +174,31 @@ const stringWidthCache = new LRUCache<string, number>(
 );
 
 /**
- * Cached version of stringWidth function for better performance
+ * Count Thai SARA AM (U+0E33) and Lao SARA AM (U+0EB3) characters that
+ * are preceded by another character. Intl.Segmenter merges these with the
+ * preceding character into a single grapheme cluster, and string-width
+ * then reports width 1 for the cluster. Terminals render the cluster as
+ * 2 columns. Each such SARA AM needs +1 compensation.
+ *
+ * Standalone SARA AM (at position 0 with no preceding character) correctly
+ * gets width 1 from string-width, matching terminal behavior.
+ *
+ * See: https://github.com/google-gemini/gemini-cli/issues/25369
+ */
+function saraAmCompensation(str: string): number {
+  let count = 0;
+  for (let i = 1; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code === 0x0e33 || code === 0x0eb3) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Cached version of stringWidth function for better performance.
+ * Includes compensation for Thai/Lao SARA AM width mismatch.
  */
 export const getCachedStringWidth = (str: string): number => {
   // ASCII printable chars (32-126) have width 1.
@@ -193,7 +217,7 @@ export const getCachedStringWidth = (str: string): number => {
 
   let width: number;
   try {
-    width = stringWidth(str);
+    width = stringWidth(str) + saraAmCompensation(str);
   } catch {
     // Fallback for characters that cause string-width to crash (e.g. U+0602)
     // See: https://github.com/google-gemini/gemini-cli/issues/16418


### PR DESCRIPTION
## Summary

Fixes #25369

- `string-width@8.1.0` uses `Intl.Segmenter` which merges Consonant + SARA AM (U+0E33/U+0EB3) into a single grapheme cluster and reports width 1. Terminals render the pair as 2 columns, causing cursor desync, output duplication, and erratic line jumping in tmux.
- Adds width compensation in `getCachedStringWidth` that adds +1 for each SARA AM preceded by another character (where `Intl.Segmenter` under-counts)
- Overrides Ink's internal width function via `setStringWidthFunction` so both the text-buffer and Ink rendering paths use the corrected width

## Root Cause

```
string-width@8.1.0("กำ") → 1  (wrong, terminal renders 2 columns)
string-width@8.1.0("กำหนด") → 4  (wrong, terminal renders 5 columns)
```

`Intl.Segmenter` groups Consonant + SARA AM into one grapheme cluster. `string-width` then computes width using only the East Asian Width of the first code point (the consonant = 1), ignoring SARA AM which terminals render as an additional column.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/ui/utils/textUtils.ts` | Add `saraAmCompensation()` helper, apply in `getCachedStringWidth` (both happy path and fallback) |
| `packages/cli/src/interactiveCli.tsx` | Call `setStringWidthFunction(getCachedStringWidth)` to override Ink's width calculation |
| `packages/cli/src/ui/utils/textUtils.test.ts` | 6 new tests covering Thai, Lao, standalone, multi-cluster, and mixed text |

## Test plan

- [x] `vitest run packages/cli/src/ui/utils/textUtils.test.ts` — 82 tests pass
- [x] TypeScript compiles (no new errors in changed files)
- [x] Pre-commit hooks pass (prettier + eslint)
- [ ] Manual verification with Thai text in tmux