### PR TITLE
feat(cli): add /note command to append and view workspace notes

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -42,6 +42,7 @@ import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
+import { noteCommand } from '../ui/commands/noteCommand.js';
 import { oncallCommand } from '../ui/commands/oncallCommand.js';
 import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
 import { planCommand } from '../ui/commands/planCommand.js';
@@ -184,6 +185,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
         : [mcpCommand]),
       memoryCommand,
       modelCommand,
+      noteCommand,
       ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
       ...(this.config?.isPlanEnabled() ? [planCommand] : []),
       policiesCommand,

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -185,8 +185,9 @@ export class BuiltinCommandLoader implements ICommandLoader {
         : [mcpCommand]),
       memoryCommand,
       modelCommand,
-      noteCommand,
-      ...(this.config?.getFolderTrust() ? [permissionsCommand] : []),
+      ...(this.config?.getFolderTrust()
+        ? [permissionsCommand, noteCommand]
+        : []),
       ...(this.config?.isPlanEnabled() ? [planCommand] : []),
       policiesCommand,
       privacyCommand,

--- a/packages/cli/src/ui/commands/noteCommand.test.ts
+++ b/packages/cli/src/ui/commands/noteCommand.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { noteCommand } from './noteCommand.js';
+import * as fsPromises from 'node:fs/promises';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import * as path from 'node:path';
+import type { MessageActionReturn } from '@google/gemini-cli-core';
+
+vi.mock('node:fs/promises');
+
+describe('noteCommand', () => {
+  const mockContext = createMockCommandContext();
+  const workspaceRoot = process.cwd();
+  const notesFile = path.join(workspaceRoot, 'notes.md');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('append action', () => {
+    it('should append a note to notes.md when args are provided', async () => {
+      const noteText = 'This is a test note';
+      vi.mocked(fsPromises.appendFile).mockResolvedValue(undefined);
+
+      const result = (await noteCommand.action!(
+        mockContext,
+        noteText,
+      )) as MessageActionReturn;
+
+      expect(fsPromises.appendFile).toHaveBeenCalledWith(
+        notesFile,
+        expect.stringContaining(noteText),
+      );
+      expect(fsPromises.appendFile).toHaveBeenCalledWith(
+        notesFile,
+        expect.stringContaining('## '),
+      );
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: `Note saved to ${notesFile}`,
+      });
+    });
+
+    it('should return a usage message when no args are provided', async () => {
+      const result = (await noteCommand.action!(
+        mockContext,
+        '  ',
+      )) as MessageActionReturn;
+
+      expect(fsPromises.appendFile).not.toHaveBeenCalled();
+      expect(result.content).toContain('Please provide a note to save');
+    });
+
+    it('should return an error message when appendFile fails', async () => {
+      vi.mocked(fsPromises.appendFile).mockRejectedValue(new Error('FS Error'));
+
+      const result = (await noteCommand.action!(
+        mockContext,
+        'some note',
+      )) as MessageActionReturn;
+
+      expect(result.content).toContain('Failed to save note: FS Error');
+    });
+  });
+
+  describe('view subcommand', () => {
+    const viewSubcommand = noteCommand.subCommands?.find(
+      (s) => s.name === 'view',
+    );
+
+    it('should read and display notes from notes.md', async () => {
+      const notesContent = '## 4/21/2026\n\nTest note content';
+      vi.mocked(fsPromises.readFile).mockResolvedValue(notesContent);
+
+      const result = (await viewSubcommand!.action!(
+        mockContext,
+        '',
+      )) as MessageActionReturn;
+
+      expect(fsPromises.readFile).toHaveBeenCalledWith(notesFile, 'utf8');
+      expect(result.content).toContain('### Current Notes');
+      expect(result.content).toContain(notesContent);
+    });
+
+    it('should return "No notes found" if notes.md does not exist', async () => {
+      const error = new Error('Not found');
+      Object.assign(error, { code: 'ENOENT' });
+      vi.mocked(fsPromises.readFile).mockRejectedValue(error);
+
+      const result = (await viewSubcommand!.action!(
+        mockContext,
+        '',
+      )) as MessageActionReturn;
+
+      expect(result.content).toContain('No notes found in this workspace.');
+    });
+
+    it('should return an error message when readFile fails with other error', async () => {
+      vi.mocked(fsPromises.readFile).mockRejectedValue(new Error('Read Error'));
+
+      const result = (await viewSubcommand!.action!(
+        mockContext,
+        '',
+      )) as MessageActionReturn;
+
+      expect(result.content).toContain('Failed to read notes: Read Error');
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/noteCommand.ts
+++ b/packages/cli/src/ui/commands/noteCommand.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommandKind, type SlashCommand } from './types.js';
+import * as fsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+
+export const noteCommand: SlashCommand = {
+  name: 'note',
+  description: 'Manage workspace notes (append or view)',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: true,
+  subCommands: [
+    {
+      name: 'view',
+      description: 'View the current workspace notes',
+      kind: CommandKind.BUILT_IN,
+      autoExecute: true,
+      action: async () => {
+        const workspaceRoot = process.cwd();
+        const notesFile = path.join(workspaceRoot, 'notes.md');
+
+        try {
+          const content = await fsPromises.readFile(notesFile, 'utf8');
+          return {
+            type: 'message',
+            messageType: 'info',
+            content: `### Current Notes\n\n${content}`,
+          };
+        } catch (err: unknown) {
+          if (
+            err &&
+            typeof err === 'object' &&
+            'code' in err &&
+            err.code === 'ENOENT'
+          ) {
+            return {
+              type: 'message',
+              messageType: 'info',
+              content: 'No notes found in this workspace.',
+            };
+          }
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          return {
+            type: 'message',
+            messageType: 'error',
+            content: `Failed to read notes: ${errorMessage}`,
+          };
+        }
+      },
+    },
+  ],
+  action: async (context, args) => {
+    if (!args.trim()) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Please provide a note to save or use `/note view` to see your notes. Example: `/note This is a useful thought.`',
+      };
+    }
+
+    const workspaceRoot = process.cwd();
+    const notesFile = path.join(workspaceRoot, 'notes.md');
+    const timestamp = new Date().toLocaleString();
+
+    const noteEntry = `\n## ${timestamp}\n\n${args.trim()}\n`;
+
+    try {
+      await fsPromises.appendFile(notesFile, noteEntry);
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Note saved to ${notesFile}`,
+      };
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to save note: ${errorMessage}`,
+      };
+    }
+  },
+};

