### PR TITLE
feat(core): allow user feedback when cancelling a tool call

### DIFF
--- a/packages/core/src/scheduler/confirmation.ts
+++ b/packages/core/src/scheduler/confirmation.ts
@@ -46,6 +46,11 @@ export interface ConfirmationResult {
 export interface ResolutionResult {
   outcome: ToolConfirmationOutcome;
   lastDetails?: SerializableConfirmationDetails;
+  /**
+   * Final payload from the user's confirmation response. May carry feedback
+   * (when outcome is Cancel) or other outcome-specific data.
+   */
+  payload?: ToolConfirmationPayload;
 }
 
 /**
@@ -125,6 +130,7 @@ export async function resolveConfirmation(
   const callId = toolCall.request.callId;
   let outcome = ToolConfirmationOutcome.ModifyWithEditor;
   let lastDetails: SerializableConfirmationDetails | undefined;
+  let lastPayload: ToolConfirmationPayload | undefined;
 
   // Loop exists to allow the user to modify the parameters and see the new
   // diff.
@@ -173,6 +179,7 @@ export async function resolveConfirmation(
     );
     onWaitingForConfirmation?.(false);
     outcome = response.outcome;
+    lastPayload = response.payload;
 
     if ('onConfirm' in details && typeof details.onConfirm === 'function') {
       await details.onConfirm(outcome, response.payload);
@@ -195,7 +202,7 @@ export async function resolveConfirmation(
     }
   }
 
-  return { outcome, lastDetails };
+  return { outcome, lastDetails, payload: lastPayload };
 }
 
 /**

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -978,6 +978,51 @@ describe('Scheduler (Orchestrator)', () => {
       );
     });
 
+    it('should include feedback in cancel reason when payload carries feedback', async () => {
+      vi.mocked(checkPolicy).mockResolvedValue({
+        decision: PolicyDecision.ASK_USER,
+        rule: undefined,
+      });
+
+      const resolution = {
+        outcome: ToolConfirmationOutcome.Cancel,
+        lastDetails: undefined,
+        payload: { feedback: "don't overwrite, append instead" },
+      };
+      vi.mocked(resolveConfirmation).mockResolvedValue(resolution);
+
+      await scheduler.schedule(req1, signal);
+
+      expect(mockStateManager.updateStatus).toHaveBeenCalledWith(
+        'call-1',
+        CoreToolCallStatus.Cancelled,
+        "User denied execution. Feedback: don't overwrite, append instead",
+      );
+      expect(mockExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to plain reason when feedback is empty string', async () => {
+      vi.mocked(checkPolicy).mockResolvedValue({
+        decision: PolicyDecision.ASK_USER,
+        rule: undefined,
+      });
+
+      const resolution = {
+        outcome: ToolConfirmationOutcome.Cancel,
+        lastDetails: undefined,
+        payload: { feedback: '' },
+      };
+      vi.mocked(resolveConfirmation).mockResolvedValue(resolution);
+
+      await scheduler.schedule(req1, signal);
+
+      expect(mockStateManager.updateStatus).toHaveBeenCalledWith(
+        'call-1',
+        CoreToolCallStatus.Cancelled,
+        'User denied execution.',
+      );
+    });
+
     it('should preserve confirmation details (e.g. diff) in cancelled state', async () => {
       vi.mocked(checkPolicy).mockResolvedValue({
         decision: PolicyDecision.ASK_USER,

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -646,6 +646,7 @@ export class Scheduler {
     // User Confirmation Loop
     let outcome = ToolConfirmationOutcome.ProceedOnce;
     let lastDetails: SerializableConfirmationDetails | undefined;
+    let cancelFeedback: string | undefined;
 
     if (decision === PolicyDecision.ASK_USER) {
       const result = await resolveConfirmation(toolCall, signal, {
@@ -661,6 +662,15 @@ export class Scheduler {
       });
       outcome = result.outcome;
       lastDetails = result.lastDetails;
+      if (
+        outcome === ToolConfirmationOutcome.Cancel &&
+        result.payload &&
+        'feedback' in result.payload &&
+        typeof result.payload.feedback === 'string' &&
+        result.payload.feedback.length > 0
+      ) {
+        cancelFeedback = result.payload.feedback;
+      }
     }
 
     this.state.setOutcome(callId, outcome);
@@ -679,11 +689,10 @@ export class Scheduler {
 
     // Handle cancellation (cascades to entire batch)
     if (outcome === ToolConfirmationOutcome.Cancel) {
-      this.state.updateStatus(
-        callId,
-        CoreToolCallStatus.Cancelled,
-        'User denied execution.',
-      );
+      const reason = cancelFeedback
+        ? `User denied execution. Feedback: ${cancelFeedback}`
+        : 'User denied execution.';
+      this.state.updateStatus(callId, CoreToolCallStatus.Cancelled, reason);
       this.state.cancelAllQueued('User cancelled operation');
       return; // Skip execution
     }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -1005,10 +1005,21 @@ export interface ToolExitPlanModeConfirmationPayload {
   feedback?: string;
 }
 
+export interface ToolCancelWithFeedbackPayload {
+  /**
+   * User-authored reason for cancelling the tool call. When present on a
+   * response whose outcome is Cancel, the scheduler appends this string to
+   * the cancellation message delivered back to the model, so the model can
+   * see why the call was denied without waiting for the next user turn.
+   */
+  feedback: string;
+}
+
 export type ToolConfirmationPayload =
   | ToolEditConfirmationPayload
   | ToolAskUserConfirmationPayload
