### PR TITLE
fix(agents): isolate subagent thread context to prevent prompt broadcast

### DIFF
--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -66,7 +66,10 @@ export async function scheduleAgentTools(
 
   const schedulerContext = {
     config,
-    promptId: config.promptId,
+    // Fork the promptId if this is a subagent or child call to isolate history
+    promptId: parentCallId
+      ? `${config.promptId}-${parentCallId}`
+      : config.promptId,
     toolRegistry,
     promptRegistry: promptRegistry ?? config.getPromptRegistry(),
     resourceRegistry: resourceRegistry ?? config.getResourceRegistry(),
@@ -74,7 +77,6 @@ export async function scheduleAgentTools(
     geminiClient: config.geminiClient,
     sandboxManager: config.sandboxManager,
   };
-
   const scheduler = new Scheduler({
     context: schedulerContext,
     messageBus: toolRegistry.messageBus,

--- a/packages/core/src/agents/agent-scheduler.ts
+++ b/packages/core/src/agents/agent-scheduler.ts
@@ -68,7 +68,7 @@ export async function scheduleAgentTools(
     config,
     // Fork the promptId if this is a subagent or child call to isolate history
     promptId: parentCallId
-      ? `${config.promptId}-${parentCallId}`
+      ? config.promptId + '-' + parentCallId.replace(/[^a-zA-Z0-9-_]/g, '')
       : config.promptId,
     toolRegistry,
     promptRegistry: promptRegistry ?? config.getPromptRegistry(),


### PR DESCRIPTION
## Summary
Isolates subagent thread context to prevent prompt broadcast during parallel execution.

## Details
When the scheduler dispatches parallel subagents, it previously passed the global `config.promptId` to the execution context. This caused all parallel workers to share the same memory pointer and read the unpartitioned parent history, resulting in duplicated work.

This patch forks the `promptId` by appending the `parentCallId` to the scheduler context, mathematically ensuring each subagent operates within an isolated thread and only processes its specific invocation arguments without scope creep.

## Related Issues
Fixes #25533

## How to Validate
Booted the local executor and submitted the following stress-test:
> `Act as a 'Recipe Scout'. I want you to find recipes for 3 different dishes: Tacos, Sushi, and Pasta. Run these tasks in parallel using subagents.`

Verified that the subagents successfully partition the tasks (one for Tacos, one for Sushi, one for Pasta) and execute without inheriting the parent's full conversation history.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
   - [ ] MacOS
      - [ ] npm run
      - [ ] npx
      - [ ] Docker
      - [ ] Podman
      - [ ] Seatbelt
   - [ ] Windows
      - [ ] npm run
      - [ ] npx
      - [ ] Docker
   - [x] Linux
      - [x] npm run
      - [ ] npx
      - [ ] Docker