### PR TITLE
fix(ui): restore daily quota display in /stats command

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -156,6 +156,8 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
           selectedAuthType={itemForDisplay.selectedAuthType}
           userEmail={itemForDisplay.userEmail}
           tier={itemForDisplay.tier}
+          creditBalance={itemForDisplay.creditBalance}
+          quotaBuckets={itemForDisplay.quotas?.buckets}
         />
       )}
       {itemForDisplay.type === 'model_stats' && (

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -25,6 +25,7 @@ import { computeSessionStats } from '../utils/computeStats.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import type { QuotaStats } from '../types.js';
 import { LlmRole } from '@google/gemini-cli-core';
+import { ModelQuotaDisplay } from './ModelQuotaDisplay.js';
 
 // A more flexible and powerful StatRow component
 interface StatRowProps {
@@ -141,9 +142,7 @@ const ModelUsageTable: React.FC<ModelUsageTableProps> = ({ models }) => {
       <Text bold color={theme.text.primary}>
         Model Usage
       </Text>
-      <Text color={theme.text.secondary}>
-        Use /model to view model quota information
-      </Text>
+      <Text color={theme.text.secondary}>Session token usage by model</Text>
       <Box height={1} />
 
       {/* Header */}
@@ -237,6 +236,11 @@ interface StatsDisplayProps {
   currentModel?: string;
   quotaStats?: QuotaStats;
   creditBalance?: number;
+  quotaBuckets?: Array<{
+    modelId?: string;
+    remainingFraction?: number;
+    resetTime?: string;
+  }>;
 }
 
 export const StatsDisplay: React.FC<StatsDisplayProps> = ({
@@ -247,6 +251,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
   userEmail,
   tier,
   creditBalance,
+  quotaBuckets,
 }) => {
   const { stats } = useSessionStats();
   const { metrics } = stats;
@@ -394,6 +399,8 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
       </Section>
 
       {Object.keys(models).length > 0 && <ModelUsageTable models={models} />}
+
+      <ModelQuotaDisplay buckets={quotaBuckets} title="Daily Quota" />
 
       {renderFooter()}
     </Box>

--- a/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/StatsDisplay.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`<StatsDisplay /> > Conditional Rendering Tests > hides Efficiency secti
 │                                                                                                  │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Use /model to view model quota information                                                      │
+│  Session token usage by model                                                                    │
 │                                                                                                  │
 │  Model                           Reqs  Input Tokens   Cache Reads Output Tokens                  │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -206,7 +206,7 @@ exports[`<StatsDisplay /> > renders a table with two models correctly 1`] = `
 │                                                                                                  │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Use /model to view model quota information                                                      │
+│  Session token usage by model                                                                    │
 │                                                                                                  │
 │  Model                           Reqs  Input Tokens   Cache Reads Output Tokens                  │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -235,7 +235,7 @@ exports[`<StatsDisplay /> > renders all sections when all data is present 1`] = 
 │                                                                                                  │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Use /model to view model quota information                                                      │
+│  Session token usage by model                                                                    │
 │                                                                                                  │
 │  Model                           Reqs  Input Tokens   Cache Reads Output Tokens                  │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │
@@ -282,7 +282,7 @@ exports[`<StatsDisplay /> > renders role breakdown correctly under models 1`] = 
 │                                                                                                  │
 │                                                                                                  │
 │  Model Usage                                                                                     │
-│  Use /model to view model quota information                                                      │
+│  Session token usage by model                                                                    │
 │                                                                                                  │
 │  Model                           Reqs  Input Tokens   Cache Reads Output Tokens                  │
 │  ──────────────────────────────────────────────────────────────────────────────────────────────  │


### PR DESCRIPTION
## Summary

- Restores daily quota usage bars in `/stats` output, which were removed in PR #24206
- Reuses the existing `ModelQuotaDisplay` component — no new components or data fetching added
- Users can now monitor quota in real-time mid-session, which `/model` cannot do ("Slash commands cannot be queued")

## Details

- **`HistoryItemDisplay.tsx`**: Pass `creditBalance` and `quotaBuckets` from the stats history item to `StatsDisplay`
- **`StatsDisplay.tsx`**: Import and render `ModelQuotaDisplay` with quota bucket data, titled "Daily Quota"
- **`StatsDisplay.test.tsx.snap`**: Updated snapshots to reflect subtitle change

## Related Issues

Fixes #25598

## How to Validate

1. Run the CLI and trigger `/stats`
   - Verify daily quota progress bars are displayed below the Model Usage table
2. Run `/stats` while Gemini is actively working
   - Verify quota is visible in real-time (unlike `/model` which cannot be queued)
3. Run tests:
   ```bash
   npm test -w @google/gemini-cli -- --run src/ui/components/StatsDisplay.test.tsx
   npm test -w @google/gemini-cli -- --run src/ui/components/HistoryItemDisplay.test.tsx
   npm test -w @google/gemini-cli -- --run src/ui/components/ModelQuotaDisplay.test.tsx
```

## Pre-Merge Checklist

- [✔] Updated relevant documentation and README (if needed)
- [✔] Added/updated tests (if needed)
- [✔] Noted breaking changes (if any)
- [✔] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [✔] Linux
    - [✔] npm run
    - [ ] npx
    - [ ] Docker
