### PR TITLE
fix(core): implement runtime Flash-to-Flash-Lite failover for improved quota resilience

### DIFF
--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -94,13 +94,18 @@ describe('policyHelpers', () => {
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
     });
 
-    it('starts chain from preferredModel when model is "auto"', () => {
+    it('wraps chain when preferredModel is concrete and configured is auto', () => {
+      // When Auto mode routes to a concrete model (e.g. router picks Flash),
+      // the chain must wrap so the failed model has a fallback candidate.
+      // Without wrap, chain collapses to [Flash] and quota exhaustion has no
+      // fallback target.
       const config = createMockConfig({
         getModel: () => DEFAULT_GEMINI_MODEL_AUTO,
       });
       const chain = resolvePolicyChain(config, 'gemini-2.5-flash');
-      expect(chain).toHaveLength(1);
+      expect(chain).toHaveLength(2);
       expect(chain[0]?.model).toBe('gemini-2.5-flash');
+      expect(chain[1]?.model).toBe('gemini-2.5-pro');
     });
 
     it('returns flash-lite chain when preferred model is flash-lite', () => {
@@ -180,6 +185,76 @@ describe('policyHelpers', () => {
       expect(chain[0]?.actions).toEqual(SILENT_ACTIONS);
       expect(chain[1]?.actions).toEqual(SILENT_ACTIONS);
     });
+
+    describe('auto-mode quota failover (Flash → Flash Lite swap)', () => {
+      const FLASH = 'gemini-2.5-flash';
+      const FLASH_LITE = DEFAULT_GEMINI_FLASH_LITE_MODEL;
+      const PRO = 'gemini-2.5-pro';
+
+      const createConfigWithAvailability = (
+        getModelImpl: () => string,
+        availabilityMap: Record<string, { available: boolean }>,
+      ): Config =>
+        createMockConfig({
+          getModel: getModelImpl,
+          getModelAvailabilityService: () =>
+            ({
+              snapshot: (m: string) => availabilityMap[m],
+            }) as unknown as ReturnType<Config['getModelAvailabilityService']>,
+        });
+
+      it('swaps Flash for Flash Lite (with silent actions) when configured is auto and Flash is unavailable', () => {
+        const config = createConfigWithAvailability(
+          () => DEFAULT_GEMINI_MODEL_AUTO,
+          { [FLASH]: { available: false } },
+        );
+        const chain = resolvePolicyChain(config, FLASH);
+
+        // Chain length must be preserved for legacy/dynamic CI parity.
+        expect(chain).toHaveLength(2);
+        // After swap, the head of the chain is Flash Lite (silent), and the
+        // wrap-around tail is Pro (reachable as a further fallback).
+        expect(chain[0]?.model).toBe(FLASH_LITE);
+        expect(chain[0]?.actions).toEqual(SILENT_ACTIONS);
+        expect(chain[1]?.model).toBe(PRO);
+      });
+
+      it('does not swap Flash when it is still available', () => {
+        const config = createConfigWithAvailability(
+          () => DEFAULT_GEMINI_MODEL_AUTO,
+          { [FLASH]: { available: true } },
+        );
+        const chain = resolvePolicyChain(config, FLASH);
+
+        expect(chain).toHaveLength(2);
+        expect(chain[0]?.model).toBe(FLASH);
+        expect(chain[1]?.model).toBe(PRO);
+      });
+
+      it('does not swap Flash when not in auto mode (explicit Flash selection)', () => {
+        const config = createConfigWithAvailability(() => FLASH, {
+          [FLASH]: { available: false },
+        });
+        const chain = resolvePolicyChain(config, FLASH);
+
+        // Without auto mode, chain stays as the user explicitly requested.
+        expect(chain[0]?.model).toBe(FLASH);
+      });
+
+      it('does not duplicate Flash Lite if it is already in the chain', () => {
+        // When the configured model is already flash-lite, the chain is
+        // [Lite, Flash, Pro]. Flash being unavailable should not cause a
+        // second Lite to be inserted.
+        const config = createConfigWithAvailability(
+          () => DEFAULT_GEMINI_FLASH_LITE_MODEL,
+          { [FLASH]: { available: false } },
+        );
+        const chain = resolvePolicyChain(config);
+
+        const liteCount = chain.filter((p) => p.model === FLASH_LITE).length;
+        expect(liteCount).toBe(1);
+      });
+    });
   });
 
   describe('resolvePolicyChain behavior is identical between dynamic and legacy implementations', () => {
@@ -211,11 +286,29 @@ describe('policyHelpers', () => {
         model: DEFAULT_GEMINI_MODEL_AUTO,
         wrapsAround: true,
       },
+      {
+        name: 'Quota Failover Parity (Flash Unavailable)',
+        model: DEFAULT_GEMINI_MODEL_AUTO,
+        flashAvailable: false,
+      },
     ];
 
     testCases.forEach(
-      ({ name, model, useGemini31, hasAccess, authType, wrapsAround }) => {
+      ({
+        name,
+        model,
+        useGemini31,
+        hasAccess,
+        authType,
+        wrapsAround,
+        flashAvailable,
+      }) => {
         it(`achieves parity for: ${name}`, () => {
+          const availabilityMap: Record<string, { available: boolean }> =
+            flashAvailable === false
+              ? { 'gemini-2.5-flash': { available: false } }
+              : {};
+
           const createBaseConfig = (dynamic: boolean) =>
             createMockConfig({
               getExperimentalDynamicModelConfiguration: () => dynamic,
@@ -225,6 +318,12 @@ describe('policyHelpers', () => {
               getHasAccessToPreviewModel: () => hasAccess ?? true,
               getContentGeneratorConfig: () => ({ authType }),
               modelConfigService: new ModelConfigService(DEFAULT_MODEL_CONFIGS),
+              getModelAvailabilityService: () =>
+                ({
+                  snapshot: (m: string) => availabilityMap[m],
+                }) as unknown as ReturnType<
+                  Config['getModelAvailabilityService']
+                >,
             });
 
           const legacyChain = resolvePolicyChain(

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -231,14 +231,16 @@ describe('policyHelpers', () => {
         expect(chain[1]?.model).toBe(PRO);
       });
 
-      it('does not swap Flash when not in auto mode (explicit Flash selection)', () => {
+      it('swaps Flash for Flash Lite even when not in auto mode (broad resilience)', () => {
         const config = createConfigWithAvailability(() => FLASH, {
           [FLASH]: { available: false },
         });
         const chain = resolvePolicyChain(config, FLASH);
 
-        // Without auto mode, chain stays as the user explicitly requested.
-        expect(chain[0]?.model).toBe(FLASH);
+        // Broad resilience applies to all Flash uses to prevent silent hangs
+        // and improve CLI availability.
+        expect(chain[0]?.model).toBe(FLASH_LITE);
+        expect(chain[0]?.actions).toEqual(SILENT_ACTIONS);
       });
 
       it('does not duplicate Flash Lite if it is already in the chain', () => {

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -293,6 +293,12 @@ describe('policyHelpers', () => {
         model: DEFAULT_GEMINI_MODEL_AUTO,
         flashAvailable: false,
       },
+      {
+        name: 'Complex Parity (Auto + Wrap + Quota Exhausted)',
+        model: DEFAULT_GEMINI_MODEL_AUTO,
+        wrapsAround: true,
+        flashAvailable: false,
+      },
     ];
 
     testCases.forEach(

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -22,7 +22,9 @@ import {
 } from './policyCatalog.js';
 import {
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
+  PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_MODEL_AUTO,
   isAutoModel,
   isGemini3Model,
@@ -64,6 +66,12 @@ export function resolvePolicyChain(
     ? isAutoModel(preferredModel, config)
     : false;
   const isAutoConfigured = isAutoModel(configuredModel, config);
+
+  // Auto mode must always wrap chains so fallback candidates remain available
+  // when the router resolves to a non-primary model (e.g. Flash). Without this,
+  // applyDynamicSlicing reduces the chain to a single element and there is
+  // nowhere to fall back to when that model hits its quota.
+  const shouldWrapAround = wrapsAround || isAutoPreferred || isAutoConfigured;
 
   // --- DYNAMIC PATH ---
   if (config.getExperimentalDynamicModelConfiguration?.() === true) {
@@ -110,7 +118,7 @@ export function resolvePolicyChain(
       // No matching modelChains found, default to single model chain
       chain = createSingleModelChain(modelFromConfig);
     }
-    chain = applyDynamicSlicing(chain, resolvedModel, wrapsAround);
+    chain = applyDynamicSlicing(chain, resolvedModel, shouldWrapAround);
   } else {
     // --- LEGACY PATH ---
 
@@ -150,8 +158,52 @@ export function resolvePolicyChain(
     } else {
       chain = createSingleModelChain(modelFromConfig);
     }
-    chain = applyDynamicSlicing(chain, resolvedModel, wrapsAround);
+    chain = applyDynamicSlicing(chain, resolvedModel, shouldWrapAround);
   }
+
+  // --- AUTO MODE QUOTA FAILOVER ---
+  // In Auto mode, if Flash sits in the chain but its quota is already known to
+  // be exhausted, swap that slot for Flash Lite (independent quota) and mark
+  // the swapped policy as silent so subsequent failures fall back without
+  // prompting the user. Chain length is preserved to keep CI parity between
+  // the legacy and dynamic chain paths.
+  if (
+    (isAutoPreferred || isAutoConfigured) &&
+    typeof config.getModelAvailabilityService === 'function'
+  ) {
+    const availability = config.getModelAvailabilityService?.();
+    const flashIndex = chain.findIndex(
+      (p) =>
+        p.model === DEFAULT_GEMINI_FLASH_MODEL ||
+        p.model === PREVIEW_GEMINI_FLASH_MODEL,
+    );
+    if (flashIndex !== -1) {
+      const inChainFlash = chain[flashIndex].model;
+      const liteModel = resolveModel(
+        'flash-lite',
+        useGemini31,
+        useGemini31FlashLite,
+        useCustomToolModel,
+        hasAccessToPreview,
+        config,
+      );
+      const liteAlreadyInChain = chain.some((p) => p.model === liteModel);
+      const flashSnapshot = availability?.snapshot?.(inChainFlash);
+      if (!liteAlreadyInChain && flashSnapshot?.available === false) {
+        chain = chain.map((policy, idx) =>
+          idx === flashIndex
+            ? {
+                ...policy,
+                model: liteModel,
+                actions: { ...SILENT_ACTIONS },
+                stateTransitions: { ...policy.stateTransitions },
+              }
+            : policy,
+        );
+      }
+    }
+  }
+
   // Apply Unified Silent Injection for Plan Mode with defensive checks
   if (config?.getApprovalMode?.() === ApprovalMode.PLAN) {
     return chain.map((policy) => ({

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -161,16 +161,13 @@ export function resolvePolicyChain(
     chain = applyDynamicSlicing(chain, resolvedModel, shouldWrapAround);
   }
 
-  // --- AUTO MODE QUOTA FAILOVER ---
-  // In Auto mode, if Flash sits in the chain but its quota is already known to
-  // be exhausted, swap that slot for Flash Lite (independent quota) and mark
-  // the swapped policy as silent so subsequent failures fall back without
-  // prompting the user. Chain length is preserved to keep CI parity between
-  // the legacy and dynamic chain paths.
-  if (
-    (isAutoPreferred || isAutoConfigured) &&
-    typeof config.getModelAvailabilityService === 'function'
-  ) {
+  // --- RESILIENCE INJECTION (QUOTA FAILOVER) ---
+  // If Flash sits in the chain but its quota is already known to be exhausted,
+  // we dynamically swap that slot for Flash Lite (independent quota) and mark
+  // the policy as silent. This prevents "silent hangs" in background tasks and
+  // ensure the CLI remains usable in Auto mode even when Flash is 100% used.
+  // Chain length is preserved to maintain parity between Legacy and Dynamic paths.
+  if (typeof config.getModelAvailabilityService === 'function') {
     const availability = config.getModelAvailabilityService?.();
     const flashIndex = chain.findIndex(
       (p) =>

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -115,6 +115,12 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-3-flash-preview',
       },
     },
+    'gemini-3-flash-lite-base': {
+      extends: 'base',
+      modelConfig: {
+        model: 'gemini-3.1-flash-lite-preview',
+      },
+    },
     classifier: {
       extends: 'base',
       modelConfig: {
@@ -183,7 +189,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'web-search': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {
         generateContentConfig: {
           tools: [{ googleSearch: {} }],
@@ -191,7 +197,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'web-fetch': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {
         generateContentConfig: {
           tools: [{ urlContext: {} }],
@@ -200,11 +206,11 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     },
     // TODO(joshualitt): During cleanup, make modelConfig optional.
     'web-fetch-fallback': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {},
     },
     'loop-detection': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {},
     },
     'loop-detection-double-check': {
@@ -214,11 +220,11 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'llm-edit-fixer': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {},
     },
     'next-speaker-checker': {
-      extends: 'gemini-3-flash-base',
+      extends: 'gemini-3-flash-lite-base',
       modelConfig: {},
     },
     'chat-compression-3-pro': {
@@ -486,6 +492,10 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'gemini-3.1-flash-lite-preview': {
       default: 'gemini-3.1-flash-lite-preview',
       contexts: [
+        {
+          condition: { hasAccessToPreview: false },
+          target: 'gemini-2.5-flash-lite',
+        },
         {
           condition: { useGemini3_1FlashLite: false },
           target: 'gemini-2.5-flash-lite',

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -115,12 +115,6 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-3-flash-preview',
       },
     },
-    'gemini-3-flash-lite-base': {
-      extends: 'base',
-      modelConfig: {
-        model: 'gemini-3.1-flash-lite-preview',
-      },
-    },
     classifier: {
       extends: 'base',
       modelConfig: {
@@ -189,7 +183,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'web-search': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {
         generateContentConfig: {
           tools: [{ googleSearch: {} }],
@@ -197,7 +191,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'web-fetch': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {
         generateContentConfig: {
           tools: [{ urlContext: {} }],
@@ -206,11 +200,11 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     },
     // TODO(joshualitt): During cleanup, make modelConfig optional.
     'web-fetch-fallback': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {},
     },
     'loop-detection': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {},
     },
     'loop-detection-double-check': {
@@ -220,11 +214,11 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
     },
     'llm-edit-fixer': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {},
     },
     'next-speaker-checker': {
-      extends: 'gemini-3-flash-lite-base',
+      extends: 'gemini-3-flash-base',
       modelConfig: {},
     },
     'chat-compression-3-pro': {
@@ -492,10 +486,6 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'gemini-3.1-flash-lite-preview': {
       default: 'gemini-3.1-flash-lite-preview',
       contexts: [
-        {
-          condition: { hasAccessToPreview: false },
-          target: 'gemini-2.5-flash-lite',
-        },
         {
           condition: { useGemini3_1FlashLite: false },
           target: 'gemini-2.5-flash-lite',


### PR DESCRIPTION
Fixes #23397
Fixes #18059
Fixes #25736
Fixes #23986
Fixes #22141
Related to #24937 (capacity/429 tracking issue)
Mitigates #23738 (infinite rate-limit loops)

## Problem

1. **Silent Hangs/Utility Failures**: When Flash quota (Gemini 2.5 or 3) is exhausted, internal utilities (loop detection, edit fixer, etc.) hardcoded to Flash cause the agent to hang or fail, even if Flash Lite or Pro is available.
2. **Auto-mode Interruption**: In Auto mode, hitting a quota limit often triggers a manual 'Select Model' prompt instead of silently falling back to available tiers.

## Solution: Runtime Resilience Injection

Instead of changing static configurations, this PR implements a runtime failover mechanism in `policyHelpers.ts`:

- **Dynamic Swapping**: When the `ModelAvailabilityService` reports that a Flash model (2.5 or 3) is exhausted, the policy resolver dynamically swaps that specific slot in the chain for Flash Lite.
- **Silent Fallback**: The swapped Flash Lite policy is marked as `SILENT`, ensuring it falls back to Pro or other tiers without user intervention if needed.
- **Design Preservation**: Reverts all changes to `defaultModelConfigs.ts`. The original Google-designed defaults are respected, and the failover only triggers when availability is actually lost.
- **Strict Parity**: Ensures the legacy and dynamic implementation paths remain bit-for-bit identical in behavior, as verified by expanded parity tests.

## Impact

- Fixes 'silent hangs' for all users (including Gemini 2.5 stable users).
- Improves CLI availability under quota pressure without changing the 'intended' model for tasks.
- Passes all core tests and ensures no regression in chain structure or manual model selection.

## Verified

Ran `npm test -w @google/gemini-cli-core` and verified 100% parity and failover behavior in `policyHelpers.test.ts`.