### PR TITLE
[codex] Keep ACP console patch active during shutdown

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -357,16 +357,19 @@ export async function main() {
   }
 
   const isDebugMode = cliConfig.isDebugMode(argv);
+  const isAcpMode = argv.acp === true;
   const consolePatcher = new ConsolePatcher({
     stderr: true,
-    interactive: isHeadlessMode() ? false : true,
+    interactive: isHeadlessMode() || isAcpMode ? false : true,
     debugMode: isDebugMode,
     onNewMessage: (msg) => {
       coreEvents.emitConsoleLog(msg.type, msg.content);
     },
   });
   consolePatcher.patch();
-  registerCleanup(consolePatcher.cleanup);
+  if (!isAcpMode) {
+    registerCleanup(consolePatcher.cleanup);
+  }
 
   dns.setDefaultResultOrder(
     validateDnsResolutionOrder(settings.merged.advanced.dnsResolutionOrder),

--- a/packages/cli/src/gemini_cleanup.test.tsx
+++ b/packages/cli/src/gemini_cleanup.test.tsx
@@ -136,6 +136,10 @@ vi.mock('./nonInteractiveCli.js', () => ({
   runNonInteractive: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./acp/acpClient.js', () => ({
+  runAcpClient: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('./utils/cleanup.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./utils/cleanup.js')>();
   return {
@@ -293,6 +297,39 @@ describe('gemini.tsx main function cleanup', () => {
     expect(mockHookSystem.fireSessionEndEvent).toHaveBeenCalledWith(
       SessionEndReason.Exit,
     );
+  });
+
+  it('should keep the global console patch active in ACP mode', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { registerCleanup } = await import('./utils/cleanup.js');
+    const { runAcpClient } = await import('./acp/acpClient.js');
+
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: { advanced: {}, security: { auth: {} }, ui: {} },
+      workspace: { settings: {} },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      errors: [],
+    } as unknown as ReturnType<typeof loadSettings>);
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      promptInteractive: false,
+      acp: true,
+    } as unknown as Awaited<ReturnType<typeof parseArguments>>);
+
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      buildMockConfig({
+        getAcpMode: vi.fn(() => true),
+      }),
+    );
+
+    await main();
+
+    expect(runAcpClient).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(registerCleanup)).toHaveBeenCalledTimes(3);
   });
 
   function buildMockConfig(overrides: Partial<Config> = {}): Config {


### PR DESCRIPTION
## Summary

- keep the global console patch active for the full ACP shutdown lifecycle
- treat the global patcher as non-interactive in ACP mode so stray console log/info output stays suppressed
- add a regression test covering ACP startup cleanup registration

## Root Cause

ACP mode awaited `runExitCleanup()` after the connection closed, but `main()` had already registered the global `ConsolePatcher.cleanup`. During shutdown that cleanup could restore the original console before SessionEnd hook debug logging finished, letting hook planner/runner messages leak onto stdout.

## Testing

- `npm run build --workspace @google/gemini-cli-core`
- `npm run test --workspace @google/gemini-cli -- src/gemini_cleanup.test.tsx`
- `npx eslint packages/cli/src/gemini.tsx packages/cli/src/gemini_cleanup.test.tsx`

Closes #25345
