### PR TITLE
fix(extensions): suppress non-actionable errors during extension install

### DIFF
--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -261,10 +261,10 @@ export class ExtensionManager extends ExtensionLoader {
             installMetadata.type = result.type;
             installMetadata.releaseTag = result.tagName;
           } else if (
-            // This repo has no github releases, and wasn't explicitly installed
-            // from a github release, unconditionally just clone it.
-            (result.failureReason === 'no release data' &&
-              installMetadata.type === 'git') ||
+            // The user provided a plain git URL (not explicitly a github-release
+            // install), so silently fall through to git clone on any release
+            // download failure -- no need to alarm the user with error details.
+            installMetadata.type === 'git' ||
             // Otherwise ask the user if they would like to try a git clone.
             (await (requestConsentOverride ?? this.requestConsent)(
               `Error downloading github release for ${installMetadata.source} with the following error: ${result.errorMessage}.

--- a/packages/core/src/services/keychainService.ts
+++ b/packages/core/src/services/keychainService.ts
@@ -114,7 +114,7 @@ export class KeychainService {
     }
 
     // If native failed or was skipped, return the secure file fallback.
-    debugLogger.log('Using FileKeychain fallback for secure storage.');
+    debugLogger.debug('Using FileKeychain fallback for secure storage.');
     return new FileKeychain();
   }
 
@@ -130,7 +130,7 @@ export class KeychainService {
 
       // Probing macOS prevents process-blocking popups when no keychain exists.
       if (os.platform() === 'darwin' && !this.isMacOSKeychainAvailable()) {
-        debugLogger.log(
+        debugLogger.debug(
           'MacOS default keychain not found; skipping functional verification.',
         );
         return null;
@@ -140,12 +140,15 @@ export class KeychainService {
         return keychainModule;
       }
 
-      debugLogger.log('Keychain functional verification failed');
+      debugLogger.debug('Keychain functional verification failed');
       return null;
     } catch (error) {
       // Avoid logging full error objects to prevent PII exposure.
       const message = error instanceof Error ? error.message : String(error);
-      debugLogger.log('Keychain initialization encountered an error:', message);
+      debugLogger.debug(
+        'Keychain initialization encountered an error:',
+        message,
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- Silently fall through to `git clone` when GitHub release download fails for plain git URL installs, instead of showing an error prompt
- Downgrade keychain fallback messages from `debugLogger.log()` to `debugLogger.debug()` so they are hidden unless `--debug` is enabled
Fixes #24966