### PR TITLE
fix(cli): add missing custom theme properties to settings schema

### DIFF
--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -273,6 +273,36 @@ describe('settings-validation', () => {
     });
 
     it('should validate complex nested customThemes configuration', () => {
+      const validSettings = {
+        ui: {
+          customThemes: {
+            'my-theme': {
+              type: 'custom' as const,
+              name: 'My Theme',
+              text: {
+                primary: '#ffffff',
+                secondary: '#cccccc',
+                link: '#0000ff',
+                accent: '#ff00ff',
+                response: '#00ff00',
+              },
+              ui: {
+                comment: '#888888',
+                symbol: '#ffffff',
+                active: '#0000ff',
+                focus: '#00ff00',
+                gradient: ['#000000', '#ffffff'],
+              },
+            },
+          },
+        },
+      };
+
+      const result = validateSettings(validSettings);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid customThemes configuration', () => {
       const invalidSettings = {
         ui: {
           customThemes: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3118,6 +3118,7 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
           secondary: { type: 'string' },
           link: { type: 'string' },
           accent: { type: 'string' },
+          response: { type: 'string' },
         },
       },
       background: {
@@ -3149,6 +3150,8 @@ export const SETTINGS_SCHEMA_DEFINITIONS: Record<
         properties: {
           comment: { type: 'string' },
           symbol: { type: 'string' },
+          active: { type: 'string' },
+          focus: { type: 'string' },
           gradient: {
             type: 'array',
             items: { type: 'string' },

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -309,6 +309,7 @@ export interface CustomTheme {
   };
   border?: {
     default?: string;
+    focused?: string;
   };
   ui?: {
     comment?: string;


### PR DESCRIPTION
## Summary

This PR fixes a validation error when using certain properties in a custom theme configuration. Specifically, it adds support for `text.response`, `ui.active`, and `ui.focus` in the settings schema.

## Details

- Added missing properties (`text.response`, `ui.active`, `ui.focus`) to the `CustomTheme` definition in `packages/cli/src/config/settingsSchema.ts`.
- Synchronized the `CustomTheme` interface in `packages/core/src/config/config.ts` by adding `border.focused` (which was already in the schema but missing from the interface).
- Added a comprehensive validation test case in `packages/cli/src/config/settings-validation.test.ts` to verify that these properties are now correctly accepted.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/25689

## How to Validate

1. Run the new validation tests: `npm test -w @google/gemini-cli -- src/config/settings-validation.test.ts`
2. Manually verify by creating a custom theme in your settings:
   ```yaml
   ui:
     customThemes:
       test-theme:
         type: custom
         name: "Test Theme"
         text:
           response: "#00ff00"
   ```
   The CLI should no longer warn about unrecognized keys.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on MacOS
