### PR TITLE
Fix: Aborted Task and Closed Agent

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -163,11 +163,12 @@ export function getNodeMemoryArgs(isDebugMode: boolean): string[] {
 
 export function setupUnhandledRejectionHandler() {
   let unhandledRejectionOccurred = false;
-  process.on('unhandledRejection', (reason, _promise) => {
-    // AbortError is expected when the user cancels a request (e.g. pressing ESC).
+  const handleError = (reason: any) => {
+    // AbortError is expected when the user cancels a request (e.g. pressing ESC)
+    // or when the client performs internal recovery.
     // It may surface as an unhandled rejection due to async timing in the
     // streaming pipeline, but it is not a bug.
-    if (reason instanceof Error && reason.name === 'AbortError') {
+    if (reason?.name === 'AbortError') {
       debugLogger.log(`Suppressed unhandled AbortError: ${reason.message}`);
       return;
     }
@@ -188,6 +189,14 @@ ${reason.stack}`
       unhandledRejectionOccurred = true;
       appEvents.emit(AppEvent.OpenDebugConsole);
     }
+  };
+
+  process.on('unhandledRejection', (reason, _promise) => {
+    handleError(reason);
+  });
+
+  process.on('uncaughtException', (error) => {
+    handleError(error);
   });
 }
 
@@ -490,7 +499,7 @@ export async function main() {
           );
           if (promptIndex > -1 && finalArgs.length > promptIndex + 1) {
             // If there's a prompt argument, prepend stdin to it
-            finalArgs[promptIndex + 1] =
+            finalArgs[promptIndex + 1] = 
               `${stdinData}\n\n${finalArgs[promptIndex + 1]}`;
           } else {
             // If there's no prompt argument, add stdin as the prompt


### PR DESCRIPTION
The issue was caused by an internal `AbortError` (likely triggered by loop recovery in `GeminiClient`) surfacing as an unhandled rejection or uncaught exception, which then caused the agent to crash or show a scary stack trace. 

The fix involved updating `setupUnhandledRejectionHandler` in `packages/cli/src/gemini.tsx` to:
1. Use a more robust check for `AbortError` by checking `reason?.name === 'AbortError'`. This is safer than `instanceof Error` because in bundled environments or different Node versions (where `AbortError` might be a `DOMException`), the `instanceof` check can fail.
2. Add a listener for `uncaughtException` to handle cases where the error isn't caught by promise rejection logic, which prevents the Node.js process from exiting unexpectedly (the 'Closed Agent' part of the issue).
3. Keep the suppression silent (logging only to `debugLogger.log`) to prevent transient internal recovery state changes from being displayed to the user as fatal errors.

Test: To verify the fix:
1. Run the Gemini CLI in interactive mode with an image input that might trigger a complex or long-running task.
2. If the internal client triggers a loop recovery (calling `abort()`), ensure that no `AbortError` stack trace appears on the screen and the CLI session remains active (instead of closing the agent).
3. You can also manually trigger an unhandled `AbortError` rejection in a development build and verify it is caught silently by checking the debug logs, while a non-AbortError still triggers the 'CRITICAL' error message and opens the debug console.