### PR TITLE
docs: add Gemini CLI course link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ for planned features and priorities.
 
 ## 📖 Resources
 
+- **[Free Course](https://learn.deeplearning.ai/courses/gemini-cli-code-and-create-with-an-open-source-agent/information)** -
+  Learn the basics.
 - **[Official Roadmap](./ROADMAP.md)** - See what's coming next.
 - **[Changelog](https://www.geminicli.com/docs/changelogs)** - See recent
   notable updates.


### PR DESCRIPTION

<img width="1405" height="508" alt="Screenshot from 2026-04-24 20-40-17" src="https://github.com/user-attachments/assets/7e05d773-f981-45e9-ba3c-05ed9ed1fa49" />

## Summary

Adds a link to the free course "Gemini CLI: Code & Create with an Open-Source Agent" to the Resources section of the README.

## Details

The course is a valuable resource for beginners to learn how to use Gemini CLI effectively. The link is placed at the top of the Resources section for visibility.

## Related Issues

Closes #25924

## How to Validate

1. Open README.md.
2. Verify the link "Free Course: Gemini CLI: Code & Create with an Open-Source Agent" exists in the Resources section.
3. Verify the link points to: https://learn.deeplearning.ai/courses/gemini-cli-code-and-create-with-an-open-source-agent/information

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
