### PR TITLE
fix(ui): corrected background color check in user message components

### DIFF
--- a/packages/cli/src/ui/components/messages/HintMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/HintMessage.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { HintMessage } from './HintMessage.js';
+import { describe, it, expect, vi } from 'vitest';
+import { makeFakeConfig } from '@google/gemini-cli-core';
+
+describe('HintMessage', () => {
+  it('renders normal hint message with correct prefix', async () => {
+    const { lastFrame, unmount } = await renderWithProviders(
+      <HintMessage text="Try this instead" />,
+      { width: 80 },
+    );
+    const output = lastFrame();
+
+    expect(output).toContain('💡');
+    expect(output).toContain('Steering Hint: Try this instead');
+    unmount();
+  });
+
+  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const { lastFrame, unmount } = await renderWithProviders(
+      <HintMessage text="Try this instead" />,
+      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+    );
+    const output = lastFrame();
+
+    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+    expect(output).not.toContain('▄');
+    expect(output).not.toContain('▀');
+
+    const lines = output.split('\n').filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('💡');
+    expect(lines[0]).toContain('Steering Hint: Try this instead');
+
+    vi.unstubAllEnvs();
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/messages/HintMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/HintMessage.test.tsx
@@ -10,6 +10,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { makeFakeConfig } from '@google/gemini-cli-core';
 
 describe('HintMessage', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders normal hint message with correct prefix', async () => {
     const { lastFrame, unmount } = await renderWithProviders(
       <HintMessage text="Try this instead" />,
@@ -22,24 +26,28 @@ describe('HintMessage', () => {
     unmount();
   });
 
-  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const { lastFrame, unmount } = await renderWithProviders(
-      <HintMessage text="Try this instead" />,
-      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
-    );
-    const output = lastFrame();
+  describe('with NO_COLOR set', () => {
+    beforeEach(() => {
+      vi.stubEnv('NO_COLOR', '1');
+    });
 
-    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
-    expect(output).not.toContain('▄');
-    expect(output).not.toContain('▀');
+    it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(
+        <HintMessage text="Try this instead" />,
+        { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+      );
+      const output = lastFrame();
 
-    const lines = output.split('\n').filter((l) => l.trim() !== '');
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('💡');
-    expect(lines[0]).toContain('Steering Hint: Try this instead');
+      // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+      expect(output).not.toContain('▄');
+      expect(output).not.toContain('▀');
 
-    vi.unstubAllEnvs();
-    unmount();
+      const lines = output.split('\n').filter((l) => l.trim() !== '');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('💡');
+      expect(lines[0]).toContain('Steering Hint: Try this instead');
+
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/HintMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/HintMessage.test.tsx
@@ -12,6 +12,7 @@ import { makeFakeConfig } from '@google/gemini-cli-core';
 describe('HintMessage', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it('renders normal hint message with correct prefix', async () => {
@@ -46,6 +47,8 @@ describe('HintMessage', () => {
       expect(lines).toHaveLength(1);
       expect(lines[0]).toContain('💡');
       expect(lines[0]).toContain('Steering Hint: Try this instead');
+
+      expect(output).toMatchSnapshot();
 
       unmount();
     });

--- a/packages/cli/src/ui/components/messages/HintMessage.tsx
+++ b/packages/cli/src/ui/components/messages/HintMessage.tsx
@@ -19,7 +19,9 @@ export const HintMessage: React.FC<HintMessageProps> = ({ text }) => {
   const prefix = '💡 ';
   const prefixWidth = prefix.length;
   const config = useConfig();
-  const useBackgroundColor = config.getUseBackgroundColor();
+  const useBackgroundColorSetting = config.getUseBackgroundColor();
+  const useBackgroundColor =
+    useBackgroundColorSetting && !!theme.background.message;
 
   return (
     <HalfLinePaddedBox

--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
@@ -15,6 +15,10 @@ vi.mock('../../utils/commandUtils.js', () => ({
 }));
 
 describe('UserMessage', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders normal user message with correct prefix', async () => {
     const { lastFrame, unmount } = await renderWithProviders(
       <UserMessage text="Hello Gemini" width={80} />,
@@ -62,25 +66,29 @@ describe('UserMessage', () => {
     unmount();
   });
 
-  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const { lastFrame, unmount } = await renderWithProviders(
-      <UserMessage text="Hello Gemini" width={80} />,
-      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
-    );
-    const output = lastFrame();
+  describe('with NO_COLOR set', () => {
+    beforeEach(() => {
+      vi.stubEnv('NO_COLOR', '1');
+    });
 
-    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
-    expect(output).not.toContain('▄');
-    expect(output).not.toContain('▀');
+    it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(
+        <UserMessage text="Hello Gemini" width={80} />,
+        { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+      );
+      const output = lastFrame();
 
-    // There should be empty lines above and below the message due to marginY={1}.
-    // lastFrame() returns the full buffer, so we can check for leading/trailing newlines or empty lines.
-    const lines = output.split('\n').filter((l) => l.trim() !== '');
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('> Hello Gemini');
+      // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+      expect(output).not.toContain('▄');
+      expect(output).not.toContain('▀');
 
-    vi.unstubAllEnvs();
-    unmount();
+      // There should be empty lines above and below the message due to marginY={1}.
+      // lastFrame() returns the full buffer, so we can check for leading/trailing newlines or empty lines.
+      const lines = output.split('\n').filter((l) => l.trim() !== '');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('> Hello Gemini');
+
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
@@ -7,6 +7,7 @@
 import { renderWithProviders } from '../../../test-utils/render.js';
 import { UserMessage } from './UserMessage.js';
 import { describe, it, expect, vi } from 'vitest';
+import { makeFakeConfig } from '@google/gemini-cli-core';
 
 // Mock the commandUtils to control isSlashCommand behavior
 vi.mock('../../utils/commandUtils.js', () => ({
@@ -58,6 +59,28 @@ describe('UserMessage', () => {
 
     expect(output).toContain('[Image my-image.png]');
     expect(output).toMatchSnapshot();
+    unmount();
+  });
+
+  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const { lastFrame, unmount } = await renderWithProviders(
+      <UserMessage text="Hello Gemini" width={80} />,
+      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+    );
+    const output = lastFrame();
+
+    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+    expect(output).not.toContain('▄');
+    expect(output).not.toContain('▀');
+
+    // There should be empty lines above and below the message due to marginY={1}.
+    // lastFrame() returns the full buffer, so we can check for leading/trailing newlines or empty lines.
+    const lines = output.split('\n').filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('> Hello Gemini');
+
+    vi.unstubAllEnvs();
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/messages/UserMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../utils/commandUtils.js', () => ({
 describe('UserMessage', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it('renders normal user message with correct prefix', async () => {
@@ -87,6 +88,8 @@ describe('UserMessage', () => {
       const lines = output.split('\n').filter((l) => l.trim() !== '');
       expect(lines).toHaveLength(1);
       expect(lines[0]).toContain('> Hello Gemini');
+
+      expect(output).toMatchSnapshot();
 
       unmount();
     });

--- a/packages/cli/src/ui/components/messages/UserMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserMessage.tsx
@@ -27,7 +27,9 @@ export const UserMessage: React.FC<UserMessageProps> = ({ text, width }) => {
   const prefixWidth = prefix.length;
   const isSlashCommand = checkIsSlashCommand(text);
   const config = useConfig();
-  const useBackgroundColor = config.getUseBackgroundColor();
+  const useBackgroundColorSetting = config.getUseBackgroundColor();
+  const useBackgroundColor =
+    useBackgroundColorSetting && !!theme.background.message;
 
   const textColor = isSlashCommand ? theme.text.accent : theme.text.primary;
 

--- a/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
@@ -10,6 +10,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { makeFakeConfig } from '@google/gemini-cli-core';
 
 describe('UserShellMessage', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders normal shell message with correct prefix', async () => {
     const { lastFrame, unmount } = await renderWithProviders(
       <UserShellMessage text="ls -la" width={80} />,
@@ -21,23 +25,27 @@ describe('UserShellMessage', () => {
     unmount();
   });
 
-  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
-    vi.stubEnv('NO_COLOR', '1');
-    const { lastFrame, unmount } = await renderWithProviders(
-      <UserShellMessage text="ls -la" width={80} />,
-      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
-    );
-    const output = lastFrame();
+  describe('with NO_COLOR set', () => {
+    beforeEach(() => {
+      vi.stubEnv('NO_COLOR', '1');
+    });
 
-    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
-    expect(output).not.toContain('▄');
-    expect(output).not.toContain('▀');
+    it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(
+        <UserShellMessage text="ls -la" width={80} />,
+        { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+      );
+      const output = lastFrame();
 
-    const lines = output.split('\n').filter((l) => l.trim() !== '');
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('$ ls -la');
+      // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+      expect(output).not.toContain('▄');
+      expect(output).not.toContain('▀');
 
-    vi.unstubAllEnvs();
-    unmount();
+      const lines = output.split('\n').filter((l) => l.trim() !== '');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('$ ls -la');
+
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
@@ -12,6 +12,7 @@ import { makeFakeConfig } from '@google/gemini-cli-core';
 describe('UserShellMessage', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it('renders normal shell message with correct prefix', async () => {
@@ -44,6 +45,8 @@ describe('UserShellMessage', () => {
       const lines = output.split('\n').filter((l) => l.trim() !== '');
       expect(lines).toHaveLength(1);
       expect(lines[0]).toContain('$ ls -la');
+
+      expect(output).toMatchSnapshot();
 
       unmount();
     });

--- a/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/UserShellMessage.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../../test-utils/render.js';
+import { UserShellMessage } from './UserShellMessage.js';
+import { describe, it, expect, vi } from 'vitest';
+import { makeFakeConfig } from '@google/gemini-cli-core';
+
+describe('UserShellMessage', () => {
+  it('renders normal shell message with correct prefix', async () => {
+    const { lastFrame, unmount } = await renderWithProviders(
+      <UserShellMessage text="ls -la" width={80} />,
+      { width: 80 },
+    );
+    const output = lastFrame();
+
+    expect(output).toContain('$ ls -la');
+    unmount();
+  });
+
+  it('uses margins instead of background blocks when NO_COLOR is set', async () => {
+    vi.stubEnv('NO_COLOR', '1');
+    const { lastFrame, unmount } = await renderWithProviders(
+      <UserShellMessage text="ls -la" width={80} />,
+      { width: 80, config: makeFakeConfig({ useBackgroundColor: true }) },
+    );
+    const output = lastFrame();
+
+    // In NO_COLOR mode, the block characters (▄/▀) should NOT be present.
+    expect(output).not.toContain('▄');
+    expect(output).not.toContain('▀');
+
+    const lines = output.split('\n').filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('$ ls -la');
+
+    vi.unstubAllEnvs();
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/components/messages/UserShellMessage.tsx
+++ b/packages/cli/src/ui/components/messages/UserShellMessage.tsx
@@ -20,7 +20,9 @@ export const UserShellMessage: React.FC<UserShellMessageProps> = ({
   width,
 }) => {
   const config = useConfig();
-  const useBackgroundColor = config.getUseBackgroundColor();
+  const useBackgroundColorSetting = config.getUseBackgroundColor();
+  const useBackgroundColor =
+    useBackgroundColorSetting && !!theme.background.message;
 
   // Remove leading '!' if present, as App.tsx adds it for the processor.
   const commandToDisplay = text.startsWith('!') ? text.substring(1) : text;

--- a/packages/cli/src/ui/components/messages/__snapshots__/HintMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/HintMessage.test.tsx.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`HintMessage > with NO_COLOR set > uses margins instead of background blocks when NO_COLOR is set 1`] = `
+"
+💡 Steering Hint: Try this instead
+"
+`;

--- a/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/UserMessage.test.tsx.snap
@@ -28,3 +28,9 @@ exports[`UserMessage > transforms image paths in user message 1`] = `
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 "
 `;
+
+exports[`UserMessage > with NO_COLOR set > uses margins instead of background blocks when NO_COLOR is set 1`] = `
+"
+> Hello Gemini
+"
+`;

--- a/packages/cli/src/ui/components/messages/__snapshots__/UserShellMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/UserShellMessage.test.tsx.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`UserShellMessage > with NO_COLOR set > uses margins instead of background blocks when NO_COLOR is set 1`] = `
+"
+$ ls -la
+"
+`;


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Fixed check for background color in user message components, correctly adding padding around them in the process.


## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
Fixed 
- `packages/cli/src/ui/components/messages/HintMessage.tsx`
- `packages/cli/src/ui/components/messages/UserMessage.tsx`
- `packages/cli/src/ui/components/messages/UserShellMessage.tsx`

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #25879 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Start the CLI after typing `export NO_COLOR=true` in the terminal. After asking multiple commands, there should be space around the user messages in the history. Typing a shell command like `! ls` should also have padding.

Screenshot:
<img width="937" height="518" alt="Screenshot 2026-04-23 at 2 38 23 PM" src="https://github.com/user-attachments/assets/9fa3088a-32c6-4373-84d8-636ae892d179" />

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
