### PR TITLE
shell tool rc

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1452,6 +1452,11 @@ their corresponding top-level category object in your `settings.json` file.
     performance.
   - **Default:** `true`
 
+- **`tools.shell.rcFile`** (string):
+  - **Description:** The path to a bash file (e.g., .bashrc) to source before
+    executing shell commands.
+  - **Default:** `undefined`
+
 - **`tools.core`** (array):
   - **Description:** Restrict the set of built-in tools with an allowlist. Match
     semantics mirror tools.allowed; see the built-in tools documentation for

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -925,6 +925,7 @@ export async function loadCliConfig(
     toolDiscoveryCommand: settings.tools?.discoveryCommand,
     toolCallCommand: settings.tools?.callCommand,
     mcpServerCommand,
+    shellToolRcFile: settings.tools?.shell?.rcFile,
     mcpServers,
     mcpEnablementCallbacks,
     mcpEnabled,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1637,6 +1637,16 @@ const SETTINGS_SCHEMA = {
               'Enable shell output efficiency optimizations for better performance.',
             showInDialog: false,
           },
+          rcFile: {
+            type: 'string',
+            label: 'Shell Tool RC File',
+            category: 'Tools',
+            requiresRestart: false,
+            default: undefined as string | undefined,
+            description:
+              'The path to a bash file (e.g., .bashrc) to source before executing shell commands.',
+            showInDialog: false,
+          },
         },
       },
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -602,6 +602,7 @@ export interface ConfigParameters {
   toolDiscoveryCommand?: string;
   toolCallCommand?: string;
   mcpServerCommand?: string;
+  shellToolRcFile?: string;
   mcpServers?: Record<string, MCPServerConfig>;
   mcpEnablementCallbacks?: McpEnablementCallbacks;
   userMemory?: string | HierarchicalMemory;
@@ -779,6 +780,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly toolDiscoveryCommand: string | undefined;
   private readonly toolCallCommand: string | undefined;
   private readonly mcpServerCommand: string | undefined;
+  private readonly shellToolRcFile: string | undefined;
   private readonly mcpEnabled: boolean;
   private readonly extensionsEnabled: boolean;
   private mcpServers: Record<string, MCPServerConfig> | undefined;
@@ -1047,6 +1049,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.toolDiscoveryCommand = params.toolDiscoveryCommand;
     this.toolCallCommand = params.toolCallCommand;
     this.mcpServerCommand = params.mcpServerCommand;
+    this.shellToolRcFile = params.shellToolRcFile;
     this.mcpServers = params.mcpServers;
     this.mcpEnablementCallbacks = params.mcpEnablementCallbacks;
     this.mcpEnabled = params.mcpEnabled ?? true;
@@ -2316,6 +2319,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getMcpServerCommand(): string | undefined {
     return this.mcpServerCommand;
+  }
+
+  getShellToolRcFile(): string | undefined {
+    return this.shellToolRcFile;
   }
 
   /**

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -165,6 +165,7 @@ describe('ShellTool', () => {
         addSessionApproval: vi.fn(),
       },
       getShellToolRcFile: vi.fn().mockReturnValue(undefined),
+      isTrustedFolder: vi.fn().mockReturnValue(true),
     } as unknown as Config;
 
     const bus = createMockMessageBus();
@@ -487,9 +488,10 @@ EOF`;
       expect(mockShellExecutionService.mock.calls[0][0]).toMatch(/\nEOF\n\)\n/);
     });
 
-    it('should source rcfile when shellToolRcFile setting is present', async () => {
+    it('should source rcfile when shellToolRcFile setting is present and folder is trusted', async () => {
       const rcFilePath = '~/.geminirc';
       (mockConfig.getShellToolRcFile as Mock).mockReturnValue(rcFilePath);
+      (mockConfig.isTrustedFolder as Mock).mockReturnValue(true);
 
       const invocation = shellTool.build({ command: 'my-command' });
       const promise = invocation.execute({ abortSignal: mockAbortSignal });
@@ -497,7 +499,51 @@ EOF`;
       await promise;
 
       expect(mockShellExecutionService).toHaveBeenCalledWith(
-        expect.stringContaining(`source ${rcFilePath} && my-command`),
+        expect.stringContaining(
+          `source '${rcFilePath.replace('~', '/home/user')}'; export PAGER=cat`,
+        ),
+        expect.any(String),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.any(Object),
+      );
+    });
+
+    it('should NOT source rcfile when shellToolRcFile setting is present but folder is untrusted', async () => {
+      const rcFilePath = '~/.geminirc';
+      (mockConfig.getShellToolRcFile as Mock).mockReturnValue(rcFilePath);
+      (mockConfig.isTrustedFolder as Mock).mockReturnValue(false);
+
+      const invocation = shellTool.build({ command: 'my-command' });
+      const promise = invocation.execute({ abortSignal: mockAbortSignal });
+      resolveShellExecution();
+      await promise;
+
+      expect(mockShellExecutionService).not.toHaveBeenCalledWith(
+        expect.stringContaining(`source '${rcFilePath}'`),
+        expect.any(String),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.any(Object),
+      );
+    });
+
+    it('should properly escape quotes in rcFilePath', async () => {
+      const rcFilePath = "/path/with/'quotes'/rc";
+      (mockConfig.getShellToolRcFile as Mock).mockReturnValue(rcFilePath);
+      (mockConfig.isTrustedFolder as Mock).mockReturnValue(true);
+
+      const invocation = shellTool.build({ command: 'my-command' });
+      const promise = invocation.execute({ abortSignal: mockAbortSignal });
+      resolveShellExecution();
+      await promise;
+
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `source '/path/with/'\\''quotes'\\''/rc'; export PAGER=cat`,
+        ),
         expect.any(String),
         expect.any(Function),
         expect.any(AbortSignal),

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -164,6 +164,7 @@ describe('ShellTool', () => {
         addPersistentApproval: vi.fn(),
         addSessionApproval: vi.fn(),
       },
+      getShellToolRcFile: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
 
     const bus = createMockMessageBus();
@@ -484,6 +485,25 @@ EOF`;
         expect.any(Object),
       );
       expect(mockShellExecutionService.mock.calls[0][0]).toMatch(/\nEOF\n\)\n/);
+    });
+
+    it('should source rcfile when shellToolRcFile setting is present', async () => {
+      const rcFilePath = '~/.geminirc';
+      (mockConfig.getShellToolRcFile as Mock).mockReturnValue(rcFilePath);
+
+      const invocation = shellTool.build({ command: 'my-command' });
+      const promise = invocation.execute({ abortSignal: mockAbortSignal });
+      resolveShellExecution();
+      await promise;
+
+      expect(mockShellExecutionService).toHaveBeenCalledWith(
+        expect.stringContaining(`source ${rcFilePath} && my-command`),
+        expect.any(String),
+        expect.any(Function),
+        expect.any(AbortSignal),
+        false,
+        expect.any(Object),
+      );
     });
 
     it('should format error messages correctly', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -462,13 +462,19 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const combinedController = new AbortController();
 
     const onAbort = () => combinedController.abort();
+    let strippedCommandWithRc = strippedCommand;
+    const rcFilePath = this.context.config.getShellToolRcFile();
+    if (rcFilePath) {
+      strippedCommandWithRc = `source ${rcFilePath} && ${strippedCommand}`;
+    }
+
     try {
       tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-shell-'));
       tempFilePath = path.join(tempDir, 'pgrep.tmp');
 
       // pgrep is not available on Windows, so we can't get background PIDs
       const commandToExecute = this.wrapCommandForPgrep(
-        strippedCommand,
+        strippedCommandWithRc,
         tempFilePath,
         isWindows,
       );

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -466,6 +466,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const rcFilePath = this.context.config.getShellToolRcFile();
     if (rcFilePath) {
       strippedCommandWithRc = `source ${rcFilePath} && ${strippedCommand}`;
+    } else if (!isWindows) {
+      strippedCommandWithRc = `export PAGER=cat GIT_PAGER=cat; more() { cat "$@"; }; less() { cat "$@"; }; ${strippedCommand}`;
     }
 
     try {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -50,7 +50,12 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { getShellDefinition } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
-import { toPathKey, isSubpath, resolveToRealPath } from '../utils/paths.js';
+import {
+  homedir,
+  toPathKey,
+  isSubpath,
+  resolveToRealPath,
+} from '../utils/paths.js';
 import {
   getProactiveToolSuggestions,
   isNetworkReliantCommand,
@@ -463,11 +468,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
     const onAbort = () => combinedController.abort();
     let strippedCommandWithRc = strippedCommand;
-    const rcFilePath = this.context.config.getShellToolRcFile();
-    if (rcFilePath) {
-      strippedCommandWithRc = `source ${rcFilePath} && ${strippedCommand}`;
-    } else if (!isWindows) {
-      strippedCommandWithRc = `export PAGER=cat GIT_PAGER=cat; more() { cat "$@"; }; less() { cat "$@"; }; ${strippedCommand}`;
+    if (!isWindows) {
+      strippedCommandWithRc = `export PAGER=cat GIT_PAGER=cat; ${strippedCommand}`;
+      const rcFilePath = this.context.config.getShellToolRcFile();
+      if (rcFilePath && this.context.config.isTrustedFolder()) {
+        let resolvedRcFilePath = rcFilePath;
+        if (rcFilePath === '~' || rcFilePath.startsWith('~/')) {
+          resolvedRcFilePath = homedir() + rcFilePath.substring(1);
+        }
+        const escapedRcFilePath = resolvedRcFilePath.replace(
+          /'/g,
+          () => "'\\''",
+        );
+        strippedCommandWithRc = `source '${escapedRcFilePath}'; ${strippedCommandWithRc}`;
+      }
     }
 
     try {

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2509,6 +2509,12 @@
               "markdownDescription": "Enable shell output efficiency optimizations for better performance.\n\n- Category: `Tools`\n- Requires restart: `no`\n- Default: `true`",
               "default": true,
               "type": "boolean"
+            },
+            "rcFile": {
+              "title": "Shell Tool RC File",
+              "description": "The path to a bash file (e.g., .bashrc) to source before executing shell commands.",
+              "markdownDescription": "The path to a bash file (e.g., .bashrc) to source before executing shell commands.\n\n- Category: `Tools`\n- Requires restart: `no`",
+              "type": "string"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
- **Add support for a shellToolRcFile setting**
- **fix(shell): explicitly set PAGER=cat when rcFile is not used**

## Summary

This brings back
https://github.com/google-gemini/gemini-cli/pull/5953

I went slightly further so "more" and "less" won't hang things. Happy to remove those from the defaults as they could be a step too far.