### PR TITLE
fix: keep console patch active in ACP mode to prevent stdout pollution

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -366,7 +366,13 @@ export async function main() {
     },
   });
   consolePatcher.patch();
-  registerCleanup(consolePatcher.cleanup);
+  // In ACP mode, keep the console patch active for the entire process lifecycle.
+  // Cleaning it up before SessionEnd hooks fire would let debugLogger output
+  // leak to stdout, corrupting the ACP NDJSON stream.
+  // See: https://github.com/google-gemini/gemini-cli/issues/25345
+  if (!argv.acp && !argv.experimentalAcp) {
+    registerCleanup(consolePatcher.cleanup);
+  }
 
   dns.setDefaultResultOrder(
     validateDnsResolutionOrder(settings.merged.advanced.dnsResolutionOrder),


### PR DESCRIPTION
## Summary

Fixes #25345

During ACP shutdown, the `ConsolePatcher` cleanup was registered (line 369) before the `SessionEnd` hook handler (line 548) in `gemini.tsx`. When `runExitCleanup()` iterated cleanup functions in registration order, `console.*` reverted to stdout before hooks fired, causing `debugLogger.debug()` output to corrupt the ACP NDJSON stream.

**Fix:** Skip registering `consolePatcher.cleanup` when `argv.acp` or `argv.experimentalAcp` is set. The console stays patched (routing to stderr) for the entire ACP process lifecycle. This is safe because ACP mode exits via `return runAcpClient(...)`, after which `main()` returns and the process exits.

Non-ACP modes (interactive, non-interactive) are completely unaffected.

## Test plan

- [x] All 37 existing tests in `gemini.test.tsx` pass
- [x] Pre-commit hooks pass (prettier, eslint)
- [x] TypeScript compiles (no new errors; pre-existing errors in unrelated files only)
- [x] Verified `argv.acp` and `argv.experimentalAcp` match the same flags used in `config.ts:751` (`isAcpMode`)