### PR TITLE
fix(ui): revert theme preview when quitting from theme dialog

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -977,6 +977,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       openAgentConfigDialog,
       openPermissionsDialog,
       quit: (messages: HistoryItem[]) => {
+        closeThemeDialog();
         setQuittingMessages(messages);
         setTimeout(async () => {
           await runExitCleanup();
@@ -1005,6 +1006,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     [
       setAuthState,
       openThemeDialog,
+      closeThemeDialog,
       openEditorDialog,
       openSettingsDialog,
       openSessionBrowser,


### PR DESCRIPTION
## Summary

When the Theme Dialog is open and the user highlights a theme (which previews it immediately), then exits the CLI via double Ctrl+C or Ctrl+D without pressing Enter, the preview theme stays applied to the goodbye banner and the post-exit terminal state.

`useThemeCommand.closeThemeDialog` already re-applies the saved theme on close (`packages/cli/src/ui/hooks/useThemeCommand.ts:80-84`), so the fix is to invoke it from the `quit` action handler before `setQuittingMessages` fires.

## Details

Previous attempt: PR #22542 landed this exact 2-line shape and was closed 2026-04-08 by the 14-day stale-PR auto-close (the issue was not labeled `help wanted` at the time). @psinha40898 confirmed the final shape was correct on that PR: "iirc the PR is now using the action registry to execute the logic on user press, akin to an event handler." The issue was subsequently labeled `help wanted` on 2026-04-08 by @cocosheng-g, which is why this re-submission.

The diff is intentionally minimal and matches the accepted shape. No changes to `ThemeDialog.tsx` or `useThemeCommand.ts` - the fix belongs in the quit event handler, not the component or hook.

## Related Issues

Fixes #22541

## How to Validate

1. `npm install && npm run build`
2. `npm run start`
3. Run `/theme` inside the CLI
4. Arrow down to highlight a different theme (preview applies)
5. Do NOT press Enter
6. Press Ctrl+C twice to exit
7. Verify: the "Goodbye" banner and your terminal prompt use the originally saved theme, not the preview
8. Repeat with Ctrl+D twice instead of Ctrl+C twice

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

This contribution was developed with AI assistance (Claude Code).
