### PR TITLE
feat: add compactToolOutputAllowlist setting

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -617,6 +617,17 @@ const SETTINGS_SCHEMA = {
           'Display tool outputs (like directory listings and file reads) in a compact, structured format.',
         showInDialog: true,
       },
+      compactToolOutputAllowlist: {
+        type: 'array',
+        label: 'Compact Tool Output Allowlist',
+        category: 'UI',
+        requiresRestart: false,
+        default: [] as string[],
+        description:
+          'Additional tool names to display in compact format (e.g. MCP tool names). Extends the built-in list when compactToolOutput is enabled.',
+        showInDialog: false,
+        items: { type: 'string' },
+      },
       hideBanner: {
         type: 'boolean',
         label: 'Hide Banner',

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -123,7 +123,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const isLowErrorVerbosity = settings.merged.ui?.errorVerbosity !== 'full';
   const isCompactModeEnabled = settings.merged.ui?.compactToolOutput === true;
   const compactAllowlist = useMemo(
-    () => settings.merged.ui?.compactToolOutputAllowlist ?? [],
+    () => new Set(settings.merged.ui?.compactToolOutputAllowlist ?? []),
     [settings.merged.ui?.compactToolOutputAllowlist],
   );
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -60,8 +60,11 @@ const COMPACT_OUTPUT_ALLOWLIST = new Set([
 export const isCompactTool = (
   tool: IndividualToolCallDisplay,
   isCompactModeEnabled: boolean,
+  extraAllowlist: readonly string[] = [],
 ): boolean => {
-  const hasCompactOutputSupport = COMPACT_OUTPUT_ALLOWLIST.has(tool.name);
+  const hasCompactOutputSupport =
+    COMPACT_OUTPUT_ALLOWLIST.has(tool.name) ||
+    extraAllowlist.includes(tool.name);
   const displayStatus = mapCoreStatusToDisplayStatus(tool.status);
   return (
     isCompactModeEnabled &&
@@ -119,6 +122,10 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const settings = useSettings();
   const isLowErrorVerbosity = settings.merged.ui?.errorVerbosity !== 'full';
   const isCompactModeEnabled = settings.merged.ui?.compactToolOutput === true;
+  const compactAllowlist = useMemo(
+    () => settings.merged.ui?.compactToolOutputAllowlist ?? [],
+    [settings.merged.ui?.compactToolOutputAllowlist],
+  );
 
   // Filter out tool calls that should be hidden (e.g. in-progress Ask User, or Plan Mode operations).
   const visibleToolCalls = useMemo(
@@ -190,20 +197,21 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       const prevIsCompact =
         prevGroup &&
         !Array.isArray(prevGroup) &&
-        isCompactTool(prevGroup, isCompactModeEnabled);
+        isCompactTool(prevGroup, isCompactModeEnabled, compactAllowlist);
 
       const nextGroup = !isLast ? groupedTools[i + 1] : null;
       const nextIsCompact =
         nextGroup &&
         !Array.isArray(nextGroup) &&
-        isCompactTool(nextGroup, isCompactModeEnabled);
+        isCompactTool(nextGroup, isCompactModeEnabled, compactAllowlist);
 
       const nextIsTopicToolCall =
         nextGroup && !Array.isArray(nextGroup) && isTopicTool(nextGroup.name);
 
       const isAgentGroup = Array.isArray(group);
       const isCompact =
-        !isAgentGroup && isCompactTool(group, isCompactModeEnabled);
+        !isAgentGroup &&
+        isCompactTool(group, isCompactModeEnabled, compactAllowlist);
       const isTopicToolCall = !isAgentGroup && isTopicTool(group.name);
 
       // Align isFirst logic with rendering
@@ -270,12 +278,12 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
       }
     }
     return height;
-  }, [groupedTools, isCompactModeEnabled, borderTopOverride]);
+  }, [groupedTools, isCompactModeEnabled, compactAllowlist, borderTopOverride]);
 
   let countToolCallsWithResults = 0;
   for (const tool of visibleToolCalls) {
     if (tool.kind !== Kind.Agent) {
-      if (isCompactTool(tool, isCompactModeEnabled)) {
+      if (isCompactTool(tool, isCompactModeEnabled, compactAllowlist)) {
         if (hasDensePayload(tool)) {
           countToolCallsWithResults++;
         }
@@ -362,19 +370,20 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         const prevIsCompact =
           prevGroup &&
           !Array.isArray(prevGroup) &&
-          isCompactTool(prevGroup, isCompactModeEnabled);
+          isCompactTool(prevGroup, isCompactModeEnabled, compactAllowlist);
 
         const nextGroup = !isLast ? groupedTools[index + 1] : null;
         const nextIsCompact =
           nextGroup &&
           !Array.isArray(nextGroup) &&
-          isCompactTool(nextGroup, isCompactModeEnabled);
+          isCompactTool(nextGroup, isCompactModeEnabled, compactAllowlist);
         const nextIsTopicToolCall =
           nextGroup && !Array.isArray(nextGroup) && isTopicTool(nextGroup.name);
 
         const isAgentGroup = Array.isArray(group);
         const isCompact =
-          !isAgentGroup && isCompactTool(group, isCompactModeEnabled);
+          !isAgentGroup &&
+          isCompactTool(group, isCompactModeEnabled, compactAllowlist);
         const isTopicToolCall = !isAgentGroup && isTopicTool(group.name);
 
         const isFirstProp = !!(isFirst

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -302,6 +302,8 @@ export const useGeminiStream = (
         if (toolsToPush.length > 0) {
           const isCompactModeEnabled =
             settings.merged.ui?.compactToolOutput === true;
+          const compactAllowlist =
+            settings.merged.ui?.compactToolOutputAllowlist ?? [];
           const firstToolToPush = toolsToPush[0];
           const tcIndex = toolCalls.indexOf(firstToolToPush);
           const prevTool = tcIndex > 0 ? toolCalls[tcIndex - 1] : null;
@@ -313,10 +315,12 @@ export const useGeminiStream = (
             const currentIsCompact = isCompactTool(
               mapTrackedToolCallsToDisplay(firstToolToPush).tools[0],
               isCompactModeEnabled,
+              compactAllowlist,
             );
             const prevWasCompact = isCompactTool(
               mapTrackedToolCallsToDisplay(prevTool).tools[0],
               isCompactModeEnabled,
+              compactAllowlist,
             );
             if (!currentIsCompact && prevWasCompact) {
               borderTop = true;
@@ -493,6 +497,8 @@ export const useGeminiStream = (
       const isFirstInThisPush = isFirstToolInGroupRef.current;
       const isCompactModeEnabled =
         settings.merged.ui?.compactToolOutput === true;
+      const compactAllowlist =
+        settings.merged.ui?.compactToolOutputAllowlist ?? [];
 
       const groups: TrackedToolCall[][] = [];
       let currentGroup: TrackedToolCall[] = [];
@@ -543,14 +549,22 @@ export const useGeminiStream = (
         // Determine if this group starts with a compact tool
         const currentIsCompact =
           historyItem.tools.length === 1 &&
-          isCompactTool(historyItem.tools[0], isCompactModeEnabled);
+          isCompactTool(
+            historyItem.tools[0],
+            isCompactModeEnabled,
+            compactAllowlist,
+          );
 
         let nextIsCompact = false;
         if (nextTcInBatch) {
           const nextHistoryItem = mapTrackedToolCallsToDisplay(nextTcInBatch);
           nextIsCompact =
             nextHistoryItem.tools.length === 1 &&
-            isCompactTool(nextHistoryItem.tools[0], isCompactModeEnabled);
+            isCompactTool(
+              nextHistoryItem.tools[0],
+              isCompactModeEnabled,
+              compactAllowlist,
+            );
         }
 
         let prevWasCompact = false;
@@ -558,7 +572,11 @@ export const useGeminiStream = (
           const prevHistoryItem = mapTrackedToolCallsToDisplay(prevTcInBatch);
           prevWasCompact =
             prevHistoryItem.tools.length === 1 &&
-            isCompactTool(prevHistoryItem.tools[0], isCompactModeEnabled);
+            isCompactTool(
+              prevHistoryItem.tools[0],
+              isCompactModeEnabled,
+              compactAllowlist,
+            );
         }
 
         historyItem.borderTop =
@@ -594,6 +612,7 @@ export const useGeminiStream = (
     isShellFocused,
     backgroundTasks,
     settings.merged.ui?.compactToolOutput,
+    settings.merged.ui?.compactToolOutputAllowlist,
   ]);
   const pendingToolGroupItems = useMemo((): HistoryItemWithoutId[] => {
     const remainingTools = toolCalls.filter(
@@ -667,11 +686,17 @@ export const useGeminiStream = (
 
     let lastVisibleIsCompact = false;
     const isCompactModeEnabled = settings.merged.ui?.compactToolOutput === true;
+    const compactAllowlist =
+      settings.merged.ui?.compactToolOutputAllowlist ?? [];
     for (let i = toolCalls.length - 1; i >= 0; i--) {
       if (isToolVisible(toolCalls[i])) {
         const mapped = mapTrackedToolCallsToDisplay(toolCalls[i]);
         lastVisibleIsCompact = mapped.tools[0]
-          ? isCompactTool(mapped.tools[0], isCompactModeEnabled)
+          ? isCompactTool(
+              mapped.tools[0],
+              isCompactModeEnabled,
+              compactAllowlist,
+            )
           : false;
         break;
       }
@@ -700,6 +725,7 @@ export const useGeminiStream = (
     isShellFocused,
     backgroundTasks,
     settings.merged.ui?.compactToolOutput,
+    settings.merged.ui?.compactToolOutputAllowlist,
   ]);
 
   const lastQueryRef = useRef<PartListUnion | null>(null);


### PR DESCRIPTION
# feat: add compactToolOutputAllowlist setting

Introduces a new UI setting `compactToolOutputAllowlist` (`string[]`) that extends the built-in compact tool output list. When `compactToolOutput` is enabled, any tool whose name appears in this list is rendered using the compact `DenseToolMessage` instead of the full `ToolResultDisplay`.

This allows external tools (e.g. MCP servers) to opt in to compact rendering by adding their tool names during setup, without requiring changes to the built-in allowlist.

## Summary

The existing `compactToolOutput` setting collapses verbose tool output into a single summary line, but only for a hardcoded set of built-in Gemini tools. MCP server tools — which can have any name and are user-defined — were always rendered verbosely regardless of this setting.

This PR adds a `compactToolOutputAllowlist` UI setting (string array, default empty) that extends the built-in list at runtime. Any tool name in the allowlist is treated as compact-eligible when `compactToolOutput` is enabled. MCP server setup scripts can populate this list in `settings.json` so their tools benefit from compact rendering without requiring upstream code changes.

## Details

- `compactToolOutputAllowlist` is defined in `settingsSchema.ts` as an array of strings, not shown in the settings dialog (it's intended for programmatic population by tool setup scripts).
- `isCompactTool()` in `ToolGroupMessage.tsx` gains an optional `extraAllowlist` parameter (defaults to `[]`) checked alongside the built-in `COMPACT_OUTPUT_ALLOWLIST`.
- All call sites in `ToolGroupMessage.tsx` and `useGeminiStream.ts` pass the allowlist read from settings. Hook dependency arrays updated accordingly.
- No behaviour change for existing users — the allowlist defaults to empty.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Add tool names to `~/.gemini/settings.json`:
   ```json
   {
     "ui": {
       "compactToolOutput": true,
       "compactToolOutputAllowlist": ["my_mcp_tool"]
     }
   }
   ```
2. Configure an MCP server that exposes a tool named `my_mcp_tool`.
3. Start Gemini CLI and trigger a call to `my_mcp_tool`.
4. Confirm the result renders as a single compact line (tool name + summary) rather than the full output block.
5. Set `compactToolOutput: false` and confirm the tool reverts to full output (allowlist has no effect when compact mode is off).
6. Remove the tool name from the allowlist and confirm it reverts to full output.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
