### PR TITLE
fix(release): exclude ripgrep binaries from npm tarballs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,7 @@
     "typecheck": "tsc --noEmit"
   },
   "files": [
-    "dist",
-    "vendor"
+    "dist"
   ],
   "dependencies": {
     "@a2a-js/sdk": "0.3.11",

--- a/scripts/build_binary.js
+++ b/scripts/build_binary.js
@@ -179,12 +179,8 @@ try {
   process.exit(1);
 }
 
-// 2b. Copy host-platform ripgrep binary into bundle/vendor/ripgrep/.
-// The npm `bundle` step intentionally omits these binaries (they would push
-// the published tarball past the registry's upload limit). The SEA build,
-// being per-platform, only needs the binary for the host it's targeting,
-// so we copy just one. The runtime resolver in packages/core/src/tools/
-// ripGrep.ts (getRipgrepPath) looks for rg-${platform}-${arch}.
+// 2b. Copy host-platform ripgrep binary into the bundle for the SEA.
+// (npm tarballs omit these to stay under the registry upload limit.)
 const ripgrepVendorSrc = join(root, 'packages/core/vendor/ripgrep');
 const ripgrepVendorDest = join(bundleDir, 'vendor', 'ripgrep');
 if (existsSync(ripgrepVendorSrc)) {
@@ -324,6 +320,23 @@ if (existsSync(policyDir)) {
     // Use a unique key to avoid collision if filenames overlap (though unlikely here)
     // But sea-launch writes to 'path', so key is just for lookup.
     const assetKey = `policies:${policyFile}`;
+    assets[assetKey] = fsPath;
+    manifest.files.push({ key: assetKey, path: relativePath, hash: hash });
+  }
+}
+
+// Add ripgrep binary (copied in step 2b). Must be registered here so that
+// sea-launch.cjs extracts it to runtimeDir/vendor/ripgrep/ on startup; the
+// runtime resolver in packages/core/src/tools/ripGrep.ts uses __dirname-
+// relative paths to find it.
+if (existsSync(ripgrepVendorDest)) {
+  const rgFiles = globSync('*', { cwd: ripgrepVendorDest, nodir: true });
+  for (const rgFile of rgFiles) {
+    const fsPath = join(ripgrepVendorDest, rgFile);
+    const relativePath = join('vendor', 'ripgrep', rgFile);
+    const content = readFileSync(fsPath);
+    const hash = sha256(content);
+    const assetKey = `vendor:${rgFile}`;
     assets[assetKey] = fsPath;
     manifest.files.push({ key: assetKey, path: relativePath, hash: hash });
   }

--- a/scripts/build_binary.js
+++ b/scripts/build_binary.js
@@ -179,6 +179,31 @@ try {
   process.exit(1);
 }
 
+// 2b. Copy host-platform ripgrep binary into bundle/vendor/ripgrep/.
+// The npm `bundle` step intentionally omits these binaries (they would push
+// the published tarball past the registry's upload limit). The SEA build,
+// being per-platform, only needs the binary for the host it's targeting,
+// so we copy just one. The runtime resolver in packages/core/src/tools/
+// ripGrep.ts (getRipgrepPath) looks for rg-${platform}-${arch}.
+const ripgrepVendorSrc = join(root, 'packages/core/vendor/ripgrep');
+const ripgrepVendorDest = join(bundleDir, 'vendor', 'ripgrep');
+if (existsSync(ripgrepVendorSrc)) {
+  const rgBinName = `rg-${process.platform}-${process.arch}${
+    process.platform === 'win32' ? '.exe' : ''
+  }`;
+  const rgSrc = join(ripgrepVendorSrc, rgBinName);
+  if (existsSync(rgSrc)) {
+    mkdirSync(ripgrepVendorDest, { recursive: true });
+    cpSync(rgSrc, join(ripgrepVendorDest, rgBinName), { dereference: true });
+    console.log(`Copied ${rgBinName} to bundle/vendor/ripgrep/`);
+  } else {
+    console.warn(
+      `Warning: bundled ripgrep binary not found for ${process.platform}/${process.arch} at ${rgSrc}. ` +
+        `The SEA will fall back to system grep at runtime.`,
+    );
+  }
+}
+
 // 3. Stage & Sign Native Modules
 const includeNativeModules = process.env.BUNDLE_NATIVE_MODULES !== 'false';
 console.log(`Include Native Modules: ${includeNativeModules}`);

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -108,19 +108,7 @@ if (!existsSync(bundleMcpSrc)) {
 cpSync(bundleMcpSrc, bundleMcpDest, { recursive: true, dereference: true });
 console.log('Copied bundled chrome-devtools-mcp to bundle/bundled/');
 
-// 7. Copy pre-built ripgrep vendor binaries
-const ripgrepVendorSrc = join(root, 'packages/core/vendor/ripgrep');
-const ripgrepVendorDest = join(bundleDir, 'vendor', 'ripgrep');
-if (existsSync(ripgrepVendorSrc)) {
-  mkdirSync(ripgrepVendorDest, { recursive: true });
-  cpSync(ripgrepVendorSrc, ripgrepVendorDest, {
-    recursive: true,
-    dereference: true,
-  });
-  console.log('Copied ripgrep vendor binaries to bundle/vendor/ripgrep/');
-}
-
-// 8. Copy Extension Examples
+// 7. Copy Extension Examples
 const extensionExamplesSrc = join(
   root,
   'packages/cli/src/commands/extensions/examples',


### PR DESCRIPTION
## Summary

Unblocks the `Release: Promote` workflow, which has been failing with `npm error code E413 Request Entity Too Large` from wombat-dressing-room since 2026-04-15 because the `@google/gemini-cli` tarball grew past the registry's per-package upload limit.

The growth came from PR #25342, which checked in 5 cross-platform `ripgrep` binaries (~21 MB raw) under `packages/core/vendor/ripgrep/` and unconditionally copied them into `bundle/vendor/ripgrep/` on every `npm run bundle` — including the npm-publish path. Wombat rejected the resulting 28.4 MB compressed `cli` tarball.

This change keeps the binaries in the SEA build (where offline support was the goal) and stops shipping them through the npm registry, where users can rely on the existing `GrepTool` JS fallback when `ripgrep` isn't installed.

## Details

Three surgical edits, all in `scripts/` and `packages/core/package.json`:

- **`scripts/copy_bundle_assets.js`** — Removed the unconditional 5-binary ripgrep copy. This script is invoked from `npm run bundle`, which feeds the npm-publish path (via `prepare-npm-release.js`).
- **`scripts/build_binary.js`** — Added a new step (2b) that copies *only the host-platform* ripgrep binary into `bundle/vendor/ripgrep/`. Per-platform copy (vs all 5) also shrinks per-platform SEA artifacts. The runtime resolver `getRipgrepPath()` already looks for `rg-${platform}-${arch}`, so no code change required there.
- **`packages/core/package.json`** — Removed `"vendor"` from the published `files` field so the binaries don't leak through `@google/gemini-cli-core` either.

Verified locally with `npm pack --dry-run`:

| Package | Before #25342 | After #25342 (current main, fails E413) | **With this PR** |
|---|---|---|---|
| `@google/gemini-cli` compressed | 22.3 MB | 28.4 MB ❌ | **12.2 MB** ✅ |
| `@google/gemini-cli-core` compressed | — | 19.3 MB | **10.5 MB** ✅ |
| `@google/gemini-cli-core` unpacked | 52 MB | 63 MB | **42 MB** |
| SEA artifact | works (no ripgrep) | works (5 binaries) | works (1 binary, host only) |

### Why this is the right shape today

Three options exist for keeping #25342's offline-SEA goal while unblocking npm publish:

1. **Strip from npm tarball, keep in SEA** (this PR) — minimal, validated, ships today.
2. Convert to platform-specific `optionalDependencies` (esbuild/swc/rollup pattern) — better long-term shape but requires 5 new scoped packages, 5 new wombat tokens, and rework of `.github/actions/publish-release/action.yml`. Days to weeks of OSPO/release-infra work.
3. Compress the binaries in the tarball — half-day, but adds first-run decompression latency and a writable cache requirement.

Option 1 is the right unblock; option 2 can follow as a separate, larger PR if we want offline `ripgrep` for npm-installed users too.

### Behavioral side-effects (intentional and benign)

- **npm-installed users**: lose the bundled `ripgrep`. `canUseRipgrep()` in `packages/core/src/config/config.ts` already catches this, registers the legacy `GrepTool` instead, and emits a `RipgrepFallbackEvent` for telemetry. **This is the pre-#25342 behavior.** Anyone with system `rg` (Homebrew, apt, etc.) gets it via PATH.
- **SEA users**: still get bundled offline `ripgrep` — the PR's stated goal. Bonus: per-platform SEA artifacts also shrink (1 binary instead of 5).

## Related Issues

Fixes #25507
Related to #18007

## How to Validate

```bash
# 1. Confirm the npm tarballs no longer ship ripgrep
npm run bundle
node scripts/prepare-npm-release.js
npm pack --dry-run -w @google/gemini-cli       | grep -iE "(ripgrep|vendor|rg-)" || echo "OK: no ripgrep in cli tarball"
npm pack --dry-run -w @google/gemini-cli-core  | grep -iE "(vendor|rg-)" || echo "OK: no ripgrep binaries in core tarball"

# 2. Confirm tarball sizes are well under wombat's limit
npm pack --dry-run -w @google/gemini-cli      2>&1 | grep -E "package size"   # expect ~12 MB
npm pack --dry-run -w @google/gemini-cli-core 2>&1 | grep -E "package size"   # expect ~10 MB

# 3. Smoke-test the bundled cli still launches
node ./bundle/gemini.js --version

# 4. SEA build (per-platform; run on at least one matrix host)
npm run build:binary
ls -la bundle/vendor/ripgrep/    # expect exactly one rg-${platform}-${arch} binary
./dist/$(node -p '`${process.platform}-${process.arch}`')/gemini --version

# 5. Confirm the runtime fallback is intact when ripgrep is missing
#    (covered by existing tests in packages/core/src/tools/ripGrep.test.ts;
#     `canUseRipgrep` returns false → GrepTool registered → RipgrepFallbackEvent
#     emitted, no crash)
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — n/a, no user-facing surface changed
- [x] Noted breaking changes (if any) — npm-install users without system `rg` will use the slower `GrepTool` fallback (pre-#25342 behavior, telemetry already in place)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
