### PR TITLE
feature: add Windows shell interoperability for &&, ||, and /dev/null

### DIFF
--- a/packages/core/src/utils/env-aware.test.ts
+++ b/packages/core/src/utils/env-aware.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import os from 'node:os';
+import {
+  getShellConfiguration,
+  getEnvironmentAwareCommand,
+} from './shell-utils.js';
+
+vi.mock('node:os');
+
+const mockPlatform = os.platform as Mock;
+
+describe('getEnvironmentAwareCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should not change command on non-Windows', () => {
+    mockPlatform.mockReturnValue('linux');
+    expect(getEnvironmentAwareCommand('ls -la')).toBe('ls -la');
+    expect(getEnvironmentAwareCommand('cat file.txt')).toBe('cat file.txt');
+  });
+
+  describe('on Windows with PowerShell', () => {
+    beforeEach(() => {
+      mockPlatform.mockReturnValue('win32');
+    });
+
+    it('should map ls and cat to their aliases/equivalents', () => {
+      expect(getEnvironmentAwareCommand('ls', 'powershell')).toBe('ls');
+      expect(getEnvironmentAwareCommand('ls -la', 'powershell')).toBe('ls -la');
+      expect(getEnvironmentAwareCommand('cat file.txt', 'powershell')).toBe(
+        'cat file.txt',
+      );
+    });
+
+    it('should map rm -rf to PowerShell flags', () => {
+      expect(getEnvironmentAwareCommand('rm -rf folder', 'powershell')).toBe(
+        'rm -Recurse -Force folder',
+      );
+      expect(getEnvironmentAwareCommand('rm -f file', 'powershell')).toBe(
+        'rm -Force file',
+      );
+      expect(getEnvironmentAwareCommand('rm -r folder', 'powershell')).toBe(
+        'rm -Recurse folder',
+      );
+    });
+
+    it('should map mkdir -p to mkdir', () => {
+      expect(
+        getEnvironmentAwareCommand('mkdir -p path/to/dir', 'powershell'),
+      ).toBe('mkdir path/to/dir');
+    });
+
+    it('should map cp -r to Copy-Item flags', () => {
+      expect(getEnvironmentAwareCommand('cp -r src dest', 'powershell')).toBe(
+        'cp -Recurse src dest',
+      );
+    });
+
+    it('should map touch to New-Item', () => {
+      expect(
+        getEnvironmentAwareCommand('touch newfile.txt', 'powershell'),
+      ).toBe('New-Item -ItemType File -Force newfile.txt');
+    });
+
+    it('should map which to Get-Command', () => {
+      expect(getEnvironmentAwareCommand('which git', 'powershell')).toBe(
+        'Get-Command git',
+      );
+    });
+
+    it('should map /dev/null to $null', () => {
+      expect(
+        getEnvironmentAwareCommand('echo hello > /dev/null', 'powershell'),
+      ).toBe('echo hello > $null');
+      expect(getEnvironmentAwareCommand('cat /dev/null', 'powershell')).toBe(
+        'cat $null',
+      );
+    });
+
+    it('should map && and || to PowerShell equivalents for compatibility', () => {
+      expect(
+        getEnvironmentAwareCommand('npm install && npm test', 'powershell'),
+      ).toBe('npm install; if ($?) { npm test }');
+      expect(
+        getEnvironmentAwareCommand('git commit || echo error', 'powershell'),
+      ).toBe('git commit; if (-not $?) { echo error }');
+      expect(getEnvironmentAwareCommand('a && b || c', 'powershell')).toBe(
+        'a; if ($?) { b; if (-not $?) { c } }',
+      );
+    });
+  });
+
+  describe('on Windows with CMD', () => {
+    beforeEach(() => {
+      mockPlatform.mockReturnValue('win32');
+    });
+
+    it('should map ls to dir and cat to type', () => {
+      expect(getEnvironmentAwareCommand('ls', 'cmd')).toBe('dir');
+      expect(getEnvironmentAwareCommand('cat file.txt', 'cmd')).toBe(
+        'type file.txt',
+      );
+    });
+
+    it('should map /dev/null to nul', () => {
+      expect(getEnvironmentAwareCommand('echo hello > /dev/null', 'cmd')).toBe(
+        'echo hello > nul',
+      );
+    });
+
+    it('should map touch to type nul >', () => {
+      expect(getEnvironmentAwareCommand('touch file.txt', 'cmd')).toBe(
+        'type nul > file.txt',
+      );
+    });
+
+    it('should map which to where', () => {
+      expect(getEnvironmentAwareCommand('which git', 'cmd')).toBe('where git');
+    });
+  });
+});
+
+describe('getShellConfiguration', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should include defaultPager', () => {
+    mockPlatform.mockReturnValue('linux');
+    const config = getShellConfiguration();
+    expect(config.defaultPager).toBe('cat');
+
+    mockPlatform.mockReturnValue('win32');
+    const winConfig = getShellConfiguration();
+    expect(winConfig.defaultPager).toBe('');
+  });
+});

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -136,7 +136,7 @@ export function getEnvironmentAwareCommand(
       // cp -r -> cp -Recurse
       .replace(/\bcp\s+-[ra](\s|$)/g, 'cp -Recurse$1')
       // touch -> New-Item
-      .replace(/\btouch\s+(\S+)/g, 'New-Item -ItemType File -Force $1')
+      .replace(/\btouch\s+((?:"[^"]*"|'[^']*'|\S)+)/g, 'New-Item -ItemType File -Force $1')
       // which -> Get-Command
       .replace(/\bwhich\s+(\S+)/g, 'Get-Command $1')
       // /dev/null -> $null

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -74,6 +74,8 @@ export interface ShellConfiguration {
   argsPrefix: string[];
   /** An identifier for the shell type. */
   shell: ShellType;
+  /** The default pager to use for this environment. */
+  defaultPager: string;
 }
 
 export async function resolveExecutable(
@@ -103,6 +105,81 @@ export async function resolveExecutable(
     }
   }
   return undefined;
+}
+
+/**
+ * Maps common Unix commands to their Windows equivalents if running on Windows.
+ * This is a best-effort mapping to improve model reliability.
+ *
+ * @param command The command string to potentially map.
+ * @param shell The type of shell being used (powershell or cmd).
+ * @returns The (potentially) mapped command string.
+ */
+export function getEnvironmentAwareCommand(
+  command: string,
+  shell: ShellType = 'powershell',
+): string {
+  if (!isWindows()) {
+    return command;
+  }
+
+  const trimmed = command.trim();
+  if (shell === 'powershell') {
+    // PowerShell has aliases for many Unix commands, but flags often differ.
+    let result = trimmed
+      // rm -rf -> rm -Recurse -Force
+      .replace(/\brm\s+-rf(\s|$)/g, 'rm -Recurse -Force$1')
+      .replace(/\brm\s+-r(\s|$)/g, 'rm -Recurse$1')
+      .replace(/\brm\s+-f(\s|$)/g, 'rm -Force$1')
+      // mkdir -p -> mkdir (PS mkdir function handles multiple levels)
+      .replace(/\bmkdir\s+-p(\s|$)/g, 'mkdir$1')
+      // cp -r -> cp -Recurse
+      .replace(/\bcp\s+-[ra](\s|$)/g, 'cp -Recurse$1')
+      // touch -> New-Item
+      .replace(/\btouch\s+(\S+)/g, 'New-Item -ItemType File -Force $1')
+      // which -> Get-Command
+      .replace(/\bwhich\s+(\S+)/g, 'Get-Command $1')
+      // /dev/null -> $null
+      .replace(/\/dev\/null\b/g, '$null')
+      // && and || (PowerShell 7+ only, so emulate for PS 5.1 compatibility)
+      // We do a simple replacement for common chained patterns.
+      .replace(/\s+&&\s+/g, '; if ($?) { ')
+      .replace(/\s+\|\|\s+/g, '; if (-not $?) { ')
+      // General replacements for cat and ls if they are used in pipes/chains
+      .replace(/^ls(\s|$)/, 'ls$1')
+      .replace(/^cat(\s|$)/, 'cat$1')
+      .replace(/(\||&&|;)\s*ls(\s|$)/g, '$1 ls$2')
+      .replace(/(\||&&|;)\s*cat(\s|$)/g, '$1 cat$2');
+
+    // Add closing braces for any opened blocks
+    const openedBlocks = (result.match(/\{ /g) || []).length;
+    if (openedBlocks > 0) {
+      result += ' }'.repeat(openedBlocks);
+    }
+    return result;
+  }
+
+  if (shell === 'cmd') {
+    return (
+      trimmed
+        // ls -> dir
+        .replace(/^ls(\s|$)/, 'dir$1')
+        .replace(/(\||&&|;)\s*ls(\s|$)/g, '$1 dir$2')
+        // cat -> type
+        .replace(/^cat(\s|$)/, 'type$1')
+        .replace(/(\||&&|;)\s*cat(\s|$)/g, '$1 type$2')
+        // mkdir -p -> mkdir
+        .replace(/\bmkdir\s+-p(\s|$)/g, 'mkdir$1')
+        // touch -> type nul >
+        .replace(/\btouch\s+(\S+)/g, 'type nul > $1')
+        // which -> where
+        .replace(/\bwhich\s+(\S+)/g, 'where $1')
+        // /dev/null -> nul
+        .replace(/\/dev\/null\b/g, 'nul')
+    );
+  }
+
+  return trimmed;
 }
 
 let bashLanguage: Language | null = null;
@@ -647,6 +724,7 @@ export function getShellConfiguration(): ShellConfiguration {
           executable: comSpec,
           argsPrefix: ['-NoProfile', '-Command'],
           shell: 'powershell',
+          defaultPager: '',
         };
       }
     }
@@ -656,11 +734,17 @@ export function getShellConfiguration(): ShellConfiguration {
       executable: 'powershell.exe',
       argsPrefix: ['-NoProfile', '-Command'],
       shell: 'powershell',
+      defaultPager: '',
     };
   }
 
   // Unix-like systems (Linux, macOS)
