### PR TITLE
fix(cli): use os.homedir() for home directory warning check

### DIFF
--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -19,11 +19,11 @@ import {
 } from '@google/gemini-cli-core';
 
 // Mock os.homedir to control the home directory in tests
-vi.mock('os', async (importOriginal) => {
+vi.mock('node:os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
   return {
     ...actualOs,
-    homedir: vi.fn(),
+    homedir: vi.fn(() => actualOs.homedir()),
   };
 });
 
@@ -32,7 +32,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
-    homedir: () => os.homedir(),
     getCompatibilityWarnings: vi.fn().mockReturnValue([]),
     isHeadlessMode: vi.fn().mockReturnValue(false),
     WarningPriority: {
@@ -66,6 +65,7 @@ describe('getUserStartupWarnings', () => {
 
   afterEach(async () => {
     await fs.rm(testRootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -95,6 +95,54 @@ describe('getUserStartupWarnings', () => {
         { ui: { showHomeDirectoryWarning: false } },
         homeDir,
       );
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+
+    it('should not return a warning when running in a subdirectory of home', async () => {
+      const subDir = path.join(homeDir, 'projects', 'my-app');
+      await fs.mkdir(subDir, { recursive: true });
+      const warnings = await getUserStartupWarnings({}, subDir);
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+
+    it('should not return a warning when home directory is a symlink and running in a subdirectory', async () => {
+      const realHome = path.join(testRootDir, 'real-home');
+      await fs.mkdir(realHome, { recursive: true });
+      const symlinkedHome = path.join(testRootDir, 'symlinked-home');
+      await fs.symlink(realHome, symlinkedHome);
+      vi.mocked(os.homedir).mockReturnValue(symlinkedHome);
+
+      const subDir = path.join(symlinkedHome, 'projects');
+      await fs.mkdir(subDir, { recursive: true });
+      const warnings = await getUserStartupWarnings({}, subDir);
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+
+    it('should return a warning when home directory is a symlink and running in it', async () => {
+      const realHome = path.join(testRootDir, 'real-home2');
+      await fs.mkdir(realHome, { recursive: true });
+      const symlinkedHome = path.join(testRootDir, 'symlinked-home2');
+      await fs.symlink(realHome, symlinkedHome);
+      vi.mocked(os.homedir).mockReturnValue(symlinkedHome);
+
+      const warnings = await getUserStartupWarnings({}, symlinkedHome);
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          id: 'home-directory',
+          message: expect.stringContaining(
+            'Warning you are running Gemini CLI in your home directory',
+          ),
+          priority: WarningPriority.Low,
+        }),
+      );
+    });
+
+    it('should not return a warning when GEMINI_CLI_HOME differs from os.homedir', async () => {
+      const projectDir = path.join(testRootDir, 'project');
+      await fs.mkdir(projectDir, { recursive: true });
+      vi.stubEnv('GEMINI_CLI_HOME', projectDir);
+
+      const warnings = await getUserStartupWarnings({}, projectDir);
       expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
     });
 

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -5,10 +5,10 @@
  */
 
 import fs from 'node:fs/promises';
+import { homedir as osHomedir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import {
-  homedir,
   getCompatibilityWarnings,
   WarningPriority,
   type StartupWarning,
@@ -39,10 +39,10 @@ const homeDirectoryCheck: WarningCheck = {
     try {
       const [workspaceRealPath, homeRealPath] = await Promise.all([
         fs.realpath(workspaceRoot),
-        fs.realpath(homedir()),
+        fs.realpath(osHomedir()),
       ]);
 
-      if (workspaceRealPath === homeRealPath) {
+      if (path.resolve(workspaceRealPath) === path.resolve(homeRealPath)) {
         // If folder trust is enabled and the user trusts the home directory, don't show the warning.
         if (
           isFolderTrustEnabled(settings) &&


### PR DESCRIPTION
The home directory warning incorrectly used the core homedir() helper
which respects the GEMINI_CLI_HOME environment variable. When
GEMINI_CLI_HOME is set to a non-home directory, the warning could fire
in subdirectories or miss the actual home directory entirely.

Switch to Node's native os.homedir() so the check always compares
against the real OS home directory, and normalize both resolved paths
before comparison to handle trailing-slash and separator edge cases.

Add test coverage for subdirectories, symlinked home directories, and
GEMINI_CLI_HOME override scenarios.

Fixes #22309

## Summary

Fix home directory warning triggering incorrectly in subdirectories by using `os.homedir()` instead of the core `homedir()` helper, and normalizing paths before comparison.

## Details

- The core `homedir()` from `@google/gemini-cli-core` respects the `GEMINI_CLI_HOME` env var, which is intended for config directory resolution — not for checking if the user is literally in their OS home directory. Replaced with Node's native `os.homedir()`.
- Added `path.normalize()` on both `fs.realpath()` outputs before the `===` comparison to handle trailing-slash and separator edge cases across platforms.
- Added 4 new test cases: subdirectory of home, symlinked home + subdirectory, symlinked home (exact match), and `GEMINI_CLI_HOME` override scenario.

## Related Issues

Fixes #22309

## How to Validate

1. Run the unit tests: `npx vitest run packages/cli/src/utils/userStartupWarnings.test.ts` - All 13 tests should pass.
2. Run the type check: `npx tsc --noEmit -p packages/cli/tsconfig.json`
3. Run the build: `npm run build`
4. Manual validation:
   - Run `gemini` from your home directory (`cd ~`) — warning should appear
   - Run `gemini` from a subdirectory (`cd ~/some-project`) — warning should NOT appear

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker