### PR TITLE
fix(core): only show `list` suggestion if the partial input is empty

### DIFF
--- a/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
@@ -513,6 +513,70 @@ describe('useSlashCompletion', () => {
       unmountResume();
     });
 
+    it('should NOT suggest the auto-list command when typing a non-matching partial after /chat', async () => {
+      const slashCommands = [
+        createTestCommand({
+          name: 'chat',
+          description: 'Manage chat history',
+          subCommands: [
+            createTestCommand({ name: 'list', description: 'List chats' }),
+          ],
+        }),
+      ];
+
+      const { result, unmount } = await renderHook(() =>
+        useTestHarnessForSlashCompletion(
+          true,
+          '/chat x', // 'x' does not match 'list'
+          slashCommands,
+          mockCommandContext,
+        ),
+      );
+
+      await resolveMatch();
+
+      await waitFor(() => {
+        // It should NOT have the 'auto' section 'list' suggestion
+        const autoSuggestion = result.current.suggestions.find(
+          (s) => s.sectionTitle === 'auto',
+        );
+        expect(autoSuggestion).toBeUndefined();
+      });
+      unmount();
+    });
+
+    it('should STILL suggest the auto-list command when typing a matching partial after /chat', async () => {
+      const slashCommands = [
+        createTestCommand({
+          name: 'chat',
+          description: 'Manage chat history',
+          subCommands: [
+            createTestCommand({ name: 'list', description: 'List chats' }),
+          ],
+        }),
+      ];
+
+      const { result, unmount } = await renderHook(() =>
+        useTestHarnessForSlashCompletion(
+          true,
+          '/chat l', // 'l' matches 'list'
+          slashCommands,
+          mockCommandContext,
+        ),
+      );
+
+      await resolveMatch();
+
+      await waitFor(() => {
+        const autoSuggestion = result.current.suggestions.find(
+          (s) => s.sectionTitle === 'auto',
+        );
+        expect(autoSuggestion).toBeDefined();
+        expect(autoSuggestion?.label).toBe('list');
+      });
+      unmount();
+    });
+
     it('should sort exact altName matches to the top', async () => {
       const slashCommands = [
         createTestCommand({

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -338,17 +338,23 @@ function useCommandSuggestions(
 
           if (isTopLevelChatOrResumeContext) {
             const canonicalParentName = leafCommand.name;
-            const autoSectionSuggestion: Suggestion = {
-              label: 'list',
-              value: 'list',
-              insertValue: canonicalParentName,
-              description: 'Browse auto-saved chats',
-              commandKind: CommandKind.BUILT_IN,
-              sectionTitle: 'auto',
-              submitValue: `/${canonicalParentName}`,
-            };
-            setSuggestions([autoSectionSuggestion, ...finalSuggestions]);
-            return;
+            const autoLabel = 'list';
+            if (
+              partial === '' ||
+              autoLabel.toLowerCase().startsWith(partial.toLowerCase())
+            ) {
+              const autoSectionSuggestion: Suggestion = {
+                label: autoLabel,
+                value: autoLabel,
+                insertValue: canonicalParentName,
+                description: 'Browse auto-saved chats',
+                commandKind: CommandKind.BUILT_IN,
+                sectionTitle: 'auto',
+                submitValue: `/${canonicalParentName}`,
+              };
+              setSuggestions([autoSectionSuggestion, ...finalSuggestions]);
+              return;
+            }
           }
 
           setSuggestions(finalSuggestions);


### PR DESCRIPTION
## Summary

Fixes a bug in the slash command autocomplete where the `auto` list suggestion (e.g.`/chat list`) would incorrectly appear even when typing a non-matching partial word (e.g., `/chat x`). This ensures that the autocomplete suggestions are filtered correctly based on the user's input.

## Details

- Modified `useCommandSuggestions` in `packages/cli/src/ui/hooks/useSlashCompletion.ts` to only show the `auto` section suggestion (`list`) if the partial input is empty or matches the start of the word `list`.
- Added unit tests in `packages/cli/src/ui/hooks/useSlashCompletion.test.ts` to verify the correct behavior for both non-matching and matching partial inputs after a top-level command like `/chat`

## Related Issues

Fixes #23541 

## How to Validate

1. Start the CLI.
2. Type `/chat ` (with a trailing space). You should see `list` under the `auto` section.
3. Type `/chat l`. You should still see `list`.
4. Type `/chat x`. You should **not** see `list`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
