### PR TITLE
feat(cli): show elapsed time on tool executions running longer than 3 seconds

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolShared.tsx
+++ b/packages/cli/src/ui/components/messages/ToolShared.tsx
@@ -153,15 +153,35 @@ export const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
       ? theme.ui.active
       : theme.status.warning;
 
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  useEffect(() => {
+    if (status !== ToolCallStatus.Executing) {
+      setElapsedSeconds(0);
+      return;
+    }
+    setElapsedSeconds(0);
+    const interval = setInterval(() => {
+      setElapsedSeconds((s) => s + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [status]);
+
   return (
     <Box minWidth={STATUS_INDICATOR_WIDTH}>
       {status === ToolCallStatus.Pending && (
         <Text color={theme.status.success}>{TOOL_STATUS.PENDING}</Text>
       )}
       {status === ToolCallStatus.Executing && (
-        <Text color={statusColor}>
-          <CliSpinner type="toggle" />
-        </Text>
+        <Box flexDirection="row" gap={1}>
+          <Text color={statusColor}>
+            <CliSpinner type="toggle" />
+          </Text>
+          {elapsedSeconds >= 3 && (
+            <Text color={theme.text.secondary} dimColor>
+              {elapsedSeconds}s
+            </Text>
+          )}
+        </Box>
       )}
       {status === ToolCallStatus.Success && (
         <Text color={theme.status.success} aria-label={'Success:'}>


### PR DESCRIPTION
## Summary

- Tool calls that run longer than 3 seconds now display a live elapsed timer (e.g. `⠿ 7s`) next to the spinner in the `ToolStatusIndicator`
- Timer appears after 3 seconds to avoid visual noise for fast operations
- Resets cleanly to zero when execution completes
- Works for all tool types (shell commands, file operations, MCP tools, etc.)

## Motivation

Long-running tool calls — particularly shell commands like builds, installs, or test suites — give no feedback about how long they've been running. Users had no way to distinguish "this is taking 30 seconds" from "this hung". The elapsed timer provides that visibility with minimal UI impact.

## Implementation

The timer is a `useState`/`useEffect` pair added to `ToolStatusIndicator` in `ToolShared.tsx`. It uses `setInterval(1000)` while `status === Executing` and clears itself on status change. No new dependencies or external timers needed — the existing `useState`/`useEffect` imports already present in the file are used.

## Test plan

- [ ] Run a shell command that takes >3 seconds — timer should appear and count up
- [ ] Run a fast operation — no timer should appear
- [ ] Verify timer clears after the tool completes (success or error)
- [ ] Verify spinner animation still renders correctly alongside timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)