### PR TITLE
feat(acp): surface Gemini status and permission visibility

### DIFF
--- a/packages/cli/src/acp/acpClient.test.ts
+++ b/packages/cli/src/acp/acpClient.test.ts
@@ -803,14 +803,123 @@ describe('Session', () => {
     });
 
     expect(mockChat.sendMessageStream).toHaveBeenCalled();
-    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      update: {
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: 'Hello' },
-      },
-    });
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Hello' },
+          messageId: expect.any(String),
+        }),
+      }),
+    );
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: '' },
+          messageId: expect.any(String),
+          _meta: {
+            anyharness: {
+              transcriptEvent: 'assistant_message_completed',
+            },
+          },
+        }),
+      }),
+    );
     expect(result).toMatchObject({ stopReason: 'end_turn' });
+  });
+
+  it('should surface retry as transient status and close the active assistant stream', async () => {
+    const stream = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [{ content: { parts: [{ text: 'Partial' }] } }],
+        },
+      },
+      { type: StreamEventType.RETRY },
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          candidates: [{ content: { parts: [{ text: 'Retry result' }] } }],
+        },
+      },
+    ]);
+    mockChat.sendMessageStream.mockResolvedValue(stream);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: '' },
+          _meta: {
+            anyharness: {
+              transcriptEvent: 'assistant_message_completed',
+            },
+          },
+        }),
+      }),
+    );
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'Retrying Gemini request...' },
+          _meta: {
+            anyharness: {
+              transcriptEvent: 'transient_status',
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  it('should keep blocked and stopped execution messages durable', async () => {
+    const stream = createMockStream([
+      {
+        type: StreamEventType.AGENT_EXECUTION_BLOCKED,
+        reason: 'policy rejected the action',
+      },
+      {
+        type: StreamEventType.AGENT_EXECUTION_STOPPED,
+        reason: 'hook stopped execution',
+      },
+    ]);
+    mockChat.sendMessageStream.mockResolvedValue(stream);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    const updates = mockConnection.sessionUpdate.mock.calls.map(
+      ([call]) => call.update,
+    );
+    const blocked = updates.find(
+      (update) =>
+        update.sessionUpdate === 'agent_message_chunk' &&
+        update.content.type === 'text' &&
+        update.content.text ===
+          'Gemini agent execution blocked: policy rejected the action',
+    );
+    const stopped = updates.find(
+      (update) =>
+        update.sessionUpdate === 'agent_message_chunk' &&
+        update.content.type === 'text' &&
+        update.content.text ===
+          'Gemini agent execution stopped: hook stopped execution',
+    );
+
+    expect(blocked?._meta).toBeUndefined();
+    expect(stopped?._meta).toBeUndefined();
   });
 
   it('should use model router to determine model', async () => {
@@ -919,6 +1028,19 @@ describe('Session', () => {
     expect(handleCommandSpy).toHaveBeenCalledWith(
       '/memory view',
       expect.any(Object),
+    );
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'Running /memory...' },
+          _meta: {
+            anyharness: {
+              transcriptEvent: 'transient_status',
+            },
+          },
+        }),
+      }),
     );
     expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
   });
@@ -1060,9 +1182,72 @@ describe('Session', () => {
     expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
+  it('should bound raw tool input and output metadata', async () => {
+    const largeText = 'x'.repeat(40 * 1024);
+    mockTool.build.mockReturnValue({
+      getDescription: () => 'Test Tool',
+      toolLocations: () => [],
+      shouldConfirmExecute: vi.fn().mockResolvedValue(null),
+      execute: vi.fn().mockResolvedValue({
+        llmContent: largeText,
+        returnDisplay: largeText,
+      }),
+    });
+
+    const stream1 = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          functionCalls: [{ name: 'test_tool', args: { largeText } }],
+        },
+      },
+    ]);
+    const stream2 = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: { candidates: [] },
+      },
+    ]);
+
+    mockChat.sendMessageStream
+      .mockResolvedValueOnce(stream1)
+      .mockResolvedValueOnce(stream2);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Call tool' }],
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'tool_call',
+          rawInput: expect.objectContaining({
+            _truncated: true,
+            originalBytes: expect.any(Number),
+            preview: expect.any(String),
+          }),
+        }),
+      }),
+    );
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'tool_call_update',
+          rawOutput: expect.objectContaining({
+            _truncated: true,
+            originalBytes: expect.any(Number),
+            preview: expect.any(String),
+          }),
+        }),
+      }),
+    );
+  });
+
   it('should handle tool call permission request', async () => {
     const confirmationDetails = {
       type: 'info',
+      systemMessage: 'Confirm test tool',
       onConfirm: vi.fn(),
     };
     mockTool.build.mockReturnValue({
@@ -1103,7 +1288,31 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: 'Call tool' }],
     });
 
