### PR TITLE
fix(core): retain Gemini 3 thought and thoughtSignature in history

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -48,6 +48,7 @@ import {
   type OutputFormat,
   detectIdeFromEnv,
   generalistProfile,
+  validateModelName,
 } from '@google/gemini-cli-core';
 import {
   type Settings,
@@ -803,6 +804,13 @@ export async function loadCliConfig(
   const defaultModel = PREVIEW_GEMINI_MODEL_AUTO;
   const specifiedModel =
     argv.model || process.env['GEMINI_MODEL'] || settings.model?.name;
+
+  if (specifiedModel) {
+    const customAliases = new Set(
+      Object.keys(settings.modelConfigs?.aliases ?? {}),
+    );
+    validateModelName(specifiedModel, customAliases);
+  }
 
   const resolvedModel =
     specifiedModel === GEMINI_MODEL_ALIAS_AUTO

--- a/packages/cli/src/config/model-validation.test.ts
+++ b/packages/cli/src/config/model-validation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { loadCliConfig, type CliArgs } from './config.js';
+import { createTestMergedSettings } from './settings.js';
+
+vi.mock('./trustedFolders.js', () => ({
+  isWorkspaceTrusted: vi.fn(() => ({ isTrusted: true, source: 'file' })),
+}));
+
+vi.mock('./extension-manager.js', () => ({
+  ExtensionManager: vi.fn().mockImplementation(() => ({
+    loadExtensions: vi.fn(),
+    getExtensions: vi.fn().mockReturnValue([]),
+  })),
+}));
+
+describe('Model Selection Validation', () => {
+  it('should throw an error for an invalid gemini model name', async () => {
+    const settings = createTestMergedSettings();
+    const argv = {
+      model: 'gemini-3-pro-perview', // typo
+      query: 'hello',
+    } as unknown as CliArgs;
+
+    // Currently this DOES NOT throw, but we want it to.
+    // After our fix, this should throw a helpful error.
+    await expect(loadCliConfig(settings, 'test-session', argv)).rejects.toThrow(
+      /Invalid model name/,
+    );
+  });
+
+  it('should allow valid gemini model names', async () => {
+    const settings = createTestMergedSettings();
+    const argv = {
+      model: 'gemini-3-pro-preview',
+      query: 'hello',
+    } as unknown as CliArgs;
+
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getModel()).toBe('gemini-3-pro-preview');
+  });
+
+  it('should allow custom (non-gemini) model names', async () => {
+    const settings = createTestMergedSettings();
+    const argv = {
+      model: 'my-custom-model',
+      query: 'hello',
+    } as unknown as CliArgs;
+
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getModel()).toBe('my-custom-model');
+  });
+
+  it('should allow custom aliases from settings', async () => {
+    const settings = createTestMergedSettings();
+    settings.modelConfigs = {
+      ...settings.modelConfigs,
+      aliases: {
+        'my-cool-alias': {
+          modelConfig: { model: 'gemini-3-pro-preview' },
+        },
+      },
+    };
+    const argv = {
+      model: 'my-cool-alias',
+      query: 'hello',
+    } as unknown as CliArgs;
+
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getModel()).toBe('my-cool-alias');
+  });
+});

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -461,3 +461,50 @@ export function isActiveModel(
     );
   }
 }
