### PR TITLE
fix(core): handle malformed project registry data during ACP startup

### DIFF
--- a/integration-tests/acp-project-registry.test.ts
+++ b/integration-tests/acp-project-registry.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestRig, GEMINI_DIR } from './test-helper.js';
+import { spawn, ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { Writable, Readable } from 'node:stream';
+import { env } from 'node:process';
+import { inspect } from 'node:util';
+import * as acp from '@agentclientprotocol/sdk';
+
+const sandboxEnv = env['GEMINI_SANDBOX'];
+const itMaybe = sandboxEnv && sandboxEnv !== 'false' ? it.skip : it;
+class SessionUpdateCollector implements acp.Client {
+  updates: acp.SessionNotification[] = [];
+
+  sessionUpdate = async (params: acp.SessionNotification) => {
+    this.updates.push(params);
+  };
+
+  requestPermission = async (): Promise<acp.RequestPermissionResponse> => {
+    throw new Error('unexpected');
+  };
+}
+
+function assertValidRegistryFile(projectsPath: string) {
+  expect(existsSync(projectsPath)).toBe(true);
+
+  const data = JSON.parse(readFileSync(projectsPath, 'utf8')) as unknown;
+  expect(data).toMatchObject({
+    projects: expect.any(Object),
+  });
+
+  expect(Array.isArray((data as { projects: unknown }).projects)).toBe(false);
+
+  const entries = Object.entries(
+    (data as { projects: Record<string, string> }).projects,
+  );
+  expect(entries.length).toBeGreaterThan(0);
+
+  for (const [projectPath, shortId] of entries) {
+    expect(typeof projectPath).toBe('string');
+    expect(typeof shortId).toBe('string');
+    expect(projectPath.length).toBeGreaterThan(0);
+    expect(shortId.length).toBeGreaterThan(0);
+  }
+}
+
+describe('ACP project registry startup recovery', () => {
+  let rig: TestRig;
+  let child: ChildProcess | undefined;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => {
+    child?.kill();
+    child = undefined;
+    await rig.cleanup();
+  });
+
+  const testCases: Array<{
+    name: string;
+    setupProjectsFile: (projectsPath: string) => void;
+  }> = [
+    {
+      name: 'missing projects.json',
+      setupProjectsFile: (projectsPath) => {
+        rmSync(projectsPath, { force: true });
+      },
+    },
+    {
+      name: 'projects.json as empty object',
+      setupProjectsFile: (projectsPath) => {
+        writeFileSync(projectsPath, '{}');
+      },
+    },
+    {
+      name: 'projects.json with invalid projects shape',
+      setupProjectsFile: (projectsPath) => {
+        writeFileSync(projectsPath, '{"projects":[]}');
+      },
+    },
+    {
+      name: 'projects.json with invalid JSON',
+      setupProjectsFile: (projectsPath) => {
+        writeFileSync(projectsPath, '{"projects":');
+      },
+    },
+  ];
+
+  testCases.forEach(({ name, setupProjectsFile }) => {
+    itMaybe(`recovers from ${name} during ACP startup`, async () => {
+      rig.setup(`acp-project-registry-${name}`);
+
+      const userGeminiDir = join(rig.homeDir!, GEMINI_DIR);
+      mkdirSync(userGeminiDir, { recursive: true });
+      const projectsPath = join(userGeminiDir, 'projects.json');
+      setupProjectsFile(projectsPath);
+
+      const bundlePath = join(import.meta.dirname, '..', 'bundle/gemini.js');
+      child = spawn(
+        'node',
+        [bundlePath, '--acp'],
+        {
+          cwd: rig.testDir!,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: {
+            ...process.env,
+            GEMINI_API_KEY: 'fake-key',
+            GEMINI_CLI_HOME: rig.homeDir!,
+          },
+        },
+      );
+
+      let stderr = '';
+      child.stderr!.setEncoding('utf8');
+      child.stderr!.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+
+      const input = Writable.toWeb(child.stdin!);
+      const output = Readable.toWeb(
+        child.stdout!,
+      ) as ReadableStream<Uint8Array>;
+      const testClient = new SessionUpdateCollector();
+      const stream = acp.ndJsonStream(input, output);
+      const connection = new acp.ClientSideConnection(() => testClient, stream);
+
+      let sessionId = '';
+      try {
+        await connection.initialize({
+          protocolVersion: acp.PROTOCOL_VERSION,
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+          },
+        });
+
+        ({ sessionId } = await connection.newSession({
+          cwd: rig.testDir!,
+          mcpServers: [],
+        }));
+      } catch (error) {
+        throw new Error(
+          `ACP startup failed for case "${name}". stderr:\n${stderr}\nOriginal error: ${String(
+            error,
+          )}\nInspected error: ${inspect(error, { depth: 10 })}`,
+        );
+      }
+
+      expect(child.exitCode).toBeNull();
+      expect(sessionId.length).toBeGreaterThan(0);
+      assertValidRegistryFile(projectsPath);
+
+      child.stdin!.end();
+    }, 30000);
+  });
+});

--- a/packages/core/src/config/projectRegistry.test.ts
+++ b/packages/core/src/config/projectRegistry.test.ts
@@ -95,6 +95,49 @@ describe('ProjectRegistry', () => {
     expect(data.projects[normalizedPath]).toBe('project-a');
   });
 
