### PR TITLE
fix(cli): restrict ctrl+backspace detection to Windows Terminal only

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -480,7 +480,7 @@ describe('KeypressContext', () => {
       );
     });
 
-    it('should treat \\b as ctrl when OS is Windows_NT', async () => {
+    it('should NOT treat \\b as ctrl when OS is Windows_NT but WT_SESSION is absent', async () => {
       vi.stubEnv('WT_SESSION', '');
       vi.stubEnv('OS', 'Windows_NT');
       const { keyHandler } = await setupKeypressTest();
@@ -492,7 +492,7 @@ describe('KeypressContext', () => {
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'backspace',
-          ctrl: true,
+          ctrl: false,
         }),
       );
     });

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -654,12 +654,10 @@ function* emitKeys(
     } else if (ch === '\b') {
       // ctrl+h / ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
       name = 'backspace';
-      // In Windows environments, \b is sent for Ctrl+Backspace (standard backspace is translated to \x7f).
-      // We scope this to Windows/WT_SESSION to avoid breaking other unixes where \b is a plain backspace.
-      if (
-        typeof process !== 'undefined' &&
-        (process.env?.['OS'] === 'Windows_NT' || !!process.env?.['WT_SESSION'])
-      ) {
+      // Windows Terminal sends \b for Ctrl+Backspace (regular backspace is \x7f).
+      // Only set ctrl=true for WT_SESSION (Windows Terminal); cmd.exe and PowerShell
+      // send \b for plain backspace so we must not treat them as Ctrl+Backspace.
+      if (typeof process !== 'undefined' && !!process.env?.['WT_SESSION']) {
         ctrl = true;
       }
       alt = escaped;


### PR DESCRIPTION
## Summary

- PR #21447 introduced `ctrl+backspace` word deletion for Windows, but the condition `OS === 'Windows_NT'` was too broad
- `cmd.exe` and `PowerShell` send `\b` (0x08) for **plain backspace**, not `\x7f` — so they were incorrectly being treated as `Ctrl+Backspace`, deleting a whole word on every backspace press
- Fixed by scoping `ctrl=true` to `WT_SESSION` only (Windows Terminal), which is the only terminal that sends `\b` for `Ctrl+Backspace` and `\x7f` for plain backspace
- Updated the test that expected `OS=Windows_NT` alone to set `ctrl=true`

Fixes #25867

## Test plan

- [ ] Windows Terminal (`WT_SESSION` set): `Ctrl+Backspace` deletes word, plain backspace deletes one character
- [ ] cmd.exe / PowerShell (no `WT_SESSION`): plain backspace deletes one character (regression from #21447 is fixed)
- [ ] Linux/macOS: behavior unchanged
