### PR TITLE
fix(cli): filter blocked MCP servers case-insensitively

### DIFF
--- a/packages/cli/src/ui/components/views/McpStatus.test.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.test.tsx
@@ -202,6 +202,30 @@ describe('McpStatus', () => {
     unmount();
   });
 
+  it('filters blocked servers case-insensitively and ignores whitespace', async () => {
+    const { lastFrame, unmount } = await render(
+      <McpStatus
+        {...baseProps}
+        servers={{
+          'SERVER-1 ': {
+            url: 'http://localhost:8080',
+            description: 'A test server',
+          },
+          ' server-2': {
+            url: 'http://localhost:8081',
+            description: 'A blocked server',
+          },
+        }}
+        blockedServers={[
+          { name: ' server-1', extensionName: 'test-extension' },
+          { name: 'SERVER-2 ', extensionName: 'test-extension' },
+        ]}
+      />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+    unmount();
+  });
+
   it('renders only blocked servers when no configured servers exist', async () => {
     const { lastFrame, unmount } = await render(
       <McpStatus

--- a/packages/cli/src/ui/components/views/McpStatus.tsx
+++ b/packages/cli/src/ui/components/views/McpStatus.tsx
@@ -50,7 +50,9 @@ export const McpStatus: React.FC<McpStatusProps> = ({
   const serverNames = Object.keys(servers).filter(
     (serverName) =>
       !blockedServers.some(
-        (blockedServer) => blockedServer.name === serverName,
+        (blockedServer) =>
+          blockedServer.name.trim().toLowerCase() ===
+          serverName.trim().toLowerCase(),
       ),
   );
 

--- a/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/McpStatus.test.tsx.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`McpStatus > filters blocked servers case-insensitively and ignores whitespace 1`] = `
+"Configured MCP servers:
+
+🔴  server-1 (from test-extension) - Blocked
+
+🔴 SERVER-2  (from test-extension) - Blocked
+"
+`;
+
 exports[`McpStatus > renders correctly when discovery is in progress 1`] = `
 "⏳ MCP servers are starting up (0 initializing)...
 Note: First startup may take longer. Tool availability will update automatically.


### PR DESCRIPTION
## Summary

Fixes a bug where disconnected MCP servers were listed twice in `/mcp list` (once as 'Disconnected' and once as 'Blocked') due to a strict string equality check that failed when extension server names had different casing or trailing whitespace compared to user configuration. Updated the filter in `McpStatus.tsx` to use `.trim().toLowerCase()`.

## Details

The logic in `McpStatus.tsx` that removes blocked servers from the main list relies on a strict string equality check (`blockedServer.name === serverName`). If an extension registers a server with a slight casing difference or trailing whitespace compared to its name in the blocked configuration, the filter fails to remove it from the main list. Because it isn't "Connected" or "Connecting", it defaults to "Disconnected" in the main UI rendering block before being rendered again by the Blocked list logic.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1634

## How to Validate

1. Run `npm run test -w @google/gemini-cli -- src/ui/components/views/McpStatus.test.tsx`
2. Alternatively, configure a blocked MCP server with trailing spaces or different cases in the extension vs user config, and run `/mcp list`. The server should only appear once under "Blocked".

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
