### PR TITLE
feat(core): fallback to system ripgrep if bundled binary is missing

### DIFF
--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -25,12 +25,22 @@ import { PassThrough, Readable } from 'node:stream';
 import EventEmitter from 'node:events';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { fileExists } from '../utils/fileUtils.js';
+import { resolveExecutable } from '../utils/shell-utils.js';
 
 vi.mock('../utils/fileUtils.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/fileUtils.js')>();
   return {
     ...actual,
     fileExists: vi.fn(),
+  };
+});
+
+vi.mock('../utils/shell-utils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/shell-utils.js')>();
+  return {
+    ...actual,
+    resolveExecutable: vi.fn(),
   };
 });
 
@@ -2007,6 +2017,15 @@ describe('getRipgrepPath', () => {
 
       const resolvedPath = await getRipgrepPath();
       expect(resolvedPath).toBeNull();
+    });
+
+    it('should fall back to system PATH if both bundled paths are missing', async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(resolveExecutable).mockResolvedValue('/usr/bin/rg');
+
+      const resolvedPath = await getRipgrepPath();
+      expect(resolvedPath).toBe('/usr/bin/rg');
+      expect(resolveExecutable).toHaveBeenCalledWith('rg');
     });
   });
 });

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -30,7 +30,7 @@ import {
   COMMON_DIRECTORY_EXCLUDES,
 } from '../utils/ignorePatterns.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
-import { execStreaming } from '../utils/shell-utils.js';
+import { execStreaming, resolveExecutable } from '../utils/shell-utils.js';
 import {
   DEFAULT_TOTAL_MAX_MATCHES,
   DEFAULT_SEARCH_TIMEOUT_MS,
@@ -61,7 +61,8 @@ export async function getRipgrepPath(): Promise<string | null> {
     }
   }
 
-  return null;
+  // 3. System PATH fallback
+  return (await resolveExecutable('rg')) ?? null;
 }
 
 /**


### PR DESCRIPTION

Updates `getRipgrepPath` to resolve `rg` from the system `PATH` when
the bundled binaries are not found. This allows users with a locally installed
ripgrep to bypass missing binary issues on unsupported architectures.

Co-authored-by: Gemini <gemini@google.com>
