### PR TITLE
feat(cli): apply MRU active extension context with UI transparency

### DIFF
--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -175,6 +175,13 @@ export type SlashCommandActionReturn =
   | OpenCustomDialogActionReturn
   | LogoutActionReturn;
 
+export enum CommandSource {
+  CORE = 'core',
+  EXTENSION = 'extension',
+  USER = 'user',
+  WORKSPACE = 'workspace',
+}
+
 export enum CommandKind {
   BUILT_IN = 'built-in',
   USER_FILE = 'user-file',

--- a/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextSummaryDisplay.tsx
@@ -12,6 +12,7 @@ import { Command } from '../key/keyMatchers.js';
 import { formatCommand } from '../key/keybindingUtils.js';
 
 interface ContextSummaryDisplayProps {
+  activeExtensionName?: string;
   geminiMdFileCount: number;
   contextFileNames: string[];
   mcpServers?: Record<string, MCPServerConfig>;
@@ -29,6 +30,7 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
   ideContext,
   skillCount,
   backgroundProcessCount = 0,
+  activeExtensionName,
 }) => {
   const mcpServerCount = Object.keys(mcpServers || {}).length;
   const blockedMcpServerCount = blockedMcpServers?.length || 0;
@@ -40,7 +42,8 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     blockedMcpServerCount === 0 &&
     openFileCount === 0 &&
     skillCount === 0 &&
-    backgroundProcessCount === 0
+    backgroundProcessCount === 0 &&
+    !activeExtensionName
   ) {
     return null;
   }
