### PR TITLE
fix(config): coerce env var strings to booleans and numbers in settings validation

### DIFF
--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -300,6 +300,66 @@ describe('settings-validation', () => {
     });
   });
 
+  describe('env variable string coercion', () => {
+    it('should coerce string "true" to boolean true', () => {
+      const settings = {
+        ui: { autoThemeSwitching: 'true' as unknown as boolean },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.data as any).ui.autoThemeSwitching).toBe(true);
+    });
+
+    it('should coerce string "false" to boolean false', () => {
+      const settings = {
+        ui: { autoThemeSwitching: 'false' as unknown as boolean },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.data as any).ui.autoThemeSwitching).toBe(false);
+    });
+
+    it('should handle case-insensitive "TRUE"/"FALSE"', () => {
+      const settings = {
+        ui: { autoThemeSwitching: 'TRUE' as unknown as boolean },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.data as any).ui.autoThemeSwitching).toBe(true);
+    });
+
+    it('should trim whitespace around boolean strings', () => {
+      const settings = {
+        ui: { autoThemeSwitching: '  true  ' as unknown as boolean },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.data as any).ui.autoThemeSwitching).toBe(true);
+    });
+
+    it('should still reject non-boolean strings like "yes"', () => {
+      const settings = {
+        ui: { autoThemeSwitching: 'yes' as unknown as boolean },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(false);
+    });
+
+    it('should coerce numeric strings to numbers', () => {
+      const settings = {
+        model: { maxSessionTurns: '50' as unknown as number },
+      };
+      const result = validateSettings(settings);
+      expect(result.success).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((result.data as any).model.maxSessionTurns).toBe(50);
+    });
+  });
+
   describe('formatValidationError', () => {
     it('should format error with file path and helpful message for model.name', () => {
       const invalidSettings = {

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -27,8 +27,10 @@ function buildZodSchemaFromJsonSchema(def: any): z.ZodTypeAny {
     if (def.enum) return z.enum(def.enum as [string, ...string[]]);
     return z.string();
   }
-  if (def.type === 'number') return z.number();
-  if (def.type === 'boolean') return z.boolean();
+  if (def.type === 'number')
+    return z.preprocess(coerceNumberString, z.number());
+  if (def.type === 'boolean')
+    return z.preprocess(coerceBooleanString, z.boolean());
 
   if (def.type === 'array') {
     if (def.items) {
@@ -123,6 +125,27 @@ function buildObjectShapeFromProperties(
   return shape;
 }
 
+// Env vars like "${GEMINI_AUTO_THEME:-true}" resolve to the string "true"
+// but Zod expects an actual boolean. Same deal with numbers.
+function coerceBooleanString(val: unknown): unknown {
+  if (typeof val === 'string') {
+    const trimmed = val.trim().toLowerCase();
+    if (trimmed === 'true') return true;
+    if (trimmed === 'false') return false;
+  }
+  return val;
+}
+
+function coerceNumberString(val: unknown): unknown {
+  if (typeof val === 'string') {
+    const trimmed = val.trim();
+    if (trimmed !== '' && !isNaN(Number(trimmed))) {
+      return Number(trimmed);
+    }
+  }
+  return val;
+}
+
 /**
  * Builds a Zod schema for primitive types (string, number, boolean)
  */
@@ -133,9 +156,9 @@ function buildPrimitiveSchema(
     case 'string':
       return z.string();
     case 'number':
-      return z.number();
+      return z.preprocess(coerceNumberString, z.number());
     case 'boolean':
-      return z.boolean();
+      return z.preprocess(coerceBooleanString, z.boolean());
     default:
       return z.unknown();
   }


### PR DESCRIPTION
Hey team! Ran into this while debugging a config issue.

## What's going on

When you use env vars in `settings.json` like this:

```json
{
  "ui": {
    "autoThemeSwitching": "${GEMINI_AUTO_THEME:-true}"
  }
}
```

The resolved value is the string `"true"` — not boolean `true`. Zod blows up with a validation error because it expects an actual boolean. Same thing happens with number fields getting string values from env vars.

## How I fixed it

Added `z.preprocess` coercion in both schema-building paths (`buildPrimitiveSchema` and `buildZodSchemaFromJsonSchema`). Pretty straightforward:

- `"true"` / `"false"` → `true` / `false` (case-insensitive, whitespace-trimmed)
- Numeric strings like `"50"` → `50`
- Everything else (like `"yes"` or `"maybe"`) still fails validation as it should

This avoids the schema-traversal complexity that tripped up earlier PRs — just hooks into Zod's own preprocessing pipeline.

## Why not the existing PRs?

- #25608 doesn't handle `$ref` schema references and has type compatibility issues
- #25634 misses case-insensitive matching and whitespace trimming

## Tests

Added 6 tests covering all the edge cases — coercion, case insensitivity, whitespace, rejection of non-boolean strings, and numeric coercion. All existing tests still pass.

```
Test Files  1 passed (1)
     Tests  31 passed (31)
```

Fixes #25573

cc @scidomino @NTaylorMullen would appreciate a look when you get a chance 🙏