### PR TITLE
fix(cli): copy extension examples to dist during build

### DIFF
--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -43,6 +43,16 @@ if (packageName === 'core' && existsSync(bundleScript)) {
 // copy .{md,json} files
 execSync('node ../../scripts/copy_files.js', { stdio: 'inherit' });
 
+// Copy extension examples for the cli package
+if (packageName === 'cli') {
+  const examplesSource = join(process.cwd(), 'src', 'commands', 'extensions', 'examples');
+  const examplesTarget = join(process.cwd(), 'dist', 'src', 'commands', 'extensions', 'examples');
+  if (existsSync(examplesSource)) {
+    cpSync(examplesSource, examplesTarget, { recursive: true });
+    console.log('Copied extension examples to dist/src/commands/extensions/examples/');
+  }
+}
+
 // Copy documentation for the core package
 if (packageName === 'core') {
   const docsSource = join(process.cwd(), '..', '..', 'docs');

--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -46,10 +46,10 @@ execSync('node ../../scripts/copy_files.js', { stdio: 'inherit' });
 // Copy extension examples for the cli package
 if (packageName === 'cli') {
   const examplesSource = join(process.cwd(), 'src', 'commands', 'extensions', 'examples');
-  const examplesTarget = join(process.cwd(), 'dist', 'src', 'commands', 'extensions', 'examples');
+  const examplesTarget = join(process.cwd(), 'dist', 'commands', 'extensions', 'examples');
   if (existsSync(examplesSource)) {
-    cpSync(examplesSource, examplesTarget, { recursive: true });
-    console.log('Copied extension examples to dist/src/commands/extensions/examples/');
+    cpSync(examplesSource, examplesTarget, { recursive: true, dereference: true });
+    console.log('Copied extension examples to dist/commands/extensions/examples/');
   }
 }
 


### PR DESCRIPTION
The 'gemini extensions new' command was failing because the extension example templates were not included in the published package. This adds a step to copy the examples directory to dist/src/commands/extensions/examples during the CLI package build process.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
