### PR TITLE
fix: Enter key unresponsive after selecting a skill from / command dropdown

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1126,6 +1126,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               // Default behavior: auto-complete to prompt box
               completion.handleAutocomplete(targetIndex);
               setExpandedSuggestionIndex(-1); // Reset expansion after selection
+              hasUserNavigatedSuggestions.current = false;
             }
           }
           return true;


### PR DESCRIPTION
## Problem
    
When using the `/` command in Gemini CLI to invoke a skill, pressing **Enter** after selecting a skill from the autocomplete dropdown does nothing. The CLI silently ignores the keypress and the skill is never triggered.
    
### Steps to reproduce
    
1. Type `/` in the Gemini CLI prompt — the dropdown shows available skills
2. Use arrow keys to navigate and select a skill
3. Press **Enter** to run the selected skill
    
| | |
|---|---|
| **Expected** | The skill executes immediately |
| **Actual** | Enter does nothing — the skill is never triggered |
    
> **Workaround:** Manually delete the last character of the inserted skill name and retype it — after this, Enter works as expected.
    
---
    
## Root Cause
    
When the user navigates the suggestion dropdown with arrow keys, `hasUserNavigatedSuggestions.current` is set to `true`. When Enter is pressed to select a skill, `handleAutocomplete` inserts the skill name into the buffer — but `hasUserNavigatedSuggestions.current` was **never reset** in the default autocomplete code path.
    
On the subsequent Enter press (intended to execute the skill), the `isPerfectMatch` fast-path in `InputPrompt.tsx` evaluates:
    
``` typescript
   if (
     completion.isPerfectMatch &&
     keyMatchers[Command.SUBMIT](key) &&
     recentUnsafePasteTime === null &&
     (!(completion.showSuggestions && isShellSuggestionsVisible) ||
       (completion.activeSuggestionIndex <= 0 &&
         !hasUserNavigatedSuggestions.current))  // ← still true from arrow-key navigation!
   ) {
     handleSubmit(buffer.text);
   }
```

Since hasUserNavigatedSuggestions.current was still true, the condition short-circuits to false. Enter falls through to the ACCEPT_SUGGESTION handler, which calls handleAutocomplete again (a no-op since the text is already complete), and the keypress is effectively swallowed.

│ This also explains the workaround: deleting and retyping a character triggers a non-navigation keypress, which resets hasUserNavigatedSuggestions.current = false, allowing the next Enter to work.

---

## Fix
Reset hasUserNavigatedSuggestions.current = false immediately after the default handleAutocomplete call in the ACCEPT_SUGGESTION handler. This mirrors what the shell mode path already does correctly.

```typescript
                 // Default behavior: auto-complete to prompt box
                 completion.handleAutocomplete(targetIndex);
                 setExpandedSuggestionIndex(-1); // Reset expansion after selection
   +             hasUserNavigatedSuggestions.current = false;
```