### PR TITLE
feat(cli): add Tab key file path completion in normal prompt mode

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -764,6 +764,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
         }
       } else if (isPlainTab) {
+        if (
+          completion.completionMode === CompletionMode.IDLE &&
+          !hasTabCompletionInteraction
+        ) {
+          // Trigger file path completion in normal prompt mode
+          setForceShowShellSuggestions(true);
+          resetPlainTabPress();
+          return true;
+        }
         if (!hasTabCompletionInteraction) {
           if (registerPlainTabPress() === 2) {
             toggleCleanUiDetailsVisible();

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -201,13 +201,29 @@ export function useCommandCompletion({
       };
     }
 
+    if (forceShowShellSuggestions) {
+      return {
+        completionMode: CompletionMode.SHELL,
+        query: null,
+        completionStart: -1,
+        completionEnd: -1,
+      };
+    }
+
     return {
       completionMode: CompletionMode.IDLE,
       query: null,
       completionStart: -1,
       completionEnd: -1,
     };
-  }, [cursorRow, cursorCol, buffer.lines, buffer.text, shellModeActive]);
+  }, [
+    cursorRow,
+    cursorCol,
+    buffer.lines,
+    buffer.text,
+    shellModeActive,
+    forceShowShellSuggestions,
+  ]);
 
   useAtCompletion({
     enabled: active && completionMode === CompletionMode.AT,
@@ -236,6 +252,7 @@ export function useCommandCompletion({
     cwd,
     setSuggestions,
     setIsLoadingSuggestions,
+    suppressCommandSuggestions: !shellModeActive,
   });
 
   const query =

--- a/packages/cli/src/ui/hooks/useShellCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useShellCompletion.test.ts
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { useState } from 'react';
 import {
   getTokenAtCursor,
   escapeShellPath,
   resolvePathCompletions,
   scanPathExecutables,
+  useShellCompletion,
 } from './useShellCompletion.js';
+import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import { renderHook } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
 import {
   createTmpDir,
   cleanupTmpDir,
@@ -179,17 +184,10 @@ describe('useShellCompletion utilities', () => {
     });
 
     it('should escape tabs, newlines, carriage returns, and backslashes', () => {
-      if (isWin) {
-        expect(escapeShellPath('a\tb')).toBe('a\tb');
-        expect(escapeShellPath('a\nb')).toBe('a\nb');
-        expect(escapeShellPath('a\rb')).toBe('a\rb');
-        expect(escapeShellPath('a\\b')).toBe('a\\b');
-      } else {
-        expect(escapeShellPath('a\tb')).toBe('a\\\tb');
-        expect(escapeShellPath('a\nb')).toBe('a\\\nb');
-        expect(escapeShellPath('a\rb')).toBe('a\\\rb');
-        expect(escapeShellPath('a\\b')).toBe('a\\\\b');
-      }
+      expect(escapeShellPath('a\tb')).toBe(isWin ? 'a\tb' : 'a\\\tb');
+      expect(escapeShellPath('a\nb')).toBe(isWin ? 'a\nb' : 'a\\\nb');
+      expect(escapeShellPath('a\rb')).toBe(isWin ? 'a\rb' : 'a\\\rb');
+      expect(escapeShellPath('a\\b')).toBe(isWin ? 'a\\b' : 'a\\\\b');
     });
 
     it('should handle empty string', () => {
@@ -385,13 +383,9 @@ describe('useShellCompletion utilities', () => {
       const results = await scanPathExecutables();
       expect(Array.isArray(results)).toBe(true);
       // Very basic sanity check: common commands should be found
-      if (process.platform !== 'win32') {
-        expect(results).toContain('ls');
-      } else {
-        expect(results).toContain('dir');
-        expect(results).toContain('cls');
-        expect(results).toContain('copy');
-      }
+      const isWin = process.platform === 'win32';
+      const expected = isWin ? 'dir' : 'ls';
+      expect(results).toContain(expected);
     });
 
     it('should support abort signal', async () => {
@@ -405,13 +399,125 @@ describe('useShellCompletion utilities', () => {
     it('should handle empty PATH', async () => {
       vi.stubEnv('PATH', '');
       const results = await scanPathExecutables();
-      if (process.platform === 'win32') {
-        expect(results.length).toBeGreaterThan(0);
-        expect(results).toContain('dir');
-      } else {
-        expect(results).toEqual([]);
-      }
+      const isWin = process.platform === 'win32';
+      // On Windows, built-in shell commands are always included even with empty PATH
+      expect(isWin ? results.length > 0 : results.length === 0).toBe(true);
       vi.unstubAllEnvs();
     });
+  });
+});
+
+describe('useShellCompletion hook', () => {
+  const fs: FileSystemStructure = {
+    'srcfile.txt': 'content',
+    'srcdir/': {
+      'nested.txt': 'nested',
+    },
+    'other.txt': 'content',
+  };
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir(fs);
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  function useShellCompletionHarness(props: {
+    line: string;
+    cursorCol: number;
+    suppressCommandSuggestions?: boolean;
+  }) {
+    const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const range = useShellCompletion({
+      enabled: true,
+      line: props.line,
+      cursorCol: props.cursorCol,
+      cwd: tmpDir,
+      setSuggestions,
+      setIsLoadingSuggestions: setIsLoading,
+      suppressCommandSuggestions: props.suppressCommandSuggestions,
+    });
+    return { suggestions, isLoading, ...range };
+  }
+
+  it('returns path completions instead of commands when suppressCommandSuggestions is true and cursor is in command position', async () => {
+    const scanSpy = vi.spyOn(
+      await import('./useShellCompletion.js'),
+      'scanPathExecutables',
+    );
+
+    const { result } = await renderHook(
+      (props) => useShellCompletionHarness(props),
+      {
+        initialProps: {
+          line: 'src',
+          cursorCol: 3,
+          suppressCommandSuggestions: true,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBeGreaterThan(0);
+    });
+
+    // Should NOT have called scanPathExecutables
+    expect(scanSpy).not.toHaveBeenCalled();
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    // Should include the file and directory starting with "src"
+    expect(labels).toContain('srcdir/');
+    expect(labels).toContain('srcfile.txt');
+    // Should not include unrelated files
+    expect(labels).not.toContain('other.txt');
+  });
+
+  it('returns command suggestions (not path completions) for command position when suppressCommandSuggestions is false', async () => {
+    // Use 'git' which exists on the system but matches no file in tmpDir,
+    // so any suggestion returned must come from PATH scanning.
+    const { result } = await renderHook(
+      (props) => useShellCompletionHarness(props),
+      {
+        initialProps: {
+          line: 'git',
+          cursorCol: 3,
+          suppressCommandSuggestions: false,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBeGreaterThan(0);
+    });
+
+    // Every suggestion should be a command (from PATH), not a file/directory
+    const descriptions = result.current.suggestions.map((s) => s.description);
+    expect(descriptions.every((d) => d === 'command')).toBe(true);
+  });
+
+  it('returns path completions in argument position regardless of suppressCommandSuggestions', async () => {
+    const { result } = await renderHook(
+      (props) => useShellCompletionHarness(props),
+      {
+        initialProps: {
+          line: 'cat src',
+          cursorCol: 7,
+          suppressCommandSuggestions: true,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBeGreaterThan(0);
+    });
+
+    const labels = result.current.suggestions.map((s) => s.label);
+    expect(labels).toContain('srcdir/');
+    expect(labels).toContain('srcfile.txt');
   });
 });

--- a/packages/cli/src/ui/hooks/useShellCompletion.ts
+++ b/packages/cli/src/ui/hooks/useShellCompletion.ts
@@ -429,6 +429,11 @@ export interface UseShellCompletionProps {
   setSuggestions: (suggestions: Suggestion[]) => void;
   /** Callback to set loading state on the parent. */
   setIsLoadingSuggestions: (isLoading: boolean) => void;
+  /**
+   * When true, skip command/executable scanning and only offer path completions.
+   * Used when Tab-completing file paths in the normal (non-shell) prompt mode.
+   */
+  suppressCommandSuggestions?: boolean;
 }
 
 export interface UseShellCompletionReturn {
@@ -447,6 +452,7 @@ export function useShellCompletion({
   cwd,
   setSuggestions,
   setIsLoadingSuggestions,
+  suppressCommandSuggestions = false,
 }: UseShellCompletionProps): UseShellCompletionReturn {
   const pathCachePromiseRef = useRef<Promise<string[]> | null>(null);
   const pathEnvRef = useRef<string>(process.env['PATH'] ?? '');
@@ -509,7 +515,12 @@ export function useShellCompletion({
     try {
       let results: Suggestion[];
 
-      if (isCommandPosition) {
+      if (suppressCommandSuggestions) {
+        // Normal prompt mode: skip all shell command/argument logic and only
+        // offer file path completions to avoid irrelevant flag suggestions.
+        setIsLoadingSuggestions(true);
+        results = await resolvePathCompletions(query, cwd, signal);
+      } else if (isCommandPosition) {
         setIsLoadingSuggestions(true);
 
         if (!pathCachePromiseRef.current) {
@@ -594,6 +605,7 @@ export function useShellCompletion({
     tokenInfo,
     query,
     isCommandPosition,
+    suppressCommandSuggestions,
     tokens,
     cursorIndex,
     commandToken,


### PR DESCRIPTION
## Summary

Pressing Tab in the normal (Gemini) prompt now triggers file path completion, consistent with standard shell UX. Previously, file completion was only available via the `@` prefix (fuzzy search) or in shell mode (`!`). Now users can type a partial path and press Tab to get completions without switching modes.

Command/executable suggestions are suppressed in normal mode — only files and directories are shown.

## Details

Three targeted changes wire up the existing shell completion pipeline to the normal prompt:

- **`useShellCompletion.ts`**: Added `suppressCommandSuggestions` option. When `true`, the hook skips PATH executable scanning and falls through to `resolvePathCompletions`, so only file/directory suggestions are returned in the command-token position.

- **`useCommandCompletion.tsx`**: `forceShowShellSuggestions` is now included in the `completionMode` `useMemo`. When `true` and no `@` or `/` completion is active, `completionMode` returns `CompletionMode.SHELL`, enabling the shell completion pipeline without requiring shell mode. `suppressCommandSuggestions: !shellModeActive` is passed to `useShellCompletion` so command scanning only occurs in actual shell mode.

- **`InputPrompt.tsx`**: Tab key handler extended — when `completionMode === IDLE` and no other completion is active, Tab calls `setForceShowShellSuggestions(true)`. Subsequent Tab presses are handled by the existing suggestion navigation and acceptance logic.

The `@` prefix and `/` slash command completions are unaffected and retain priority over Tab-triggered path completion. Escape dismisses the dropdown as usual.

## Related Issues

Closes #18990

## How to Validate

1. Start the CLI: `npm run dev` or `gemini`
2. At the normal prompt (no `!` prefix), type a partial file or directory path (e.g. `src/` or `pack`)
3. Press **Tab** — a file path completion dropdown should appear
4. Press **Tab** again to cycle through suggestions, or **Enter** to accept
5. Press **Escape** to dismiss without completing
6. Verify that `@path` and `/command` completions are unaffected
7. Verify that in shell mode (`!`), Tab still completes both commands and file paths

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