+  it('treats a missing projects map as an empty registry', async () => {
+    fs.writeFileSync(registryPath, '{}');
+
+    const registry = new ProjectRegistry(registryPath);
+    await registry.initialize();
+
+    const projectPath = path.join(tempDir, 'project-from-empty-object');
+    const shortId = await registry.getShortId(projectPath);
+
+    expect(shortId).toBe('project-from-empty-object');
+
+    const data = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    expect(data).toEqual({
+      projects: {
+        [normalizePath(projectPath)]: 'project-from-empty-object',
+      },
+    });
+  });
+
+  it('treats an invalid projects value as an empty registry', async () => {
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({
+        projects: [],
+      }),
+    );
+
+    const registry = new ProjectRegistry(registryPath);
+    await registry.initialize();
+
+    const projectPath = path.join(tempDir, 'project-from-invalid-projects');
+    const shortId = await registry.getShortId(projectPath);
+
+    expect(shortId).toBe('project-from-invalid-projects');
+
+    const data = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    expect(data).toEqual({
+      projects: {
+        [normalizePath(projectPath)]: 'project-from-invalid-projects',
+      },
+    });
+  });
+
   it('normalizes paths', async () => {
     const registry = new ProjectRegistry(registryPath);
     await registry.initialize();

--- a/packages/core/src/config/projectRegistry.ts
+++ b/packages/core/src/config/projectRegistry.ts
@@ -19,6 +19,23 @@ const PROJECT_ROOT_FILE = '.project_root';
 const LOCK_TIMEOUT_MS = 10000;
 const LOCK_RETRY_DELAY_MS = 100;
 
+function createEmptyRegistry(): RegistryData {
+  return { projects: {} };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    isRecord(value) &&
+    Object.values(value).every(
+      (entry): entry is string => typeof entry === 'string',
+    )
+  );
+}
+
 /**
  * Manages a mapping between absolute project paths and short, human-readable identifiers.
  * This helps reduce context bloat and makes temporary directories easier to work with.
@@ -55,18 +72,25 @@ export class ProjectRegistry {
 
   private async loadData(): Promise<RegistryData> {
     if (!fs.existsSync(this.registryPath)) {
-      return { projects: {} };
+      return createEmptyRegistry();
     }
 
     try {
       const content = await fs.promises.readFile(this.registryPath, 'utf8');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return JSON.parse(content);
+      return this.normalizeRegistryData(JSON.parse(content));
     } catch (e) {
       debugLogger.debug('Failed to load registry: ', e);
       // If the registry is corrupted, we'll start fresh to avoid blocking the CLI
-      return { projects: {} };
+      return createEmptyRegistry();
     }
+  }
+
+  private normalizeRegistryData(value: unknown): RegistryData {
+    if (!isRecord(value) || !isStringRecord(value['projects'])) {
+      return createEmptyRegistry();
+    }
+
+    return { projects: value['projects'] };
   }
 
   private normalizePath(projectPath: string): string {


### PR DESCRIPTION
Fixes #25509

## Summary

This fixes ACP startup failures caused by malformed `~/.gemini/projects.json` content.

The reported repro was a `projects.json` file containing `{}`. `ProjectRegistry.loadData()` previously trusted `JSON.parse()` and returned that value directly, which meant `getShortId()` could later access `currentData.projects[...]` when `projects` was missing and crash during ACP session startup.

This change hardens registry loading so invalid or malformed registry content is normalized to an empty valid shape before use.

## What Changed

- Added registry normalization in `ProjectRegistry.loadData()`
- Treat invalid registry payloads as an empty registry
- Preserved existing slug generation / lock / ownership-marker behavior
- Added unit regression tests for:
  - `{}`
  - `{"projects":[]}`
- Added ACP integration coverage for:
  - missing `projects.json`
  - `{}`
  - `{"projects":[]}`
  - invalid JSON

## Why This Fix

`ProjectRegistry` expects this runtime shape:

```json
{
  "projects": {}
}
```

But previously any parsed JSON object was accepted as-is. If the file contained `{}`, ACP startup could fail while initializing storage for a new session.

Now parsed content is validated and normalized before use, so ACP startup remains resilient even when the registry file is missing, malformed, or structurally invalid.

## Validation

Automated:
- `npx vitest run packages/core/src/config/projectRegistry.test.ts packages/core/src/config/storage.test.ts`
- `npx vitest run --root integration-tests --reporter verbose --no-file-parallelism --retry=0 acp-project-registry.test.ts`
- `npx vitest run --root integration-tests --reporter verbose --no-file-parallelism --retry=0 acp-telemetry.test.ts`
- `npx eslint packages/core/src/config/projectRegistry.ts packages/core/src/config/projectRegistry.test.ts integration-tests/acp-project-registry.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`

Manual check:
1. Create a fresh temp home directory.
2. Create `<temp-home>/.gemini/projects.json` containing `{}`.
3. Start ACP with:
   ```bash
   GEMINI_CLI_HOME=<temp-home> node bundle/gemini.js --acp
   ```
4. Open an ACP session / call `newSession`.
5. Verify:
   - ACP startup does not crash
   - session creation succeeds
   - `<temp-home>/.gemini/projects.json` is rewritten into a valid registry object with a `projects` map