### PR TITLE
fix(fileUtils): validate image mime types and prevent traversal

### DIFF
--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -412,6 +412,15 @@ export async function processSingleFileContent(
   endLine?: number,
 ): Promise<ProcessedFileReadResult> {
   try {
+    if (!isWithinRoot(filePath, rootDirectory)) {
+      return {
+        llmContent: `Could not read file because it is outside the project root: ${filePath}`,
+        returnDisplay: 'Path outside project root.',
+        error: `Path outside project root: ${filePath}`,
+        errorType: ToolErrorType.PATH_NOT_IN_WORKSPACE,
+      };
+    }
+
     if (!fs.existsSync(filePath)) {
       // Sync check is acceptable before async read
       return {
@@ -549,20 +558,27 @@ export async function processSingleFileContent(
             'image/heif',
           ];
           if (!supportedImageTypes.includes(detectedMime)) {
-            throw new Error(
-              `Unsupported image format: ${detectedMime}. ` +
+            return {
+              llmContent: `Unsupported image format: ${detectedMime}.`,
+              returnDisplay: `Unsupported image format: ${detectedMime}.`,
+              error:
+                `Unsupported image format: ${detectedMime}. ` +
                 `Supported formats: PNG, JPEG, WEBP, HEIC, HEIF.`,
-            );
+              errorType: ToolErrorType.READ_CONTENT_FAILURE,
+            };
           }
 
           // Check file size to prevent excessively large uploads
-          const stats = await fs.promises.stat(filePath);
+          const imageStats = await fs.promises.stat(filePath);
           const maxSize = 20 * 1024 * 1024; // 20MB
-          if (stats.size > maxSize) {
-            const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
-            throw new Error(
-              `Image file too large (${sizeMB} MB). Maximum allowed size is 20MB.`,
-            );
+          if (imageStats.size > maxSize) {
+            const sizeMB = (imageStats.size / (1024 * 1024)).toFixed(1);
+            return {
+              llmContent: `Image file too large (${sizeMB} MB).`,
+              returnDisplay: `Image file too large (${sizeMB} MB).`,
+              error: `Image file too large (${sizeMB} MB). Maximum allowed size is 20MB.`,
+              errorType: ToolErrorType.FILE_TOO_LARGE,
+            };
           }
         }
 

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -536,13 +536,43 @@ export async function processSingleFileContent(
       case 'pdf':
       case 'audio':
       case 'video': {
+        const detectedMime =
+          mime.getType(filePath) || 'application/octet-stream';
+
+        // Additional validation for images to provide clearer errors and avoid API rejections
+        if (fileType === 'image') {
+          const supportedImageTypes = [
+            'image/png',
+            'image/jpeg',
+            'image/webp',
+            'image/heic',
+            'image/heif',
+          ];
+          if (!supportedImageTypes.includes(detectedMime)) {
+            throw new Error(
+              `Unsupported image format: ${detectedMime}. ` +
+                `Supported formats: PNG, JPEG, WEBP, HEIC, HEIF.`,
+            );
+          }
+
+          // Check file size to prevent excessively large uploads
+          const stats = await fs.promises.stat(filePath);
+          const maxSize = 20 * 1024 * 1024; // 20MB
+          if (stats.size > maxSize) {
+            const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
+            throw new Error(
+              `Image file too large (${sizeMB} MB). Maximum allowed size is 20MB.`,
+            );
+          }
+        }
+
         const contentBuffer = await fs.promises.readFile(filePath);
         const base64Data = contentBuffer.toString('base64');
         return {
           llmContent: {
             inlineData: {
               data: base64Data,
-              mimeType: mime.getType(filePath) || 'application/octet-stream',
+              mimeType: detectedMime,
             },
           },
           returnDisplay: `Read ${fileType} file: ${relativePathForDisplay}`,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -569,10 +569,9 @@ export async function processSingleFileContent(
           }
 
           // Check file size to prevent excessively large uploads
-          const imageStats = await fs.promises.stat(filePath);
           const maxSize = 20 * 1024 * 1024; // 20MB
-          if (imageStats.size > maxSize) {
-            const sizeMB = (imageStats.size / (1024 * 1024)).toFixed(1);
+          if (stats.size > maxSize) {
+            const sizeMB = (stats.size / (1024 * 1024)).toFixed(1);
             return {
               llmContent: `Image file too large (${sizeMB} MB).`,
               returnDisplay: `Image file too large (${sizeMB} MB).`,


### PR DESCRIPTION
This PR enhances image file validation by verifying MIME types and ensuring path safety. Replaces #24886.