-    expect(mockConnection.requestPermission).toHaveBeenCalled();
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'tool_call',
+          status: 'pending',
+          rawInput: {},
+        }),
+      }),
+    );
+    expect(mockConnection.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _meta: {
+          gemini: {
+            permissionContext: {
+              displayName: 'Test Tool',
+              decisionReason: 'Confirm test tool',
+              agentId: 'test_tool',
+            },
+          },
+        },
+        toolCall: expect.objectContaining({
+          rawInput: {},
+        }),
+      }),
+    );
     expect(confirmationDetails.onConfirm).toHaveBeenCalledWith(
       ToolConfirmationOutcome.ProceedOnce,
     );
@@ -1502,6 +1711,76 @@ describe('Session', () => {
     expect(updatePolicy).toHaveBeenCalled();
   });
 
+  it('should preserve exact MCP permission option IDs', async () => {
+    const confirmationDetails = {
+      type: 'mcp',
+      serverName: 'server-a',
+      toolName: 'search',
+      toolDisplayName: 'Search',
+      toolDescription: 'Search using MCP',
+      onConfirm: vi.fn(),
+    };
+    mockTool.build.mockReturnValue({
+      getDescription: () => 'MCP Search',
+      toolLocations: () => [],
+      shouldConfirmExecute: vi.fn().mockResolvedValue(confirmationDetails),
+      execute: vi.fn().mockResolvedValue({ llmContent: 'Tool Result' }),
+    });
+
+    mockConnection.requestPermission.mockResolvedValue({
+      outcome: {
+        outcome: 'selected',
+        optionId: ToolConfirmationOutcome.ProceedAlwaysTool,
+      },
+    });
+
+    const stream1 = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: {
+          functionCalls: [{ name: 'test_tool', args: {} }],
+        },
+      },
+    ]);
+    const stream2 = createMockStream([
+      {
+        type: StreamEventType.CHUNK,
+        value: { candidates: [] },
+      },
+    ]);
+
+    mockChat.sendMessageStream
+      .mockResolvedValueOnce(stream1)
+      .mockResolvedValueOnce(stream2);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Call tool' }],
+    });
+
+    expect(mockConnection.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            optionId: ToolConfirmationOutcome.ProceedAlwaysServer,
+            name: 'Allow all server tools for this session',
+          }),
+          expect.objectContaining({
+            optionId: ToolConfirmationOutcome.ProceedAlwaysTool,
+            name: 'Allow tool for this session',
+          }),
+          expect.objectContaining({
+            optionId: ToolConfirmationOutcome.ProceedAlwaysAndSave,
+            name: 'Allow tool for all future sessions',
+          }),
+        ]),
+      }),
+    );
+    expect(confirmationDetails.onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.ProceedAlwaysTool,
+    );
+  });
+
   it('should use filePath for ACP diff content in tool result', async () => {
     mockTool.build.mockReturnValue({
       getDescription: () => 'Test Tool',
@@ -1604,6 +1883,22 @@ describe('Session', () => {
       sessionId: 'session-1',
       prompt: [{ type: 'text', text: 'Call tool' }],
     });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'tool_call_update',
+          status: 'failed',
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.objectContaining({
+                text: expect.stringContaining('canceled by the user'),
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
 
     // When cancelled, it sends an error response to the model
     // We can verify that the second call to sendMessageStream contains the error
@@ -2224,6 +2519,13 @@ describe('Session', () => {
     expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
       ApprovalMode.AUTO_EDIT,
     );
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'current_mode_update',
+        currentModeId: ApprovalMode.AUTO_EDIT,
+      },
+    });
   });
 
   it('should throw error for invalid mode', () => {

--- a/packages/cli/src/acp/acpClient.ts
+++ b/packages/cli/src/acp/acpClient.ts
@@ -57,6 +57,13 @@ import * as acp from '@agentclientprotocol/sdk';
 import { AcpFileSystemService } from './fileSystemService.js';
 import { getAcpErrorMessage } from './acpErrors.js';
 import { Readable, Writable } from 'node:stream';
+import {
+  assistantMessageCompletedUpdate,
+  boundedRawJson,
+  createAcpMessageId,
+  geminiPermissionContextMeta,
+  transientStatusUpdate,
+} from './anyharnessMetadata.js';
 
 function hasMeta(obj: unknown): obj is { _meta?: Record<string, unknown> } {
   return typeof obj === 'object' && obj !== null && '_meta' in obj;
@@ -595,6 +602,10 @@ export class Session {
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     this.context.config.setApprovalMode(mode.id as ApprovalMode);
+    void this.sendUpdate({
+      sessionUpdate: 'current_mode_update',
+      currentModeId: mode.id,
+    });
     return {};
   }
 
@@ -730,6 +741,10 @@ export class Session {
       // If we found a command, pass it to handleCommand
       // Note: handleCommand currently expects `commandText` to be the command string
       // It uses `parts` argument but effectively ignores it in current implementation
+      await this.sendTransientStatus(
+        `Running ${commandText.split(/\s+/)[0]}...`,
+        createAcpMessageId(),
+      );
       const handled = await this.handleCommand(commandText, parts);
       if (handled) {
         return {
@@ -747,6 +762,9 @@ export class Session {
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     const modelUsageMap = new Map<string, { input: number; output: number }>();
+    let assistantMessageId = createAcpMessageId();
+    let thoughtMessageId = createAcpMessageId();
+    const retryStatusMessageId = createAcpMessageId();
 
     let nextMessage: Content | null = { role: 'user', parts };
 
@@ -786,6 +804,31 @@ export class Session {
             return { stopReason: CoreToolCallStatus.Cancelled };
           }
 
+          if (resp.type === StreamEventType.RETRY) {
+            await this.sendAssistantMessageCompleted(assistantMessageId);
+            await this.sendTransientStatus(
+              'Retrying Gemini request...',
+              retryStatusMessageId,
+            );
+            assistantMessageId = createAcpMessageId();
+            thoughtMessageId = createAcpMessageId();
+            continue;
+          }
+
+          if (resp.type === StreamEventType.AGENT_EXECUTION_STOPPED) {
+            await this.sendDurableWarning(
+              `Gemini agent execution stopped: ${resp.reason}`,
+            );
+            continue;
+          }
+
+          if (resp.type === StreamEventType.AGENT_EXECUTION_BLOCKED) {
+            await this.sendDurableWarning(
+              `Gemini agent execution blocked: ${resp.reason}`,
+            );
+            continue;
+          }
+
           if (resp.type === StreamEventType.CHUNK && resp.value.usageMetadata) {
             turnInputTokens =
               resp.value.usageMetadata.promptTokenCount ?? turnInputTokens;
@@ -818,6 +861,7 @@ export class Session {
                   ? 'agent_thought_chunk'
                   : 'agent_message_chunk',
                 content,
+                messageId: part.thought ? thoughtMessageId : assistantMessageId,
               });
             }
           }
@@ -840,6 +884,9 @@ export class Session {
           modelUsageMap.set(turnModelId, existing);
         }
 
+        await this.sendAssistantMessageCompleted(assistantMessageId);
+        assistantMessageId = createAcpMessageId();
+        thoughtMessageId = createAcpMessageId();
         if (pendingSend.signal.aborted) {
           return { stopReason: CoreToolCallStatus.Cancelled };
         }
@@ -870,6 +917,9 @@ export class Session {
         ) {
           // The stream ended with an empty response or malformed tool call.
           // Treat this as a graceful end to the model's turn rather than a crash.
+          await this.sendDurableWarning(
+            `Gemini ended the turn without a valid response: ${getAcpErrorMessage(error)}`,
+          );
           return {
             stopReason: 'end_turn',
             _meta: {
@@ -964,6 +1014,29 @@ export class Session {
     await this.connection.sessionUpdate(params);
   }
 
+  private async sendAssistantMessageCompleted(
+    messageId: string,
+  ): Promise<void> {
+    await this.sendUpdate(assistantMessageCompletedUpdate(messageId));
+  }
+
+  private async sendTransientStatus(
+    text: string,
+    messageId: string,
+  ): Promise<void> {
+    await this.sendUpdate(transientStatusUpdate(text, messageId));
+  }
+
+  private async sendDurableWarning(text: string): Promise<void> {
+    const messageId = createAcpMessageId();
+    await this.sendUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text },
+      messageId,
+    });
+    await this.sendAssistantMessageCompleted(messageId);
+  }
+
   private async runTool(
     abortSignal: AbortSignal,
     promptId: string,
@@ -1023,6 +1096,7 @@ export class Session {
         typeof invocation.getDisplayTitle === 'function'
           ? invocation.getDisplayTitle()
           : invocation.getDescription();
+      const rawInput = boundedRawJson(args);
 
       const explanation =
         typeof invocation.getExplanation === 'function'
@@ -1058,8 +1132,26 @@ export class Session {
           });
         }
 
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call',
+          toolCallId: callId,
+          status: 'pending',
+          title: displayTitle,
+          content,
+          locations: invocation.toolLocations(),
+          kind: toAcpToolKind(tool.kind),
+          rawInput,
+        });
+
         const params: acp.RequestPermissionRequest = {
           sessionId: this.id,
+          _meta: geminiPermissionContextMeta(
+            permissionContextForConfirmation(
+              confirmationDetails,
+              displayTitle,
+              fc.name,
+            ),
+          ),
           options: toPermissionOptions(
             confirmationDetails,
             this.context.config,
@@ -1072,6 +1164,7 @@ export class Session {
             content,
             locations: invocation.toolLocations(),
             kind: toAcpToolKind(tool.kind),
+            rawInput,
           },
         };
 
@@ -1100,6 +1193,27 @@ export class Session {
 
         switch (outcome) {
           case ToolConfirmationOutcome.Cancel:
+            await this.sendUpdate({
+              sessionUpdate: 'tool_call_update',
+              toolCallId: callId,
+              status: 'failed',
+              title: displayTitle,
+              content: [
+                {
+                  type: 'content',
+                  content: {
+                    type: 'text',
+                    text: `Tool "${fc.name}" was canceled by the user.`,
+                  },
+                },
+              ],
+              locations: invocation.toolLocations(),
+              kind: toAcpToolKind(tool.kind),
+              rawInput,
+              rawOutput: boundedRawJson({
+                error: `Tool "${fc.name}" was canceled by the user.`,
+              }),
+            });
             return errorResponse(
               new Error(`Tool "${fc.name}" was canceled by the user.`),
             );
@@ -1126,6 +1240,7 @@ export class Session {
           content,
           locations: invocation.toolLocations(),
           kind: toAcpToolKind(tool.kind),
+          rawInput,
         });
       }
 
@@ -1144,6 +1259,10 @@ export class Session {
         content: updateContent,
         locations: invocation.toolLocations(),
         kind: toAcpToolKind(tool.kind),
+        rawInput,
+        rawOutput: boundedRawJson(
+          toolResult.returnDisplay ?? toolResult.llmContent,
+        ),
       });
 
       const durationMs = Date.now() - startTime;
@@ -1208,6 +1327,8 @@ export class Session {
           { type: 'content', content: { type: 'text', text: error.message } },
         ],
         kind: toAcpToolKind(tool.kind),
+        rawInput: boundedRawJson(args),
+        rawOutput: boundedRawJson({ error: error.message }),
       });
 
       this.chat.recordCompletedToolCalls(this.context.config.getActiveModel(), [
@@ -1351,8 +1472,33 @@ export class Session {
             const stats = await fs.stat(absolutePath);
             if (stats.isFile()) {
               const syntheticCallId = `resolve-prompt-${pathName}-${randomUUID()}`;
+              const rawInput = boundedRawJson({ path: absolutePath });
+              await this.sendUpdate({
+                sessionUpdate: 'tool_call',
+                toolCallId: syntheticCallId,
+                status: 'pending',
+                title: `Allow access to absolute path: ${pathName}`,
+                content: [
+                  {
+                    type: 'content',
+                    content: {
+                      type: 'text',
+                      text: `The Agent needs access to read an attached file outside your workspace: ${pathName}`,
+                    },
+                  },
+                ],
+                locations: [],
+                kind: 'read',
+                rawInput,
+              });
               const params = {
                 sessionId: this.id,
+                _meta: geminiPermissionContextMeta({
+                  displayName: `Allow access to absolute path: ${pathName}`,
+                  blockedPath: absolutePath,
+                  decisionReason: 'Read attached file outside workspace',
+                  agentId: 'gemini',
+                }),
                 options: [
                   {
                     optionId: ToolConfirmationOutcome.ProceedOnce,
@@ -1380,6 +1526,7 @@ export class Session {
                   ],
                   locations: [],
                   kind: 'read',
+                  rawInput,
                 },
               };
 
@@ -1400,6 +1547,27 @@ export class Session {
                   .addReadOnlyPath(absolutePath);
                 validationError = null;
               } else {
+                await this.sendUpdate({
+                  sessionUpdate: 'tool_call_update',
+                  toolCallId: syntheticCallId,
+                  status: 'failed',
+                  title: `Allow access to absolute path: ${pathName}`,
+                  content: [
+                    {
+                      type: 'content',
+                      content: {
+                        type: 'text',
+                        text: `Access to absolute path \`${pathName}\` denied by user.`,
+                      },
+                    },
+                  ],
+                  locations: [],
+                  kind: 'read',
+                  rawInput,
+                  rawOutput: boundedRawJson({
+                    error: `Access to absolute path \`${pathName}\` denied by user.`,
+                  }),
+                });
                 this.debug(
                   `Direct read authorization denied for absolute path ${pathName}`,
                 );
@@ -1659,6 +1827,7 @@ export class Session {
       };
 
       const callId = GeminiAgent.generateCallId(readManyFilesTool.name);
+      const rawInput = boundedRawJson(toolArgs);
 
       try {
         const invocation = readManyFilesTool.build(toolArgs);
@@ -1671,6 +1840,7 @@ export class Session {
           content: [],
           locations: invocation.toolLocations(),
           kind: toAcpToolKind(readManyFilesTool.kind),
+          rawInput,
         });
 
         const result = await invocation.execute({ abortSignal });
@@ -1689,6 +1859,8 @@ export class Session {
           content: content ? [content] : [],
           locations: invocation.toolLocations(),
           kind: toAcpToolKind(readManyFilesTool.kind),
+          rawInput,
+          rawOutput: boundedRawJson(result.returnDisplay ?? result.llmContent),
         });
         if (Array.isArray(result.llmContent)) {
           const fileContentRegex = /^--- (.*?) ---\n\n([\s\S]*?)\n\n$/;
@@ -1733,6 +1905,8 @@ export class Session {
             },
           ],
           kind: toAcpToolKind(readManyFilesTool.kind),
+          rawInput,
+          rawOutput: boundedRawJson({ error: getErrorMessage(error) }),
         });
 
         throw error;
@@ -1948,6 +2122,60 @@ function toPermissionOptions(
   }
 
   return options;
+}
+
+function permissionContextForConfirmation(
+  confirmation: ToolCallConfirmationDetails,
+  displayName: string,
+  agentId: string | undefined,
+): {
+  displayName?: string;
+  blockedPath?: string;
+  decisionReason?: string;
+  agentId?: string;
+} {
+  switch (confirmation.type) {
+    case 'edit':
+      return {
+        displayName,
+        blockedPath: confirmation.filePath,
+        decisionReason: confirmation.systemMessage,
+        agentId,
+      };
+    case 'exec':
+      return {
+        displayName,
+        decisionReason: confirmation.systemMessage ?? confirmation.command,
+        agentId,
+      };
+    case 'mcp':
+      return {
+        displayName:
+          confirmation.toolDisplayName ||
+          `${confirmation.serverName}:${confirmation.toolName}`,
+        decisionReason:
+          confirmation.systemMessage ?? confirmation.toolDescription,
+        agentId: confirmation.serverName,
+      };
+    case 'info':
+      return {
+        displayName,
+        decisionReason: confirmation.systemMessage ?? confirmation.prompt,
+        agentId,
+      };
+    case 'ask_user':
+    case 'exit_plan_mode':
+    case 'sandbox_expansion':
+      return {
+        displayName,
+        decisionReason: confirmation.systemMessage,
+        agentId,
+      };
+    default: {
+      const unreachable: never = confirmation;
+      throw new Error(`Unexpected: ${unreachable}`);
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/acp/anyharnessMetadata.ts
+++ b/packages/cli/src/acp/anyharnessMetadata.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as acp from '@agentclientprotocol/sdk';
+import { randomUUID } from 'node:crypto';
+
+const MAX_RAW_JSON_BYTES = 32 * 1024;
+export const ASSISTANT_MESSAGE_COMPLETED_EVENT = 'assistant_message_completed';
+export const TRANSIENT_STATUS_EVENT = 'transient_status';
+
+type PermissionContextInput = {
+  displayName?: string;
+  blockedPath?: string;
+  decisionReason?: string;
+  agentId?: string;
+};
+
+export function createAcpMessageId(): string {
+  return randomUUID();
+}
+
+export function assistantMessageCompletedUpdate(
+  messageId: string,
+): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: '' },
+    messageId,
+    _meta: {
+      anyharness: {
+        transcriptEvent: ASSISTANT_MESSAGE_COMPLETED_EVENT,
+      },
+    },
+  };
+}
+
+export function transientStatusUpdate(
+  text: string,
+  messageId: string,
+): acp.SessionUpdate {
+  return {
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'text', text },
+    messageId,
+    _meta: {
+      anyharness: {
+        transcriptEvent: TRANSIENT_STATUS_EVENT,
+      },
+    },
+  };
+}
+
+export function geminiPermissionContextMeta(
+  input: PermissionContextInput,
+): acp.RequestPermissionRequest['_meta'] | undefined {
+  const permissionContext = compactRecord({
+    displayName: nonEmptyString(input.displayName),
+    blockedPath: nonEmptyString(input.blockedPath),
+    decisionReason: nonEmptyString(input.decisionReason),
+    agentId: nonEmptyString(input.agentId),
+  });
+  if (Object.keys(permissionContext).length === 0) {
+    return undefined;
+  }
+  return {
+    gemini: {
+      permissionContext,
+    },
+  };
+}
+
+export function boundedRawJson(value: unknown): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    return {
+      _truncated: true,
+      originalBytes: 0,
+      preview: '[unserializable]',
+    };
+  }
+
+  if (serialized === undefined) {
+    return value;
+  }
+
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(serialized);
+  if (bytes.byteLength <= MAX_RAW_JSON_BYTES) {
+    return value;
+  }
+
+  return {
+    _truncated: true,
+    originalBytes: bytes.byteLength,
+    preview: new TextDecoder().decode(bytes.slice(0, MAX_RAW_JSON_BYTES)),
+  };
+}
+
+function compactRecord(
+  record: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}


### PR DESCRIPTION
## Summary\n- add AnyHarness ACP markers and bounded raw JSON helpers for Gemini ACP\n- emit stable message IDs, assistant completion markers, transient retry/slash-command status, and durable blocked/stopped/no-response warnings\n- emit pre-approval tool calls and failed terminal updates when permission is denied/cancelled\n- attach display-safe Gemini permission context metadata and preserve exact MCP option IDs\n\n## Verification\n- npm run test --workspace @google/gemini-cli -- src/acp/acpClient.test.ts src/acp/commandHandler.test.ts\n- npm run typecheck --workspace @google/gemini-cli\n\nPaired with the Proliferate stacked PR on codex/gemini-acp-visibility.