### PR TITLE
fix(theme): add missing 'response' property to text schema in CustomTheme

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3098,6 +3098,7 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
           secondary: { type: 'string' },
           link: { type: 'string' },
           accent: { type: 'string' },
+          response: { type: 'string' },
         },
       },
       background: {


### PR DESCRIPTION
## Problem

Setting `text.response` in a custom theme triggers a validation error at startup:

```
Invalid configuration... Unrecognized key(s) in object: 'response'
```

This is because the `text` object in the `CustomTheme` schema definition has `additionalProperties: false` but is missing the `response` property.

Reported in issue #25689.

## Root cause

In `settingsSchema.ts`, the `text` properties block only lists `primary`, `secondary`, `link`, and `accent`. However, the runtime theme logic explicitly uses `text.response`:

```ts
response: customTheme.text?.response ?? customTheme.text?.primary ?? colors.Foreground
```

Since the schema has `additionalProperties: false`, any key not listed there is rejected — even though it's a documented, supported field.

## Fix

Add `response: { type: 'string' }` to the `text` properties in the `CustomTheme` schema, consistent with the other color properties.

Fixes #25689