--- a/packages/cli/src/ui/commands/noteCommand.ts
+++ b/packages/cli/src/ui/commands/noteCommand.ts
@@ -19,6 +19,7 @@ export const noteCommand: SlashCommand = {
       description: 'View the current workspace notes',
       kind: CommandKind.BUILT_IN,
       autoExecute: true,
+      takesArgs: false,
       action: async () => {
         const workspaceRoot = process.cwd();
         const notesFile = path.join(workspaceRoot, 'notes.md');


### PR DESCRIPTION
## Summary
This PR adds a new `/note` slash command to the Gemini CLI, allowing users to quickly capture thoughts and notes within their workspace.

## Details
- Implemented `/note <text>` to append a timestamped note to `notes.md` in the current working directory.
- Implemented `/note view` subcommand to display the contents of `notes.md`.
- Added comprehensive unit tests for both appending and viewing notes, including error handling for file system operations.
- Registered the command in `BuiltinCommandLoader`.
- Fixed ESLint `any` warnings and ensured type safety in the new implementation.

## Related Issues
None.

## How to Validate
1. Run `npm start` to open the Gemini CLI.
2. Type `/note This is a test note.` and press Enter.
3. Verify the message "Note saved to .../notes.md" appears.
4. Type `/note view` and press Enter.
5. Verify your note is displayed in the chat.
6. Check the `notes.md` file in the root directory to confirm the content and timestamp.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on MacOS
  - [x] npm run
  - [ ] npx
  - [ ] Docker
  - [ ] Podman
  - [ ] Seatbelt
- [ ] Windows
  - [ ] npm run
  - [ ] npx
  - [ ] Docker
- [ ] Linux
  - [ ] npm run
  - [ ] npx
  - [ ] Docker
