### PR TITLE
feat(core): enable topic update narration by default and promote to general

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -2,8 +2,7 @@
   "experimental": {
     "extensionReloading": true,
     "modelSteering": true,
-    "memoryManager": true,
-    "topicUpdateNarration": true
+    "memoryManager": true
   },
   "general": {
     "devtools": true

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -39,6 +39,7 @@ they appear in the UI.
 | Debug Keystroke Logging       | `general.debugKeystrokeLogging`    | Enable debug logging of keystrokes to the console.                                                                                                                                                                                                            | `false`     |
 | Enable Session Cleanup        | `general.sessionRetention.enabled` | Enable automatic session cleanup                                                                                                                                                                                                                              | `true`      |
 | Keep chat history             | `general.sessionRetention.maxAge`  | Automatically delete chats older than this time period (e.g., "30d", "7d", "24h", "1w")                                                                                                                                                                       | `"30d"`     |
+| Topic & Update Narration      | `general.topicUpdateNarration`     | Enable the Topic & Update communication model for reduced chattiness and structured progress reporting.                                                                                                                                                       | `true`      |
 
 ### Output
 
@@ -160,17 +161,16 @@ they appear in the UI.
 
 ### Experimental
 
-| UI Label                                             | Setting                             | Description                                                                                                                                               | Default |
-| ---------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Enable Git Worktrees                                 | `experimental.worktrees`            | Enable automated Git worktree management for parallel work.                                                                                               | `false` |
-| Use OSC 52 Paste                                     | `experimental.useOSC52Paste`        | Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
-| Use OSC 52 Copy                                      | `experimental.useOSC52Copy`         | Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
-| Model Steering                                       | `experimental.modelSteering`        | Enable model steering (user hints) to guide the model during tool execution.                                                                              | `false` |
-| Direct Web Fetch                                     | `experimental.directWebFetch`       | Enable web fetch behavior that bypasses LLM summarization.                                                                                                | `false` |
-| Memory Manager Agent                                 | `experimental.memoryManager`        | Replace the built-in save_memory tool with a memory manager subagent that supports adding, removing, de-duplicating, and organizing memories.             | `false` |
-| Use the generalist profile to manage agent contexts. | `experimental.generalistProfile`    | Suitable for general coding and software development tasks.                                                                                               | `false` |
-| Enable Context Management                            | `experimental.contextManagement`    | Enable logic for context management.                                                                                                                      | `false` |
-| Topic & Update Narration                             | `experimental.topicUpdateNarration` | Enable the experimental Topic & Update communication model for reduced chattiness and structured progress reporting.                                      | `false` |
+| UI Label                                             | Setting                          | Description                                                                                                                                               | Default |
+| ---------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Enable Git Worktrees                                 | `experimental.worktrees`         | Enable automated Git worktree management for parallel work.                                                                                               | `false` |
+| Use OSC 52 Paste                                     | `experimental.useOSC52Paste`     | Use OSC 52 for pasting. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
+| Use OSC 52 Copy                                      | `experimental.useOSC52Copy`      | Use OSC 52 for copying. This may be more robust than the default system when using remote terminal sessions (if your terminal is configured to allow it). | `false` |
+| Model Steering                                       | `experimental.modelSteering`     | Enable model steering (user hints) to guide the model during tool execution.                                                                              | `false` |
+| Direct Web Fetch                                     | `experimental.directWebFetch`    | Enable web fetch behavior that bypasses LLM summarization.                                                                                                | `false` |
+| Memory Manager Agent                                 | `experimental.memoryManager`     | Replace the built-in save_memory tool with a memory manager subagent that supports adding, removing, de-duplicating, and organizing memories.             | `false` |
+| Use the generalist profile to manage agent contexts. | `experimental.generalistProfile` | Suitable for general coding and software development tasks.                                                                                               | `false` |
+| Enable Context Management                            | `experimental.contextManagement` | Enable logic for context management.                                                                                                                      | `false` |
 
 ### Skills
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -198,6 +198,11 @@ their corresponding top-level category object in your `settings.json` file.
   - **Description:** Minimum retention period (safety limit, defaults to "1d")
   - **Default:** `"1d"`
 
+- **`general.topicUpdateNarration`** (boolean):
+  - **Description:** Enable the Topic & Update communication model for reduced
+    chattiness and structured progress reporting.
+  - **Default:** `true`
+
 #### `output`
 
 - **`output.format`** (enum):
@@ -1735,8 +1740,7 @@ their corresponding top-level category object in your `settings.json` file.
   - **Requires restart:** Yes
 
 - **`experimental.topicUpdateNarration`** (boolean):
-  - **Description:** Enable the experimental Topic & Update communication model
-    for reduced chattiness and structured progress reporting.
+  - **Description:** Deprecated: Use general.topicUpdateNarration instead.
   - **Default:** `false`
 
 #### `skills`

--- a/evals/update_topic.eval.ts
+++ b/evals/update_topic.eval.ts
@@ -43,7 +43,7 @@ describe('update_topic_behavior', () => {
         2,
       ),
       '.gemini/settings.json': JSON.stringify({
-        experimental: {
+        general: {
           topicUpdateNarration: true,
         },
       }),
@@ -127,7 +127,7 @@ describe('update_topic_behavior', () => {
       'Explain the difference between Map and Object in JavaScript and provide a performance-focused code snippet for each.',
     files: {
       '.gemini/settings.json': JSON.stringify({
-        experimental: {
+        general: {
           topicUpdateNarration: true,
         },
       }),
@@ -156,7 +156,7 @@ describe('update_topic_behavior', () => {
       'packages/core/src/tools/tool-names.ts':
         "export const UPDATE_TOPIC_TOOL_NAME = 'update_topic';",
       '.gemini/settings.json': JSON.stringify({
-        experimental: {
+        general: {
           topicUpdateNarration: true,
         },
       }),
@@ -204,7 +204,7 @@ app.post('/users', (req, res) => {
 export default app;
       `,
       '.gemini/settings.json': JSON.stringify({
-        experimental: {
+        general: {
           topicUpdateNarration: true,
         },
       }),
@@ -249,7 +249,7 @@ export default app;
     files: {
       'package.json': JSON.stringify({ name: 'test-project' }),
       '.gemini/settings.json': JSON.stringify({
-        experimental: {
+        general: {
           topicUpdateNarration: true,
         },
       }),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -992,7 +992,9 @@ export async function loadCliConfig(
     experimentalMemoryManager: settings.experimental?.memoryManager,
     contextManagement,
     modelSteering: settings.experimental?.modelSteering,
-    topicUpdateNarration: settings.experimental?.topicUpdateNarration,
+    topicUpdateNarration:
+      settings.general?.topicUpdateNarration ??
+      settings.experimental?.topicUpdateNarration,
     noBrowser: !!process.env['NO_BROWSER'],
     summarizeToolOutput: settings.model?.summarizeToolOutput,
     ideMode,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -418,6 +418,16 @@ const SETTINGS_SCHEMA = {
         },
         description: 'Settings for automatic session cleanup.',
       },
+      topicUpdateNarration: {
+        type: 'boolean',
+        label: 'Topic & Update Narration',
+        category: 'General',
+        requiresRestart: false,
+        default: true,
+        description:
+          'Enable the Topic & Update communication model for reduced chattiness and structured progress reporting.',
+        showInDialog: true,
+      },
     },
   },
   output: {
@@ -2228,9 +2238,8 @@ const SETTINGS_SCHEMA = {
         category: 'Experimental',
         requiresRestart: false,
         default: false,
-        description:
-          'Enable the experimental Topic & Update communication model for reduced chattiness and structured progress reporting.',
-        showInDialog: true,
+        description: 'Deprecated: Use general.topicUpdateNarration instead.',
+        showInDialog: false,
       },
     },
   },

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -977,6 +977,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       openAgentConfigDialog,
       openPermissionsDialog,
       quit: (messages: HistoryItem[]) => {
+        closeThemeDialog();
         setQuittingMessages(messages);
         setTimeout(async () => {
           await runExitCleanup();
@@ -1005,6 +1006,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
     [
       setAuthState,
       openThemeDialog,
+      closeThemeDialog,
       openEditorDialog,
       openSettingsDialog,
       openSessionBrowser,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1196,7 +1196,7 @@ export class Config implements McpContext, AgentLoopContext {
         },
       },
     };
-    this.topicUpdateNarration = params.topicUpdateNarration ?? false;
+    this.topicUpdateNarration = params.topicUpdateNarration ?? true;
     this.modelSteering = params.modelSteering ?? false;
     this.injectionService = new InjectionService(() =>
       this.isModelSteeringEnabled(),

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -209,6 +209,13 @@
             }
           },
           "additionalProperties": false
+        },
+        "topicUpdateNarration": {
+          "title": "Topic & Update Narration",
+          "description": "Enable the Topic & Update communication model for reduced chattiness and structured progress reporting.",
+          "markdownDescription": "Enable the Topic & Update communication model for reduced chattiness and structured progress reporting.\n\n- Category: `General`\n- Requires restart: `no`\n- Default: `true`",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -2963,8 +2970,8 @@
         },
         "topicUpdateNarration": {
           "title": "Topic & Update Narration",
-          "description": "Enable the experimental Topic & Update communication model for reduced chattiness and structured progress reporting.",
-          "markdownDescription": "Enable the experimental Topic & Update communication model for reduced chattiness and structured progress reporting.\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
+          "description": "Deprecated: Use general.topicUpdateNarration instead.",
+          "markdownDescription": "Deprecated: Use general.topicUpdateNarration instead.\n\n- Category: `Experimental`\n- Requires restart: `no`\n- Default: `false`",
           "default": false,
           "type": "boolean"
         }


### PR DESCRIPTION
## Summary

This PR enables the `topicUpdateNarration` setting by default and moves it from the `experimental` category to the `general` category, as it is now ready for wider use.

## Details

- Modified `packages/core/src/config/config.ts` to default `topicUpdateNarration` to `true` and read from `settings.general.topicUpdateNarration` with a fallback to `settings.experimental.topicUpdateNarration`.
- Updated `packages/cli/src/config/settingsSchema.ts` and `schemas/settings.schema.json` to move the setting to the `general` block and set the default to `true`.
- Updated documentation in `docs/cli/settings.md` and `docs/reference/configuration.md`.
- Updated `evals/update_topic.eval.ts` to reflect the new `general` setting location.

## Related Issues

## How to Validate

1. Run the CLI without any specific settings for `topicUpdateNarration` in your `.gemini/settings.json`.
2. Verify that topic update narration occurs by default during multi-step tasks.
3. Check the settings UI to confirm the setting is under "General" and not "Experimental".

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker