### PR TITLE
fix(TableRenderer): guard against negative column widths in renderBorder

### DIFF
--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -251,7 +251,7 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     };
 
     const char = chars[type];
-    const borderParts = adjustedWidths.map((w) => char.horizontal.repeat(w));
+    const borderParts = adjustedWidths.map((w) => char.horizontal.repeat(Math.max(0, w)));
     const border = char.left + borderParts.join(char.middle) + char.right;
 
     return <Text color={theme.border.default}>{border}</Text>;


### PR DESCRIPTION
## Problem

When the terminal is very narrow, `adjustedWidths` can contain values that, after the column allocation algorithm scales them down, result in a width of `0` or negative. Calling `String.prototype.repeat()` with a negative count throws:

```
RangeError: Invalid count value: -1
```

This crash was reported in issue #25665.

## Root cause

In `renderBorder`, the border segments are built with:

```ts
const borderParts = adjustedWidths.map((w) => char.horizontal.repeat(w));
```

`repeat()` requires a non-negative integer. When the terminal is too narrow for the table, `adjustedWidths` can contain negative values, crashing the renderer.

## Fix

Clamp each width to a minimum of `0` before passing it to `repeat()`:

```ts
const borderParts = adjustedWidths.map((w) => char.horizontal.repeat(Math.max(0, w)));
```

This matches the existing defensive pattern already used in `renderCell`:
```ts
const contentWidth = Math.max(0, width - COLUMN_PADDING);
```

Fixes #25665