+
+/**
+ * Checks if a model name is a known Gemini model or alias.
+ *
+ * @param model The model name or alias to check.
+ * @returns True if the model is known.
+ */
+export function isKnownModel(model: string): boolean {
+  if (VALID_GEMINI_MODELS.has(model)) return true;
+  if (isAutoModel(model)) return true;
+  if (
+    model === GEMINI_MODEL_ALIAS_PRO ||
+    model === GEMINI_MODEL_ALIAS_FLASH ||
+    model === GEMINI_MODEL_ALIAS_FLASH_LITE
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Validates a model name or alias.
+ *
+ * @param model The model name or alias to validate.
+ * @param customModelNames Optional set of custom model names or aliases to allow.
+ * @throws Error if the model name is invalid.
+ */
+export function validateModelName(
+  model: string | undefined,
+  customModelNames?: Set<string>,
+): void {
+  if (!model) return;
+
+  if (isKnownModel(model)) return;
+  if (customModelNames?.has(model)) return;
+
+  // If it starts with 'gemini-' but isn't known, it's likely a typo.
+  if (model.startsWith('gemini-')) {
+    const knownModels = Array.from(VALID_GEMINI_MODELS).join(', ');
+    throw new Error(
+      `Invalid model name: "${model}". Please check for typos. ` +
+        `Supported models include: ${knownModels}, or aliases like 'pro', 'flash', 'auto'.`,
+    );
+  }
+
+  // Custom models (non-gemini) are allowed without validation for now.
+}

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -129,7 +129,12 @@ function isValidContent(content: Content): boolean {
     if (part === undefined || Object.keys(part).length === 0) {
       return false;
     }
-    if (!part.thought && part.text !== undefined && part.text === '') {
+    if (
+      !part.thought &&
+      !part.thoughtSignature &&
+      part.text !== undefined &&
+      part.text === ''
+    ) {
       return false;
     }
   }
@@ -906,9 +911,7 @@ export class GeminiChat {
             hasToolCall = true;
           }
 
-          modelResponseParts.push(
-            ...content.parts.filter((part) => !part.thought),
-          );
+          modelResponseParts.push(...content.parts);
         }
       }
 
@@ -956,6 +959,9 @@ export class GeminiChat {
         isValidNonThoughtTextPart(part)
       ) {
         lastPart.text += part.text;
+        if (part.thoughtSignature) {
+          lastPart.thoughtSignature = part.thoughtSignature;
+        }
       } else {
         consolidatedParts.push(part);
       }

--- a/packages/core/src/core/thought-retention.test.ts
+++ b/packages/core/src/core/thought-retention.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { GeminiChat } from './geminiChat.js';
+import { type AgentLoopContext } from '../config/agent-loop-context.js';
+import {
+  type GenerateContentResponse,
+  type GenerateContentParameters,
+  type Part,
+} from '@google/genai';
+
+// Mock dependencies
+vi.mock('../services/chatRecordingService.js', () => ({
+  getProjectHash: vi.fn(() => 'mock-hash'),
+  ChatRecordingService: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn(),
+    recordMessage: vi.fn(),
+    recordThought: vi.fn(),
+    recordMessageTokens: vi.fn(),
+    updateMessagesFromHistory: vi.fn(),
+  })),
+}));
+
+// Subclass to expose internal processStreamResponse for testing
+class TestGeminiChat extends GeminiChat {
+  async testProcessStream(
+    model: string,
+    stream: AsyncGenerator<GenerateContentResponse>,
+    request: GenerateContentParameters,
+  ) {
+    // @ts-expect-error - access private method for testing
+    const generator = this.processStreamResponse(model, stream, request);
+    for await (const _ of generator) {
+      // exhaust
+    }
+  }
+}
+
+describe('Thought Retention in Chat History', () => {
+  it('should retain thought parts in chat history', async () => {
+    const mockContext = {
+      config: {
+        getHookSystem: () => null,
+        getMaxAttempts: () => 1,
+        getProjectRoot: () => '/mock/root',
+        getQuotaRemaining: () => undefined,
+        modelConfigService: {
+          getResolvedConfig: () => ({ model: 'gemini-3-pro-preview' }),
+        },
+      },
+      toolRegistry: {
+        getAllTools: () => [],
+      },
+      modelAvailabilityService: {
+        reset: () => {},
+      },
+      promptId: 'test-session',
+    } as unknown as AgentLoopContext;
+
+    const chat = new TestGeminiChat(mockContext, '', [], []);
+
+    const modelResponseChunks: GenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  thought: true,
+                  text: 'Thinking about the problem...',
+                } as unknown as Part,
+              ],
+            },
+          },
+        ],
+      } as unknown as GenerateContentResponse,
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'The answer is 42.' }],
+            },
+            finishReason: 'STOP' as string,
+          },
+        ],
+      } as unknown as GenerateContentResponse,
+    ];
+
+    async function* mockStream() {
+      for (const chunk of modelResponseChunks) {
+        yield chunk;
+      }
+    }
+
+    await chat.testProcessStream(
+      'gemini-3-pro-preview',
+      mockStream(),
+      {} as unknown as GenerateContentParameters,
+    );
+
+    const history = chat.getHistory();
+    const modelTurn = history.find((h) => h.role === 'model');
+
+    expect(modelTurn).toBeDefined();
+
+    // Check if the thought part is present in history
+    const hasThought = modelTurn!.parts!.some(
+      (p) => (p as Part & { thought?: boolean }).thought,
+    );
+
+    // With our fix in geminiChat.ts, this should now be TRUE
+    expect(hasThought).toBe(true);
+    expect(modelTurn!.parts!.some((p) => p.text === 'The answer is 42.')).toBe(
+      true,
+    );
+  });
+
+  it('should retain thoughtSignature in text parts (even if empty)', async () => {
+    const mockContext = {
+      config: {
+        getHookSystem: () => null,
+        getMaxAttempts: () => 1,
+        getProjectRoot: () => '/mock/root',
+        getQuotaRemaining: () => undefined,
+        modelConfigService: {
+          getResolvedConfig: () => ({ model: 'gemini-3-pro-preview' }),
+        },
+      },
+      toolRegistry: {
+        getAllTools: () => [],
+      },
+      modelAvailabilityService: {
+        reset: () => {},
+      },
+      promptId: 'test-session',
+    } as unknown as AgentLoopContext;
+
+    const chat = new TestGeminiChat(mockContext, '', [], []);
+
+    const modelResponseChunks: GenerateContentResponse[] = [
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'The answer ' }],
+            },
+          },
+        ],
+      } as unknown as GenerateContentResponse,
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  text: 'is 42.',
+                  thoughtSignature: 'sig-123',
+                } as unknown as Part,
+              ],
+            },
+          },
+        ],
+      } as unknown as GenerateContentResponse,
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  text: '',
+                  thoughtSignature: 'sig-456',
+                } as unknown as Part,
+              ],
+            },
+            finishReason: 'STOP' as string,
+          },
+        ],
+      } as unknown as GenerateContentResponse,
+    ];
+
+    async function* mockStream() {
+      for (const chunk of modelResponseChunks) {
+        yield chunk;
+      }
+    }
+
+    await chat.testProcessStream(
+      'gemini-3-pro-preview',
+      mockStream(),
+      {} as unknown as GenerateContentParameters,
+    );
+
+    const history = chat.getHistory();
+    const modelTurn = history.find((h) => h.role === 'model');
+
+    expect(modelTurn).toBeDefined();
+    // Consolidation should have merged the text and preserved the LATEST thoughtSignature
+    expect(modelTurn!.parts![0].text).toBe('The answer is 42.');
+    expect(modelTurn!.parts![0].thoughtSignature).toBe('sig-456');
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes Issue #25808 where Gemini 3 thought parts and thoughtSignatures were being silently dropped from chat history during streaming and part consolidation. 

Additionally, it adds model name validation to prevent 404 errors from the API when a typo is provided (related to Issue #5586).

## Changes
- **packages/core/src/core/geminiChat.ts**: 
  - Stop filtering out `thought` parts in `processStreamResponse`.
  - Update `isValidContent` to allow parts with a `thoughtSignature` even if text is empty.
  - Update consolidation logic to preserve `thoughtSignature` when merging text parts.
- **packages/core/src/config/models.ts**: Added `isKnownModel` and `validateModelName`.
- **packages/cli/src/config/config.ts**: Integrated `validateModelName` into CLI config loading.
- Added comprehensive tests for both fixes.

Fixes #25808.