### PR TITLE
feat(config): support string coercion for boolean settings

### DIFF
--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -180,6 +180,34 @@ describe('settings-validation', () => {
       expect(result.success).toBe(false);
     });
 
+    it('should coerce "true" and "false" strings to boolean', () => {
+      const stringBoolSettings = {
+        general: {
+          vimMode: 'true',
+          enableAutoUpdate: 'false',
+        },
+      };
+
+      const result = validateSettings(stringBoolSettings);
+      expect(result.success).toBe(true);
+      if (result.success && result.data) {
+        const data = result.data as any;
+        expect(data.general.vimMode).toBe(true);
+        expect(data.general.enableAutoUpdate).toBe(false);
+      }
+    });
+
+    it('should still reject other string values for boolean fields', () => {
+      const invalidSettings = {
+        general: {
+          vimMode: '1',
+        },
+      };
+
+      const result = validateSettings(invalidSettings);
+      expect(result.success).toBe(false);
+    });
+
     it('should validate number fields correctly', () => {
       const validSettings = {
         model: {

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -28,7 +28,13 @@ function buildZodSchemaFromJsonSchema(def: any): z.ZodTypeAny {
     return z.string();
   }
   if (def.type === 'number') return z.number();
-  if (def.type === 'boolean') return z.boolean();
+  if (def.type === 'boolean') {
+    return z.preprocess((val) => {
+      if (val === 'true') return true;
+      if (val === 'false') return false;
+      return val;
+    }, z.boolean());
+  }
 
   if (def.type === 'array') {
     if (def.items) {
@@ -135,7 +141,11 @@ function buildPrimitiveSchema(
     case 'number':
       return z.number();
     case 'boolean':
-      return z.boolean();
+      return z.preprocess((val) => {
+        if (val === 'true') return true;
+        if (val === 'false') return false;
+        return val;
+      }, z.boolean());
     default:
       return z.unknown();
   }


### PR DESCRIPTION
## Summary

This solve #25573 . It allow boolean input as strings, so that environment variable interpolation works.

## Details

I asked Gemini-CLI to modify itself. The code looks okay to me.

## Related Issues

Fixes #25573

## How to Validate

You could run the tests, or try the `settings.json` field in #25573

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
