### PR TITLE
fix(cli): round slow render latency to avoid opentelemetry float warning

### DIFF
--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -151,7 +151,7 @@ export async function startInteractiveUI(
       isScreenReaderEnabled: config.getScreenReader(),
       onRender: ({ renderTime }: { renderTime: number }) => {
         if (renderTime > SLOW_RENDER_MS) {
-          recordSlowRender(config, renderTime);
+          recordSlowRender(config, Math.round(renderTime));
         }
         profiler.reportFrameRendered();
       },


### PR DESCRIPTION
## Description

This PR fixes a warning from the OpenTelemetry SDK where a floating-point value was being provided for a metric configured to accept only integers.

### What happened?
When Ink triggers its `onRender` callback, `renderTime` is provided as a floating-point number (e.g., 204.85ms) because it relies on high-resolution timers. `recordSlowRender` then passes this directly to the OpenTelemetry counter for `gemini_cli.ui.slow_render.latency`, which is strictly defined as `ValueType.INT`. This mismatch caused the OTel SDK to drop the fractional digits and emit a console warning: `INT value type cannot accept a floating-point value for gemini_cli.ui.slow_render.latency, ignoring the fractional digits.`

### How is it fixed?
We now explicitly round the `renderTime` to the nearest integer before recording the slow render latency metric.

Fixes internal bug b/500713004.
