### PR TITLE
feat(cli): enhance /copy command with index support and tool result text

### DIFF
--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -218,6 +218,186 @@ describe('copyCommand', () => {
     });
   });
 
+  it('should copy second-to-last AI message with /copy 2', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const history = [
+      {
+        role: 'model',
+        parts: [{ text: 'First AI response' }],
+      },
+      {
+        role: 'user',
+        parts: [{ text: 'User message' }],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'Second AI response' }],
+      },
+    ];
+
+    mockGetHistory.mockReturnValue(history);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '2');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'First AI response',
+      expect.anything(),
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Output #2 from last copied to the clipboard',
+    });
+  });
+
+  it('should return info when index exceeds available AI messages', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const history = [
+      {
+        role: 'model',
+        parts: [{ text: 'Only AI response' }],
+      },
+    ];
+
+    mockGetHistory.mockReturnValue(history);
+
+    const result = await copyCommand.action(mockContext, '3');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Only 1 AI response(s) in history.',
+    });
+
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it('should return error for invalid index argument', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistory.mockReturnValue([]);
+
+    const result = await copyCommand.action(mockContext, 'abc');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Invalid index. Usage: /copy or /copy <number> (e.g. /copy 2)',
+    });
+
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it('should return error for zero or negative index', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    mockGetHistory.mockReturnValue([]);
+
+    const result = await copyCommand.action(mockContext, '0');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Invalid index. Usage: /copy or /copy <number> (e.g. /copy 2)',
+    });
+  });
+
+  it('should extract text from functionResponse parts', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const historyWithFunctionResponse = [
+      {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              response: { output: 'Tool result text' },
+            },
+          },
+        ],
+      },
+    ];
+
+    mockGetHistory.mockReturnValue(historyWithFunctionResponse);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      'Tool result text',
+      expect.anything(),
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Last output copied to the clipboard',
+    });
+  });
+
+  it('should handle falsy but valid functionResponse output values', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const historyWithZeroOutput = [
+      {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              response: { output: 0 },
+            },
+          },
+        ],
+      },
+    ];
+
+    mockGetHistory.mockReturnValue(historyWithZeroOutput);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('0', expect.anything());
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Last output copied to the clipboard',
+    });
+  });
+
+  it('should JSON.stringify object functionResponse output', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const historyWithObjectOutput = [
+      {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              response: { output: { summary: 'video summary text' } },
+            },
+          },
+        ],
+      },
+    ];
+
+    mockGetHistory.mockReturnValue(historyWithObjectOutput);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      JSON.stringify({ summary: 'video summary text' }),
+      expect.anything(),
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Last output copied to the clipboard',
+    });
+  });
+
   it('should handle clipboard copy error', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
@@ -291,7 +471,7 @@ describe('copyCommand', () => {
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
-      content: 'Last AI output contains no text to copy.',
+      content: 'AI output contains no text to copy.',
     });
 
     expect(mockCopyToClipboard).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -12,42 +12,83 @@ import {
   type SlashCommandActionReturn,
 } from './types.js';
 
+function extractTextFromParts(
+  parts: Array<{
+    text?: string;
+    functionResponse?: { response?: { output?: unknown } };
+  }>,
+): string {
+  return parts
+    .map((part) => {
+      if (part.text?.trim()) return part.text;
+      const output = part.functionResponse?.response?.output;
+      if (output !== undefined && output !== null) {
+        return typeof output === 'string'
+          ? output.trim()
+          : JSON.stringify(output);
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('');
+}
+
 export const copyCommand: SlashCommand = {
   name: 'copy',
-  description: 'Copy the last result or code snippet to clipboard',
+  description:
+    'Copy the last AI response to clipboard. Use /copy 2 for second-to-last, /copy 3 for third, etc.',
   kind: CommandKind.BUILT_IN,
   autoExecute: true,
-  action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
+  action: async (context, args): Promise<SlashCommandActionReturn | void> => {
+    const index = args?.trim() ? parseInt(args.trim(), 10) : 1;
+
+    if (isNaN(index) || index < 1) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Invalid index. Usage: /copy or /copy <number> (e.g. /copy 2)',
+      };
+    }
+
     const chat = context.services.agentContext?.geminiClient?.getChat();
     const history = chat?.getHistory();
 
-    // Get the last message from the AI (model role)
-    const lastAiMessage = history
-      ? history.filter((item) => item.role === 'model').pop()
-      : undefined;
+    const modelMessages = history
+      ? history.filter((item) => item.role === 'model')
+      : [];
 
-    if (!lastAiMessage) {
+    if (modelMessages.length === 0) {
       return {
         type: 'message',
         messageType: 'info',
         content: 'No output in history',
       };
     }
-    // Extract text from the parts
-    const lastAiOutput = lastAiMessage.parts
-      ?.filter((part) => part.text)
-      .map((part) => part.text)
-      .join('');
 
-    if (lastAiOutput) {
+    // index 1 = most recent, index 2 = second most recent, etc.
+    const target = modelMessages[modelMessages.length - index];
+
+    if (!target) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: `Only ${modelMessages.length} AI response(s) in history.`,
+      };
+    }
+
+    const output = extractTextFromParts(target.parts ?? []);
+
+    if (output) {
       try {
         const settings = context.services.settings.merged;
-        await copyToClipboard(lastAiOutput, settings);
+        await copyToClipboard(output, settings);
 
+        const label =
+          index === 1 ? 'Last output' : `Output #${index} from last`;
         return {
           type: 'message',
           messageType: 'info',
-          content: 'Last output copied to the clipboard',
+          content: `${label} copied to the clipboard`,
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -63,7 +104,7 @@ export const copyCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'info',
-        content: 'Last AI output contains no text to copy.',
+        content: 'AI output contains no text to copy.',
       };
     }
   },


### PR DESCRIPTION
Allow /copy N to copy the Nth most recent AI response (1 = latest, 2 = second-to-last, etc.), replacing the previous hard-coded "last only" behavior. Also extract text from functionResponse parts so MCP tool output is included when it is the sole content of a turn.

Closes #16341

## Summary

Enhances the `/copy` command to accept an optional numeric index, so users can copy any recent AI response — not just the last one. Also extends text extraction to include `functionResponse` parts, enabling MCP tool output (e.g. video summarization) to be copied when it's the sole content of a turn.

## Details

Previously `/copy` always grabbed the single most recent model message. This was a problem for multi-step workflows (e.g. MCP summarization) where the final message might just be a short confirmation, not the actual content the user wants.

The index is 1-based and counts back from most recent: `/copy` and `/copy 1` are equivalent. Invalid input (non-numeric, zero, negative, or out-of-bounds) returns a descriptive error message. No breaking changes — the default behavior is unchanged.

## Related Issues

Closes #16341

## How to Validate

1. Start a session and ask Gemini a question — note the response.
2. Ask a follow-up question to produce a second response.
3. Run `/copy` — should copy the most recent response.
4. Run `/copy 2` — should copy the first response.
5. Run `/copy 99` — should return: `Only 2 AI response(s) in history.`
6. Run `/copy abc` — should return the invalid index error with usage hint.
7. (MCP) Run a tool that returns output as the sole model turn content, then `/copy` — output should be on clipboard.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — no doc changes required, description is self-evident
- [x] Added/updated tests (if needed) — 5 new test cases covering index selection, out-of-bounds, invalid args, and `functionResponse` extraction
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
