### PR TITLE
feat(cli): add hostname to footer status bar

### DIFF
--- a/packages/cli/src/config/footerItems.ts
+++ b/packages/cli/src/config/footerItems.ts
@@ -23,6 +23,11 @@ export const ALL_ITEMS = [
     description: 'Sandbox type and trust indicator',
   },
   {
+    id: 'hostname',
+    header: 'host',
+    description: 'System hostname',
+  },
+  {
     id: 'model-name',
     header: '/model',
     description: 'Current model identifier',
@@ -70,6 +75,7 @@ export const DEFAULT_ORDER = [
   'workspace',
   'git-branch',
   'sandbox',
+  'hostname',
   'model-name',
   'context-used',
   'quota',
@@ -87,6 +93,7 @@ export function deriveItemsFromLegacySettings(
     'workspace',
     'git-branch',
     'sandbox',
+    'hostname',
     'model-name',
     'quota',
   ];

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -36,6 +36,8 @@ import {
 } from '../../config/footerItems.js';
 import { isDevelopment } from '../../utils/installationInfo.js';
 
+const SYSTEM_HOSTNAME = hostname();
+
 interface CwdIndicatorProps {
   targetDir: string;
   maxWidth: number;
@@ -321,14 +323,12 @@ export const Footer: React.FC = () => {
         break;
       }
       case 'hostname': {
-        const hostnameStr = hostname();
-
-        if (hostnameStr) {
+        if (SYSTEM_HOSTNAME) {
           addCol(
             id,
             header,
-            () => <Text color={itemColor}>{hostnameStr}</Text>,
-            hostnameStr.length,
+            () => <Text color={itemColor}>{SYSTEM_HOSTNAME}</Text>,
+            SYSTEM_HOSTNAME.length,
           );
         }
         break;

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -18,6 +18,7 @@ import {
 } from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 import process from 'node:process';
+import { hostname } from 'node:os';
 import { MemoryUsageDisplay } from './MemoryUsageDisplay.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { QuotaDisplay } from './QuotaDisplay.js';
@@ -317,6 +318,19 @@ export const Footer: React.FC = () => {
           () => <SandboxIndicator isTrustedFolder={isTrustedFolder} />,
           str.length,
         );
+        break;
+      }
+      case 'hostname': {
+        const hostnameStr = hostname();
+
+        if (hostnameStr) {
+          addCol(
+            id,
+            header,
+            () => <Text color={itemColor}>{hostnameStr}</Text>,
+            hostnameStr.length,
+          );
+        }
         break;
       }
       case 'model-name': {


### PR DESCRIPTION
## Summary

Adds the current system hostname to the persistent bottom status border.

This helps users quickly distinguish between multiple Gemini CLI sessions running across SSH hosts, virtual machines, containers, or remote systems.

## Details

This change adds a new footer item: `hostname`.

- Added `hostname` to available footer items
- Added hostname to the default footer order
- Added hostname to legacy-derived defaults for backward compatibility
- Displays hostname using Node's built-in `os.hostname()`

The hostname uses the existing footer column layout, so current overflow and spacing behavior remain unchanged.

## Related Issues

Closes #25661

## How to Validate

1. Run Gemini CLI locally.
2. Check the persistent bottom status border.
3. Confirm a new `host` field is shown.
4. Verify the displayed hostname matches the current machine.
5. Resize terminal width and confirm footer layout still behaves correctly.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker