### PR TITLE
fix(cli): use active keybinding config for UI shortcuts

### DIFF
--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -426,6 +426,19 @@ export const defaultKeyBindingConfig: KeyBindingConfig = new Map([
   [Command.LINK_EXTENSION, [new KeyBinding('l')]],
 ]);
 
+/**
+ * The active key binding configuration for the application.
+ * Defaults to defaultKeyBindingConfig until custom bindings are loaded.
+ */
+export let activeKeyBindingConfig: KeyBindingConfig = defaultKeyBindingConfig;
+
+/**
+ * Internal setter for testing and initialization.
+ */
+export function setActiveKeyBindingConfig(config: KeyBindingConfig) {
+  activeKeyBindingConfig = config;
+}
+
 interface CommandCategory {
   readonly title: string;
   readonly commands: readonly Command[];
@@ -775,5 +788,6 @@ export async function loadCustomKeybindings(): Promise<{
     }
   }
 
+  activeKeyBindingConfig = config;
   return { config, errors };
 }

--- a/packages/cli/src/ui/key/keybindingUtils.test.ts
+++ b/packages/cli/src/ui/key/keybindingUtils.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, it, expect } from 'vitest';
 import { formatKeyBinding, formatCommand } from './keybindingUtils.js';
-import { Command, KeyBinding } from './keyBindings.js';
+import {
+  Command,
+  KeyBinding,
+  setActiveKeyBindingConfig,
+  defaultKeyBindingConfig,
+} from './keyBindings.js';
 
 describe('keybindingUtils', () => {
   describe('formatKeyBinding', () => {
@@ -137,6 +142,29 @@ describe('keybindingUtils', () => {
           'default',
         ),
       ).toBe('');
+    });
+
+    it('falls back to activeKeyBindingConfig when no config is provided', () => {
+      try {
+        // Initially it should be default (Ctrl+G)
+        expect(
+          formatCommand(Command.OPEN_EXTERNAL_EDITOR, undefined, 'default'),
+        ).toBe('Ctrl+G');
+
+        // Set a custom active config
+        const customConfig = new Map([
+          [Command.OPEN_EXTERNAL_EDITOR, [new KeyBinding('ctrl+x')]],
+        ]);
+        setActiveKeyBindingConfig(customConfig);
+
+        // Now it should be Ctrl+X
+        expect(
+          formatCommand(Command.OPEN_EXTERNAL_EDITOR, undefined, 'default'),
+        ).toBe('Ctrl+X');
+      } finally {
+        // Reset to default for other tests
+        setActiveKeyBindingConfig(defaultKeyBindingConfig);
+      }
     });
   });
 });

--- a/packages/cli/src/ui/key/keybindingUtils.ts
+++ b/packages/cli/src/ui/key/keybindingUtils.ts
@@ -9,7 +9,7 @@ import {
   type Command,
   type KeyBinding,
   type KeyBindingConfig,
-  defaultKeyBindingConfig,
+  activeKeyBindingConfig,
 } from './keyBindings.js';
 
 /**
@@ -97,7 +97,7 @@ export function formatKeyBinding(
  */
 export function formatCommand(
   command: Command,
-  config: KeyBindingConfig = defaultKeyBindingConfig,
+  config: KeyBindingConfig = activeKeyBindingConfig,
   platform?: string,
 ): string {
   const bindings = config.get(command);


### PR DESCRIPTION
## Summary
Fixes an issue where UI prompts would display default shortcuts (e.g., `Ctrl+G` for external editor) even when remapped by the user.

## Details
`formatCommand` was defaulting to `defaultKeyBindingConfig`. I introduced `activeKeyBindingConfig` in `keyBindings.ts` which is updated whenever custom keybindings are loaded. `formatCommand` now falls back to this active config, ensuring visual consistency without requiring changes to the React component tree.

## Related Issues
(User reported issue)

## How to Validate
1. Set a custom keybinding in `keybindings.json` (e.g., `{"command": "input.openExternalEditor", "key": "ctrl+x"}`).
2. Enter plan mode or any dialog that shows the external editor shortcut.
3. Verify the prompt shows "Ctrl+X" instead of "Ctrl+G".
4. Run `npm test -w @google/gemini-cli -- src/ui/key/keybindingUtils.test.ts`.

## Pre-Merge Checklist
- [x] Added/updated tests
- [x] Validated on Linux (npm run)