-  | ToolExitPlanModeConfirmationPayload;
+  | ToolExitPlanModeConfirmationPayload
+  | ToolCancelWithFeedbackPayload;
 
 export interface ToolSandboxExpansionConfirmationDetails {
   type: 'sandbox_expansion';


### PR DESCRIPTION
## Summary

Extends `ToolConfirmationPayload` with a `ToolCancelWithFeedbackPayload` variant (`{ feedback: string }`). When a `TOOL_CONFIRMATION_RESPONSE` carries this payload with `outcome=Cancel`, the scheduler interpolates the user's reason into the cancellation message delivered back to the model.

**Before:**

```
functionResponse.response.error
  = "[Operation Cancelled] Reason: User denied execution."
```

**After (with feedback):**

```
functionResponse.response.error
  = "[Operation Cancelled] Reason: User denied execution. Feedback: <text>"
```

Behavior without a feedback payload is unchanged. The existing `[Operation Cancelled] Reason:` prefix is preserved for backward compatibility.

## Motivation

When the SDK asks the user to confirm a destructive tool call, the user can Allow or Cancel. On Cancel, the model receives only a generic `"User denied execution."` — not enough signal to correct the call. In practice the user often knows exactly what's wrong ("do a smoke run first, not the real run", "write to `notes.md` instead of overwriting `README.md`") and wants the model to retry with that fix applied.

**What's possible today:** the user cancels, then types the reason as a chat message. The problem is ordering — the model sees the cancellation result *before* the user's follow-up message arrives, so it can freely decide to retry (often with a slightly different command that the user would still deny) without ever seeing the feedback. The user's reason ends up scolding the model after it's already wasted a step.

This change lets hosts optionally thread a short user-authored reason through the same `payload` channel already used by `ToolExitPlanModeConfirmationPayload.feedback`, so the feedback is embedded *in the cancelled call's `functionResponse`* — the model cannot retry without first reading it. The result: a revised tool call in the next step of the same turn, no follow-up user message, no blind retry.

The addition is backward-compatible (absent payload → existing behavior unchanged) and opt-in per host.

## Changes

- `tools/tools.ts`: add `ToolCancelWithFeedbackPayload` to the `ToolConfirmationPayload` union
- `scheduler/confirmation.ts`: propagate the final `payload` through `ResolutionResult` so the scheduler can inspect it
- `scheduler/scheduler.ts`: on `Cancel`, use `payload.feedback` to build the cancel reason
- `scheduler/scheduler.test.ts`: cover feedback-present and empty-string-fallback cases

## Test plan

- [x] `npm test -- src/scheduler` — all 146 scheduler tests pass (144 existing + 2 new)
- [x] `npm run typecheck` — clean
- [ ] Reviewer: confirm no prompt/eval pipeline pattern-matches specifically on the pre-existing cancellation string without the feedback suffix
