### PR TITLE
security: improve dangerous command detection for rm and fix YOLO bypass

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -352,14 +352,15 @@ export const ToolConfirmationMessage: React.FC<
         key: 'Allow once',
       });
       if (isTrustedFolder) {
+        const rootCommand = confirmationDetails.rootCommand || 'this command';
         options.push({
-          label: `Allow for this session`,
+          label: `Allow all '${rootCommand}' commands for this session`,
           value: ToolConfirmationOutcome.ProceedAlways,
           key: `Allow for this session`,
         });
         if (allowPermanentApproval) {
           options.push({
-            label: `Allow this command for all future sessions`,
+            label: `Allow all '${rootCommand}' commands for all future sessions`,
             value: ToolConfirmationOutcome.ProceedAlwaysAndSave,
             key: `Allow for all future sessions`,
           });

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolConfirmationMessage.test.tsx.snap
@@ -96,8 +96,8 @@ exports[`ToolConfirmationMessage > height allocation and layout > should expand 
 ╰──────────────────────────────────────────────────────────────────────────────╯
 Allow execution of [echo]?
 
-● 1. Allow once               
-  2. Allow for this session
+● 1. Allow once                                
+  2. Allow all 'echo' commands for this session
   3. No, suggest changes (esc)
 "
 `;
@@ -112,8 +112,8 @@ exports[`ToolConfirmationMessage > should display multiple commands for exec typ
 ╰──────────────────────────────────────────────────────────────────────────────╯
 Allow execution of [echo, ls, whoami]?
 
-● 1. Allow once               
-  2. Allow for this session
+● 1. Allow once                                
+  2. Allow all 'echo' commands for this session
   3. No, suggest changes (esc)
 "
 `;
@@ -150,8 +150,8 @@ exports[`ToolConfirmationMessage > should render multiline shell scripts with co
 ╰──────────────────────────────────────────────────────────────────────────────╯
 Allow execution of [echo]?
 
-● 1. Allow once               
-  2. Allow for this session
+● 1. Allow once                                
+  2. Allow all 'echo' commands for this session
   3. No, suggest changes (esc)"
 `;
 
@@ -213,8 +213,8 @@ exports[`ToolConfirmationMessage > with folder trust > 'for exec confirmations' 
 ╰──────────────────────────────────────────────────────────────────────────────╯
 Allow execution of [echo]?
 
-● 1. Allow once               
-  2. Allow for this session
+● 1. Allow once                                
+  2. Allow all 'echo' commands for this session
   3. No, suggest changes (esc)
 "
 `;

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -433,6 +433,17 @@ describe('PolicyEngine', () => {
       ).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should downgrade dangerous commands to ASK_USER in YOLO mode', async () => {
+      engine = new PolicyEngine({ approvalMode: ApprovalMode.YOLO });
+
+      // rm is considered dangerous
+      const { decision } = await engine.check(
+        { name: 'run_shell_command', args: { command: 'rm test.txt' } },
+        undefined,
+      );
+      expect(decision).toBe(PolicyDecision.ASK_USER);
+    });
+
     it('should respect rule priority in YOLO mode when a match exists', async () => {
       const rules: PolicyRule[] = [
         {
@@ -1762,39 +1773,6 @@ describe('PolicyEngine', () => {
   });
 
   describe('shell command parsing failure', () => {
-    it('should return ALLOW in YOLO mode for dangerous commands due to heuristics override', async () => {
-      // Create an engine with YOLO mode and a sandbox manager that flags a command as dangerous
-      const rules: PolicyRule[] = [
-        {
-          toolName: '*',
-          decision: PolicyDecision.ALLOW,
-          priority: 999,
-          modes: [ApprovalMode.YOLO],
-        },
-      ];
-
-      const mockSandboxManager = new NoopSandboxManager();
-      mockSandboxManager.isDangerousCommand = vi.fn().mockReturnValue(true);
-      mockSandboxManager.isKnownSafeCommand = vi.fn().mockReturnValue(false);
-
-      engine = new PolicyEngine({
-        rules,
-        approvalMode: ApprovalMode.YOLO,
-        sandboxManager: mockSandboxManager,
-      });
-
-      const result = await engine.check(
-        {
-          name: 'run_shell_command',
-          args: { command: 'powershell echo "dangerous"' },
-        },
-        undefined,
-      );
-
-      // Even though the command is flagged as dangerous, YOLO mode should preserve the ALLOW decision
-      expect(result.decision).toBe(PolicyDecision.ALLOW);
-    });
-
     it('should return ALLOW in YOLO mode even if shell command parsing fails', async () => {
       const { splitCommands } = await import('../utils/shell-utils.js');
       const rules: PolicyRule[] = [

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -312,13 +312,6 @@ export class PolicyEngine {
       const parsedArgs = parsedObjArgs.map(extractStringFromParseEntry);
 
       if (this.sandboxManager.isDangerousCommand(parsedArgs)) {
-        if (this.approvalMode === ApprovalMode.YOLO) {
-          debugLogger.debug(
-            `[PolicyEngine.check] Command evaluated as dangerous, but YOLO mode is active. Preserving decision: ${command}`,
-          );
-          return decision;
-        }
-
         debugLogger.debug(
           `[PolicyEngine.check] Command evaluated as dangerous, forcing ASK_USER: ${command}`,
         );
@@ -629,20 +622,12 @@ export class PolicyEngine {
 
     // Default if no rule matched
     if (decision === undefined) {
-      if (this.approvalMode === ApprovalMode.YOLO) {
-        debugLogger.debug(
-          `[PolicyEngine.check] NO MATCH in YOLO mode - using ALLOW`,
-        );
-        return {
-          decision: PolicyDecision.ALLOW,
-        };
-      }
-
-      debugLogger.debug(
-        `[PolicyEngine.check] NO MATCH - using default decision: ${this.defaultDecision}`,
-      );
       if (toolName && SHELL_TOOL_NAMES.includes(toolName)) {
-        let heuristicDecision = this.defaultDecision;
+        let heuristicDecision =
+          this.approvalMode === ApprovalMode.YOLO
+            ? PolicyDecision.ALLOW
+            : this.defaultDecision;
+
         if (command) {
           heuristicDecision = await this.applyShellHeuristics(
             command,
@@ -663,6 +648,13 @@ export class PolicyEngine {
         );
         decision = shellResult.decision;
         matchedRule = shellResult.rule;
+      } else if (this.approvalMode === ApprovalMode.YOLO) {
+        debugLogger.debug(
+          `[PolicyEngine.check] NO MATCH in YOLO mode - using ALLOW`,
+        );
+        return {
+          decision: PolicyDecision.ALLOW,
+        };
       } else {
         decision = this.defaultDecision;
       }

--- a/packages/core/src/sandbox/utils/commandSafety.test.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock shell-utils to avoid relying on tree-sitter WASM
+vi.mock('../../utils/shell-utils.js', () => ({
+  initializeShellParsers: vi.fn().mockResolvedValue(undefined),
+  splitCommands: (cmd: string) => [cmd],
+  stripShellWrapper: (cmd: string) => cmd,
+  extractStringFromParseEntry: (entry: any) =>
+    typeof entry === 'string' ? entry : entry.content,
+  normalizeCommand: (cmd: string) => {
+    // Simple mock normalization: /bin/rm -> rm
+    if (cmd.startsWith('/')) {
+      const parts = cmd.split('/');
+      return parts[parts.length - 1];
+    }
+    return cmd;
+  },
+}));
+
+import { isKnownSafeCommand, isDangerousCommand } from './commandSafety.js';
+
+describe('POSIX commandSafety', () => {
+  describe('isKnownSafeCommand', () => {
+    it('should identify known safe commands', () => {
+      expect(isKnownSafeCommand(['ls', '-la'])).toBe(true);
+      expect(isKnownSafeCommand(['cat', 'file.txt'])).toBe(true);
+      expect(isKnownSafeCommand(['pwd'])).toBe(true);
+      expect(isKnownSafeCommand(['echo', 'hello'])).toBe(true);
+    });
+
+    it('should identify safe git commands', () => {
+      expect(isKnownSafeCommand(['git', 'status'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'log'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'diff'])).toBe(true);
+    });
+
+    it('should reject unsafe git commands', () => {
+      expect(isKnownSafeCommand(['git', 'commit'])).toBe(false);
+      expect(isKnownSafeCommand(['git', 'push'])).toBe(false);
+      expect(isKnownSafeCommand(['git', 'checkout'])).toBe(false);
+    });
+
+    it('should reject commands with redirection', () => {
+      // isKnownSafeCommand handles bash -c "..." which can have redirections
+      // but the simple check for atomic commands doesn't see redirection because it's already parsed
+    });
+  });
+
+  describe('isDangerousCommand', () => {
+    it('should identify destructive rm commands', () => {
+      expect(isDangerousCommand(['rm', 'file.txt'])).toBe(true);
+      expect(isDangerousCommand(['rm', '-rf', '/'])).toBe(true);
+      expect(isDangerousCommand(['rm', '-f', 'file'])).toBe(true);
+      expect(isDangerousCommand(['rm', '-r', 'dir'])).toBe(true);
+      expect(isDangerousCommand(['/bin/rm', 'file'])).toBe(true);
+    });
+
+    it('should allow non-destructive rm help/version', () => {
+      expect(isDangerousCommand(['rm', '--help'])).toBe(false);
+      expect(isDangerousCommand(['rm', '--version'])).toBe(false);
+    });
+
+    it('should identify sudo as dangerous if command is dangerous', () => {
+      expect(isDangerousCommand(['sudo', 'rm', 'file'])).toBe(true);
+    });
+
+    it('should identify find -exec as dangerous', () => {
+      expect(isDangerousCommand(['find', '.', '-exec', 'rm', '{}', '+'])).toBe(true);
+    });
+
+    it('should identify dangerous rg flags', () => {
+      expect(isDangerousCommand(['rg', '--hostname-bin', 'something'])).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -428,10 +428,20 @@ export function isDangerousCommand(args: string[]): boolean {
     return false;
   }
 
-  const cmd = args[0];
+  const cmd = normalizeCommand(args[0]);
 
   if (cmd === 'rm') {
-    return args[1] === '-f' || args[1] === '-rf' || args[1] === '-fr';
+    // rm is always destructive unless it's just a help or version request.
+    const isHelp = args.some((arg) => arg === '--help' || arg === '--version');
+    return !isHelp;
+  }
+
+  if (cmd === 'del' || cmd === 'erase') {
+    // del and erase are always destructive unless they are just help requests.
+    const isHelp = args.some(
+      (arg) => arg === '/?' || arg === '--help' || arg === '--version',
+    );
+    return !isHelp;
   }
 
   if (cmd === 'sudo') {

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -9,6 +9,7 @@ import {
   initializeShellParsers,
   splitCommands,
   stripShellWrapper,
+  normalizeCommand,
 } from '../../utils/shell-utils.js';
 
 /**


### PR DESCRIPTION
## Summary
Improve dangerous command detection for `rm`, `del`, and `erase` to prevent accidental mass deletion. Fix a bug where shell heuristics were bypassed in YOLO mode.

## Details
- **Robust `rm` Detection**: Updated `isDangerousCommand` to correctly identify `rm`, `del`, and `erase` regardless of path qualification or flag ordering.
- **Inherently Dangerous Tools**: These commands are now always flagged as dangerous unless they are help/version requests (`--help`, etc.).
- **YOLO Mode Safety Net**: Fixed a bug in `PolicyEngine.check` to ensure shell heuristics are always applied in YOLO mode, preventing silent bypasses for dangerous commands.
- **UI Transparency**: Updated confirmation labels to clearly state that permissions apply to the entire tool (e.g., "Allow all 'rm' commands for this session").

## Related Issues
Closes #25543

## How to Validate
1. Run `npm test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts` to verify the new test cases.
2. Manually test with `rm test.txt` in YOLO mode and verify it triggers a confirmation prompt.
3. Verify that path-qualified calls like `/bin/rm -rf` are also caught.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run