### PR TITLE
fix(core): robust cross-boundary cancellation detection

### DIFF
--- a/packages/core/src/agents/browser/browserAgentInvocation.test.ts
+++ b/packages/core/src/agents/browser/browserAgentInvocation.test.ts
@@ -267,6 +267,29 @@ describe('BrowserAgentInvocation', () => {
       expect(removeInputBlocker).toHaveBeenCalled();
     });
 
+    it('should throw plain cancellation messages after emitting cancelled progress', async () => {
+      mockExecutor.run.mockRejectedValue(
+        new Error('The user aborted a request.'),
+      );
+
+      const invocation = new BrowserAgentInvocation(
+        mockConfig,
+        mockParams,
+        mockMessageBus,
+      );
+
+      const updateOutput = vi.fn();
+      await expect(
+        invocation.execute(new AbortController().signal, updateOutput),
+      ).rejects.toThrow('The user aborted a request.');
+
+      const lastCall = updateOutput.mock.calls[
+        updateOutput.mock.calls.length - 1
+      ]?.[0] as SubagentProgress;
+      expect(lastCall.state).toBe('cancelled');
+      expect(cleanupBrowserAgent).toHaveBeenCalled();
+    });
+
     // ─── Structured SubagentProgress emission tests ───────────────────────
 
     /**

--- a/packages/core/src/agents/browser/browserAgentInvocation.ts
+++ b/packages/core/src/agents/browser/browserAgentInvocation.ts
@@ -43,6 +43,7 @@ import {
   sanitizeErrorMessage,
 } from '../../utils/agent-sanitization-utils.js';
 import { removeAutomationOverlay } from './automationOverlay.js';
+import { isCancellationError } from '../../utils/errors.js';
 
 const INPUT_PREVIEW_MAX_LENGTH = 50;
 const DESCRIPTION_MAX_LENGTH = 200;
@@ -359,9 +360,7 @@ ${output.result}`;
     } catch (error) {
       const rawErrorMessage =
         error instanceof Error ? error.message : String(error);
-      const isAbort =
-        (error instanceof Error && error.name === 'AbortError') ||
-        rawErrorMessage.includes('Aborted');
+      const isAbort = isCancellationError(error);
       const errorMessage = sanitizeErrorMessage(rawErrorMessage);
 
       // Mark any running items as error/cancelled
@@ -382,9 +381,11 @@ ${output.result}`;
         updateOutput(progress);
       }
 
-      const llmContent = isAbort
-        ? 'Browser agent execution was aborted.'
-        : `Browser agent failed. Error: ${errorMessage}`;
+      if (isAbort) {
+        throw error;
+      }
+
+      const llmContent = `Browser agent failed. Error: ${errorMessage}`;
 
       return {
         llmContent: [{ text: llmContent }],

--- a/packages/core/src/agents/local-invocation.test.ts
+++ b/packages/core/src/agents/local-invocation.test.ts
@@ -512,6 +512,20 @@ describe('LocalSubagentInvocation', () => {
       );
     });
 
+    it('should treat plain cancellation messages as cancellation', async () => {
+      const abortError = new Error('The user aborted a request.');
+      mockExecutorInstance.run.mockRejectedValue(abortError);
+
+      await expect(invocation.execute(signal, updateOutput)).rejects.toThrow(
+        'The user aborted a request.',
+      );
+
+      const lastCall = updateOutput.mock.calls[
+        updateOutput.mock.calls.length - 1
+      ]?.[0] as SubagentProgress;
+      expect(lastCall.state).toBe('cancelled');
+    });
+
     it('should throw an error and bubble cancellation when execution returns ABORTED', async () => {
       const mockOutput = {
         result: 'Cancelled by user',

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -33,6 +33,7 @@ import {
   sanitizeErrorMessage,
 } from '../utils/agent-sanitization-utils.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { isCancellationError } from '../utils/errors.js';
 
 const INPUT_PREVIEW_MAX_LENGTH = 50;
 const DESCRIPTION_MAX_LENGTH = 200;
@@ -328,9 +329,7 @@ ${output.result}`;
 
       debugLogger.error(`Subagent '${this.definition.name}' failed:`, error);
 
-      const isAbort =
-        (error instanceof Error && error.name === 'AbortError') ||
-        errorMessage.includes('Aborted');
+      const isAbort = isCancellationError(error);
 
       // Mark any running items as error/cancelled
       for (const item of recentActivity) {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -832,6 +832,21 @@ describe('Gemini Client (client.ts)', () => {
       expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
     });
 
+    it('yields UserCancelled when processTurn throws a plain cancellation message', async () => {
+      vi.spyOn(client['loopDetector'], 'turnStarted').mockRejectedValueOnce(
+        new Error('The user aborted a request.'),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-id-user-abort-message',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
+    });
+
     it.each([
       {
         compressionStatus:

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -35,7 +35,7 @@ import {
   type RetryAvailabilityContext,
 } from '../utils/retry.js';
 import type { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
-import { getErrorMessage, isAbortError } from '../utils/errors.js';
+import { getErrorMessage, isCancellationError } from '../utils/errors.js';
 import { tokenLimit } from './tokenLimits.js';
 import type {
   ChatRecordingService,
@@ -1012,7 +1012,7 @@ export class GeminiClient {
         }
       }
     } catch (error) {
-      if (signal?.aborted || isAbortError(error)) {
+      if (signal?.aborted || isCancellationError(error)) {
         yield { type: GeminiEventType.UserCancelled };
         return turn;
       }

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -37,7 +37,7 @@ import { toContents } from '../code_assist/converter.js';
 import { isStructuredError } from '../utils/quotaErrorDetection.js';
 import { runInDevTraceSpan, type SpanMetadata } from '../telemetry/trace.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { isAbortError, getErrorType } from '../utils/errors.js';
+import { isCancellationError, getErrorType } from '../utils/errors.js';
 import {
   GeminiCliOperation,
   GEN_AI_PROMPT_NAME,
@@ -322,7 +322,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     generationConfig?: GenerateContentConfig,
     serverDetails?: ServerDetails,
   ): void {
-    if (isAbortError(error)) {
+    if (isCancellationError(error)) {
       // Don't log aborted requests (e.g., user cancellation, internal timeouts) as API errors.
       return;
     }

--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -34,6 +34,7 @@ import {
 import type { DiffUpdateResult } from '../ide/ide-client.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
+import { isCancellationError } from '../utils/errors.js';
 
 export interface ConfirmationResult {
   outcome: ToolConfirmationOutcome;
@@ -90,8 +91,7 @@ async function awaitConfirmation(
       }
     }
   } catch (error) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if (signal.aborted || (error as Error).name === 'AbortError') {
+    if (signal.aborted || isCancellationError(error)) {
       throw new Error('Operation cancelled');
     }
     throw error;

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -49,6 +49,7 @@ import {
   type McpProgressPayload,
 } from '../utils/events.js';
 import { GeminiCliOperation } from '../telemetry/constants.js';
+import { isCancellationError } from '../utils/errors.js';
 
 interface SchedulerQueueItem {
   requests: ToolCallRequestInfo[];
@@ -556,7 +557,7 @@ export class Scheduler {
       const err = error instanceof Error ? error : new Error(String(error));
       // If the signal aborted while we were waiting on something, treat as
       // cancelled. Otherwise, it's a genuine unhandled system exception.
-      if (signal.aborted || err.name === 'AbortError') {
+      if (signal.aborted || isCancellationError(err)) {
         this.state.updateStatus(
           active.request.callId,
           CoreToolCallStatus.Cancelled,

--- a/packages/core/src/scheduler/tool-executor.test.ts
+++ b/packages/core/src/scheduler/tool-executor.test.ts
@@ -288,7 +288,47 @@ describe('ToolExecutor', () => {
     if (result.status === CoreToolCallStatus.Cancelled) {
       const response = result.response.responseParts[0]?.functionResponse
         ?.response as Record<string, unknown>;
-      expect(response['error']).toContain('User cancelled tool execution.');
+      expect(response['error']).toContain('Operation cancelled.');
+    }
+  });
+
+  it('should return cancelled result when executeToolWithHooks rejects with plain user-aborted message', async () => {
+    const mockTool = new MockTool({
+      name: 'someTool',
+      description: 'Mock',
+    });
+    const invocation = mockTool.build({});
+
+    const cancelErr = new Error('The user aborted a request.');
+    vi.mocked(coreToolHookTriggers.executeToolWithHooks).mockRejectedValue(
+      cancelErr,
+    );
+
+    const scheduledCall: ScheduledToolCall = {
+      status: CoreToolCallStatus.Scheduled,
+      request: {
+        callId: 'call-user-abort-msg',
+        name: 'someTool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'prompt-user-abort-msg',
+      },
+      tool: mockTool,
+      invocation: invocation as unknown as AnyToolInvocation,
+      startTime: Date.now(),
+    };
+
+    const result = await executor.execute({
+      call: scheduledCall,
+      signal: new AbortController().signal,
+      onUpdateToolCall: vi.fn(),
+    });
+
+    expect(result.status).toBe(CoreToolCallStatus.Cancelled);
+    if (result.status === CoreToolCallStatus.Cancelled) {
+      const response = result.response.responseParts[0]?.functionResponse
+        ?.response as Record<string, unknown>;
+      expect(response['error']).toContain('Operation cancelled.');
     }
   });
 

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -16,7 +16,7 @@ import {
   type AgentLoopContext,
   type ToolLiveOutput,
 } from '../index.js';
-import { isAbortError } from '../utils/errors.js';
+import { isCancellationError } from '../utils/errors.js';
 import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { ToolOutputDistillationService } from '../context/toolDistillationService.js';
@@ -163,17 +163,12 @@ export class ToolExecutor {
           }
         } catch (executionError: unknown) {
           spanMetadata.error = executionError;
-          const abortedByError =
-            isAbortError(executionError) ||
-            (executionError instanceof Error &&
-              executionError.message.includes('Operation cancelled by user'));
+          const abortedByError = isCancellationError(executionError);
 
           if (signal.aborted || abortedByError) {
             completedToolCall = await this.createCancelledResult(
               call,
-              isAbortError(executionError)
-                ? 'Operation cancelled.'
-                : 'User cancelled tool execution.',
+              'Operation cancelled.',
             );
           } else {
             const error =

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -17,7 +17,7 @@ import {
 } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 
-import { getErrorMessage, isAbortError } from '../utils/errors.js';
+import { getErrorMessage, isCancellationError } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { WEB_SEARCH_DEFINITION } from './definitions/coreTools.js';
@@ -178,7 +178,7 @@ class WebSearchToolInvocation extends BaseToolInvocation<
         sources,
       };
     } catch (error: unknown) {
-      if (isAbortError(error)) {
+      if (isCancellationError(error)) {
         return {
           llmContent: 'Web search was cancelled.',
           returnDisplay: 'Search cancelled.',

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isAuthenticationError,
   isAbortError,
+  isCancellationError,
   UnauthorizedError,
   toFriendlyError,
   BadRequestError,
@@ -69,6 +70,35 @@ describe('isAbortError', () => {
     expect(isAbortError({ name: 'AbortError' })).toBe(false);
     expect(isAbortError(null)).toBe(false);
     expect(isAbortError('AbortError')).toBe(false);
+  });
+});
+
+describe('isCancellationError', () => {
+  it('should return true for AbortError', () => {
+    const error = new Error('Aborted');
+    error.name = 'AbortError';
+    expect(isCancellationError(error)).toBe(true);
+  });
+
+  it('should return true for CanceledError', () => {
+    const error = new Error('The operation was canceled.');
+    error.name = 'CanceledError';
+    expect(isCancellationError(error)).toBe(true);
+  });
+
+  it('should return true for lower-level cancellation messages', () => {
+    expect(isCancellationError(new Error('The user aborted a request.'))).toBe(
+      true,
+    );
+    expect(isCancellationError(new Error('Operation cancelled by user'))).toBe(
+      true,
+    );
+    expect(isCancellationError(new Error('Request was aborted'))).toBe(true);
+  });
+
+  it('should return false for unrelated errors', () => {
+    expect(isCancellationError(new Error('Other error'))).toBe(false);
+    expect(isCancellationError({ name: 'AbortError' })).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -33,6 +33,34 @@ export function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
 
+const CANCELLATION_ERROR_MESSAGE_PATTERNS = [
+  /\bthe user aborted a request\b/i,
+  /\boperation cancel(?:led|ed)\b/i,
+  /\buser cancel(?:led|ed)\b/i,
+  /\b(?:this )?operation was aborted\b/i,
+  /\b(?:request|tool call|tool execution|execution) was aborted\b/i,
+  /\b(?:request|tool call|tool execution|execution) aborted\b/i,
+];
+
+/**
+ * Checks if an error represents a cancelled operation, even when lower layers
+ * do not preserve AbortError typing.
+ */
+export function isCancellationError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (isAbortError(error) || error.name === 'CanceledError') {
+    return true;
+  }
+
+  const message = error.message.trim();
+  return CANCELLATION_ERROR_MESSAGE_PATTERNS.some((pattern) =>
+    pattern.test(message),
+  );
+}
+
 export function getErrorMessage(error: unknown): string {
   const friendlyError = toFriendlyError(error);
   if (friendlyError instanceof Error) {


### PR DESCRIPTION
Fixes #20106
Related: #25457

## Summary
Introduces `isCancellationError()` to reliably detect aborted requests even when the original `AbortError` type is lost as errors cross system boundaries. Directly addresses #20106 (Fatal CLI Crash on Loop Detection via Unhandled AbortError) — the `@google/genai` async iterator detaches error listeners during yield suspensions, so synchronous `controller.abort()` errors arrive at higher layers stripped of their `AbortError` typing. Existing `error.name === 'AbortError'` checks miss them, and the crash surfaces as unhandled.

Also updates `browserAgentInvocation`, `local-invocation`, and tool executors to treat cancellations as a clean terminal state instead of unhandled errors.

## Changes
- New `isCancellationError(error)` helper in `errors.ts` (checks name, `CanceledError`, and common cancellation message patterns so typing loss across async boundaries doesn't cause false negatives)
- Replace ad-hoc `error.name === 'AbortError' || message.includes('Aborted')` checks at boundary sites with the helper
- Mark running activity items as `cancelled` (not `error`) on cancel

## Test plan
- [x] New unit tests for `isCancellationError`
- [x] Updated local/browser agent invocation tests
- [ ] Manual: trigger loop detection on repetitive LLM output and confirm the CLI no longer crashes (repro from #20106)
- [ ] Manual: cancel a long-running tool call and confirm UI shows cancelled state, not error toast

Replaces #23235 (auto-closed per contribution policy).