### PR TITLE
fix(cli): reset plan session state on /clear

### DIFF
--- a/packages/cli/src/test-utils/mockConfig.ts
+++ b/packages/cli/src/test-utils/mockConfig.ts
@@ -44,6 +44,7 @@ export const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     getListSessions: vi.fn(() => false),
     getDeleteSession: vi.fn(() => undefined),
     setSessionId: vi.fn(),
+    resetNewSessionState: vi.fn(),
     getSessionId: vi.fn().mockReturnValue('mock-session-id'),
     getWorktreeSettings: vi.fn(() => undefined),
     getContentGeneratorConfig: vi.fn(() => ({ authType: 'google' })),

--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -39,7 +39,7 @@ describe('clearCommand', () => {
         agentContext: {
           config: {
             getEnableHooks: vi.fn().mockReturnValue(false),
-            setSessionId: vi.fn(),
+            resetNewSessionState: vi.fn(),
             getMessageBus: vi.fn().mockReturnValue(undefined),
             getHookSystem: vi.fn().mockReturnValue({
               fireSessionEndEvent: vi.fn().mockResolvedValue(undefined),
@@ -74,6 +74,9 @@ describe('clearCommand', () => {
 
     expect(mockResetChat).toHaveBeenCalledTimes(1);
     expect(mockHintClear).toHaveBeenCalledTimes(1);
+    expect(
+      mockContext.services.agentContext?.config.resetNewSessionState,
+    ).toHaveBeenCalledTimes(1);
     expect(uiTelemetryService.clear).toHaveBeenCalled();
     expect(uiTelemetryService.clear).toHaveBeenCalledTimes(1);
     expect(mockContext.ui.clear).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -39,7 +39,7 @@ export const clearCommand: SlashCommand = {
     let newSessionId: string | undefined;
     if (config) {
       newSessionId = randomUUID();
-      config.setSessionId(newSessionId);
+      config.resetNewSessionState(newSessionId);
     }
 
     if (geminiClient) {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1805,6 +1805,51 @@ describe('Server Config (config.ts)', () => {
     );
   });
 
+  it('does not throw when changing sessions before the previous plans dir exists', async () => {
+    const config = new Config({
+      ...baseParams,
+      sessionId: 'session-one',
+      plan: true,
+    });
+
+    await config.initialize();
+    const missingPlansDir = config.storage.getProjectTempPlansDir();
+    const realpathMock = vi.mocked(fs.realpathSync);
+    const originalImplementation = realpathMock.getMockImplementation();
+
+    try {
+      realpathMock.mockImplementation((input) => {
+        const normalizedInput =
+          typeof input === 'string' || Buffer.isBuffer(input)
+            ? input
+            : input.toString();
+
+        if (normalizedInput === missingPlansDir) {
+          const error = new Error(
+            `ENOENT: no such file or directory, ${normalizedInput}`,
+          );
+          Object.assign(error, { code: 'ENOENT' });
+          throw error;
+        }
+        if (originalImplementation) {
+          return originalImplementation(input);
+        }
+        return normalizedInput;
+      });
+
+      expect(() => config.setSessionId('session-two')).not.toThrow();
+    } finally {
+      realpathMock.mockImplementation((input) => {
+        if (originalImplementation) {
+          return originalImplementation(input);
+        }
+        return typeof input === 'string' || Buffer.isBuffer(input)
+          ? input
+          : input.toString();
+      });
+    }
+  });
+
   it('clears the approved plan when starting a new session', () => {
     const config = new Config({
       ...baseParams,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1774,6 +1774,50 @@ describe('Server Config (config.ts)', () => {
     expect(config1.topicState.getTopic()).toBe('Topic 1');
     expect(config2.topicState.getTopic()).toBe('Topic 2');
   });
+
+  it('updates storage session-scoped directories when the sessionId changes', async () => {
+    const config = new Config({
+      ...baseParams,
+      sessionId: 'session-one',
+      plan: true,
+    });
+
+    await config.initialize();
+    const tempDir = config.storage.getProjectTempDir();
+    const oldPlansDir = path.join(tempDir, 'session-one', 'plans');
+    const oldTrackerService = config.getTrackerService();
+
+    config.setSessionId('session-two');
+
+    expect(config.getSessionId()).toBe('session-two');
+    expect(config.storage.getProjectTempPlansDir()).toBe(
+      path.join(tempDir, 'session-two', 'plans'),
+    );
+    expect(config.storage.getProjectTempTrackerDir()).toBe(
+      path.join(tempDir, 'session-two', 'tracker'),
+    );
+    expect(config.getTrackerService()).not.toBe(oldTrackerService);
+    expect(config.getTrackerService().trackerDir).toBe(
+      path.join(tempDir, 'session-two', 'tracker'),
+    );
+    expect(config.getWorkspaceContext().getDirectories()).not.toContain(
+      oldPlansDir,
+    );
+  });
+
+  it('clears the approved plan when starting a new session', () => {
+    const config = new Config({
+      ...baseParams,
+      sessionId: 'session-one',
+    });
+
+    config.setApprovedPlanPath('/tmp/session-one/plans/approved.md');
+
+    expect(() => config.resetNewSessionState('session-two')).not.toThrow();
+
+    expect(config.getSessionId()).toBe('session-two');
+    expect(config.getApprovedPlanPath()).toBeUndefined();
+  });
 });
 
 describe('GemmaModelRouterSettings', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2070,10 +2070,17 @@ export class Config implements McpContext, AgentLoopContext {
       return;
     }
 
-    const previousPlansDirRealPath = resolveToRealPath(previousPlansDir);
+    const pathsToRemove = new Set([previousPlansDir]);
+    try {
+      pathsToRemove.add(resolveToRealPath(previousPlansDir));
+    } catch {
+      // The previous session's plans directory may never have been created.
+      // In that case there is nothing to resolve or remove beyond the raw path.
+    }
+
     const currentDirectories = this.workspaceContext
       .getDirectories()
-      .filter((dir) => dir !== previousPlansDirRealPath);
+      .filter((dir) => !pathsToRemove.has(dir));
 
     this.workspaceContext.setDirectories(currentDirectories);
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1760,7 +1760,22 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   setSessionId(sessionId: string): void {
+    const previousPlansDir = this.storage.isInitialized()
+      ? this.storage.getPlansDir()
+      : undefined;
+
     this._sessionId = sessionId;
+    this.storage.setSessionId(sessionId);
+    this.trackerService = undefined;
+
+    if (previousPlansDir) {
+      this.refreshSessionScopedPlansDirectory(previousPlansDir);
+    }
+  }
+
+  resetNewSessionState(sessionId: string): void {
+    this.setSessionId(sessionId);
+    this.approvedPlanPath = undefined;
   }
 
   setTerminalBackground(terminalBackground: string | undefined): void {
@@ -2047,6 +2062,30 @@ export class Config implements McpContext, AgentLoopContext {
 
   getWorkspaceContext(): WorkspaceContext {
     return getWorkspaceContextOverride() ?? this.workspaceContext;
+  }
+
+  private refreshSessionScopedPlansDirectory(previousPlansDir: string): void {
+    const nextPlansDir = this.storage.getPlansDir();
+    if (previousPlansDir === nextPlansDir) {
+      return;
+    }
+
+    const previousPlansDirRealPath = resolveToRealPath(previousPlansDir);
+    const currentDirectories = this.workspaceContext
+      .getDirectories()
+      .filter((dir) => dir !== previousPlansDirRealPath);
+
+    this.workspaceContext.setDirectories(currentDirectories);
+
+    try {
+      if (fs.existsSync(nextPlansDir)) {
+        this.workspaceContext.addDirectory(nextPlansDir);
+      }
+    } catch {
+      // Ignore invalid or unreadable plans directories here. This mirrors
+      // initialization behavior, which only adds the plans directory when it
+      // already exists and is readable.
+    }
   }
 
   getAgentRegistry(): AgentRegistry {

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -211,6 +211,27 @@ describe('Storage – additional helpers', () => {
     expect(storageWithSession.getProjectTempTrackerDir()).toBe(expected);
   });
 
+  it('updates session-scoped directories when the sessionId changes', async () => {
+    const storageWithSession = new Storage(projectRoot, 'session-one');
+    ProjectRegistry.prototype.getShortId = vi
+      .fn()
+      .mockReturnValue(PROJECT_SLUG);
+    await storageWithSession.initialize();
+    const tempDir = storageWithSession.getProjectTempDir();
+
+    storageWithSession.setSessionId('session-two');
+
+    expect(storageWithSession.getProjectTempPlansDir()).toBe(
+      path.join(tempDir, 'session-two', 'plans'),
+    );
+    expect(storageWithSession.getProjectTempTrackerDir()).toBe(
+      path.join(tempDir, 'session-two', 'tracker'),
+    );
+    expect(storageWithSession.getProjectTempTasksDir()).toBe(
+      path.join(tempDir, 'session-two', 'tasks'),
+    );
+  });
+
   describe('Session and JSON Loading', () => {
     beforeEach(async () => {
       await storage.initialize();

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -28,7 +28,7 @@ export const AUTO_SAVED_POLICY_FILENAME = 'auto-saved.toml';
 
 export class Storage {
   private readonly targetDir: string;
-  private readonly sessionId: string | undefined;
+  private sessionId: string | undefined;
   private projectIdentifier: string | undefined;
   private initPromise: Promise<void> | undefined;
   private customPlansDir: string | undefined;
@@ -40,6 +40,14 @@ export class Storage {
 
   setCustomPlansDir(dir: string | undefined): void {
     this.customPlansDir = dir;
+  }
+
+  setSessionId(sessionId: string | undefined): void {
+    this.sessionId = sessionId;
+  }
+
+  isInitialized(): boolean {
+    return !!this.projectIdentifier;
   }
 
   static getGlobalGeminiDir(): string {


### PR DESCRIPTION
Fixes #25500

## Summary

`/clear` was only rotating the session ID on `Config`, while several pieces of session-scoped planning state continued to point at the previous session.

This change makes `/clear` start a true new planning session by resetting the approved plan pointer and rebinding session-scoped services and paths.

## What changed

- Added `Storage.setSessionId(...)` so session-scoped temp paths can move with the active session.
- Updated `Config.setSessionId(...)` to:
  - update `Storage`
  - reset the cached `TrackerService`
  - refresh session-scoped plans directory registration when storage is initialized
- Added `Config.resetNewSessionState(...)` for brand-new session resets.
- Updated `/clear` to call `resetNewSessionState(...)` instead of only rotating the session ID.
- Added regression coverage for:
  - storage session path updates
  - config session-scoped service/path updates
  - clearing approved plan state on new session reset
  - `/clear` calling the new session reset path

## Why

Before this change, `/clear` created a new session ID but could still retain old plan-mode state:
- `/plan` could still show the previously approved plan
- tracker state could remain bound to the old session directory
- session-scoped plan/tracker/task paths could stay stale

## Validation

Passed:

- `npm run build --workspace @google/gemini-cli-core`
- `npm run build --workspace @google/gemini-cli`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run typecheck --workspace @google/gemini-cli`
- `npm run lint --workspace @google/gemini-cli-core`
- `npm run lint --workspace @google/gemini-cli`
- `npm run test --workspace @google/gemini-cli-core -- src/config/storage.test.ts src/config/config.test.ts`
- `npm run test --workspace @google/gemini-cli-core -- src/tools/trackerTools.test.ts src/routing/strategies/approvalModeStrategy.test.ts src/prompts/promptProvider.test.ts`
- `npm run test --workspace @google/gemini-cli -- src/ui/commands/clearCommand.test.ts src/ui/commands/planCommand.test.ts`
- `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useSessionBrowser.test.ts`

Manual repro also passed:
1. Create and approve a plan
2. Confirm `/plan` shows it
3. Run `/clear`
4. Confirm `/plan` no longer shows the old approved plan
5. Confirm `/plan copy` reports that no approved plan exists

<img width="689" height="350" alt="image" src="https://github.com/user-attachments/assets/25ad0086-f6ac-4f81-99b5-7cb4cbd7459e" />
(screenshot of the /plan and /plan copy commands after doing /clear on an already-approved plan)
