### PR TITLE
fix(ui): hide frames in alternate buffer mode (#18701)

### DIFF
--- a/1,gh
+++ b/1,gh
@@ -1,0 +1,2 @@
+accepts 1 arg(s), received 7
+accepts 1 arg(s), received 7

--- a/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
+++ b/packages/cli/src/ui/__snapshots__/App.test.tsx.snap
@@ -119,19 +119,19 @@ Tips for getting started:
 3. Ask coding questions, edit code or run commands
 4. Be specific for the best results
 HistoryItemDisplay
-╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Action Required                                                                                  │
-│                                                                                                  │
-│ ?  ls list directory                                                                             │
-│                                                                                                  │
-│ ls                                                                                               │
-│ Allow execution of: 'ls'?                                                                        │
-│                                                                                                  │
-│ ● 1. Allow once                                                                                  │
-│   2. Allow for this session                                                                      │
-│   3. No, suggest changes (esc)                                                                   │
-│                                                                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+ Action Required
+
+ ?  ls list directory
+
+ ls
+ Allow execution of: 'ls'?
+
+ ● 1. Allow once               
+   2. Allow for this session
+   3. No, suggest changes (esc)
+
+
+
 
 
 

--- a/packages/cli/src/ui/components/StickyHeader.tsx
+++ b/packages/cli/src/ui/components/StickyHeader.tsx
@@ -8,6 +8,8 @@ import type React from 'react';
 import { Box, type DOMElement } from 'ink';
 import { theme } from '../semantic-colors.js';
 
+import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+
 export interface StickyHeaderProps {
   children: React.ReactNode;
   width: number;
@@ -24,53 +26,59 @@ export const StickyHeader: React.FC<StickyHeaderProps> = ({
   borderColor,
   borderDimColor,
   containerRef,
-}) => (
-  <Box
-    ref={containerRef}
-    sticky
-    minHeight={1}
-    flexShrink={0}
-    width={width}
-    stickyChildren={
+}) => {
+  const isAlternateBuffer = useAlternateBuffer();
+
+  return (
+    <Box
+      ref={containerRef}
+      sticky
+      minHeight={1}
+      flexShrink={0}
+      width={width}
+      stickyChildren={
+        <Box
+          borderStyle={isAlternateBuffer ? undefined : 'round'}
+          flexDirection="column"
+          width={width}
+          opaque
+          borderColor={borderColor}
+          borderDimColor={borderDimColor}
+          borderBottom={false}
+          borderTop={isAlternateBuffer ? false : isFirst}
+          borderLeft={!isAlternateBuffer}
+          borderRight={!isAlternateBuffer}
+          paddingTop={isFirst ? 0 : 1}
+        >
+          <Box paddingX={1}>{children}</Box>
+          {/* Dark border to separate header from content. */}
+          <Box
+            width={width - 2}
+            borderColor={theme.ui.dark}
+            borderStyle={isAlternateBuffer ? undefined : 'single'}
+            borderTop={false}
+            borderBottom={!isAlternateBuffer}
+            borderLeft={false}
+            borderRight={false}
+          ></Box>
+        </Box>
+      }
+    >
       <Box
-        borderStyle="round"
-        flexDirection="column"
+        borderStyle={isAlternateBuffer ? undefined : 'round'}
         width={width}
-        opaque
         borderColor={borderColor}
         borderDimColor={borderDimColor}
         borderBottom={false}
-        borderTop={isFirst}
+        borderTop={isAlternateBuffer ? false : isFirst}
+        borderLeft={!isAlternateBuffer}
+        borderRight={!isAlternateBuffer}
+        paddingX={1}
+        paddingBottom={1}
         paddingTop={isFirst ? 0 : 1}
       >
-        <Box paddingX={1}>{children}</Box>
-        {/* Dark border to separate header from content. */}
-        <Box
-          width={width - 2}
-          borderColor={theme.ui.dark}
-          borderStyle="single"
-          borderTop={false}
-          borderBottom={true}
-          borderLeft={false}
-          borderRight={false}
-        ></Box>
+        {children}
       </Box>
-    }
-  >
-    <Box
-      borderStyle="round"
-      width={width}
-      borderColor={borderColor}
-      borderDimColor={borderDimColor}
-      borderBottom={false}
-      borderTop={isFirst}
-      borderLeft={true}
-      borderRight={true}
-      paddingX={1}
-      paddingBottom={1}
-      paddingTop={isFirst ? 0 : 1}
-    >
-      {children}
     </Box>
-  </Box>
-);
+  );
+};

--- a/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
+++ b/packages/cli/src/ui/components/ToolConfirmationQueue.tsx
@@ -18,6 +18,8 @@ import { StickyHeader } from './StickyHeader.js';
 import type { SerializableConfirmationDetails } from '@google/gemini-cli-core';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 
+import { useAlternateBuffer } from '../hooks/useAlternateBuffer.js';
+
 function getConfirmationHeader(
   details: SerializableConfirmationDetails | undefined,
 ): string {
@@ -48,6 +50,9 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
     constrainHeight,
     availableTerminalHeight: uiAvailableHeight,
   } = useUIState();
+
+  const isAlternateBuffer = useAlternateBuffer();
+
   const { tool, index, total } = confirmingTool;
 
   // Safety check: ToolConfirmationMessage requires confirmationDetails
@@ -116,12 +121,12 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
 
         <Box
           width={mainAreaWidth}