@@ -103,12 +106,20 @@ export const ContextSummaryDisplay: React.FC<ContextSummaryDisplayProps> = ({
     }`;
   })();
 
+  const extensionText = (() => {
+    if (!activeExtensionName) {
+      return '';
+    }
+    return `Extension: ${activeExtensionName}`;
+  })();
+
   const summaryParts = [
     openFilesText,
     geminiMdText,
     mcpText,
     skillText,
     backgroundText,
+    extensionText,
   ].filter(Boolean);
 
   return (

--- a/packages/cli/src/ui/components/StatusDisplay.tsx
+++ b/packages/cli/src/ui/components/StatusDisplay.tsx
@@ -39,6 +39,7 @@ export const StatusDisplay: React.FC<StatusDisplayProps> = ({
         }
         skillCount={config.getSkillManager().getDisplayableSkills().length}
         backgroundProcessCount={uiState.backgroundTaskCount}
+        activeExtensionName={config.activeExtensionName}
       />
     );
   }

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -670,6 +670,8 @@ describe('useSlashCommandProcessor', () => {
       expect(actionResult).toEqual({
         type: 'submit_prompt',
         content: [{ text: 'The actual prompt from the TOML file.' }],
+        activeExtensionName: undefined,
+        clearExtensionMRU: false,
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
@@ -704,6 +706,8 @@ describe('useSlashCommandProcessor', () => {
       expect(actionResult).toEqual({
         type: 'submit_prompt',
         content: [{ text: 'The actual prompt from the mcp command.' }],
+        activeExtensionName: undefined,
+        clearExtensionMRU: false,
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -47,7 +47,12 @@ import type {
 } from '../types.js';
 import { MessageType } from '../types.js';
 import type { LoadedSettings } from '../../config/settings.js';
-import { type CommandContext, type SlashCommand } from '../commands/types.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandSource,
+  CommandKind,
+} from '../commands/types.js';
 import { CommandService } from '../../services/CommandService.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
@@ -92,6 +97,43 @@ interface SlashCommandProcessorActions {
 /**
  * Hook to define and process slash commands (e.g., /help, /clear).
  */
+
+function getCommandSource(command: SlashCommand): CommandSource {
+  if (
+    command.extensionName ||
+    command.kind === CommandKind.EXTENSION_FILE ||
+    command.kind === CommandKind.MCP_PROMPT ||
+    command.kind === CommandKind.SKILL
+  )
+    return CommandSource.EXTENSION;
+  if (command.kind === CommandKind.WORKSPACE_FILE)
+    return CommandSource.WORKSPACE;
+  if (command.kind === CommandKind.USER_FILE) return CommandSource.USER;
+  return CommandSource.CORE;
+}
+
+function shouldClearExtensionMRU(command: SlashCommand | undefined): boolean {
+  if (!command) return false;
+
+  // Explicitly reset commands
+  if (command.name === 'clear' || command.name === 'extension reset')
+    return true;
+
+  // Exempt informational commands
+  const exemptions = [
+    'help',
+    'settings',
+    'status',
+    'history',
+    'bug',
+    'exit',
+    'quit',
+  ];
+  if (exemptions.includes(command.name)) return false;
+
+  return getCommandSource(command) === CommandSource.CORE;
+}
+
 export const useSlashCommandProcessor = (
   config: Config | null,
   settings: LoadedSettings,
@@ -449,7 +491,8 @@ export const useSlashCommandProcessor = (
                     toolArgs: result.toolArgs,
                     postSubmitPrompt: result.postSubmitPrompt,
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 case 'message':
                   addItem(
@@ -465,7 +508,8 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'handled',
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 case 'logout':
                   // Show logout confirmation dialog with Login/Exit options
@@ -485,7 +529,8 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'handled',
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 case 'dialog':
                   switch (result.dialog) {
@@ -494,49 +539,56 @@ export const useSlashCommandProcessor = (
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'theme':
                       actions.openThemeDialog();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'editor':
                       actions.openEditorDialog();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'privacy':
                       actions.openPrivacyNotice();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'sessionBrowser':
                       actions.openSessionBrowser();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'settings':
                       actions.openSettingsDialog();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'model':
                       actions.openModelDialog();
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'agentConfig': {
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -563,7 +615,8 @@ export const useSlashCommandProcessor = (
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     }
                     case 'permissions':
@@ -574,13 +627,15 @@ export const useSlashCommandProcessor = (
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     case 'help':
                       return {
                         type: 'handled',
                         activeExtensionName: commandToExecute?.extensionName,
-                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                        clearExtensionMRU:
+                          shouldClearExtensionMRU(commandToExecute),
                       };
                     default: {
                       const unhandled: never = result.dialog;
@@ -598,7 +653,8 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'handled',
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 }
                 case 'quit':
@@ -606,7 +662,8 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'handled',
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
 
                 case 'submit_prompt':
@@ -614,7 +671,8 @@ export const useSlashCommandProcessor = (
                     type: 'submit_prompt',
                     content: result.content,
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 case 'confirm_shell_commands': {
                   const callId = `expansion-${Date.now()}`;
@@ -674,7 +732,8 @@ export const useSlashCommandProcessor = (
                     return {
                       type: 'handled',
                       activeExtensionName: commandToExecute?.extensionName,
-                      clearExtensionMRU: commandToExecute?.name === 'clear',
+                      clearExtensionMRU:
+                        shouldClearExtensionMRU(commandToExecute),
                     };
                   }
 
@@ -716,7 +775,8 @@ export const useSlashCommandProcessor = (
                     return {
                       type: 'handled',
                       activeExtensionName: commandToExecute?.extensionName,
-                      clearExtensionMRU: commandToExecute?.name === 'clear',
+                      clearExtensionMRU:
+                        shouldClearExtensionMRU(commandToExecute),
                     };
                   }
 
@@ -731,7 +791,8 @@ export const useSlashCommandProcessor = (
                   return {
                     type: 'handled',
                     activeExtensionName: commandToExecute?.extensionName,
-                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                    clearExtensionMRU:
+                      shouldClearExtensionMRU(commandToExecute),
                   };
                 }
                 default: {
@@ -746,7 +807,7 @@ export const useSlashCommandProcessor = (
             return {
               type: 'handled',
               activeExtensionName: commandToExecute?.extensionName,
-              clearExtensionMRU: commandToExecute?.name === 'clear',
+              clearExtensionMRU: shouldClearExtensionMRU(commandToExecute),
             };
           } else if (commandToExecute.subCommands) {
             const helpText = `Command '/${commandToExecute.name}' requires a subcommand. Available:\n${commandToExecute.subCommands
@@ -760,7 +821,7 @@ export const useSlashCommandProcessor = (
             return {
               type: 'handled',
               activeExtensionName: commandToExecute?.extensionName,
-              clearExtensionMRU: commandToExecute?.name === 'clear',
+              clearExtensionMRU: shouldClearExtensionMRU(commandToExecute),
             };
           }
         }
@@ -768,7 +829,7 @@ export const useSlashCommandProcessor = (
         return {
           type: 'handled',
           activeExtensionName: commandToExecute?.extensionName,
-          clearExtensionMRU: commandToExecute?.name === 'clear',
+          clearExtensionMRU: shouldClearExtensionMRU(commandToExecute),
         };
       } catch (e: unknown) {
         hasError = true;
@@ -791,7 +852,7 @@ export const useSlashCommandProcessor = (
         return {
           type: 'handled',
           activeExtensionName: commandToExecute?.extensionName,
-          clearExtensionMRU: commandToExecute?.name === 'clear',
+          clearExtensionMRU: shouldClearExtensionMRU(commandToExecute),
         };
       } finally {
         if (config && resolvedCommandPath[0] && !hasError) {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -448,6 +448,8 @@ export const useSlashCommandProcessor = (
                     toolName: result.toolName,
                     toolArgs: result.toolArgs,
                     postSubmitPrompt: result.postSubmitPrompt,
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
                   };
                 case 'message':
                   addItem(
@@ -460,7 +462,11 @@ export const useSlashCommandProcessor = (
                     },
                     Date.now(),
                   );
-                  return { type: 'handled' };
+                  return {
+                    type: 'handled',
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                  };
                 case 'logout':
                   // Show logout confirmation dialog with Login/Exit options
                   setCustomDialog(
@@ -476,30 +482,62 @@ export const useSlashCommandProcessor = (
                       },
                     }),
                   );
-                  return { type: 'handled' };
+                  return {
+                    type: 'handled',
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                  };
                 case 'dialog':
                   switch (result.dialog) {
                     case 'auth':
                       actions.openAuthDialog();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'theme':
                       actions.openThemeDialog();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'editor':
                       actions.openEditorDialog();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'privacy':
                       actions.openPrivacyNotice();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'sessionBrowser':
                       actions.openSessionBrowser();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'settings':
                       actions.openSettingsDialog();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'model':
                       actions.openModelDialog();
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'agentConfig': {
                       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
                       const props = result.props as Record<string, unknown>;
@@ -522,16 +560,28 @@ export const useSlashCommandProcessor = (
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
                         props['definition'] as AgentDefinition,
                       );
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     }
                     case 'permissions':
                       actions.openPermissionsDialog(
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
                         result.props as { targetDirectory?: string },
                       );
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     case 'help':
-                      return { type: 'handled' };
+                      return {
+                        type: 'handled',
+                        activeExtensionName: commandToExecute?.extensionName,
+                        clearExtensionMRU: commandToExecute?.name === 'clear',
+                      };
                     default: {
                       const unhandled: never = result.dialog;
                       throw new Error(
@@ -545,16 +595,26 @@ export const useSlashCommandProcessor = (
                   result.history.forEach((item, index) => {
                     fullCommandContext.ui.addItem(item, index);
                   });
-                  return { type: 'handled' };
+                  return {
+                    type: 'handled',
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                  };
                 }
                 case 'quit':
                   actions.quit(result.messages);
-                  return { type: 'handled' };
+                  return {
+                    type: 'handled',
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                  };
 
                 case 'submit_prompt':
                   return {
                     type: 'submit_prompt',
                     content: result.content,
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
                   };
                 case 'confirm_shell_commands': {
                   const callId = `expansion-${Date.now()}`;
@@ -611,7 +671,11 @@ export const useSlashCommandProcessor = (
                       },
                       Date.now(),
                     );
-                    return { type: 'handled' };
+                    return {
+                      type: 'handled',
+                      activeExtensionName: commandToExecute?.extensionName,
+                      clearExtensionMRU: commandToExecute?.name === 'clear',
+                    };
                   }
 
                   if (outcome === ToolConfirmationOutcome.ProceedAlways) {
@@ -649,7 +713,11 @@ export const useSlashCommandProcessor = (
                       },
                       Date.now(),
                     );
-                    return { type: 'handled' };
+                    return {
+                      type: 'handled',
+                      activeExtensionName: commandToExecute?.extensionName,
+                      clearExtensionMRU: commandToExecute?.name === 'clear',
+                    };
                   }
 
                   return await handleSlashCommand(
@@ -660,7 +728,11 @@ export const useSlashCommandProcessor = (
                 }
                 case 'custom_dialog': {
                   setCustomDialog(result.component);
-                  return { type: 'handled' };
+                  return {
+                    type: 'handled',
+                    activeExtensionName: commandToExecute?.extensionName,
+                    clearExtensionMRU: commandToExecute?.name === 'clear',
+                  };
                 }
                 default: {
                   const unhandled: never = result;
@@ -671,7 +743,11 @@ export const useSlashCommandProcessor = (
               }
             }
 
-            return { type: 'handled' };
+            return {
+              type: 'handled',
+              activeExtensionName: commandToExecute?.extensionName,
+              clearExtensionMRU: commandToExecute?.name === 'clear',
+            };
           } else if (commandToExecute.subCommands) {
             const helpText = `Command '/${commandToExecute.name}' requires a subcommand. Available:\n${commandToExecute.subCommands
               .map((sc) => `  - ${sc.name}: ${sc.description || ''}`)
@@ -681,11 +757,19 @@ export const useSlashCommandProcessor = (
               content: helpText,
               timestamp: new Date(),
             });
-            return { type: 'handled' };
+            return {
+              type: 'handled',
+              activeExtensionName: commandToExecute?.extensionName,
+              clearExtensionMRU: commandToExecute?.name === 'clear',
+            };
           }
         }
 
-        return { type: 'handled' };
+        return {
+          type: 'handled',
+          activeExtensionName: commandToExecute?.extensionName,
+          clearExtensionMRU: commandToExecute?.name === 'clear',
+        };
       } catch (e: unknown) {
         hasError = true;
         if (config) {
@@ -704,7 +788,11 @@ export const useSlashCommandProcessor = (
           },
           Date.now(),
         );
-        return { type: 'handled' };
+        return {
+          type: 'handled',
+          activeExtensionName: commandToExecute?.extensionName,
+          clearExtensionMRU: commandToExecute?.name === 'clear',
+        };
       } finally {
         if (config && resolvedCommandPath[0] && !hasError) {
           const event = makeSlashCommandEvent({

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -100,6 +100,7 @@ const MockedGeminiClientClass = vi.hoisted(() =>
       recordMessageTokens: vi.fn(),
       recordToolCalls: vi.fn(),
       getConversationFile: vi.fn(),
+      recordActiveExtensionName: vi.fn(),
     });
     this.getCurrentSequenceModel = vi
       .fn()
@@ -310,6 +311,8 @@ describe('useGeminiStream', () => {
     debugMode: false,
     question: undefined,
     coreTools: [],
+    activeExtensionName: undefined,
+    setActiveExtensionName: vi.fn(),
     toolDiscoveryCommand: undefined,
     toolCallCommand: undefined,
     mcpServerCommand: undefined,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -937,10 +937,20 @@ export const useGeminiStream = (
           if (slashCommandResult) {
             if (slashCommandResult.clearExtensionMRU) {
               config.setActiveExtensionName(undefined);
+              config
+                .getGeminiClient()
+                ?.getChatRecordingService()
+                ?.recordActiveExtensionName(undefined);
             } else if (slashCommandResult.activeExtensionName) {
               config.setActiveExtensionName(
                 slashCommandResult.activeExtensionName,
               );
+              config
+                .getGeminiClient()
+                ?.getChatRecordingService()
+                ?.recordActiveExtensionName(
+                  slashCommandResult.activeExtensionName,
+                );
             }
             switch (slashCommandResult.type) {
               case 'schedule_tool': {
@@ -1762,6 +1772,10 @@ export const useGeminiStream = (
         newApprovalMode !== ApprovalMode.PLAN
       ) {
         config.setActiveExtensionName(undefined);
+        config
+          .getGeminiClient()
+          ?.getChatRecordingService()
+          ?.recordActiveExtensionName(undefined);
       }
       if (
         previousApprovalModeRef.current === ApprovalMode.PLAN &&

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -935,6 +935,13 @@ export const useGeminiStream = (
             : false;
 
           if (slashCommandResult) {
+            if (slashCommandResult.clearExtensionMRU) {
+              config.setActiveExtensionName(undefined);
+            } else if (slashCommandResult.activeExtensionName) {
+              config.setActiveExtensionName(
+                slashCommandResult.activeExtensionName,
+              );
+            }
             switch (slashCommandResult.type) {
               case 'schedule_tool': {
                 const { toolName, toolArgs, postSubmitPrompt } =
@@ -1750,6 +1757,12 @@ export const useGeminiStream = (
 
   const handleApprovalModeChange = useCallback(
     async (newApprovalMode: ApprovalMode) => {
+      if (
+        previousApprovalModeRef.current === ApprovalMode.PLAN &&
+        newApprovalMode !== ApprovalMode.PLAN
+      ) {
+        config.setActiveExtensionName(undefined);
+      }
       if (
         previousApprovalModeRef.current === ApprovalMode.PLAN &&
         newApprovalMode !== ApprovalMode.PLAN &&

--- a/packages/cli/src/ui/hooks/useSessionResume.ts
+++ b/packages/cli/src/ui/hooks/useSessionResume.ts
@@ -83,6 +83,13 @@ export function useSessionResume({
           workspaceContext.addDirectories(resumedData.conversation.directories);
         }
 
+        // Restore active extension context
+        if (resumedData.conversation.activeExtensionName) {
+          config.setActiveExtensionName(
+            resumedData.conversation.activeExtensionName,
+          );
+        }
+
         // Give the history to the Gemini client.
         await config.getGeminiClient()?.resumeChat(clientHistory, resumedData);
       } catch (error) {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -498,6 +498,8 @@ export interface ConsoleMessageItem {
 export interface SubmitPromptResult {
   type: 'submit_prompt';
   content: PartListUnion;
+  activeExtensionName?: string;
+  clearExtensionMRU?: boolean;
 }
 
 /**
@@ -509,9 +511,13 @@ export type SlashCommandProcessorResult =
       toolName: string;
       toolArgs: Record<string, unknown>;
       postSubmitPrompt?: PartListUnion;
+      activeExtensionName?: string;
+      clearExtensionMRU?: boolean;
     }
   | {
       type: 'handled'; // Indicates the command was processed and no further action is needed.
+      activeExtensionName?: string;
+      clearExtensionMRU?: boolean;
     }
   | SubmitPromptResult;
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -603,6 +603,18 @@ export class ChatRecordingService {
     }
   }
 
+  recordActiveExtensionName(activeExtensionName: string | undefined): void {
+    if (!this.conversationFile) return;
+    try {
+      this.updateMetadata({ activeExtensionName });
+    } catch (error) {
+      debugLogger.error(
+        'Error saving active extension to chat history.',
+        error,
+      );
+    }
+  }
+
   getConversation(): ConversationRecord | null {
     if (!this.conversationFile) return null;
     return this.cachedConversation;

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -87,6 +87,8 @@ export interface ConversationRecord {
   directories?: string[];
   /** The kind of conversation (main agent or subagent) */
   kind?: 'main' | 'subagent';
+  /** The last active extension context for the session */
+  activeExtensionName?: string;
 }
 
 /**

--- a/packages/core/src/tools/exit-plan-mode.ts
+++ b/packages/core/src/tools/exit-plan-mode.ts
@@ -64,7 +64,6 @@ export class ExitPlanModeTool extends BaseDeclarativeTool<
     }
     return this.config.storage.getPlansDir(customDir);
   }
-
   protected override validateToolParamValues(
     params: ExitPlanModeParams,
   ): string | null {


### PR DESCRIPTION
## Summary

Phase 5 of the dynamic extension plan directory resolution implementation. This PR focuses on the UX and state management of the active extension context.

## Details

- **Session Persistence**: Adds `activeExtensionName` to `ConversationRecord` and the `chatRecordingService`. It correctly saves the state to the JSONL history and restores it via `useSessionResume.ts` on CLI startup.
- **UI Transparency**: Updates the `ContextSummaryDisplay` used by the `StatusRow` to display an indicator (`Extension: [Name]`) whenever an extension is actively overriding the global context.
- **Automatic Deactivation Mapping**: Implements a `CommandSource` map for `SlashCommand` kinds. This allows the CLI to automatically clear the MRU active extension when a user runs a Built-in "Core" command (exempting informational commands like `/help` and `/status`), preventing extension settings from leaking into standard usage.

## Related Issues

Depends on Phase 4 (PR #25396).
Completes the Lazy-Loading Extension Context design.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
