### PR TITLE
feat: add priority setting to send priority requests to the API

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1947,6 +1947,22 @@ describe('loadCliConfig model selection', () => {
 
     expect(config.getModel()).toBe('auto-gemini-3');
   });
+
+  it('sets geminiApiPriority flag when provided via settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(
+      createTestMergedSettings({
+        model: {
+          geminiApiPriority: true,
+        },
+      }),
+      'test-session',
+      argv,
+    );
+
+    expect(config.getGeminiApiPriority()).toBe(true);
+  });
 });
 
 describe('loadCliConfig folderTrust', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -911,6 +911,7 @@ export async function loadCliConfig(
     memoryBoundaryMarkers: settings.context?.memoryBoundaryMarkers,
     importFormat: settings.context?.importFormat,
     debugMode,
+    geminiApiPriority: settings.model?.geminiApiPriority,
     question,
     worktreeSettings,
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -986,6 +986,15 @@ const SETTINGS_SCHEMA = {
         description: 'The Gemini model to use for conversations.',
         showInDialog: true,
       },
+      geminiApiPriority: {
+        type: 'boolean',
+        label: 'Gemini API Priority',
+        category: 'Model',
+        requiresRestart: false,
+        default: false,
+        description: 'Send priority requests to the Gemini API.',
+        showInDialog: true,
+      },
       maxSessionTurns: {
         type: 'number',
         label: 'Max Session Turns',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -585,6 +585,7 @@ export interface ConfigParameters {
   toolSandboxing?: boolean;
   targetDir: string;
   debugMode: boolean;
+  geminiApiPriority?: boolean;
   question?: string;
 
   coreTools?: string[];
@@ -757,6 +758,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly targetDir: string;
   private workspaceContext: WorkspaceContext;
   private readonly debugMode: boolean;
+  private readonly geminiApiPriority: boolean | undefined;
   private readonly question: string | undefined;
   private readonly worktreeSettings: WorktreeSettings | undefined;
   readonly enableConseca: boolean;
@@ -989,6 +991,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.workspaceContext = new WorkspaceContext(this.targetDir, []);
     this.pendingIncludeDirectories = params.includeDirectories ?? [];
     this.debugMode = params.debugMode;
+    this.geminiApiPriority = params.geminiApiPriority;
     this.question = params.question;
     this.worktreeSettings = params.worktreeSettings;
 
@@ -1025,6 +1028,7 @@ export class Config implements McpContext, AgentLoopContext {
     }
 
     this.debugMode = params.debugMode;
+    this.geminiApiPriority = params.geminiApiPriority;
     this.question = params.question;
     this.worktreeSettings = params.worktreeSettings;
 
@@ -2076,6 +2080,9 @@ export class Config implements McpContext, AgentLoopContext {
 
   getDebugMode(): boolean {
     return this.debugMode;
+  }
+  getGeminiApiPriority(): boolean | undefined {
+    return this.geminiApiPriority;
   }
   getQuestion(): string | undefined {
     return this.question;

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -307,9 +307,12 @@ export class BaseLlmClient {
           currentModel = resolvedModel;
           currentGenerateContentConfig = generateContentConfig;
         }
+        // Rationale: serviceTier is an internal SDK property used to enable priority processing.
+        interface InternalSdkConfig { serviceTier: string; }
         const finalConfig: GenerateContentConfig = {
           ...currentGenerateContentConfig,
           ...(systemInstruction && { systemInstruction }),
+          ...(this.config.getGeminiApiPriority() ? ({ serviceTier: 'priority' } as InternalSdkConfig) : {}),
           ...additionalProperties,
           abortSignal,
         };

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -656,11 +656,17 @@ export class GeminiChat {
       lastConfig = config;
       lastContentsToUse = contentsToUse;
 
+      // Rationale: serviceTier is an internal SDK property used to enable priority processing.
+      interface GeminiInternalConfig { serviceTier: string; }
+      const updatedConfig = this.context.config.getGeminiApiPriority()
+        ? ({ ...config, serviceTier: 'priority' } as GenerateContentConfig & GeminiInternalConfig)
+        : config;
+
       return this.context.config.getContentGenerator().generateContentStream(
         {
           model: modelToUse,
           contents: contentsToUse,
-          config,
+          config: updatedConfig,
         },
         prompt_id,
         role,


### PR DESCRIPTION
## Summary

Users with Tier 2 and Tier 3 API access should be allowed to pass priority access to Gemini CLI.

## Details

## Related Issues



## How to Validate

Set model.geminiApiPriority: true in settings.json

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