-          borderStyle="round"
+          borderStyle={isAlternateBuffer ? undefined : 'round'}
           borderColor={borderColor}
           borderTop={false}
           borderBottom={false}
-          borderLeft={true}
-          borderRight={true}
+          borderLeft={!isAlternateBuffer}
+          borderRight={!isAlternateBuffer}
           paddingX={1}
           flexDirection="column"
         >
@@ -141,14 +146,14 @@ export const ToolConfirmationQueue: React.FC<ToolConfirmationQueueProps> = ({
           />
         </Box>
         <Box
-          height={1}
+          height={isAlternateBuffer ? 0 : 1}
           width={mainAreaWidth}
-          borderLeft={true}
-          borderRight={true}
+          borderLeft={!isAlternateBuffer}
+          borderRight={!isAlternateBuffer}
           borderTop={false}
-          borderBottom={true}
+          borderBottom={!isAlternateBuffer}
           borderColor={borderColor}
-          borderStyle="round"
+          borderStyle={isAlternateBuffer ? undefined : 'round'}
         />
       </Box>
       <ShowMoreLines constrainHeight={constrainHeight} />

--- a/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ToolConfirmationQueue.test.tsx.snap
@@ -21,109 +21,95 @@ exports[`ToolConfirmationQueue > calculates availableContentHeight based on avai
 `;
 
 exports[`ToolConfirmationQueue > does not render expansion hint when constrainHeight is false 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Action Required                                                              │
-│                                                                              │
-│ ?  replace edit file                                                         │
-│                                                                              │
-│ ╭──────────────────────────────────────────────────────────────────────────╮ │
-│ │                                                                          │ │
-│ │ No changes detected.                                                     │ │
-│ │                                                                          │ │
-│ ╰──────────────────────────────────────────────────────────────────────────╯ │
-│ Apply this change?                                                           │
-│                                                                              │
-│ ● 1. Allow once                                                              │
-│   2. Allow for this session                                                  │
-│   3. Modify with external editor                                             │
-│   4. No, suggest changes (esc)                                               │
-│                                                                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Action Required
+
+ ?  replace edit file
+
+ ╭──────────────────────────────────────────────────────────────────────────╮
+ │                                                                          │
+ │ No changes detected.                                                     │
+ │                                                                          │
+ ╰──────────────────────────────────────────────────────────────────────────╯
+ Apply this change?
+
+ ● 1. Allow once                 
+   2. Allow for this session
+   3. Modify with external editor
+   4. No, suggest changes (esc)
 "
 `;
 
 exports[`ToolConfirmationQueue > provides more height for ask_user by subtracting less overhead 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Answer Questions                                                             │
-│                                                                              │
-│ Line 1                                                                       │
-│ Line 2                                                                       │
-│ Line 3                                                                       │
-│ Line 4                                                                       │
-│ Line 5                                                                       │
-│ Line 6                                                                       │
-│                                                                              │
-│ ● 1.  Option 1                                                               │
-│       Desc                                                                   │
-│   2.  Enter a custom value                                                   │
-│                                                                              │
-│ Enter to select · ↑/↓ to navigate · Esc to cancel                            │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Answer Questions
+
+ Line 1
+ Line 2
+ Line 3
+ Line 4
+ Line 5
+ Line 6
+
+ ● 1.  Option 1                                                              
+       Desc                                                                  
+   2.  Enter a custom value
+
+ Enter to select · ↑/↓ to navigate · Esc to cancel
 "
 `;
 
 exports[`ToolConfirmationQueue > renders AskUser tool confirmation with Success color 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Answer Questions                                                             │
-│                                                                              │
-│ Review your answers:                                                         │
-│                                                                              │
-│                                                                              │
-│ Enter to submit · Tab/Shift+Tab to edit answers · Esc to cancel              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Answer Questions
+
+ Review your answers:
+
+
+ Enter to submit · Tab/Shift+Tab to edit answers · Esc to cancel
 "
 `;
 
 exports[`ToolConfirmationQueue > renders ExitPlanMode tool confirmation with Success color 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Ready to start implementation?                                               │
-│                                                                              │
-│ Plan content goes here                                                       │
-│                                                                              │
-│ ● 1.  Yes, automatically accept edits                                        │
-│       Approves plan and allows tools to run automatically                    │
-│   2.  Yes, manually accept edits                                             │
-│       Approves plan but requires confirmation for each tool                  │
-│   3.  Type your feedback...                                                  │
-│                                                                              │
-│ Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel      │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Ready to start implementation?
+
+ Plan content goes here
+
+ ● 1.  Yes, automatically accept edits                                       
+       Approves plan and allows tools to run automatically                   
+   2.  Yes, manually accept edits
+       Approves plan but requires confirmation for each tool
+   3.  Type your feedback...
+
+ Enter to select · ↑/↓ to navigate · Ctrl+X to edit plan · Esc to cancel
 "
 `;
 
 exports[`ToolConfirmationQueue > renders expansion hint when content is long and constrained 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Action Required                                                              │
-│                                                                              │
-│ ?  replace edit file                                                         │
-│                                                                              │
-│ ... 49 hidden (Ctrl+O) ...                                                   │
-│ 50 line                                                                      │
-│ Apply this change?                                                           │
-│                                                                              │
-│ ● 1. Allow once                                                              │
-│   2. Allow for this session                                                  │
-│   3. Modify with external editor                                             │
-│   4. No, suggest changes (esc)                                               │
-│                                                                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Action Required
+
+ ?  replace edit file
+
+ ... 49 hidden (Ctrl+O) ...
+ 50 line
+ Apply this change?
+
+ ● 1. Allow once                 
+   2. Allow for this session
+   3. Modify with external editor
+   4. No, suggest changes (esc)
+
  Press Ctrl+O to show more lines
 "
 `;
 
 exports[`ToolConfirmationQueue > renders the confirming tool with progress indicator 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ Action Required                                                       1 of 3 │
-│                                                                              │
-│ ?  ls list files                                                             │
-│                                                                              │
-│ ls                                                                           │
-│ Allow execution of: 'ls'?                                                    │
-│                                                                              │
-│ ● 1. Allow once                                                              │
-│   2. Allow for this session                                                  │
-│   3. No, suggest changes (esc)                                               │
-│                                                                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+" Action Required                                                       1 of 3
+
+ ?  ls list files
+
+ ls
+ Allow execution of: 'ls'?
+
+ ● 1. Allow once               
+   2. Allow for this session
+   3. No, suggest changes (esc)
 "
 `;

--- a/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ShellToolMessage.tsx
@@ -199,13 +199,13 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
       <Box
         ref={contentRef}
         width={terminalWidth}
-        borderStyle="round"
+        borderStyle={isAlternateBuffer ? undefined : 'round'}
         borderColor={borderColor}
         borderDimColor={borderDimColor}
         borderTop={false}
         borderBottom={false}
-        borderLeft={true}
-        borderRight={true}
+        borderLeft={!isAlternateBuffer}
+        borderRight={!isAlternateBuffer}
         paddingX={1}
         flexDirection="column"
       >
@@ -215,7 +215,14 @@ export const ShellToolMessage: React.FC<ShellToolMessageProps> = ({
           terminalWidth={terminalWidth}
           renderOutputAsMarkdown={renderOutputAsMarkdown}
           hasFocus={isThisShellFocused}
-          maxLines={maxLines}
+          maxLines={calculateShellMaxLines({
+            status,
+            isAlternateBuffer,
+            isThisShellFocused,
+            availableTerminalHeight,
+            constrainHeight,
+            isExpandable,
+          })}
         />
         {isThisShellFocused && config && (
           <ShellInputPrompt

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -774,6 +774,7 @@ describe('<ToolGroupMessage />', () => {
         {
           config: baseMockConfig,
           settings: fullVerbositySettings,
+          useAlternateBuffer: false,
         },
       );
 
@@ -959,6 +960,7 @@ describe('<ToolGroupMessage />', () => {
         {
           config: baseMockConfig,
           settings: fullVerbositySettings,
+          useAlternateBuffer: false,
         },
       );
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -17,6 +17,7 @@ import { ToolMessage } from './ToolMessage.js';
 import { ShellToolMessage } from './ShellToolMessage.js';
 import { theme } from '../../semantic-colors.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
+import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
 import { isShellTool } from './ToolShared.js';
 import {
   shouldHideToolCall,
@@ -82,6 +83,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     backgroundShells,
     pendingHistoryItems,
   } = useUIState();
+
+  const isAlternateBuffer = useAlternateBuffer();
 
   const { borderColor, borderDimColor } = useMemo(
     () =>
@@ -198,14 +201,14 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             )}
             {tool.outputFile && (
               <Box
-                borderLeft={true}
-                borderRight={true}
+                borderLeft={!isAlternateBuffer}
+                borderRight={!isAlternateBuffer}
                 borderTop={false}
                 borderBottom={false}
                 borderColor={borderColor}
                 borderDimColor={borderDimColor}
                 flexDirection="column"
-                borderStyle="round"
+                borderStyle={isAlternateBuffer ? undefined : 'round'}
                 paddingLeft={1}
                 paddingRight={1}
               >
@@ -228,13 +231,15 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           <Box
             height={0}
             width={contentWidth}
-            borderLeft={true}
-            borderRight={true}
+            borderLeft={!isAlternateBuffer}
+            borderRight={!isAlternateBuffer}
             borderTop={false}
-            borderBottom={borderBottomOverride ?? true}
+            borderBottom={
+              isAlternateBuffer ? false : (borderBottomOverride ?? true)
+            }
             borderColor={borderColor}
             borderDimColor={borderDimColor}
-            borderStyle="round"
+            borderStyle={isAlternateBuffer ? undefined : 'round'}
           />
         )
       }

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -25,6 +25,8 @@ import { type Config, CoreToolCallStatus, Kind } from '@google/gemini-cli-core';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
 import { SUBAGENT_MAX_LINES } from '../../constants.js';
 
+import { useAlternateBuffer } from '../../hooks/useAlternateBuffer.js';
+
 export type { TextEmphasis };
 
 export interface ToolMessageProps extends IndividualToolCallDisplay {
@@ -39,6 +41,10 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   embeddedShellFocused?: boolean;
   ptyId?: number;
   config?: Config;
+  progressMessage?: string;
+  originalRequestName?: string;
+  progress?: number;
+  progressTotal?: number;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -70,6 +76,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
     activeShellPtyId,
     embeddedShellFocused,
   );
+
+  const isAlternateBuffer = useAlternateBuffer();
 
   const isThisShellFocusable = checkIsShellFocusable(name, status, config);
 
@@ -111,13 +119,13 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       </StickyHeader>
       <Box
         width={terminalWidth}
-        borderStyle="round"
+        borderStyle={isAlternateBuffer ? undefined : 'round'}
         borderColor={borderColor}
         borderDimColor={borderDimColor}
         borderTop={false}
         borderBottom={false}
-        borderLeft={true}
-        borderRight={true}
+        borderLeft={!isAlternateBuffer}
+        borderRight={!isAlternateBuffer}
         paddingX={1}
         flexDirection="column"
       >

--- a/packages/cli/src/ui/components/messages/__snapshots__/ShellToolMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ShellToolMessage.test.tsx.snap
@@ -1,333 +1,321 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<ShellToolMessage /> > Height Constraints > defaults to ACTIVE_SHELL_MAX_LINES in alternate buffer when availableTerminalHeight is undefined 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                                             │
-│                                                                              │
-│ Line 89                                                                      │
-│ Line 90                                                                      │
-│ Line 91                                                                      │
-│ Line 92                                                                      │
-│ Line 93                                                                      │
-│ Line 94                                                                      │
-│ Line 95                                                                      │
-│ Line 96                                                                      │
-│ Line 97                                                                      │
-│ Line 98                                                                      │
-│ Line 99                                                                    ▄ │
-│ Line 100                                                                   █ │
+" ⊶  Shell Command A shell command
+
+ Line 89
+ Line 90
+ Line 91
+ Line 92
+ Line 93
+ Line 94
+ Line 95
+ Line 96
+ Line 97
+ Line 98
+ Line 99                                                                    ▄
+ Line 100                                                                   █
 "
 `;
 
 exports[`<ShellToolMessage /> > Height Constraints > fully expands in alternate buffer mode when constrainHeight is false and isExpandable is true 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  Shell Command A shell command                                             │
-│                                                                              │
-│ Line 1                                                                       │
-│ Line 2                                                                       │
-│ Line 3                                                                       │
-│ Line 4                                                                       │
-│ Line 5                                                                       │
-│ Line 6                                                                       │
-│ Line 7                                                                       │
-│ Line 8                                                                       │
-│ Line 9                                                                       │
-│ Line 10                                                                      │
-│ Line 11                                                                      │
-│ Line 12                                                                      │
-│ Line 13                                                                      │
-│ Line 14                                                                      │
-│ Line 15                                                                      │
-│ Line 16                                                                      │
-│ Line 17                                                                      │
-│ Line 18                                                                      │
-│ Line 19                                                                      │
-│ Line 20                                                                      │
-│ Line 21                                                                      │
-│ Line 22                                                                      │
-│ Line 23                                                                      │
-│ Line 24                                                                      │
-│ Line 25                                                                      │
-│ Line 26                                                                      │
-│ Line 27                                                                      │
-│ Line 28                                                                      │
-│ Line 29                                                                      │
-│ Line 30                                                                      │
-│ Line 31                                                                      │
-│ Line 32                                                                      │
-│ Line 33                                                                      │
-│ Line 34                                                                      │
-│ Line 35                                                                      │
-│ Line 36                                                                      │
-│ Line 37                                                                      │
-│ Line 38                                                                      │
-│ Line 39                                                                      │
-│ Line 40                                                                      │
-│ Line 41                                                                      │
-│ Line 42                                                                      │
-│ Line 43                                                                      │
-│ Line 44                                                                      │
-│ Line 45                                                                      │
-│ Line 46                                                                      │
-│ Line 47                                                                      │
-│ Line 48                                                                      │
-│ Line 49                                                                      │
-│ Line 50                                                                      │
-│ Line 51                                                                      │
-│ Line 52                                                                      │
-│ Line 53                                                                      │
-│ Line 54                                                                      │
-│ Line 55                                                                      │
-│ Line 56                                                                      │
-│ Line 57                                                                      │
-│ Line 58                                                                      │
-│ Line 59                                                                      │
-│ Line 60                                                                      │
-│ Line 61                                                                      │
-│ Line 62                                                                      │
-│ Line 63                                                                      │
-│ Line 64                                                                      │
-│ Line 65                                                                      │
-│ Line 66                                                                      │
-│ Line 67                                                                      │
-│ Line 68                                                                      │
-│ Line 69                                                                      │
-│ Line 70                                                                      │
-│ Line 71                                                                      │
-│ Line 72                                                                      │
-│ Line 73                                                                      │
-│ Line 74                                                                      │
-│ Line 75                                                                      │
-│ Line 76                                                                      │
-│ Line 77                                                                      │
-│ Line 78                                                                      │
-│ Line 79                                                                      │
-│ Line 80                                                                      │
-│ Line 81                                                                      │
-│ Line 82                                                                      │
-│ Line 83                                                                      │
-│ Line 84                                                                      │
-│ Line 85                                                                      │
-│ Line 86                                                                      │
-│ Line 87                                                                      │
-│ Line 88                                                                      │
-│ Line 89                                                                      │
-│ Line 90                                                                      │
-│ Line 91                                                                      │
-│ Line 92                                                                      │
-│ Line 93                                                                      │
-│ Line 94                                                                      │
-│ Line 95                                                                      │
-│ Line 96                                                                      │
-│ Line 97                                                                      │
-│ Line 98                                                                      │
-│ Line 99                                                                      │
-│ Line 100                                                                     │
+" ✓  Shell Command A shell command
+
+ Line 1
+ Line 2
+ Line 3
+ Line 4
+ Line 5
+ Line 6
+ Line 7
+ Line 8
+ Line 9
+ Line 10
+ Line 11
+ Line 12
+ Line 13
+ Line 14
+ Line 15
+ Line 16
+ Line 17
+ Line 18
+ Line 19
+ Line 20
+ Line 21
+ Line 22
+ Line 23
+ Line 24
+ Line 25
+ Line 26
+ Line 27
+ Line 28
+ Line 29
+ Line 30
+ Line 31
+ Line 32
+ Line 33
+ Line 34
+ Line 35
+ Line 36
+ Line 37
+ Line 38
+ Line 39
+ Line 40
+ Line 41
+ Line 42
+ Line 43
+ Line 44
+ Line 45
+ Line 46
+ Line 47
+ Line 48
+ Line 49
+ Line 50
+ Line 51
+ Line 52
+ Line 53
+ Line 54
+ Line 55
+ Line 56
+ Line 57
+ Line 58
+ Line 59
+ Line 60
+ Line 61
+ Line 62
+ Line 63
+ Line 64
+ Line 65
+ Line 66
+ Line 67
+ Line 68
+ Line 69
+ Line 70
+ Line 71
+ Line 72
+ Line 73
+ Line 74
+ Line 75
+ Line 76
+ Line 77
+ Line 78
+ Line 79
+ Line 80
+ Line 81
+ Line 82
+ Line 83
+ Line 84
+ Line 85
+ Line 86
+ Line 87
+ Line 88
+ Line 89
+ Line 90
+ Line 91
+ Line 92
+ Line 93
+ Line 94
+ Line 95
+ Line 96
+ Line 97
+ Line 98
+ Line 99
+ Line 100
 "
 `;
 
 exports[`<ShellToolMessage /> > Height Constraints > respects availableTerminalHeight when it is smaller than ACTIVE_SHELL_MAX_LINES 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                                             │
-│                                                                              │
-│ Line 93                                                                      │
-│ Line 94                                                                      │
-│ Line 95                                                                      │
-│ Line 96                                                                      │
-│ Line 97                                                                      │
-│ Line 98                                                                      │
-│ Line 99                                                                      │
-│ Line 100                                                                   █ │
+" ⊶  Shell Command A shell command
+
+ Line 93
+ Line 94
+ Line 95
+ Line 96
+ Line 97
+ Line 98
+ Line 99
+ Line 100                                                                   █
 "
 `;
 
 exports[`<ShellToolMessage /> > Height Constraints > stays constrained in alternate buffer mode when isExpandable is false even if constrainHeight is false 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  Shell Command A shell command                                             │
-│                                                                              │
-│ Line 89                                                                      │
-│ Line 90                                                                      │
-│ Line 91                                                                      │
-│ Line 92                                                                      │
-│ Line 93                                                                      │
-│ Line 94                                                                      │
-│ Line 95                                                                      │
-│ Line 96                                                                      │
-│ Line 97                                                                      │
-│ Line 98                                                                      │
-│ Line 99                                                                    ▄ │
-│ Line 100                                                                   █ │
+" ✓  Shell Command A shell command
+
+ Line 89
+ Line 90
+ Line 91
+ Line 92
+ Line 93
+ Line 94
+ Line 95
+ Line 96
+ Line 97
+ Line 98
+ Line 99                                                                    ▄
+ Line 100                                                                   █
 "
 `;
 
 exports[`<ShellToolMessage /> > Height Constraints > uses ACTIVE_SHELL_MAX_LINES when availableTerminalHeight is large 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                                             │
-│                                                                              │
-│ Line 89                                                                      │
-│ Line 90                                                                      │
-│ Line 91                                                                      │
-│ Line 92                                                                      │
-│ Line 93                                                                      │
-│ Line 94                                                                      │
-│ Line 95                                                                      │
-│ Line 96                                                                      │
-│ Line 97                                                                      │
-│ Line 98                                                                      │
-│ Line 99                                                                    ▄ │
-│ Line 100                                                                   █ │
+" ⊶  Shell Command A shell command
+
+ Line 89
+ Line 90
+ Line 91
+ Line 92
+ Line 93
+ Line 94
+ Line 95
+ Line 96
+ Line 97
+ Line 98
+ Line 99                                                                    ▄
+ Line 100                                                                   █
 "
 `;
 
 exports[`<ShellToolMessage /> > Height Constraints > uses full availableTerminalHeight when focused in alternate buffer mode 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                      (Shift+Tab to unfocus) │
-│                                                                              │
-│ Line 3                                                                       │
-│ Line 4                                                                       │
-│ Line 5                                                                     █ │
-│ Line 6                                                                     █ │
-│ Line 7                                                                     █ │
-│ Line 8                                                                     █ │
-│ Line 9                                                                     █ │
-│ Line 10                                                                    █ │
-│ Line 11                                                                    █ │
-│ Line 12                                                                    █ │
-│ Line 13                                                                    █ │
-│ Line 14                                                                    █ │
-│ Line 15                                                                    █ │
-│ Line 16                                                                    █ │
-│ Line 17                                                                    █ │
-│ Line 18                                                                    █ │
-│ Line 19                                                                    █ │
-│ Line 20                                                                    █ │
-│ Line 21                                                                    █ │
-│ Line 22                                                                    █ │
-│ Line 23                                                                    █ │
-│ Line 24                                                                    █ │
-│ Line 25                                                                    █ │
-│ Line 26                                                                    █ │
-│ Line 27                                                                    █ │
-│ Line 28                                                                    █ │
-│ Line 29                                                                    █ │
-│ Line 30                                                                    █ │
-│ Line 31                                                                    █ │
-│ Line 32                                                                    █ │
-│ Line 33                                                                    █ │
-│ Line 34                                                                    █ │
-│ Line 35                                                                    █ │
-│ Line 36                                                                    █ │
-│ Line 37                                                                    █ │
-│ Line 38                                                                    █ │
-│ Line 39                                                                    █ │
-│ Line 40                                                                    █ │
-│ Line 41                                                                    █ │
-│ Line 42                                                                    █ │
-│ Line 43                                                                    █ │
-│ Line 44                                                                    █ │
-│ Line 45                                                                    █ │
-│ Line 46                                                                    █ │
-│ Line 47                                                                    █ │
-│ Line 48                                                                    █ │
-│ Line 49                                                                    █ │
-│ Line 50                                                                    █ │
-│ Line 51                                                                    █ │
-│ Line 52                                                                    █ │
-│ Line 53                                                                    █ │
-│ Line 54                                                                    █ │
-│ Line 55                                                                    █ │
-│ Line 56                                                                    █ │
-│ Line 57                                                                    █ │
-│ Line 58                                                                    █ │
-│ Line 59                                                                    █ │
-│ Line 60                                                                    █ │
-│ Line 61                                                                    █ │
-│ Line 62                                                                    █ │
-│ Line 63                                                                    █ │
-│ Line 64                                                                    █ │
-│ Line 65                                                                    █ │
-│ Line 66                                                                    █ │
-│ Line 67                                                                    █ │
-│ Line 68                                                                    █ │
-│ Line 69                                                                    █ │
-│ Line 70                                                                    █ │
-│ Line 71                                                                    █ │
-│ Line 72                                                                    █ │
-│ Line 73                                                                    █ │
-│ Line 74                                                                    █ │
-│ Line 75                                                                    █ │
-│ Line 76                                                                    █ │
-│ Line 77                                                                    █ │
-│ Line 78                                                                    █ │
-│ Line 79                                                                    █ │
-│ Line 80                                                                    █ │
-│ Line 81                                                                    █ │
-│ Line 82                                                                    █ │
-│ Line 83                                                                    █ │
-│ Line 84                                                                    █ │
-│ Line 85                                                                    █ │
-│ Line 86                                                                    █ │
-│ Line 87                                                                    █ │
-│ Line 88                                                                    █ │
-│ Line 89                                                                    █ │
-│ Line 90                                                                    █ │
-│ Line 91                                                                    █ │
-│ Line 92                                                                    █ │
-│ Line 93                                                                    █ │
-│ Line 94                                                                    █ │
-│ Line 95                                                                    █ │
-│ Line 96                                                                    █ │
-│ Line 97                                                                    █ │
-│ Line 98                                                                    █ │
-│ Line 99                                                                    █ │
-│ Line 100                                                                   █ │
+" ⊶  Shell Command A shell command                        (Shift+Tab to unfocus)
+
+ Line 3
+ Line 4
+ Line 5                                                                     █
+ Line 6                                                                     █
+ Line 7                                                                     █
+ Line 8                                                                     █
+ Line 9                                                                     █
+ Line 10                                                                    █
+ Line 11                                                                    █
+ Line 12                                                                    █
+ Line 13                                                                    █
+ Line 14                                                                    █
+ Line 15                                                                    █
+ Line 16                                                                    █
+ Line 17                                                                    █
+ Line 18                                                                    █
+ Line 19                                                                    █
+ Line 20                                                                    █
+ Line 21                                                                    █
+ Line 22                                                                    █
+ Line 23                                                                    █
+ Line 24                                                                    █
+ Line 25                                                                    █
+ Line 26                                                                    █
+ Line 27                                                                    █
+ Line 28                                                                    █
+ Line 29                                                                    █
+ Line 30                                                                    █
+ Line 31                                                                    █
+ Line 32                                                                    █
+ Line 33                                                                    █
+ Line 34                                                                    █
+ Line 35                                                                    █
+ Line 36                                                                    █
+ Line 37                                                                    █
+ Line 38                                                                    █
+ Line 39                                                                    █
+ Line 40                                                                    █
+ Line 41                                                                    █
+ Line 42                                                                    █
+ Line 43                                                                    █
+ Line 44                                                                    █
+ Line 45                                                                    █
+ Line 46                                                                    █
+ Line 47                                                                    █
+ Line 48                                                                    █
+ Line 49                                                                    █
+ Line 50                                                                    █
+ Line 51                                                                    █
+ Line 52                                                                    █
+ Line 53                                                                    █
+ Line 54                                                                    █
+ Line 55                                                                    █
+ Line 56                                                                    █
+ Line 57                                                                    █
+ Line 58                                                                    █
+ Line 59                                                                    █
+ Line 60                                                                    █
+ Line 61                                                                    █
+ Line 62                                                                    █
+ Line 63                                                                    █
+ Line 64                                                                    █
+ Line 65                                                                    █
+ Line 66                                                                    █
+ Line 67                                                                    █
+ Line 68                                                                    █
+ Line 69                                                                    █
+ Line 70                                                                    █
+ Line 71                                                                    █
+ Line 72                                                                    █
+ Line 73                                                                    █
+ Line 74                                                                    █
+ Line 75                                                                    █
+ Line 76                                                                    █
+ Line 77                                                                    █
+ Line 78                                                                    █
+ Line 79                                                                    █
+ Line 80                                                                    █
+ Line 81                                                                    █
+ Line 82                                                                    █
+ Line 83                                                                    █
+ Line 84                                                                    █
+ Line 85                                                                    █
+ Line 86                                                                    █
+ Line 87                                                                    █
+ Line 88                                                                    █
+ Line 89                                                                    █
+ Line 90                                                                    █
+ Line 91                                                                    █
+ Line 92                                                                    █
+ Line 93                                                                    █
+ Line 94                                                                    █
+ Line 95                                                                    █
+ Line 96                                                                    █
+ Line 97                                                                    █
+ Line 98                                                                    █
+ Line 99                                                                    █
+ Line 100                                                                   █
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Alternate Buffer mode while focused 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                      (Shift+Tab to unfocus) │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  Shell Command A shell command                        (Shift+Tab to unfocus)
+
+ Test result
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Alternate Buffer mode while unfocused 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                                             │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  Shell Command A shell command
+
+ Test result
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Cancelled state with partial output 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ -  Shell Command A shell command                                             │
-│                                                                              │
-│ Partial output before cancellation                                           │
+" -  Shell Command A shell command
+
+ Partial output before cancellation
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Error state 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ x  Shell Command A shell command                                             │
-│                                                                              │
-│ Error output                                                                 │
+" x  Shell Command A shell command
+
+ Error output
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Executing state 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  Shell Command A shell command                                             │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  Shell Command A shell command
+
+ Test result
 "
 `;
 
 exports[`<ShellToolMessage /> > Snapshots > renders in Success state (history mode) 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  Shell Command A shell command                                             │
-│                                                                              │
-│ Test result                                                                  │
+" ✓  Shell Command A shell command
+
+ Test result
 "
 `;

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -1,167 +1,142 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<ToolGroupMessage /> > Ask User Filtering > filtering logic for status='error' and hasResult='error message' 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ x  Ask User                                                              │
-│                                                                          │
-│ error message                                                            │
-╰──────────────────────────────────────────────────────────────────────────╯
+" x  Ask User
+
+ error message
 "
 `;
 
 exports[`<ToolGroupMessage /> > Ask User Filtering > filtering logic for status='success' and hasResult='test result' 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  Ask User                                                              │
-│                                                                          │
-│ test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  Ask User
+
+ test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Ask User Filtering > shows other tools when ask_user is filtered out 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  other-tool A tool for testing                                         │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  other-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Border Color Logic > uses gray border when all tools are successful and no shell commands 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                          │
-│                                                                          │
-│ Test result                                                              │
-│                                                                          │
-│ ✓  another-tool A tool for testing                                       │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  test-tool A tool for testing
+
+ Test result
+
+ ✓  another-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Border Color Logic > uses yellow border for shell commands even when successful 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  run_shell_command A tool for testing                                  │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  run_shell_command A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders empty tool calls array 1`] = `""`;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders header when scrolled 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  tool-1 Description 1. This is a long description that will need to b… │
-│──────────────────────────────────────────────────────────────────────────│
-│ line5                                                                    │                       █
-│                                                                          │                       █
-│ ✓  tool-2 Description 2                                                  │                       █
-│                                                                          │                       █
-│ line1                                                                    │                       █
-│ line2                                                                    │                       █
-╰──────────────────────────────────────────────────────────────────────────╯                       █
+" ✓  tool-1 Description 1. This is a long description that will need to be …
+ line2                                                                                             ▄
+ line3                                                                                             █
+ line4                                                                                             █
+ line5                                                                                             █
+                                                                                                   █
+ ✓  tool-2 Description 2                                                                           █
+                                                                                                   █
+ line1                                                                                             █
+ line2                                                                                             █
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including shell command 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  read_file Read a file                                                 │
-│                                                                          │
-│ Test result                                                              │
-│                                                                          │
-│ ⊶  run_shell_command Run command                                         │
-│                                                                          │
-│ Test result                                                              │
-│                                                                          │
-│ o  write_file Write to file                                              │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  read_file Read a file
+
+ Test result
+
+ ⊶  run_shell_command Run command
+
+ Test result
+
+ o  write_file Write to file
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders multiple tool calls with different statuses (only visible ones) 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  successful-tool This tool succeeded                                   │
-│                                                                          │
-│ Test result                                                              │
-│                                                                          │
-│ o  pending-tool This tool is pending                                     │
-│                                                                          │
-│ Test result                                                              │
-│                                                                          │
-│ x  error-tool This tool failed                                           │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  successful-tool This tool succeeded
+
+ Test result
+
+ o  pending-tool This tool is pending
+
+ Test result
+
+ x  error-tool This tool failed
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders single successful tool call 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                          │
-│                                                                          │
-│ Test result                                                              │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders tool call with outputFile 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  tool-with-file Tool that saved output to file                         │
-│                                                                          │
-│ Test result                                                              │
-│ Output too long and was saved to: /path/to/output.txt                    │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  tool-with-file Tool that saved output to file
+
+ Test result
+ Output too long and was saved to: /path/to/output.txt
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where only the last line of the previous group is visible 1`] = `
-"╰──────────────────────────────────────────────────────────────────────────╯
-╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  tool-2 Description 2                                                  │
-│                                                                          │                       ▄
-│ line1                                                                    │                       █
-╰──────────────────────────────────────────────────────────────────────────╯                       █
+" ✓  tool-1 Description 1
+ line4
+ line5                                                                                             ▄
+ ✓  tool-2 Description 2                                                                           █
+                                                                                                   █
+ line1                                                                                             █
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders with limited terminal height 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  tool-with-result Tool with output                                     │
-│                                                                          │
-│ This is a long result that might need height constraints                 │
-│                                                                          │
-│ ✓  another-tool Another tool                                             │
-│                                                                          │
-│ More output here                                                         │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  tool-with-result Tool with output
+
+ This is a long result that might need height constraints
+
+ ✓  another-tool Another tool
+
+ More output here
 "
 `;
 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders with narrow terminal width 1`] = `
-"╭──────────────────────────────────╮
-│ ✓  very-long-tool-name-that-mig… │
-│                                  │
-│ Test result                      │
-╰──────────────────────────────────╯
+" ✓  very-long-tool-name-that-might…
+
+ Test result
 "
 `;
 
 exports[`<ToolGroupMessage /> > Height Calculation > calculates available height correctly with multiple tools with results 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                          │
-│                                                                          │
-│ Result 1                                                                 │
-│                                                                          │
-│ ✓  test-tool A tool for testing                                          │
-│                                                                          │
-│ Result 2                                                                 │
-│                                                                          │
-│ ✓  test-tool A tool for testing                                          │
-│                                                                          │
-╰──────────────────────────────────────────────────────────────────────────╯
+" ✓  test-tool A tool for testing
+
+ Result 1
+
+ ✓  test-tool A tool for testing
+
+ Result 2
+
+ ✓  test-tool A tool for testing
 "
 `;

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolMessage.test.tsx.snap
@@ -1,145 +1,128 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<ToolMessage /> > JSON rendering > renders pretty JSON in ink frame 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ {                                                                            │
-│   "a": 1,                                                                    │
-│   "b": 2                                                                     │
-│ }                                                                            │
+" ✓  test-tool A tool for testing
+
+ {
+   "a": 1,
+   "b": 2
+ }
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows ? for Confirming status 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ?  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ?  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows - for Canceled status 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ -  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" -  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows MockRespondingSpinner for Executing status when streamingState is Responding 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows o for Pending status 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ o  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" o  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows paused spinner for Executing status when streamingState is Idle 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows paused spinner for Executing status when streamingState is WaitingForConfirmation 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows x for Error status 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ x  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" x  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > ToolStatusIndicator rendering > shows ✓ for Success status 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ✓  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders AnsiOutputText for AnsiOutput results 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ hello                                                                        │
+" ✓  test-tool A tool for testing
+
+ hello
 "
 `;
 
 exports[`<ToolMessage /> > renders DiffRenderer for diff results 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ 1 - old                                                                      │
-│ 1 + new                                                                      │
+" ✓  test-tool A tool for testing
+
+ 1 - old
+ 1 + new
 "
 `;
 
 exports[`<ToolMessage /> > renders McpProgressIndicator with percentage and message for executing tools 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ ████████░░░░░░░░░░░░ 42%                                                     │
-│ Working on it...                                                             │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ ████████░░░░░░░░░░░░ 42%
+ Working on it...
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders basic tool information 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ✓  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders emphasis correctly 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                            ← │
-│                                                                              │
-│ Test result                                                                  │
+" ✓  test-tool A tool for testing                                              ←
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders emphasis correctly 2`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ✓  test-tool A tool for testing                                              │
-│                                                                              │
-│ Test result                                                                  │
+" ✓  test-tool A tool for testing
+
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders indeterminate progress when total is missing 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ ███████░░░░░░░░░░░░░ 7                                                       │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ ███████░░░░░░░░░░░░░ 7
+ Test result
 "
 `;
 
 exports[`<ToolMessage /> > renders only percentage when progressMessage is missing 1`] = `
-"╭──────────────────────────────────────────────────────────────────────────────╮
-│ ⊶  test-tool A tool for testing                                              │
-│                                                                              │
-│ ███████████████░░░░░ 75%                                                     │
-│ Test result                                                                  │
+" ⊶  test-tool A tool for testing
+
+ ███████████████░░░░░ 75%
+ Test result
 "
 `;


### PR DESCRIPTION
## Summary
- hide decorative frames in alternate-buffer mode across the sticky header and tool message surfaces so fullscreen terminal UIs stay visually clean
- align the tool confirmation queue with the same alternate-buffer behavior
- refresh the affected UI tests and snapshots on this branch

## Why
- issue #18701 asks the CLI to stop rendering extra frames in alternate-buffer mode
- this branch is intended as a cleaner superseding follow-up to #20066

## Validation
- `./node_modules/.bin/eslint packages/cli/src/ui/components/StickyHeader.tsx packages/cli/src/ui/components/ToolConfirmationQueue.tsx packages/cli/src/ui/components/messages/ShellToolMessage.tsx packages/cli/src/ui/components/messages/ToolGroupMessage.tsx packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx packages/cli/src/ui/components/messages/ToolMessage.tsx`
- `npm run build --workspace @google/gemini-cli-core`
- `./node_modules/.bin/vitest run packages/cli/src/ui/App.test.tsx packages/cli/src/ui/components/ToolConfirmationQueue.test.tsx packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx packages/cli/src/ui/components/messages/ShellToolMessage.test.tsx packages/cli/src/ui/components/messages/ToolMessage.test.tsx` (draft note: snapshot drift on this older branch and `ToolMessage.test.tsx` currently errors with `beforeEach is not defined`)
