### PR TITLE
fix(core): record response's modelVersion in session transcript

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -884,8 +884,12 @@ export class GeminiChat {
     let hasToolCall = false;
     let hasThoughts = false;
     let finishReason: FinishReason | undefined;
+    let observedModel: string | undefined;
 
     for await (const chunk of streamResponse) {
+      if (!observedModel && chunk?.modelVersion) {
+        observedModel = chunk.modelVersion;
+      }
       const candidateWithReason = chunk?.candidates?.find(
         (candidate) => candidate.finishReason,
       );
@@ -972,7 +976,7 @@ export class GeminiChat {
     // so that BeforeTool hooks always see the latest transcript state.
     if (responseText || hasThoughts || hasToolCall) {
       this.chatRecordingService.recordMessage({
-        model,
+        model: observedModel || model,
         type: 'gemini',
         content: responseText,
       });


### PR DESCRIPTION
Fixes https://github.com/google-gemini/gemini-cli/issues/25632.

`GeminiChat.processStreamResponse` wrote the pre-request resolved model to the session record, ignoring `chunk.modelVersion` from the server. On aliasing / A/B routing the two diverge, and `uiTelemetry.hydrate()` keys per-model stats on `message.model`.

Aligned with `LoggingContentGenerator` which already uses `responses[0]?.modelVersion || req.model` for telemetry.