### PR TITLE
feat(core): integrate MemoryService event bus into CLI lifecycle

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -92,7 +92,7 @@ import {
   ApiKeyUpdatedEvent,
   LegacyAgentProtocol,
   type InjectionSource,
-  startMemoryService,
+  createMemoryService,
 } from '@google/gemini-cli-core';
 import { validateAuthMethod } from '../config/auth.js';
 import process from 'node:process';
@@ -482,11 +482,37 @@ export const AppContainer = (props: AppContainerProps) => {
       setConfigInitialized(true);
       startupProfiler.flush(config);
 
-      // Fire-and-forget memory service (skill extraction from past sessions)
+      // Initialize the pluggable memory service and emit SessionStart.
       if (config.isMemoryManagerEnabled()) {
-        startMemoryService(config).catch((e) => {
-          debugLogger.error('Failed to start memory service:', e);
-        });
+        createMemoryService(config)
+          .then((ms) => {
+            config.setMemoryService(ms);
+            registerCleanup(async () => {
+              try {
+                const client = config.getGeminiClient();
+                if (client?.isInitialized()) {
+                  await ms.emitSessionEnd({
+                    messages: [...client.getHistory()],
+                    reason: 'exit',
+                  });
+                }
+              } catch {
+                // Best-effort during shutdown.
+              }
+              await ms.shutdown();
+            });
+            return ms.emitSessionStart(
+              {
+                sessionId: config.getSessionId(),
+                resumed: !!resumedSessionData,
+                workspaceDir: config.getProjectRoot(),
+              },
+              config,
+            );
+          })
+          .catch((e) => {
+            debugLogger.error('Failed to start memory service:', e);
+          });
       }
 
       const sessionStartSource = resumedSessionData

--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -45,6 +45,7 @@ describe('clearCommand', () => {
               fireSessionEndEvent: vi.fn().mockResolvedValue(undefined),
               fireSessionStartEvent: vi.fn().mockResolvedValue(undefined),
             }),
+            getMemoryService: vi.fn().mockReturnValue(undefined),
             injectionService: {
               clear: mockHintClear,
             },

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -30,6 +30,15 @@ export const clearCommand: SlashCommand = {
       await hookSystem.fireSessionEndEvent(SessionEndReason.Clear);
     }
 
+    // Notify memory providers that the session is ending.
+    const memoryService = config?.getMemoryService();
+    if (memoryService && geminiClient?.isInitialized()) {
+      await memoryService.emitSessionEnd({
+        messages: [...geminiClient.getHistory()],
+        reason: 'clear',
+      });
+    }
+
     // Reset user steering hints
     config?.injectionService.clear();
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -364,6 +364,7 @@ describe('useGeminiStream', () => {
     })),
     getIdeMode: vi.fn(() => false),
     getEnableHooks: vi.fn(() => false),
