### PR TITLE
fix(core): throttle shell text output UI updates

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -524,8 +524,24 @@ export class ShellToolInvocation extends BaseToolInvocation<
             switch (event.type) {
               case 'data':
                 if (isBinaryStream) break;
-                cumulativeOutput = event.chunk;
-                shouldUpdate = true;
+                // PTY mode emits AnsiOutput (full terminal snapshot) —
+                // overwrite. Pipe mode emits partial strings — accumulate
+                // so intermediate chunks aren't lost between throttled
+                // UI updates.
+                if (typeof event.chunk === 'string') {
+                  cumulativeOutput =
+                    typeof cumulativeOutput === 'string'
+                      ? cumulativeOutput + event.chunk
+                      : event.chunk;
+                } else {
+                  cumulativeOutput = event.chunk;
+                }
+                // Throttle UI updates to avoid excessive re-renders when
+                // commands produce high-volume output (e.g. thousands of
+                // warning lines).
+                if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
+                  shouldUpdate = true;
+                }
                 break;
               case 'binary_detected':
                 isBinaryStream = true;


### PR DESCRIPTION
Fixes #25459

## Summary
Shell tool text output (`data` events) triggered a React re-render on every chunk, while `binary_progress` already throttled to 1s intervals via `OUTPUT_UPDATE_INTERVAL_MS`. Commands that emit thousands of lines (verbose builds, manifest generation with ~2000 duplicate warnings) pinned the UI.

## Changes
- Apply the same `OUTPUT_UPDATE_INTERVAL_MS` throttle to text `data` chunks in `shell.ts`
- PTY mode (AnsiOutput) keeps overwrite semantics; pipe mode (string) accumulates between throttled updates so no intermediate output is lost

## Test plan
- [x] Existing shell tool tests pass
- [ ] Manual: run a command producing thousands of lines and confirm UI stays responsive
- [ ] Manual: run a PTY-mode command and confirm output still renders correctly

Replaces #22843 (auto-closed per contribution policy).