### PR TITLE
fix(core): handle ENAMETOOLONG in robustRealpath

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -601,6 +601,22 @@ describe('resolveToRealPath', () => {
       /Infinite recursion detected/,
     );
   });
+
+  it('should return path as-is if fs.realpathSync and fs.lstatSync fail with ENAMETOOLONG', () => {
+    vi.spyOn(fs, 'realpathSync').mockImplementation(() => {
+      const err = new Error('File name too long') as NodeJS.ErrnoException;
+      err.code = 'ENAMETOOLONG';
+      throw err;
+    });
+    vi.spyOn(fs, 'lstatSync').mockImplementation(() => {
+      const err = new Error('File name too long') as NodeJS.ErrnoException;
+      err.code = 'ENAMETOOLONG';
+      throw err;
+    });
+
+    const longPath = path.resolve('a'.repeat(5000));
+    expect(resolveToRealPath(longPath)).toBe(longPath);
+  });
 });
 
 describe('makeRelative', () => {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -424,7 +424,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       e &&
       typeof e === 'object' &&
       'code' in e &&
-      (e.code === 'ENOENT' || e.code === 'EISDIR')
+      (e.code === 'ENOENT' || e.code === 'EISDIR' || e.code === 'ENAMETOOLONG')
     ) {
       try {
         const stat = fs.lstatSync(p);
@@ -435,13 +435,15 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         }
       } catch (lstatError: unknown) {
         // Not a symlink, or lstat failed. Re-throw if it's not an expected
-        // ENOENT (e.g., a permissions error), otherwise resolve parent.
+        // error (e.g., a permissions error), otherwise resolve parent.
         if (
           !(
             lstatError &&
             typeof lstatError === 'object' &&
             'code' in lstatError &&
-            (lstatError.code === 'ENOENT' || lstatError.code === 'EISDIR')
+            (lstatError.code === 'ENOENT' ||
+              lstatError.code === 'EISDIR' ||
+              lstatError.code === 'ENAMETOOLONG')
           )
         ) {
           throw lstatError;


### PR DESCRIPTION
## Summary

Fixes a crash (Unhandled Promise Rejection) in the CLI when processing extremely long strings (like large Python code snippets) as potential file paths. The crash occurred because the `ENAMETOOLONG` error from the file system was not being caught in the `robustRealpath` function.

## Details

- Updated `robustRealpath` in `packages/core/src/utils/paths.ts` to catch `ENAMETOOLONG` in addition to `ENOENT` and `EISDIR`.
- This ensures that if a string is incorrectly identified as an `@path` command but is too long to be a valid path, the CLI gracefully ignores it instead of crashing.
- Added a unit test in `packages/core/src/utils/paths.test.ts` to mock this scenario and prevent regressions.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/25696

## How to Validate

1. Revert the fix and run `npm run build -w @google/gemini-cli-core`.
2. Run `npm run start` and paste a long quoted string (e.g., `@"a" * 5000`).
3. Observe the crash.
4. Apply the fix and rebuild.
5. Run `npm run start` and paste the same string.
6. Observe that the CLI no longer crashes.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
