### PR TITLE
fix(core): prevent infinite loops with hard cap on consecutive same-name tool calls

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -704,7 +704,12 @@ export const useGeminiStream = (
 
   const lastQueryRef = useRef<PartListUnion | null>(null);
   const lastPromptIdRef = useRef<string | null>(null);
-  const loopDetectedRef = useRef(false);
+  const loopDetectedRef = useRef<{
+    count: number;
+    type?: string;
+    detail?: string;
+    confirmedByModel?: string;
+  } | null>(null);
   const [
     loopDetectionConfirmationRequest,
     setLoopDetectionConfirmationRequest,
@@ -1505,7 +1510,7 @@ export const useGeminiStream = (
           case ServerGeminiEventType.LoopDetected:
             // handle later because we want to move pending history to history
             // before we add loop detected message to history
-            loopDetectedRef.current = true;
+            loopDetectedRef.current = event.value || { count: 2 };
             break;
           case ServerGeminiEventType.Retry:
           case ServerGeminiEventType.InvalidStream:
@@ -1656,7 +1661,8 @@ export const useGeminiStream = (
                 setPendingHistoryItem(null);
               }
               if (loopDetectedRef.current) {
-                loopDetectedRef.current = false;
+                const loopDetails = loopDetectedRef.current;
+                loopDetectedRef.current = null;
                 // Show the confirmation dialog to choose whether to disable loop detection
                 setLoopDetectionConfirmationRequest({
                   onComplete: async (result: {
@@ -1682,9 +1688,16 @@ export const useGeminiStream = (
                         );
                       }
                     } else {
+                      let detailText = '';
+                      if (loopDetails.detail) {
+                        detailText = ` Details: ${loopDetails.detail}.`;
+                      } else if (loopDetails.confirmedByModel) {
+                        detailText = ` Identified by model: ${loopDetails.confirmedByModel}.`;
+                      }
+
                       addItem({
                         type: 'info',
-                        text: `A potential loop was detected. This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
+                        text: `A potential loop was detected.${detailText} This can happen due to repetitive tool calls or other model behavior. The request has been halted.`,
                       });
                     }
                   },

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -689,7 +689,7 @@ export class GeminiClient {
 
     const loopResult = await this.loopDetector.turnStarted(signal);
     if (loopResult.count > 1) {
-      yield { type: GeminiEventType.LoopDetected };
+      yield { type: GeminiEventType.LoopDetected, value: loopResult };
       return turn;
     } else if (loopResult.count === 1) {
       if (boundedTurns <= 1) {
@@ -758,7 +758,7 @@ export class GeminiClient {
     for await (const event of resultStream) {
       const loopResult = this.loopDetector.addAndCheck(event);
       if (loopResult.count > 1) {
-        yield { type: GeminiEventType.LoopDetected };
+        yield { type: GeminiEventType.LoopDetected, value: loopResult };
         loopDetectedAbort = true;
         break;
       } else if (loopResult.count === 1) {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -28,6 +28,7 @@ import { InvalidStreamError, type GeminiChat } from './geminiChat.js';
 import { parseThought, type ThoughtSummary } from '../utils/thoughtUtils.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import { getCitations } from '../utils/generateContentResponseUtilities.js';
+import type { LoopType } from '../telemetry/types.js';
 import { LlmRole } from '../telemetry/types.js';
 
 import {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -206,6 +206,12 @@ export type ServerGeminiFinishedEvent = {
 
 export type ServerGeminiLoopDetectedEvent = {
   type: GeminiEventType.LoopDetected;
+  value?: {
+    count: number;
+    type?: LoopType;
+    detail?: string;
+    confirmedByModel?: string;
+  };
 };
 
 export type ServerGeminiCitationEvent = {

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -105,6 +105,31 @@ describe('LoopDetectionService', () => {
       expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
     });
 
+    it('should detect a loop for consecutive calls to a thinking tool even with different arguments', () => {
+      const toolName = 'sequentialthinking';
+      for (let i = 0; i < 15 - 1; i++) {
+        const event = createToolCallRequestEvent(toolName, {
+          thoughtNumber: i,
+        });
+        expect(service.addAndCheck(event).count).toBe(0);
+      }
+      const finalEvent = createToolCallRequestEvent(toolName, {
+        thoughtNumber: 14,
+      });
+      expect(service.addAndCheck(finalEvent).count).toBe(1);
+      expect(loggers.logLoopDetected).toHaveBeenCalledTimes(1);
+    });
+
+    it('should detect a loop for consecutive calls to a non-thinking tool with different arguments at a higher threshold', () => {
+      const toolName = 'otherTool';
+      for (let i = 0; i < 50 - 1; i++) {
+        const event = createToolCallRequestEvent(toolName, { arg: i });
+        expect(service.addAndCheck(event).count).toBe(0);
+      }
+      const finalEvent = createToolCallRequestEvent(toolName, { arg: 49 });
+      expect(service.addAndCheck(finalEvent).count).toBe(1);
+    });
+
     it('should not detect a loop for different tool calls', () => {
       const event1 = createToolCallRequestEvent('testTool', {
         param: 'value1',

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -32,6 +32,25 @@ const CONTENT_CHUNK_SIZE = 50;
 const MAX_HISTORY_LENGTH = 5000;
 
 /**
+ * Hard cap for consecutive calls to the same tool name, even if arguments differ.
+ * This prevents infinite loops in tools like 'sequentialthinking' where
+ * arguments (like thoughtNumber) change each time.
+ */
+const CONSECUTIVE_SAME_TOOL_NAME_THRESHOLD = 50;
+
+/**
+ * Lower threshold for 'thinking' tools that are known to be prone to loops.
+ */
+const THINKING_TOOL_LOOP_THRESHOLD = 15;
+
+const THINKING_TOOL_NAMES = new Set([
+  'sequentialthinking',
+  'sequential_thinking',
+  'thought',
+  'reasoning',
+]);
+
+/**
  * The number of recent conversation turns to include in the history when asking the LLM to check for a loop.
  */
 const LLM_LOOP_CHECK_HISTORY_COUNT = 20;
@@ -137,7 +156,9 @@ export class LoopDetectionService {
 
   // Tool call tracking
   private lastToolCallKey: string | null = null;
+  private lastToolName: string | null = null;
   private toolCallRepetitionCount: number = 0;
+  private sameToolNameConsecutiveCount: number = 0;
 
   // Content streaming tracking
   private streamContentHistory = '';
@@ -319,9 +340,32 @@ export class LoopDetectionService {
       this.lastToolCallKey = key;
       this.toolCallRepetitionCount = 1;
     }
+
+    // Also track consecutive calls to the same tool name, even if arguments differ.
+    // This catches "thinking" loops where arguments (like thoughtNumber) change.
+    if (this.lastToolName === toolCall.name) {
+      this.sameToolNameConsecutiveCount++;
+    } else {
+      this.lastToolName = toolCall.name;
+      this.sameToolNameConsecutiveCount = 1;
+    }
+
     if (this.toolCallRepetitionCount >= TOOL_CALL_LOOP_THRESHOLD) {
+      this.lastLoopDetail = `Consecutive identical tool call: ${toolCall.name}`;
+      this.lastLoopType = LoopType.IDENTICAL_TOOL_CALL_LOOP;
       return true;
     }
+
+    const threshold = THINKING_TOOL_NAMES.has(toolCall.name)
+      ? THINKING_TOOL_LOOP_THRESHOLD
+      : CONSECUTIVE_SAME_TOOL_NAME_THRESHOLD;
+
+    if (this.sameToolNameConsecutiveCount >= threshold) {
+      this.lastLoopDetail = `Consecutive calls to the same tool name: ${toolCall.name} (args may vary)`;
+      this.lastLoopType = LoopType.IDENTICAL_TOOL_CALL_LOOP; // Still a tool loop
+      return true;
+    }
+
     return false;
   }
 
@@ -740,7 +784,9 @@ export class LoopDetectionService {
 
   private resetToolCallCount(): void {
     this.lastToolCallKey = null;
+    this.lastToolName = null;
     this.toolCallRepetitionCount = 0;
+    this.sameToolNameConsecutiveCount = 0;
   }
 
   private resetContentTracking(resetHistory = true): void {

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -362,7 +362,7 @@ export class LoopDetectionService {
 
     if (this.sameToolNameConsecutiveCount >= threshold) {
       this.lastLoopDetail = `Consecutive calls to the same tool name: ${toolCall.name} (args may vary)`;
-      this.lastLoopType = LoopType.IDENTICAL_TOOL_CALL_LOOP; // Still a tool loop
+      this.lastLoopType = LoopType.CONSECUTIVE_SAME_NAME_TOOL_CALLS; // Still a tool loop
       return true;
     }
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -806,6 +806,7 @@ export enum LoopType {
   LLM_DETECTED_LOOP = 'llm_detected_loop',
   // Aliases for tests/internal use
   TOOL_CALL_LOOP = CONSECUTIVE_IDENTICAL_TOOL_CALLS,
+  IDENTICAL_TOOL_CALL_LOOP = CONSECUTIVE_IDENTICAL_TOOL_CALLS,
   CONTENT_CHANTING_LOOP = CHANTING_IDENTICAL_SENTENCES,
 }
 export class LoopDetectedEvent implements BaseTelemetryEvent {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -804,6 +804,7 @@ export enum LoopType {
   CONSECUTIVE_IDENTICAL_TOOL_CALLS = 'consecutive_identical_tool_calls',
   CHANTING_IDENTICAL_SENTENCES = 'chanting_identical_sentences',
   LLM_DETECTED_LOOP = 'llm_detected_loop',
+  CONSECUTIVE_SAME_NAME_TOOL_CALLS = 'consecutive_same_name_tool_calls',
   // Aliases for tests/internal use
   TOOL_CALL_LOOP = CONSECUTIVE_IDENTICAL_TOOL_CALLS,
   IDENTICAL_TOOL_CALL_LOOP = CONSECUTIVE_IDENTICAL_TOOL_CALLS,


### PR DESCRIPTION
﻿## Summary

This PR implements a hard cap for consecutive calls to the same tool name to prevent infinite loops, especially in "thinking" tools where arguments (like thought numbers) change each time. It also enhances the loop detection event to carry more details to the UI.

## Details

- Added CONSECUTIVE_SAME_TOOL_NAME_THRESHOLD (50) and THINKING_TOOL_LOOP_THRESHOLD (15) to LoopDetectionService.
- Enhanced loop detection to track consecutive calls to the same tool name even if arguments differ.
- Updated LoopDetected event to carry specific loop details (	ype, count, detail).
- Improved UI alerting in useGeminiStream to display detailed information about the detected loop.
- Added comprehensive unit tests for the new loop detection logic.

## Related Issues

Fixes #25671

## How to Validate

1. Run 
pm test -w @google/gemini-cli-core -- loopDetectionService.test.ts to verify the logic.
2. Trigger a loop in the CLI with a tool that changes arguments (e.g. sequentialthinking) and verify it stops after 15 calls with a detailed message.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
