### PR TITLE
fix(paths): handle ENAMETOOLONG and ENOTDIR in robustRealpath

### DIFF
--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -424,17 +424,17 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       e &&
       typeof e === 'object' &&
       'code' in e &&
-      (e.code === 'ENAMETOOLONG' || e.code === 'ENOTDIR')
+      e.code === 'ENAMETOOLONG'
     ) {
-      // Path is too long or contains a non-directory component; it cannot be a
-      // real filesystem path, so return it as-is.
+      // Path is too long to be a real filesystem path; return as-is to avoid
+      // stack overflows from recursive parent resolution.
       return p;
     }
     if (
       e &&
       typeof e === 'object' &&
       'code' in e &&
-      (e.code === 'ENOENT' || e.code === 'EISDIR')
+      (e.code === 'ENOENT' || e.code === 'EISDIR' || e.code === 'ENOTDIR')
     ) {
       try {
         const stat = fs.lstatSync(p);
@@ -445,7 +445,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         }
       } catch (lstatError: unknown) {
         // Not a symlink, or lstat failed. Re-throw if it's not an expected
-        // ENOENT (e.g., a permissions error), otherwise resolve parent.
+        // error code, otherwise resolve parent.
         if (
           !(
             lstatError &&
@@ -453,7 +453,6 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
             'code' in lstatError &&
             (lstatError.code === 'ENOENT' ||
               lstatError.code === 'EISDIR' ||
-              lstatError.code === 'ENAMETOOLONG' ||
               lstatError.code === 'ENOTDIR')
           )
         ) {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -424,6 +424,16 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       e &&
       typeof e === 'object' &&
       'code' in e &&
+      (e.code === 'ENAMETOOLONG' || e.code === 'ENOTDIR')
+    ) {
+      // Path is too long or contains a non-directory component; it cannot be a
+      // real filesystem path, so return it as-is.
+      return p;
+    }
+    if (
+      e &&
+      typeof e === 'object' &&
+      'code' in e &&
       (e.code === 'ENOENT' || e.code === 'EISDIR')
     ) {
       try {
@@ -441,7 +451,10 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
             lstatError &&
             typeof lstatError === 'object' &&
             'code' in lstatError &&
-            (lstatError.code === 'ENOENT' || lstatError.code === 'EISDIR')
+            (lstatError.code === 'ENOENT' ||
+              lstatError.code === 'EISDIR' ||
+              lstatError.code === 'ENAMETOOLONG' ||
+              lstatError.code === 'ENOTDIR')
           )
         ) {
           throw lstatError;


### PR DESCRIPTION
## Problem

When a user pastes a large multi-line code snippet into the CLI prompt, the auto-file-path detection logic calls `robustRealpath` on the raw input text (prepended with the home directory). This produces an extremely long string, which causes `fs.realpathSync` or `fs.lstatSync` to throw `ENAMETOOLONG`. Because this error code is not in the allow-list, the error propagates up as an unhandled promise rejection, crashing the entire CLI:

```
CRITICAL: Unhandled Promise Rejection!
Error: ENAMETOOLONG: name too long, lstat '/home/user/<pasted code...>'
```

Reported in issue #25696.

## Root cause

`robustRealpath` only handles `ENOENT` and `EISDIR` gracefully. Any other error code (including `ENAMETOOLONG` and `ENOTDIR`) is re-thrown unhandled.

## Fix

- When `realpathSync` throws `ENAMETOOLONG` or `ENOTDIR`, the string is clearly not a real filesystem path. Return `p` as-is instead of crashing.
- When `lstatSync` throws `ENAMETOOLONG` or `ENOTDIR` in the inner catch block, treat them the same as `ENOENT`/`EISDIR` (i.e., non-fatal — fall through to parent resolution).

Fixes #25696