### PR TITLE
feat(test): add a performance test in asian language

### DIFF
--- a/perf-tests/baselines.json
+++ b/perf-tests/baselines.json
@@ -12,6 +12,11 @@
       "cpuTotalUs": 12157,
       "timestamp": "2026-04-08T22:28:19.098Z"
     },
+    "asian-language-conv": {
+      "wallClockMs": 2315.1,
+      "cpuTotalUs": 6283,
+      "timestamp": "2026-04-14T15:22:56.133Z"
+    },
     "skill-loading-time": {
       "wallClockMs": 930.0920409999962,
       "cpuTotalUs": 1323,

--- a/perf-tests/perf-usage.test.ts
+++ b/perf-tests/perf-usage.test.ts
@@ -98,6 +98,36 @@ describe('CPU Performance Tests', () => {
     }
   });
 
+  it('asian-language-conv: verify perf is acceptable ', async () => {
+    const result = await harness.runScenario(
+      'asian-language-conv',
+      async () => {
+        const rig = new TestRig();
+        try {
+          rig.setup('perf-asian-language', {
+            fakeResponsesPath: join(__dirname, 'perf.asian-language.responses'),
+          });
+
+          return await harness.measure('asian-language', async () => {
+            await rig.run({
+              args: ['嗨'],
+              timeout: 120000,
+              env: { GEMINI_API_KEY: 'fake-perf-test-key' },
+            });
+          });
+        } finally {
+          await rig.cleanup();
+        }
+      },
+    );
+
+    if (UPDATE_BASELINES) {
+      harness.updateScenarioBaseline(result);
+    } else {
+      harness.assertWithinBaseline(result);
+    }
+  });
+
   it('skill-loading-time: startup with many skills within baseline', async () => {
     const SKILL_COUNT = 20;
 

--- a/perf-tests/perf.asian-language.responses
+++ b/perf-tests/perf.asian-language.responses
@@ -1,0 +1,2 @@
+{"method":"generateContent","response":{"candidates":[{"content":{"parts":[{"text":"0"}],"role":"model"},"finishReason":"STOP","index":0}]}}
+{"method":"generateContentStream","response":[{"candidates":[{"content":{"parts":[{"text":"你好！我是 Gemini CLI，你的 AI 编程助手"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":20648,"candidatesTokenCount":12,"totalTokenCount":20769,"promptTokensDetails":[{"modality":"TEXT","tokenCount":5}]}}]}


### PR DESCRIPTION
## Summary

Add a new test which will just go through one round of prompt & response in an asian language, so that it can compare with cold-startup test to make sure the performance is not significantly worse than english.

Note the number in baseline.json is not correct until @sripasg fix the issue where the baseline number vary on different machines.

## Related Issues

Fixes #24868 

## How to Validate

Run `npm run test:perf`

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
