### PR TITLE
fix(core): prevent FileHandle double-close on empty session file

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -733,6 +733,37 @@ describe('ChatRecordingService', () => {
         chatRecordingService.deleteSession('non-existent'),
       ).resolves.not.toThrow();
     });
+
+    it('should not double-close FileHandle when deleting an empty session file', async () => {
+      const shortId = 'empt0000';
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+
+      // Create an empty session file (0 bytes)
+      const sessionFile = path.join(
+        chatsDir,
+        `session-2023-01-01T00-00-${shortId}.jsonl`,
+      );
+      fs.writeFileSync(sessionFile, '');
+
+      // Create a fake FileHandle that simulates an empty file (bytesRead = 0)
+      const mockClose = vi.fn().mockResolvedValue(undefined);
+      const mockFd = {
+        read: vi
+          .fn()
+          .mockResolvedValue({ bytesRead: 0, buffer: Buffer.alloc(4096) }),
+        close: mockClose,
+      };
+      vi.mocked(fs.promises.open).mockResolvedValue(
+        mockFd as unknown as fs.promises.FileHandle,
+      );
+
+      await chatRecordingService.deleteSession(shortId);
+
+      // Bug: close() is called 2 times (once in the if-branch, once in finally)
+      // Fix: close() should only be called 1 time
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('recordDirectories', () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -693,6 +693,7 @@ export class ChatRecordingService {
         const { bytesRead } = await fd.read(buffer, 0, CHUNK_SIZE, 0);
         if (bytesRead === 0) {
           await fd.close();
+          fd = undefined;
           await fs.promises.unlink(filePath);
           return;
         }


### PR DESCRIPTION
## Problem

In `deleteSessionAndArtifacts()` (chatRecordingService.ts), when a session file has 0 bytes:

1. The code calls `fd.close()` inside the `if (bytesRead === 0)` branch
2. Then returns early
3. But the `finally` block still sees `fd !== undefined` and calls `fd.close()` a second time

This causes Node.js to throw `ERR_INVALID_STATE` / `EBADF` on the already-closed `FileHandle`. While the outer `try/catch` swallows the error silently, this is still incorrect behavior.

## Fix

Set `fd = undefined` immediately after the first `close()` call so the `finally` block skips it:

```ts
if (bytesRead === 0) {
  await fd.close();
  fd = undefined;  // ← prevents double-close in finally
  await fs.promises.unlink(filePath);
  return;
}
```

## How to Reproduce the Bug

Before the fix, `close()` would be called twice on the same `FileHandle` for empty session files. The new test mocks `fs.promises.open` and asserts that `close()` is called exactly once:

```ts
expect(mockClose).toHaveBeenCalledTimes(1);
```

## Testing

- Added a unit test in `chatRecordingService.test.ts` that creates an empty session file, mocks the `FileHandle`, and verifies `close()` is called exactly once.
- All 37 existing tests continue to pass.