### PR TITLE
fix(cli): handle optional ping in mcp list

### DIFF
--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -19,7 +19,11 @@ import {
   mergeSettings,
   type LoadedSettings,
 } from '../../config/settings.js';
-import { createTransport, debugLogger } from '@google/gemini-cli-core';
+import {
+  createTransport,
+  debugLogger,
+  MCP_DEFAULT_TIMEOUT_MSEC,
+} from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { ExtensionStorage } from '../../config/extensions/storage.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
@@ -45,6 +49,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   return {
     ...original,
     createTransport: vi.fn(),
+    MCP_DEFAULT_TIMEOUT_MSEC: 10 * 60 * 1000,
 
     MCPServerStatus: {
       CONNECTED: 'CONNECTED',
@@ -215,6 +220,28 @@ describe('mcp list command', () => {
         'test-server: /test/server  (stdio) - Disconnected',
       ),
     );
+  });
+
+  it('should use the shared default MCP timeout when testing connections', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'http-server': { httpUrl: 'https://example.com/http' },
+        },
+      },
+      isTrusted: true,
+    });
+
+    mockClient.connect.mockResolvedValue(undefined);
+    mockClient.ping.mockResolvedValue(undefined);
+
+    await listMcpServers();
+
+    expect(mockClient.connect).toHaveBeenCalledWith(mockTransport, {
+      timeout: MCP_DEFAULT_TIMEOUT_MSEC,
+    });
   });
 
   it('should merge extension servers with config servers', async () => {

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -25,6 +25,7 @@ import {
   MCP_DEFAULT_TIMEOUT_MSEC,
 } from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { ExtensionStorage } from '../../config/extensions/storage.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { McpServerEnablementManager } from '../../config/mcp/index.js';
@@ -242,6 +243,32 @@ describe('mcp list command', () => {
     expect(mockClient.connect).toHaveBeenCalledWith(mockTransport, {
       timeout: MCP_DEFAULT_TIMEOUT_MSEC,
     });
+  });
+
+  it('should treat ping MethodNotFound as connected', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'cloud-run': { httpUrl: 'https://run.googleapis.com/mcp' },
+        },
+      },
+      isTrusted: true,
+    });
+
+    mockClient.connect.mockResolvedValue(undefined);
+    mockClient.ping.mockRejectedValue(
+      new McpError(ErrorCode.MethodNotFound, 'Method not supported'),
+    );
+
+    await listMcpServers();
+
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'cloud-run: https://run.googleapis.com/mcp (http) - Connected',
+      ),
+    );
   });
 
   it('should merge extension servers with config servers', async () => {

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -17,6 +17,7 @@ import {
   debugLogger,
   applyAdminAllowlist,
   getAdminBlockedMcpServersMessage,
+  MCP_DEFAULT_TIMEOUT_MSEC,
 } from '@google/gemini-cli-core';
 import type { MCPServerConfig } from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -128,7 +129,9 @@ async function testMCPConnection(
 
   try {
     // Attempt actual MCP connection with short timeout
-    await client.connect(transport, { timeout: 5000 }); // 5s timeout
+    await client.connect(transport, {
+      timeout: config.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
+    });
 
     // Test basic MCP protocol by pinging the server
     await client.ping();

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -21,6 +21,7 @@ import {
 } from '@google/gemini-cli-core';
 import type { MCPServerConfig } from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import {
   canLoadServer,
@@ -133,8 +134,18 @@ async function testMCPConnection(
       timeout: config.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
     });
 
-    // Test basic MCP protocol by pinging the server
-    await client.ping();
+    // A successful initialize handshake is sufficient to consider the
+    // server reachable. Ping is best-effort because some MCP servers do not
+    // implement it and return MethodNotFound.
+    try {
+      await client.ping();
+    } catch (error) {
+      if (
+        !(error instanceof McpError && error.code === ErrorCode.MethodNotFound)
+      ) {
+        throw error;
+      }
+    }
 
     await client.close();
     return MCPServerStatus.CONNECTED;


### PR DESCRIPTION
Fixes #25599

## Summary
- align `gemini mcp list` connection checks with the shared MCP default timeout instead of a hardcoded 5s timeout
- treat `ping()` as best-effort in `mcp list` so servers that return `MethodNotFound` after a successful MCP initialize handshake are still reported as connected
- add focused regression tests for both the timeout behavior and the unsupported `ping()` case

## Verification
- reproduced the issue against `https://run.googleapis.com/mcp`, where `gemini mcp list` reported `Disconnected` before the fix
- verified the patched local CLI reports `cloud-run: https://run.googleapis.com/mcp (http) - Connected`

Reproduced:
<img width="724" height="120" alt="Image" src="https://github.com/user-attachments/assets/4e4b746c-642f-4c5e-8605-fd1469d11581" />

Resolved:
<img width="573" height="77" alt="Image" src="https://github.com/user-attachments/assets/7bf63afa-b655-4cc3-8139-dbfbeea75744" />