-  return { executable: 'bash', argsPrefix: ['-c'], shell: 'bash' };
+  return {
+    executable: 'bash',
+    argsPrefix: ['-c'],
+    shell: 'bash',
+    defaultPager: 'cat',
+  };
 }
 
 /**

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -138,7 +138,7 @@ export function getEnvironmentAwareCommand(
       // touch -> New-Item
       .replace(/\btouch\s+((?:"[^"]*"|'[^']*'|\S)+)/g, 'New-Item -ItemType File -Force $1')
       // which -> Get-Command
-      .replace(/\bwhich\s+(\S+)/g, 'Get-Command $1')
+      .replace(/\bwhich\s+((?:"[^"]*"|'[^']*'|\S)+)/g, 'Get-Command $1')
       // /dev/null -> $null
       .replace(/\/dev\/null\b/g, '$null')
       // && and || (PowerShell 7+ only, so emulate for PS 5.1 compatibility)

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -171,9 +171,9 @@ export function getEnvironmentAwareCommand(
         // mkdir -p -> mkdir
         .replace(/\bmkdir\s+-p(\s|$)/g, 'mkdir$1')
         // touch -> type nul >
-        .replace(/\btouch\s+(\S+)/g, 'type nul > $1')
+        .replace(/\btouch\s+((?:"[^"]*"|'[^']*'|\S)+)/g, 'type nul > $1')
         // which -> where
-        .replace(/\bwhich\s+(\S+)/g, 'where $1')
+        .replace(/\bwhich\s+((?:"[^"]*"|'[^']*'|\S)+)/g, 'where $1')
         // /dev/null -> nul
         .replace(/\/dev\/null\b/g, 'nul')
     );


### PR DESCRIPTION
## Summary

Add cross-platform interoperability for shell operators `&&`, `||` and Unix-style redirections like `/dev/null` on Windows. This ensures that common command chains and redirection patterns work seamlessly in PowerShell 5.1 and CMD.

## Details

- **PowerShell Compatibility**: Since PowerShell versions prior to 7.0 do not support `&&` and `||`, these operators are now translated into compatible conditional blocks (e.g., `cmd1; if ($?) { cmd2 }`).
- **Redirection Mapping**: Added mapping for `/dev/null` to `$null` for PowerShell and `nul` for CMD.
- **Operator Normalization**: Updated `getEnvironmentAwareCommand` to perform these translations when running on Windows.
- **Lint Fixes**: Ensured regex patterns comply with `no-useless-escape` ESLint rules.

## Related Issues
None currently

## How to Validate

1. Run `npm test -w @google/gemini-cli-core -- env-aware.test.ts` to verify all new test cases pass.
2. On a Windows machine with PowerShell 5.1, run a command like `gemini "echo 1 && echo 2"` and verify both are executed.
3. Run `gemini "echo test > /dev/null"` and verify it succeeds without creating a literal `/dev/null` file.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
  - [ ] Linux
