### PR TITLE
fix(core): ensure 1:1 part count in tool responses to prevent 400 errors

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -423,7 +423,11 @@ export function supportsMultimodalFunctionResponse(
         ?.multimodalToolUse === true
     );
   }
-  return model.startsWith('gemini-3-');
+  return (
+    model.startsWith('gemini-2.0-') ||
+    model.startsWith('gemini-2.5-') ||
+    model.startsWith('gemini-3-')
+  );
 }
 
 /**

--- a/packages/core/src/utils/generateContentResponseUtilities.test.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.test.ts
@@ -158,7 +158,7 @@ describe('generateContentResponseUtilities', () => {
       ]);
     });
 
-    it('should handle llmContent with fileData for Gemini 3 model (should be siblings)', () => {
+    it('should handle llmContent with fileData for Gemini 3 model (should be nested)', () => {
       const llmContent: Part = {
         fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
       };
@@ -174,9 +174,9 @@ describe('generateContentResponseUtilities', () => {
             name: toolName,
             id: callId,
             response: { output: 'Binary content provided (1 item(s)).' },
+            parts: [llmContent],
           },
         },
-        llmContent,
       ]);
     });
 
@@ -202,15 +202,16 @@ describe('generateContentResponseUtilities', () => {
       ]);
     });
 
-    it('should handle llmContent with fileData for non-Gemini 3 models', () => {
+    it('should handle llmContent with fileData for non-Gemini models (should not return siblings)', () => {
       const llmContent: Part = {
         fileData: { mimeType: 'application/pdf', fileUri: 'gs://...' },
       };
+      // We'll use a dummy model that doesn't start with gemini-2/3
       const result = convertToFunctionResponse(
         toolName,
         callId,
         llmContent,
-        DEFAULT_GEMINI_MODEL,
+        'old-model',
       );
       expect(result).toEqual([
         {
@@ -220,7 +221,6 @@ describe('generateContentResponseUtilities', () => {
             response: { output: 'Binary content provided (1 item(s)).' },
           },
         },
-        llmContent,
       ]);
     });
 

--- a/packages/core/src/utils/generateContentResponseUtilities.ts
+++ b/packages/core/src/utils/generateContentResponseUtilities.ts
@@ -102,17 +102,14 @@ export function convertToFunctionResponse(
     model,
     config,
   );
-  const siblingParts: Part[] = [...fileDataParts];
 
-  if (inlineDataParts.length > 0) {
-    if (isMultimodalFRSupported) {
-      // Nest inlineData if supported by the model
+  if (isMultimodalFRSupported) {
+    const multimodalParts = [...inlineDataParts, ...fileDataParts];
+    if (multimodalParts.length > 0) {
+      // Nest parts if supported by the model
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       (part.functionResponse as unknown as { parts: Part[] }).parts =
-        inlineDataParts;
-    } else {
-      // Otherwise treat as siblings
-      siblingParts.push(...inlineDataParts);
+        multimodalParts;
     }
   }
 
@@ -125,10 +122,6 @@ export function convertToFunctionResponse(
     part.functionResponse!.response = {
       output: `Binary content provided (${totalBinaryItems} item(s)).`,
     };
-  }
-
-  if (siblingParts.length > 0) {
-    return [part, ...siblingParts];
   }
 
   return [part];

--- a/packages/core/src/utils/sessionUtils.ts
+++ b/packages/core/src/utils/sessionUtils.ts
@@ -91,9 +91,9 @@ export function convertSessionToClientHistory(
 
         const functionResponseParts: Part[] = [];
         for (const toolCall of msg.toolCalls!) {
-          if (toolCall.result) {
-            let responseData: Part;
+          let responseData: Part;
 
+          if (toolCall.result) {
             if (typeof toolCall.result === 'string') {
               responseData = {
                 functionResponse: {
@@ -105,14 +105,31 @@ export function convertSessionToClientHistory(
                 },
               };
             } else if (Array.isArray(toolCall.result)) {
-              functionResponseParts.push(...ensurePartArray(toolCall.result));
-              continue;
+              // Ensure we only take the first part if it's an array,
+              // or handle multimodal nesting if present.
+              // Our fixed convertToFunctionResponse now returns [part].
+              const parts = ensurePartArray(toolCall.result);
+              responseData = parts[0];
+
+              // If for some reason there were siblings in old data, we must ignore them
+              // to maintain the 1:1 part count.
             } else {
               responseData = toolCall.result;
             }
-
-            functionResponseParts.push(responseData);
+          } else {
+            // Provide a placeholder if result is missing to preserve part count
+            responseData = {
+              functionResponse: {
+                id: toolCall.id,
+                name: toolCall.name,
+                response: {
+                  error: 'Tool execution result not recorded.',
+                },
+              },
+            };
           }
+
+          functionResponseParts.push(responseData);
         }
 
         if (functionResponseParts.length > 0) {


### PR DESCRIPTION
﻿## Summary

This PR ensures a strict 1:1 mapping between tool calls and function responses in the Gemini model interaction logic. This fixes 400 errors (Bad Request) caused by part count mismatches, especially when handling multimodal tool responses (e.g., file or inline data).

## Details

- **Nesting Multimodal Parts**: Refactored convertToFunctionResponse to nest inlineData and ileData parts directly within the unctionResponse object's parts array when supported by the model, rather than returning them as sibling parts in the same message.
- **Model Support**: Updated supportsMultimodalFunctionResponse to include gemini-2.0- and gemini-2.5- models.
- **Session History Enforcement**: Updated convertSessionToClientHistory to strictly enforce the 1:1 part count. It now ignores legacy sibling parts and provides a placeholder unctionResponse if a tool result is missing, ensuring the model receives the expected number of response parts.
- **Unit Tests**: Updated generateContentResponseUtilities.test.ts to reflect the nesting behavior and ensure correct handling of multimodal content across different model versions.

## Related Issues

Fixes part count mismatch errors (400) in tool-enabled conversations.

## How to Validate

1. Run unit tests: 
pm test -w @google/gemini-cli-core -- generateContentResponseUtilities.test.ts
2. Manually verify tool-enabled sessions with multimodal outputs (e.g., a tool returning an image) in the CLI using a Gemini 2.0+ model.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
