### PR TITLE
fix(cli): debounce TTY loss check to prevent false-positive exits

### DIFF
--- a/packages/cli/src/utils/cleanup.test.ts
+++ b/packages/cli/src/utils/cleanup.test.ts
@@ -289,8 +289,40 @@ describe('signal and TTY handling', () => {
       });
 
       const cleanup = setupTtyCheck();
-      await vi.advanceTimersByTimeAsync(5000);
+      // TTY loss is confirmed after 5000ms check + 1000ms confirmation delay
+      await vi.advanceTimersByTimeAsync(6000);
       expect(process.exit).toHaveBeenCalledWith(0);
+      cleanup();
+    });
+
+    it('should not exit when TTY is restored during confirmation delay', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
+
+      const cleanup = setupTtyCheck();
+      // Advance to when TTY loss is detected (5000ms), before confirmation fires
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(process.exit).not.toHaveBeenCalled();
+
+      // Restore TTY before the 1s confirmation window expires
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      // Advance past the confirmation delay
+      await vi.advanceTimersByTimeAsync(1500);
+      // Should NOT have exited — TTY was restored (transient flicker)
+      expect(process.exit).not.toHaveBeenCalled();
       cleanup();
     });
 

--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -150,6 +150,7 @@ export function setupSignalHandlers() {
 
 export function setupTtyCheck(): () => void {
   let intervalId: ReturnType<typeof setInterval> | null = null;
+  let confirmTimeout: ReturnType<typeof setTimeout> | null = null;
   let isCheckingTty = false;
   // TTY loss confirmation delay to avoid false positives from momentary
   // isTTY flickers on Windows terminals (PowerShell, Windows Terminal)
@@ -172,7 +173,8 @@ export function setupTtyCheck(): () => void {
         intervalId = null;
       }
 
-      setTimeout(async () => {
+      confirmTimeout = setTimeout(async () => {
+        confirmTimeout = null;
         if (isShuttingDown) {
           return;
         }
@@ -185,6 +187,7 @@ export function setupTtyCheck(): () => void {
         }
         await gracefulShutdown('TTY loss');
       }, TTY_LOSS_CONFIRM_MS);
+      confirmTimeout.unref();
     }
   };
 
@@ -194,6 +197,10 @@ export function setupTtyCheck(): () => void {
   intervalId.unref();
 
   return () => {
+    if (confirmTimeout) {
+      clearTimeout(confirmTimeout);
+      confirmTimeout = null;
+    }
     if (intervalId) {
       clearInterval(intervalId);
       intervalId = null;

--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -151,16 +151,19 @@ export function setupSignalHandlers() {
 export function setupTtyCheck(): () => void {
   let intervalId: ReturnType<typeof setInterval> | null = null;
   let isCheckingTty = false;
+  // TTY loss confirmation delay to avoid false positives from momentary
+  // isTTY flickers on Windows terminals (PowerShell, Windows Terminal)
+  // during resize, focus changes, or buffer flushes.
+  // See https://github.com/google-gemini/gemini-cli/issues/25908
+  const TTY_LOSS_CONFIRM_MS = 1000;
 
-  intervalId = setInterval(async () => {
+  const checkTty = () => {
     if (isCheckingTty || isShuttingDown) {
       return;
     }
-
     if (process.env['SANDBOX']) {
       return;
     }
-
     if (!process.stdin.isTTY && !process.stdout.isTTY) {
       isCheckingTty = true;
 
@@ -169,9 +172,23 @@ export function setupTtyCheck(): () => void {
         intervalId = null;
       }
 
-      await gracefulShutdown('TTY loss');
+      setTimeout(async () => {
+        if (isShuttingDown) {
+          return;
+        }
+        // If TTY came back, it was a transient flicker — restart monitoring.
+        if (process.stdin.isTTY || process.stdout.isTTY) {
+          isCheckingTty = false;
+          intervalId = setInterval(checkTty, 5000);
+          if (intervalId) intervalId.unref();
+          return;
+        }
+        await gracefulShutdown('TTY loss');
+      }, TTY_LOSS_CONFIRM_MS);
     }
-  }, 5000);
+  };
+
+  intervalId = setInterval(checkTty, 5000);
 
   // Don't keep the process alive just for this interval
   intervalId.unref();


### PR DESCRIPTION
## Summary

On Windows terminals (PowerShell, Windows Terminal), `process.stdin.isTTY` and `process.stdout.isTTY` can momentarily flicker to `false` during:
- Window resize
- Focus changes
- Terminal buffer flushes
- Windows Terminal multiplexer behavior

The TTY check interval (`setupTtyCheck`) would immediately trigger `gracefulShutdown()` upon detecting this, causing the CLI agent to unexpectedly exit mid-task with no error — exactly as reported in this issue.

## Fix

Add a 1-second confirmation delay before triggering shutdown. When TTY loss is first detected:
1. A 1s timer starts instead of immediately shutting down
2. When the timer fires, TTY state is re-checked
3. If TTY was restored → it was a transient flicker, monitoring restarts
4. If TTY is still lost → it's a real terminal closure, shutdown proceeds

## Changes

- `packages/cli/src/utils/cleanup.ts` — refactored `setupTtyCheck` to use a named `checkTty` function with confirmation delay
- `packages/cli/src/utils/cleanup.test.ts` — updated existing test timing, added test for transient flicker recovery

Fixes #25908