+    getMemoryService: vi.fn(() => undefined),
   } as unknown as Config;
 
   beforeEach(() => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -244,6 +244,7 @@ export const useGeminiStream = (
   const lowVerbosityFailureNoteShownRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const turnCancelledRef = useRef(false);
+  const turnCountRef = useRef(0);
   const activeQueryIdRef = useRef<string | null>(null);
   const previousApprovalModeRef = useRef<ApprovalMode>(
     config.getApprovalMode(),
@@ -1632,6 +1633,32 @@ export const useGeminiStream = (
             lastQueryRef.current = queryToSend;
             lastPromptIdRef.current = prompt_id!;
 
+            // Notify memory providers and collect injections.
+            if (!options?.isContinuation) {
+              const memoryService = config.getMemoryService();
+              if (memoryService) {
+                try {
+                  const parts = Array.isArray(queryToSend)
+                    ? queryToSend
+                    : [queryToSend];
+                  const userText = parts
+                    .map((p) =>
+                      typeof p === 'string'
+                        ? p
+                        : 'text' in p
+                          ? (p.text ?? '')
+                          : '',
+                    )
+                    .join('\n');
+                  await memoryService.emitUserInput({
+                    userMessage: userText,
+                  });
+                } catch {
+                  // Best-effort — don't block the query.
+                }
+              }
+            }
+
             try {
               const stream = geminiClient.sendMessageStream(
                 queryToSend,
@@ -1649,6 +1676,28 @@ export const useGeminiStream = (
 
               if (processingStatus === StreamProcessingStatus.UserCancelled) {
                 return;
+              }
+
+              // Notify memory providers that a turn completed.
+              if (!options?.isContinuation) {
+                const memSvc = config.getMemoryService();
+                if (memSvc) {
+                  const assistantText =
+                    (
+                      pendingHistoryItemRef.current as
+                        | { text?: string }
+                        | null
+                        | undefined
+                    )?.text ?? '';
+                  memSvc
+                    .emitTurnComplete({
+                      turnIndex: turnCountRef.current++,
+                      userContent:
+                        typeof queryToSend === 'string' ? queryToSend : '',
+                      assistantContent: assistantText,
+                    })
+                    .catch(() => {});
+                }
               }
 
               if (pendingHistoryItemRef.current) {

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -652,6 +652,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
             break;
           }
 
+          const turnIndex = turnCounter;
           const turnResult = await this.executeTurn(
             chat,
             currentMessage,
@@ -660,6 +661,30 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
             deadlineTimer.signal,
             onWaitingForConfirmation,
           );
+
+          // Notify memory providers that a turn completed.
+          const memoryService = this.context.config.getMemoryService();
+          if (memoryService) {
+            const userText = (currentMessage.parts ?? [])
+              .filter((p): p is { text: string } => 'text' in p)
+              .map((p) => p.text)
+              .join('\n');
+            const history = chat.getHistory();
+            const lastModel = [...history]
+              .reverse()
+              .find((c) => c.role === 'model');
+            const assistantText = (lastModel?.parts ?? [])
+              .filter((p): p is { text: string } => 'text' in p)
+              .map((p) => p.text)
+              .join('\n');
+            memoryService
+              .emitTurnComplete({
+                turnIndex,
+                userContent: userText,
+                assistantContent: assistantText,
+              })
+              .catch(() => {});
+          }
 
           if (turnResult.status === 'stop') {
             terminateReason = turnResult.terminateReason;
@@ -865,6 +890,19 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
   ): Promise<void> {
     const model = this.definition.modelConfig.model ?? DEFAULT_GEMINI_MODEL;
 
+    // Collect preservation hints from memory providers before compression.
+    let memoryPreserveHints = '';
+    const memoryService = this.context.config.getMemoryService();
+    if (memoryService) {
+      try {
+        memoryPreserveHints = await memoryService.emitPreCompress({
+          messages: [...chat.getHistory()],
+        });
+      } catch {
+        // Best-effort — don't block compression.
+      }
+    }
+
     const { newHistory, info } = await this.compressionService.compress(
       chat,
       prompt_id,
@@ -873,6 +911,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       this.context.config,
       this.hasFailedCompressionAttempt,
       abortSignal,
+      memoryPreserveHints,
     );
 
     if (

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -147,6 +147,7 @@ import {
   type SafetyCheckerRule,
 } from '../policy/types.js';
 import { HookSystem } from '../hooks/index.js';
+import type { MemoryService } from '../services/memoryService.js';
 import type {
   UserTierId,
   GeminiUserTier,
@@ -918,6 +919,7 @@ export class Config implements McpContext, AgentLoopContext {
   private experiments: Experiments | undefined;
   private experimentsPromise: Promise<Experiments | undefined> | undefined;
   private hookSystem?: HookSystem;
+  private memoryService?: MemoryService;
   private readonly onModelChange: ((model: string) => void) | undefined;
   private readonly onReload:
     | (() => Promise<{
@@ -3646,6 +3648,20 @@ export class Config implements McpContext, AgentLoopContext {
    */
   getHookSystem(): HookSystem | undefined {
     return this.hookSystem;
+  }
+
+  /**
+   * Get the memory service instance
+   */
+  getMemoryService(): MemoryService | undefined {
+    return this.memoryService;
+  }
+
+  /**
+   * Set the memory service instance
+   */
+  setMemoryService(service: MemoryService): void {
+    this.memoryService = service;
   }
 
   /**

--- a/packages/core/src/context/chatCompressionService.ts
+++ b/packages/core/src/context/chatCompressionService.ts
@@ -243,6 +243,7 @@ export class ChatCompressionService {
     config: Config,
     hasFailedCompressionAttempt: boolean,
     abortSignal?: AbortSignal,
+    memoryPreserveHints?: string,
   ): Promise<{ newHistory: Content[] | null; info: ChatCompressionInfo }> {
     const curatedHistory = chat.getHistory(true);
 
@@ -356,6 +357,10 @@ export class ChatCompressionService {
       ? 'A previous <state_snapshot> exists in the history. You MUST integrate all still-relevant information from that snapshot into the new one, updating it with the more recent events. Do not lose established constraints or critical knowledge.'
       : 'Generate a new <state_snapshot> based on the provided history.';
 
+    const preserveBlock = memoryPreserveHints?.trim()
+      ? `\n\nIMPORTANT — The following facts were identified by memory providers as critical to preserve in the snapshot:\n${memoryPreserveHints}`
+      : '';
+
     const summaryResponse = await config.getBaseLlmClient().generateContent({
       modelConfigKey: { model: modelStringToModelConfigAlias(model) },
       contents: [
@@ -364,7 +369,7 @@ export class ChatCompressionService {
           role: 'user',
           parts: [
             {
-              text: `${anchorInstruction}\n\nFirst, reason in your scratchpad. Then, generate the updated <state_snapshot>.`,
+              text: `${anchorInstruction}${preserveBlock}\n\nFirst, reason in your scratchpad. Then, generate the updated <state_snapshot>.`,
             },
           ],
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,9 +142,25 @@ export * from './sandbox/windows/WindowsSandboxManager.js';
 export * from './services/sessionSummaryUtils.js';
 export {
   startMemoryService,
+  createMemoryService,
+  MemoryService,
+  startSkillExtraction,
   validatePatches,
 } from './services/memoryService.js';
 export { isProjectSkillPatchTarget } from './services/memoryPatchUtils.js';
+export type {
+  MemoryProvider,
+  MemoryProviderContext,
+  MemoryEventResult,
+  SessionStartPayload,
+  UserInputPayload,
+  ContextEvictedPayload,
+  PreCompressPayload,
+  TurnCompletePayload,
+  IdlePayload,
+  SessionEndPayload,
+} from './services/memoryProvider.js';
+export { DefaultMemoryProvider } from './services/defaultMemoryProvider.js';
 export * from './context/memoryContextManager.js';
 export * from './services/trackerService.js';
 export * from './services/trackerTypes.js';

--- a/packages/core/src/services/defaultMemoryProvider.ts
+++ b/packages/core/src/services/defaultMemoryProvider.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  MemoryProvider,
+  SessionStartPayload,
+  UserInputPayload,
+  ContextEvictedPayload,
+  PreCompressPayload,
+  TurnCompletePayload,
+  IdlePayload,
+  SessionEndPayload,
+  MemoryProviderContext,
+  MemoryEventResult,
+} from './memoryProvider.js';
+import { startSkillExtraction } from './memoryService.js';
+
+/**
+ * The built-in default memory provider that ships with Gemini CLI.
+ *
+ * Currently handles:
+ * - SessionStart: runs the Skill Extraction Agent on past sessions
+ *
+ * Other event methods are stubs for future functionality
+ * (Knowledge Preservation, save_memory persistence, Dream, etc.)
+ */
+export class DefaultMemoryProvider implements MemoryProvider {
+  readonly name = 'default';
+
+  async onSessionStart(
+    _payload: SessionStartPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<void> {
+    // Run the existing skill extraction logic (fire-and-forget within provider)
+    await startSkillExtraction(ctx.config);
+  }
+
+  async onUserInput(
+    _payload: UserInputPayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<MemoryEventResult | void> {
+    // Future: inject recalled context into prompt
+  }
+
+  async onContextEvicted(
+    _payload: ContextEvictedPayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<void> {
+    // Future: Knowledge Preservation — extract insights before discarding
+  }
+
+  async onPreCompress(
+    _payload: PreCompressPayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<string | void> {
+    // Future: return preservation hints for the compressor
+  }
+
+  async onTurnComplete(
+    _payload: TurnCompletePayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<void> {
+    // Future: save_memory persistence
+  }
+
+  async onIdle(
+    _payload: IdlePayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<void> {
+    // Future: Dream?
+  }
+
+  async onSessionEnd(
+    _payload: SessionEndPayload,
+    _ctx: MemoryProviderContext,
+  ): Promise<void> {
+    // Future: flush & persist
+  }
+}

--- a/packages/core/src/services/memoryProvider.ts
+++ b/packages/core/src/services/memoryProvider.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content } from '@google/genai';
+import type { Config } from '../config/config.js';
+
+// ---------------------------------------------------------------------------
+// Event Payloads
+// ---------------------------------------------------------------------------
+
+export interface SessionStartPayload {
+  sessionId: string;
+  resumed: boolean;
+  workspaceDir: string;
+}
+
+export interface UserInputPayload {
+  userMessage: string;
+}
+
+export interface ContextEvictedPayload {
+  reason: 'compress' | 'truncate';
+  evictedTurns: Content[];
+  summary?: string;
+}
+
+export interface PreCompressPayload {
+  messages: Content[];
+}
+
+export interface TurnCompletePayload {
+  turnIndex: number;
+  userContent: string;
+  assistantContent: string;
+}
+
+export interface IdlePayload {
+  idleDurationMs: number;
+}
+
+export interface SessionEndPayload {
+  messages: Content[];
+  reason: 'exit' | 'clear';
+}
+
+// ---------------------------------------------------------------------------
+// Event Result
+// ---------------------------------------------------------------------------
+
+/**
+ * Result returned by inject-capable event methods (e.g. onUserInput).
+ * If `inject` is set, the content is injected into the current prompt.
+ */
+export interface MemoryEventResult {
+  inject?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Provider Context
+// ---------------------------------------------------------------------------
+
+export interface MemoryProviderContext {
+  config: Config;
+  signal: AbortSignal;
+  sessionId: string;
+  workspaceDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// MemoryProvider Interface
+// ---------------------------------------------------------------------------
+
+/**
+ * A pluggable memory provider that responds to CLI lifecycle events.
+ *
+ * Providers implement the event methods they care about — implementing a
+ * method implicitly subscribes to that event. All methods are optional
+ * except `name`.
+ *
+ * Lifecycle:
+ *   initialize() → onSessionStart() → onUserInput() / onTurnComplete() /
+ *   onContextEvicted() / onIdle() → onSessionEnd() → shutdown()
+ */
+export interface MemoryProvider {
+  // --- Identity ---
+
+  /** Short identifier for this provider (e.g. 'default', 'rag', 'vector'). */
+  readonly name: string;
+
+  // --- Lifecycle ---
+
+  /** Called once when the provider is registered with MemoryService. */
+  initialize?(config: Config, ctx: MemoryProviderContext): Promise<void>;
+
+  /** Called on CLI shutdown. Clean up resources, flush queues. */
+  shutdown?(): Promise<void>;
+
+  // --- Event Methods ---
+
+  /** Session started — connect, warm up, create resources. */
+  onSessionStart?(
+    payload: SessionStartPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<void>;
+
+  /**
+   * User input received — return context to inject into prompt, or void.
+   * This is the only event method that may return a result.
+   */
+  onUserInput?(
+    payload: UserInputPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<MemoryEventResult | void>;
+
+  /** Context evicted — extract/preserve before turns are discarded. */
+  onContextEvicted?(
+    payload: ContextEvictedPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<void>;
+
+  /**
+   * Called before context compression. Return text that the compressor
+   * should preserve in its summary (e.g. recalled facts, user preferences).
+   * Return empty string or void to skip.
+   */
+  onPreCompress?(
+    payload: PreCompressPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<string | void>;
+
+  /** Turn complete — sync turn data, queue next prefetch. */
+  onTurnComplete?(
+    payload: TurnCompletePayload,
+    ctx: MemoryProviderContext,
+  ): Promise<void>;
+
+  /**
+   * Idle — triggered when user idle duration exceeds this provider's threshold.
+   * Set `idleThresholdMs` to control when this fires.
+   */
+  onIdle?(payload: IdlePayload, ctx: MemoryProviderContext): Promise<void>;
+
+  /** Minimum idle duration (ms) before onIdle fires. Default: 0. */
+  readonly idleThresholdMs?: number;
+
+  /** Session ended — flush, persist. */
+  onSessionEnd?(
+    payload: SessionEndPayload,
+    ctx: MemoryProviderContext,
+  ): Promise<void>;
+
+  /**
+   * Built-in save_memory tool was called — mirror writes to your backend.
+   */
+  onMemoryWrite?(
+    action: 'add' | 'replace' | 'remove',
+    target: 'memory' | 'user',
+    content: string,
+  ): Promise<void>;
+
+  // --- Tool Surface ---
+
+  /** Tool schemas to expose to the model. Return empty array if none. */
+  getToolSchemas?(): unknown[];
+
+  /** Handle a tool call for one of this provider's tools. */
+  handleToolCall?(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string>;
+
+  // --- Prompt Contribution ---
+
+  /** Static text to include in the system prompt. Return empty string to skip. */
+  systemPromptBlock?(): string;
+}

--- a/packages/core/src/services/memoryService.test.ts
+++ b/packages/core/src/services/memoryService.test.ts
@@ -87,6 +87,7 @@ vi.mock('../utils/debugLogger.js', () => ({
     debug: vi.fn(),
     log: vi.fn(),
     warn: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -1321,6 +1322,780 @@ describe('memoryService', () => {
       await startMemoryService(mockConfig);
 
       expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('MemoryService', () => {
+    // Helper to create a minimal mock MemoryProvider
+    function createMockProvider(
+      overrides: Partial<import('./memoryProvider.js').MemoryProvider> & {
+        name: string;
+      },
+    ): import('./memoryProvider.js').MemoryProvider {
+      return { ...overrides };
+    }
+
+    // Minimal Config mock reusable across tests
+    function createMockConfig() {
+      return {
+        storage: {
+          getProjectMemoryDir: vi.fn().mockReturnValue('/tmp/fake-memory'),
+          getProjectMemoryTempDir: vi.fn().mockReturnValue('/tmp/fake-memory'),
+          getProjectSkillsMemoryDir: vi
+            .fn()
+            .mockReturnValue('/tmp/fake-skills'),
+          getProjectTempDir: vi.fn().mockReturnValue('/tmp/fake-temp'),
+        },
+        getToolRegistry: vi.fn(),
+        getMessageBus: vi.fn(),
+        getGeminiClient: vi.fn(),
+        sandboxManager: undefined,
+      } as unknown as import('../config/config.js').Config;
+    }
+
+    describe('registerProvider', () => {
+      it('adds provider to the providers list', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const provider = createMockProvider({ name: 'test-provider' });
+
+        await service.registerProvider(provider, createMockConfig());
+
+        expect(service.getProviders()).toContain(provider);
+      });
+
+      it('calls initialize if ctx has been set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        // Set ctx by emitting sessionStart first
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const initializeFn = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'late-provider',
+          initialize: initializeFn,
+        });
+
+        await service.registerProvider(provider, config);
+
+        expect(initializeFn).toHaveBeenCalledWith(
+          config,
+          expect.objectContaining({ sessionId: 's1' }),
+        );
+      });
+
+      it('does not call initialize if ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const initializeFn = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'early-provider',
+          initialize: initializeFn,
+        });
+
+        await service.registerProvider(provider, createMockConfig());
+
+        expect(initializeFn).not.toHaveBeenCalled();
+      });
+
+      it('handles initialize errors without throwing', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const provider = createMockProvider({
+          name: 'bad-init-provider',
+          initialize: vi.fn().mockRejectedValue(new Error('init boom')),
+        });
+
+        await expect(
+          service.registerProvider(provider, config),
+        ).resolves.not.toThrow();
+        expect(service.getProviders()).toContain(provider);
+      });
+    });
+
+    describe('emitSessionStart', () => {
+      it('dispatches to providers that implement onSessionStart', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onSessionStart = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'start-provider',
+          onSessionStart,
+        });
+        await service.registerProvider(provider, config);
+
+        const payload = {
+          sessionId: 'sess-1',
+          resumed: false,
+          workspaceDir: '/workspace',
+        };
+        await service.emitSessionStart(payload, config);
+
+        // Fire-and-forget — allow microtask to settle
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(onSessionStart).toHaveBeenCalledWith(
+          payload,
+          expect.objectContaining({
+            sessionId: 'sess-1',
+            workspaceDir: '/workspace',
+            config,
+          }),
+        );
+      });
+
+      it('sets context for subsequent events', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        // Before emitSessionStart, emitUserInput should no-op
+        const result = await service.emitUserInput({
+          userMessage: 'hello',
+        });
+        expect(result).toBeUndefined();
+
+        // After emitSessionStart, events should dispatch
+        await service.emitSessionStart(
+          { sessionId: 's2', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const onUserInput = vi.fn().mockResolvedValue({ inject: 'injected' });
+        const provider = createMockProvider({
+          name: 'input-provider',
+          onUserInput,
+        });
+        await service.registerProvider(provider, config);
+
+        const inputResult = await service.emitUserInput({
+          userMessage: 'test',
+        });
+        expect(inputResult).toEqual({ inject: 'injected' });
+      });
+
+      it('handles errors per-provider without throwing', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const badProvider = createMockProvider({
+          name: 'bad-start',
+          onSessionStart: vi.fn().mockRejectedValue(new Error('start boom')),
+        });
+        const goodProvider = createMockProvider({
+          name: 'good-start',
+          onSessionStart: vi.fn().mockResolvedValue(undefined),
+        });
+
+        await service.registerProvider(badProvider, config);
+        await service.registerProvider(goodProvider, config);
+
+        const payload = {
+          sessionId: 'sess-err',
+          resumed: false,
+          workspaceDir: '/tmp',
+        };
+        await expect(
+          service.emitSessionStart(payload, config),
+        ).resolves.not.toThrow();
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(goodProvider.onSessionStart).toHaveBeenCalled();
+      });
+
+      it('skips providers that do not implement onSessionStart', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider = createMockProvider({ name: 'no-start' });
+        await service.registerProvider(provider, config);
+
+        await expect(
+          service.emitSessionStart(
+            { sessionId: 's3', resumed: false, workspaceDir: '/tmp' },
+            config,
+          ),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('emitUserInput', () => {
+      it('collects inject strings from multiple providers', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider1 = createMockProvider({
+          name: 'inject-1',
+          onUserInput: vi.fn().mockResolvedValue({ inject: 'context-A' }),
+        });
+        const provider2 = createMockProvider({
+          name: 'inject-2',
+          onUserInput: vi.fn().mockResolvedValue({ inject: 'context-B' }),
+        });
+        await service.registerProvider(provider1, config);
+        await service.registerProvider(provider2, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitUserInput({
+          userMessage: 'hello',
+        });
+
+        expect(result).toEqual({
+          inject: 'context-A\n\ncontext-B',
+        });
+      });
+
+      it('returns undefined when no providers return inject', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider = createMockProvider({
+          name: 'no-inject',
+          onUserInput: vi.fn().mockResolvedValue(undefined),
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitUserInput({
+          userMessage: 'hello',
+        });
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const result = await service.emitUserInput({
+          userMessage: 'no ctx',
+        });
+
+        expect(result).toBeUndefined();
+      });
+
+      it('handles errors from one provider and still collects from others', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const badProvider = createMockProvider({
+          name: 'bad-input',
+          onUserInput: vi.fn().mockRejectedValue(new Error('input boom')),
+        });
+        const goodProvider = createMockProvider({
+          name: 'good-input',
+          onUserInput: vi.fn().mockResolvedValue({ inject: 'good-context' }),
+        });
+        await service.registerProvider(badProvider, config);
+        await service.registerProvider(goodProvider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitUserInput({
+          userMessage: 'test',
+        });
+
+        expect(result).toEqual({ inject: 'good-context' });
+      });
+    });
+
+    describe('emitContextEvicted', () => {
+      it('dispatches to providers that implement onContextEvicted', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onContextEvicted = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'evict-provider',
+          onContextEvicted,
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const payload = {
+          reason: 'compress' as const,
+          evictedTurns: [],
+          summary: 'compressed',
+        };
+        await service.emitContextEvicted(payload);
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onContextEvicted).toHaveBeenCalledWith(
+          payload,
+          expect.objectContaining({ sessionId: 's1' }),
+        );
+      });
+
+      it('no-ops when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const onContextEvicted = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'evict-noop',
+          onContextEvicted,
+        });
+        await service.registerProvider(provider, createMockConfig());
+
+        await service.emitContextEvicted({
+          reason: 'truncate',
+          evictedTurns: [],
+        });
+
+        expect(onContextEvicted).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('emitPreCompress', () => {
+      it('collects preservation hints from multiple providers', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider1 = createMockProvider({
+          name: 'hint-1',
+          onPreCompress: vi.fn().mockResolvedValue('User prefers TypeScript'),
+        });
+        const provider2 = createMockProvider({
+          name: 'hint-2',
+          onPreCompress: vi.fn().mockResolvedValue('Project uses Vitest'),
+        });
+        await service.registerProvider(provider1, config);
+        await service.registerProvider(provider2, config);
+
+        await service.emitSessionStart(
+          { sessionId: 'test', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitPreCompress({
+          messages: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        });
+
+        expect(result).toBe('User prefers TypeScript\n\nProject uses Vitest');
+      });
+
+      it('returns empty string when no providers have hints', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider = createMockProvider({
+          name: 'no-hint',
+          onPreCompress: vi.fn().mockResolvedValue(undefined),
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 'test', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitPreCompress({ messages: [] });
+        expect(result).toBe('');
+      });
+
+      it('returns empty string when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const result = await service.emitPreCompress({ messages: [] });
+        expect(result).toBe('');
+      });
+
+      it('handles errors from one provider and still collects from others', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider1 = createMockProvider({
+          name: 'error-provider',
+          onPreCompress: vi.fn().mockRejectedValue(new Error('boom')),
+        });
+        const provider2 = createMockProvider({
+          name: 'good-provider',
+          onPreCompress: vi.fn().mockResolvedValue('Keep this fact'),
+        });
+        await service.registerProvider(provider1, config);
+        await service.registerProvider(provider2, config);
+
+        await service.emitSessionStart(
+          { sessionId: 'test', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const result = await service.emitPreCompress({ messages: [] });
+        expect(result).toBe('Keep this fact');
+      });
+    });
+
+    describe('emitTurnComplete', () => {
+      it('dispatches fire-and-forget to providers', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onTurnComplete = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'turn-provider',
+          onTurnComplete,
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const payload = {
+          turnIndex: 1,
+          userContent: 'user said',
+          assistantContent: 'assistant said',
+        };
+        await service.emitTurnComplete(payload);
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onTurnComplete).toHaveBeenCalledWith(
+          payload,
+          expect.objectContaining({ sessionId: 's1' }),
+        );
+      });
+
+      it('no-ops when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const onTurnComplete = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'turn-noop',
+          onTurnComplete,
+        });
+        await service.registerProvider(provider, createMockConfig());
+
+        await service.emitTurnComplete({
+          turnIndex: 0,
+          userContent: 'x',
+          assistantContent: 'y',
+        });
+
+        expect(onTurnComplete).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('emitIdle', () => {
+      it('dispatches to provider when idleDurationMs >= threshold', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onIdle = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'idle-provider',
+          onIdle,
+          idleThresholdMs: 5000,
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        await service.emitIdle({ idleDurationMs: 5000 });
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onIdle).toHaveBeenCalledWith(
+          { idleDurationMs: 5000 },
+          expect.objectContaining({ sessionId: 's1' }),
+        );
+      });
+
+      it('skips provider when idleDurationMs < threshold', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onIdle = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'idle-skip',
+          onIdle,
+          idleThresholdMs: 10000,
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        await service.emitIdle({ idleDurationMs: 5000 });
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onIdle).not.toHaveBeenCalled();
+      });
+
+      it('treats missing idleThresholdMs as 0 (always fire)', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onIdle = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'idle-default',
+          onIdle,
+          // no idleThresholdMs — defaults to 0
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        await service.emitIdle({ idleDurationMs: 1 });
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onIdle).toHaveBeenCalled();
+      });
+
+      it('no-ops when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const onIdle = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'idle-noop',
+          onIdle,
+        });
+        await service.registerProvider(provider, createMockConfig());
+
+        await service.emitIdle({ idleDurationMs: 99999 });
+
+        expect(onIdle).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('emitSessionEnd', () => {
+      it('dispatches fire-and-forget to providers', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const onSessionEnd = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'end-provider',
+          onSessionEnd,
+        });
+        await service.registerProvider(provider, config);
+
+        await service.emitSessionStart(
+          { sessionId: 's1', resumed: false, workspaceDir: '/tmp' },
+          config,
+        );
+
+        const payload = { messages: [], reason: 'exit' as const };
+        await service.emitSessionEnd(payload);
+
+        await new Promise((r) => setTimeout(r, 10));
+        expect(onSessionEnd).toHaveBeenCalledWith(
+          payload,
+          expect.objectContaining({ sessionId: 's1' }),
+        );
+      });
+
+      it('no-ops when ctx is not set', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        const onSessionEnd = vi.fn().mockResolvedValue(undefined);
+        const provider = createMockProvider({
+          name: 'end-noop',
+          onSessionEnd,
+        });
+        await service.registerProvider(provider, createMockConfig());
+
+        await service.emitSessionEnd({ messages: [], reason: 'clear' });
+
+        expect(onSessionEnd).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('shutdown', () => {
+      it('calls shutdown on all providers that implement it', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const shutdown1 = vi.fn().mockResolvedValue(undefined);
+        const shutdown2 = vi.fn().mockResolvedValue(undefined);
+        const provider1 = createMockProvider({
+          name: 'shut-1',
+          shutdown: shutdown1,
+        });
+        const provider2 = createMockProvider({
+          name: 'shut-2',
+          shutdown: shutdown2,
+        });
+        await service.registerProvider(provider1, config);
+        await service.registerProvider(provider2, config);
+
+        await service.shutdown();
+
+        expect(shutdown1).toHaveBeenCalled();
+        expect(shutdown2).toHaveBeenCalled();
+      });
+
+      it('handles shutdown errors without throwing', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider = createMockProvider({
+          name: 'bad-shutdown',
+          shutdown: vi.fn().mockRejectedValue(new Error('shutdown boom')),
+        });
+        await service.registerProvider(provider, config);
+
+        await expect(service.shutdown()).resolves.not.toThrow();
+      });
+
+      it('skips providers without a shutdown method', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const provider = createMockProvider({ name: 'no-shutdown' });
+        await service.registerProvider(provider, config);
+
+        await expect(service.shutdown()).resolves.not.toThrow();
+      });
+    });
+
+    describe('getProviders', () => {
+      it('returns empty array initially', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+
+        expect(service.getProviders()).toEqual([]);
+      });
+
+      it('returns all registered providers in order', async () => {
+        const { MemoryService } = await import('./memoryService.js');
+        const service = new MemoryService();
+        const config = createMockConfig();
+
+        const p1 = createMockProvider({ name: 'p1' });
+        const p2 = createMockProvider({ name: 'p2' });
+        await service.registerProvider(p1, config);
+        await service.registerProvider(p2, config);
+
+        const providers = service.getProviders();
+        expect(providers).toHaveLength(2);
+        expect(providers[0].name).toBe('p1');
+        expect(providers[1].name).toBe('p2');
+      });
+    });
+  });
+
+  describe('createMemoryService', () => {
+    it('creates a service with DefaultMemoryProvider pre-registered', async () => {
+      const { createMemoryService } = await import('./memoryService.js');
+      const config = {
+        storage: {
+          getProjectMemoryDir: vi.fn().mockReturnValue('/tmp/fake-memory'),
+          getProjectMemoryTempDir: vi.fn().mockReturnValue('/tmp/fake-memory'),
+          getProjectSkillsMemoryDir: vi
+            .fn()
+            .mockReturnValue('/tmp/fake-skills'),
+          getProjectTempDir: vi.fn().mockReturnValue('/tmp/fake-temp'),
+        },
+        getToolRegistry: vi.fn(),
+        getMessageBus: vi.fn(),
+        getGeminiClient: vi.fn(),
+        sandboxManager: undefined,
+      } as unknown as Parameters<typeof createMemoryService>[0];
+
+      const service = await createMemoryService(config);
+
+      const providers = service.getProviders();
+      expect(providers).toHaveLength(1);
+      expect(providers[0].name).toBe('default');
+    });
+  });
+
+  describe('startMemoryService backward compat', () => {
+    it('calls startSkillExtraction via the legacy entry point', async () => {
+      const { startMemoryService } = await import('./memoryService.js');
+
+      // startMemoryService delegates to startSkillExtraction which
+      // tries to acquire a lock. We just verify it does not throw when
+      // the lock is already held (it gracefully skips).
+      const memoryDir = path.join(tmpDir, 'compat-memory');
+      const skillsDir = path.join(tmpDir, 'compat-skills');
+      const projectTempDir = path.join(tmpDir, 'compat-temp');
+      await fs.mkdir(memoryDir, { recursive: true });
+
+      // Pre-acquire lock so it skips extraction
+      const lockPath = path.join(memoryDir, '.extraction.lock');
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+        }),
+      );
+
+      const mockConfig = {
+        storage: {
+          getProjectMemoryDir: vi.fn().mockReturnValue(memoryDir),
+          getProjectMemoryTempDir: vi.fn().mockReturnValue(memoryDir),
+          getProjectSkillsMemoryDir: vi.fn().mockReturnValue(skillsDir),
+          getProjectTempDir: vi.fn().mockReturnValue(projectTempDir),
+        },
+        getToolRegistry: vi.fn(),
+        getMessageBus: vi.fn(),
+        getGeminiClient: vi.fn(),
+        sandboxManager: undefined,
+      } as unknown as Parameters<typeof startMemoryService>[0];
+
+      // Should not throw — gracefully skips since lock is held
+      await expect(startMemoryService(mockConfig)).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/src/services/memoryService.ts
+++ b/packages/core/src/services/memoryService.ts
@@ -581,14 +581,16 @@ export async function validatePatches(
 }
 
 /**
- * Main entry point for the skill extraction background task.
- * Designed to be called fire-and-forget on session startup.
+ * Runs the skill extraction background task.
  *
  * Coordinates across multiple CLI instances via a lock file,
  * scans past sessions for reusable patterns, and runs a sub-agent
  * to extract and write SKILL.md files.
+ *
+ * Called by DefaultMemoryProvider.onSessionStart(). Not intended to
+ * be called directly — use MemoryService.emitSessionStart() instead.
  */
-export async function startMemoryService(config: Config): Promise<void> {
+export async function startSkillExtraction(config: Config): Promise<void> {
   const memoryDir = config.storage.getProjectMemoryTempDir();
   const skillsDir = config.storage.getProjectSkillsMemoryDir();
   const lockPath = path.join(memoryDir, LOCK_FILENAME);
@@ -815,4 +817,265 @@ export async function startMemoryService(config: Config): Promise<void> {
       );
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryService — pluggable event bus for memory providers
+// ---------------------------------------------------------------------------
+
+import type {
+  MemoryProvider,
+  MemoryProviderContext,
+  MemoryEventResult,
+  SessionStartPayload,
+  UserInputPayload,
+  ContextEvictedPayload,
+  PreCompressPayload,
+  TurnCompletePayload,
+  IdlePayload,
+  SessionEndPayload,
+} from './memoryProvider.js';
+import { DefaultMemoryProvider } from './defaultMemoryProvider.js';
+
+/**
+ * MemoryService is the central event bus for memory providers.
+ *
+ * It dispatches CLI lifecycle events to registered providers. Each provider
+ * implements the event methods it cares about — implementing a method
+ * implicitly subscribes to that event.
+ *
+ * The DefaultMemoryProvider is always registered and handles built-in
+ * functionality (skill extraction). External providers can be registered
+ * for custom behavior (RAG indexer, vector recall, etc.).
+ */
+export class MemoryService {
+  private providers: MemoryProvider[] = [];
+  private ctx: MemoryProviderContext | undefined;
+
+  /**
+   * Registers a provider and calls its initialize() if available.
+   */
+  async registerProvider(
+    provider: MemoryProvider,
+    config: Config,
+  ): Promise<void> {
+    this.providers.push(provider);
+    debugLogger.log(`[MemoryService] Provider '${provider.name}' registered`);
+    if (provider.initialize && this.ctx) {
+      try {
+        await provider.initialize(config, this.ctx);
+      } catch (e) {
+        debugLogger.error(
+          `[MemoryService] Provider '${provider.name}' initialize failed:`,
+          e,
+        );
+      }
+    }
+  }
+
+  /**
+   * Emits SessionStart to all providers that implement onSessionStart.
+   * Fire-and-forget — errors are isolated per provider.
+   */
+  async emitSessionStart(
+    payload: SessionStartPayload,
+    config: Config,
+  ): Promise<void> {
+    debugLogger.log(
+      `[MemoryService] SessionStart (session=${payload.sessionId}, resumed=${payload.resumed})`,
+    );
+    this.ctx = {
+      config,
+      signal: new AbortController().signal,
+      sessionId: payload.sessionId,
+      workspaceDir: payload.workspaceDir,
+    };
+    for (const p of this.providers) {
+      if (!p.onSessionStart) continue;
+      p.onSessionStart(payload, this.ctx).catch((e) => {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onSessionStart failed:`,
+          e,
+        );
+      });
+    }
+  }
+
+  /**
+   * Emits UserInput to all providers that implement onUserInput.
+   * Collects inject results — this is the only synchronous event.
+   */
+  async emitUserInput(
+    payload: UserInputPayload,
+  ): Promise<MemoryEventResult | void> {
+    if (!this.ctx) return;
+    debugLogger.log(
+      `[MemoryService] UserInput (length=${payload.userMessage.length})`,
+    );
+    const injections: string[] = [];
+    for (const p of this.providers) {
+      if (!p.onUserInput) continue;
+      try {
+        const result = await p.onUserInput(payload, this.ctx);
+        if (result?.inject) injections.push(result.inject);
+      } catch (e) {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onUserInput failed:`,
+          e,
+        );
+      }
+    }
+    return injections.length ? { inject: injections.join('\n\n') } : undefined;
+  }
+
+  /**
+   * Emits ContextEvicted to all providers that implement onContextEvicted.
+   * Fire-and-forget.
+   */
+  async emitContextEvicted(payload: ContextEvictedPayload): Promise<void> {
+    if (!this.ctx) return;
+    for (const p of this.providers) {
+      if (!p.onContextEvicted) continue;
+      p.onContextEvicted(payload, this.ctx).catch((e) => {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onContextEvicted failed:`,
+          e,
+        );
+      });
+    }
+  }
+
+  /**
+   * Emits PreCompress to all providers that implement onPreCompress.
+   * Collects preservation hints — text that the compressor should
+   * retain in its summary. Returns combined text or empty string.
+   */
+  async emitPreCompress(payload: PreCompressPayload): Promise<string> {
+    if (!this.ctx) return '';
+    debugLogger.log(
+      `[MemoryService] PreCompress (messages=${payload.messages.length})`,
+    );
+    const hints: string[] = [];
+    for (const p of this.providers) {
+      if (!p.onPreCompress) continue;
+      try {
+        const result = await p.onPreCompress(payload, this.ctx);
+        if (result && result.trim()) hints.push(result.trim());
+      } catch (e) {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onPreCompress failed:`,
+          e,
+        );
+      }
+    }
+    return hints.join('\n\n');
+  }
+
+  /**
+   * Emits TurnComplete to all providers that implement onTurnComplete.
+   * Fire-and-forget.
+   */
+  async emitTurnComplete(payload: TurnCompletePayload): Promise<void> {
+    if (!this.ctx) return;
+    debugLogger.log(`[MemoryService] TurnComplete (turn=${payload.turnIndex})`);
+    for (const p of this.providers) {
+      if (!p.onTurnComplete) continue;
+      p.onTurnComplete(payload, this.ctx).catch((e) => {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onTurnComplete failed:`,
+          e,
+        );
+      });
+    }
+  }
+
+  /**
+   * Emits Idle to providers that implement onIdle AND whose
+   * idleThresholdMs has been exceeded.
+   */
+  async emitIdle(payload: IdlePayload): Promise<void> {
+    if (!this.ctx) return;
+    for (const p of this.providers) {
+      if (!p.onIdle) continue;
+      const threshold = p.idleThresholdMs ?? 0;
+      if (payload.idleDurationMs < threshold) continue;
+      p.onIdle(payload, this.ctx).catch((e) => {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onIdle failed:`,
+          e,
+        );
+      });
+    }
+  }
+
+  /**
+   * Emits SessionEnd to all providers that implement onSessionEnd.
+   * Fire-and-forget.
+   */
+  async emitSessionEnd(payload: SessionEndPayload): Promise<void> {
+    if (!this.ctx) return;
+    debugLogger.log(
+      `[MemoryService] SessionEnd (reason=${payload.reason}, messages=${payload.messages.length})`,
+    );
+    for (const p of this.providers) {
+      if (!p.onSessionEnd) continue;
+      p.onSessionEnd(payload, this.ctx).catch((e) => {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' onSessionEnd failed:`,
+          e,
+        );
+      });
+    }
+  }
+
+  /**
+   * Shuts down all providers.
+   */
+  async shutdown(): Promise<void> {
+    debugLogger.log(
+      `[MemoryService] Shutdown (${this.providers.length} provider(s))`,
+    );
+    for (const p of this.providers) {
+      if (!p.shutdown) continue;
+      try {
+        await p.shutdown();
+      } catch (e) {
+        debugLogger.error(
+          `[MemoryService] Provider '${p.name}' shutdown failed:`,
+          e,
+        );
+      }
+    }
+  }
+
+  /**
+   * Returns all registered providers (for testing/introspection).
+   */
+  getProviders(): readonly MemoryProvider[] {
+    return this.providers;
+  }
+}
+
+/**
+ * Creates a MemoryService with the DefaultMemoryProvider pre-registered.
+ * This is the standard factory for production use.
+ */
+export async function createMemoryService(
+  config: Config,
+): Promise<MemoryService> {
+  const service = new MemoryService();
+  await service.registerProvider(new DefaultMemoryProvider(), config);
+  return service;
+}
+
+/**
+ * Backward-compatible entry point.
+ *
+ * Directly runs the skill extraction logic. This preserves the
+ * existing awaiting behavior used by AppContainer.tsx.
+ *
+ * @deprecated Use createMemoryService() + emitSessionStart() instead.
+ */
+export async function startMemoryService(config: Config): Promise<void> {
+  await startSkillExtraction(config);
 }


### PR DESCRIPTION
## Summary

Introduces the pluggable `MemoryService` event bus and wires it into the CLI lifecycle, enabling external memory providers to receive lifecycle events without modifying core code.

## Details

**New files:**
- `memoryProvider.ts` — `MemoryProvider` interface with all event/tool/prompt methods and payload types
- `defaultMemoryProvider.ts` — Built-in provider wrapping skill extraction (always registered)

**MemoryService class** (in `memoryService.ts`):
- Event bus that dispatches CLI lifecycle events to registered providers
- Providers subscribe by implementing methods (e.g. `onUserInput`, `onPreCompress`)
- Stored on `Config` via `getMemoryService()`/`setMemoryService()`

**Wired lifecycle events:**
| Event | Call site | Behavior |
|---|---|---|
| `SessionStart` | AppContainer (startup) | Fire-and-forget |
| `UserInput` | useGeminiStream (before model call) | Sync — collects `{ inject }` strings |
| `PreCompress` | local-executor (before compression) | Sync — collects preservation hints injected into compressor prompt |
| `TurnComplete` | useGeminiStream + local-executor | Fire-and-forget |
| `SessionEnd` | clearCommand (`/clear`) + cleanup (exit) | Fire-and-forget |
| `Shutdown` | cleanup handler | Awaited sequentially |

**Defined but not wired:** `emitContextEvicted`, `emitIdle` (deferred — need additional infrastructure)

**Key design decisions:**
- `emitSessionStart` accepts `Config` parameter to properly set `MemoryProviderContext`
- `emitPreCompress` is proactive (shapes compression output) vs post-hoc notification — provider hints are injected into the summarizer prompt so the compressor preserves provider-identified facts
- Backward-compatible: `startMemoryService()` preserved as deprecated wrapper
- Error isolation: failures in one provider never block others or the main flow

## Related Issues

Related to #18007

## How to Validate

1. Enable the feature flag in `~/.gemini/settings.json`:
   ```json
   { "experimental": { "memoryManager": true } }
   ```

2. Run with debug logging:
   ```bash
   GEMINI_DEBUG_LOG_FILE=/tmp/gemini-debug.log npm run start
   ```

3. Send a message, wait for response, then check the log:
   ```bash
   grep "\[MemoryService\]" /tmp/gemini-debug.log
   ```
   Expected:
   ```
   [MemoryService] Provider 'default' registered
   [MemoryService] SessionStart (session=..., resumed=false)
   [MemoryService] UserInput (length=...)
   [MemoryService] TurnComplete (turn=0)
   ```

4. Type `/clear` — should see `[MemoryService] SessionEnd (reason=clear, messages=...)`

5. Disable the flag and restart — no `[MemoryService]` lines should appear.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
