### PR TITLE
feat(sandbox): resolve custom seatbelt profiles from $HOME/.gemini first

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -138,6 +138,7 @@ describe('sandbox', () => {
   afterEach(() => {
     process.env = originalEnv;
     process.argv = originalArgv;
+    vi.unstubAllEnvs();
   });
 
   describe('start_sandbox', () => {
@@ -178,7 +179,7 @@ describe('sandbox', () => {
 
     it('should resolve custom seatbelt profile from user home directory', async () => {
       vi.mocked(os.platform).mockReturnValue('darwin');
-      process.env['SEATBELT_PROFILE'] = 'custom-test';
+      vi.stubEnv('SEATBELT_PROFILE', 'custom-test');
       vi.mocked(fs.existsSync).mockImplementation((p) =>
         String(p).includes(
           path.join(homedir(), '.gemini', 'sandbox-macos-custom-test.sb'),
@@ -226,7 +227,7 @@ describe('sandbox', () => {
 
     it('should fall back to project .gemini directory when user profile is missing', async () => {
       vi.mocked(os.platform).mockReturnValue('darwin');
-      process.env['SEATBELT_PROFILE'] = 'custom-test';
+      vi.stubEnv('SEATBELT_PROFILE', 'custom-test');
       vi.mocked(fs.existsSync).mockImplementation((p) => {
         const s = String(p);
         return (

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -8,8 +8,13 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawn, exec, execFile, execSync } from 'node:child_process';
 import os from 'node:os';
 import fs from 'node:fs';
+import path from 'node:path';
 import { start_sandbox } from './sandbox.js';
-import { FatalSandboxError, type SandboxConfig } from '@google/gemini-cli-core';
+import {
+  FatalSandboxError,
+  homedir,
+  type SandboxConfig,
+} from '@google/gemini-cli-core';
 import { createMockSandboxConfig } from '@google/gemini-cli-test-utils';
 import { EventEmitter } from 'node:events';
 
@@ -169,6 +174,105 @@ describe('sandbox', () => {
         ]),
         expect.objectContaining({ stdio: 'inherit' }),
       );
+    });
+
+    it('should resolve custom seatbelt profile from user home directory', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      process.env['SEATBELT_PROFILE'] = 'custom-test';
+      vi.mocked(fs.existsSync).mockImplementation((p) =>
+        String(p).includes(
+          path.join(homedir(), '.gemini', 'sandbox-macos-custom-test.sb'),
+        ),
+      );
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const promise = start_sandbox(config, [], undefined, ['arg1']);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      await expect(promise).resolves.toBe(0);
+      expect(spawn).toHaveBeenCalledWith(
+        'sandbox-exec',
+        expect.any(Array),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+      const spawnArgs = vi.mocked(spawn).mock.calls[0]?.[1];
+      expect(spawnArgs).toEqual(
+        expect.arrayContaining(['-f', expect.any(String)]),
+      );
+      const profileArg = spawnArgs?.[spawnArgs.indexOf('-f') + 1];
+      expect(profileArg).toEqual(
+        expect.stringContaining(
+          path.join(homedir(), '.gemini', 'sandbox-macos-custom-test.sb'),
+        ),
+      );
+    });
+
+    it('should fall back to project .gemini directory when user profile is missing', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      process.env['SEATBELT_PROFILE'] = 'custom-test';
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        const s = String(p);
+        return (
+          s.includes(path.join('.gemini', 'sandbox-macos-custom-test.sb')) &&
+          !s.includes(path.join(homedir(), '.gemini'))
+        );
+      });
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const promise = start_sandbox(config, [], undefined, ['arg1']);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      await expect(promise).resolves.toBe(0);
+      expect(spawn).toHaveBeenCalledWith(
+        'sandbox-exec',
+        expect.any(Array),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+      const spawnArgs = vi.mocked(spawn).mock.calls[0]?.[1];
+      expect(spawnArgs).toEqual(
+        expect.arrayContaining(['-f', expect.any(String)]),
+      );
+      const profileArg = spawnArgs?.[spawnArgs.indexOf('-f') + 1];
+      expect(profileArg).toEqual(
+        expect.stringContaining(
+          path.join('.gemini', 'sandbox-macos-custom-test.sb'),
+        ),
+      );
+      expect(profileArg).not.toContain(homedir());
     });
 
     it('should throw FatalSandboxError if seatbelt profile is missing', async () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -69,9 +69,11 @@ export async function start_sandbox(
         new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
       );
       // if profile name is not recognized, look in user-level ~/.gemini first,
-      // then fall back to project-level .gemini
+      // then fall back to project-level .gemini. path.basename() strips any
+      // directory separators to prevent path traversal via SEATBELT_PROFILE.
       if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-        const fileName = `sandbox-macos-${profile}.sb`;
+        const safeProfile = path.basename(profile);
+        const fileName = `sandbox-macos-${safeProfile}.sb`;
         const userProfileFile = path.join(homedir(), GEMINI_DIR, fileName);
         const projectProfileFile = path.join(GEMINI_DIR, fileName);
         profileFile = fs.existsSync(userProfileFile)

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -68,9 +68,15 @@ export async function start_sandbox(
       let profileFile = fileURLToPath(
         new URL(`sandbox-macos-${profile}.sb`, import.meta.url),
       );
-      // if profile name is not recognized, then look for file under project settings directory
+      // if profile name is not recognized, look in user-level ~/.gemini first,
+      // then fall back to project-level .gemini
       if (!BUILTIN_SEATBELT_PROFILES.includes(profile)) {
-        profileFile = path.join(GEMINI_DIR, `sandbox-macos-${profile}.sb`);
+        const fileName = `sandbox-macos-${profile}.sb`;
+        const userProfileFile = path.join(homedir(), GEMINI_DIR, fileName);
+        const projectProfileFile = path.join(GEMINI_DIR, fileName);
+        profileFile = fs.existsSync(userProfileFile)
+          ? userProfileFile
+          : projectProfileFile;
       }
       if (!fs.existsSync(profileFile)) {
         throw new FatalSandboxError(


### PR DESCRIPTION
## Summary

Custom (non-builtin) `SEATBELT_PROFILE` values now resolve from `$HOME/.gemini/sandbox-macos-${profile}.sb` first, falling back to the existing project-level `.gemini/sandbox-macos-${profile}.sb`. This lets a user keep one custom profile that works across every workspace, which is what was requested in #24991.

## Details

The previous resolution path (in `packages/cli/src/utils/sandbox.ts:67-79`) did:

1. Bundled URL for builtin profile names in `BUILTIN_SEATBELT_PROFILES`
2. `path.join(GEMINI_DIR, 'sandbox-macos-${profile}.sb')` for everything else - i.e. only the project's `.gemini/`

The change keeps step 1 unchanged. For non-builtin profiles, it now checks `path.join(homedir(), GEMINI_DIR, fileName)` and uses that file when it exists, otherwise falls back to the project-level path. The same `FatalSandboxError` is thrown if neither location has the file.

This matches the approach proposed in [#24991 (comment)](https://github.com/google-gemini/gemini-cli/issues/24991#issuecomment) by @scidomino:

> It would be better to change the code to search the home `.gemini` folder first before searching the workspace `.gemini`. That way, you could put a custom profile in one place and have it work with all your workspaces.

@flexponsive (the issue author) confirmed this would solve the problem. Two prior PRs (#25013, #25024) implemented the alternative `SEATBELT_PROFILE`-as-absolute-path approach and were closed with "we don't want to impl it this way" - so this PR deliberately takes the maintainer-directed path.

`homedir` and `GEMINI_DIR` are already imported from `@google/gemini-cli-core` in this file, mirroring the user-level `.gemini` lookups elsewhere (e.g. `packages/core/src/services/fileKeychain.ts:19`, `packages/cli/src/config/trustedFolders.ts:30`).

## Related Issues

Fixes #24991

## How to Validate

1. `npm run build --workspace @google/gemini-cli-core && npm run build --workspace @google/gemini-cli-test-utils`
2. `npx vitest run packages/cli/src/utils/sandbox.test.ts` - 18 tests pass, including two new tests:
   - `should resolve custom seatbelt profile from user home directory`
   - `should fall back to project .gemini directory when user profile is missing`
3. `npx prettier --check packages/cli/src/utils/sandbox.ts packages/cli/src/utils/sandbox.test.ts` - clean
4. `npx eslint packages/cli/src/utils/sandbox.ts packages/cli/src/utils/sandbox.test.ts` - no errors
5. `npm run typecheck --workspace @google/gemini-cli` - passes

Manual smoke (macOS):

```bash
mkdir -p ~/.gemini
cp /path/to/your/profile.sb ~/.gemini/sandbox-macos-myprofile.sb
SEATBELT_PROFILE=myprofile gemini   # uses ~/.gemini profile
```

Run from any other workspace and the same profile resolves.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) - behavior is additive; no doc changes required, but happy to add a note in `docs/cli/sandbox.md` if you'd prefer.
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) - none; project-local profiles still work, builtin resolution unchanged.
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (vitest)
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt (the code path under change)
  - [ ] Windows (not applicable - macOS-only code path)
  - [ ] Linux (not applicable - macOS-only code path)

This contribution was developed with AI assistance (Codex).