### PR TITLE
fix(core): prevent MCP tool wiping on background discovery failures

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -1461,8 +1461,8 @@ describe('mcp-client', () => {
       // Trigger notification - should fail internally but catch the error
       await notificationCallback();
 
-      // Should try to remove tools
-      expect(mockedToolRegistry.removeMcpToolsByServer).toHaveBeenCalled();
+      // Should NOT try to remove tools when discovery fails
+      expect(mockedToolRegistry.removeMcpToolsByServer).not.toHaveBeenCalled();
 
       // Should NOT emit success feedback
       expect(coreEvents.emitFeedback).not.toHaveBeenCalledWith(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1344,6 +1344,7 @@ export async function discoverTools(
         error,
         mcpServerName,
       );
+      throw error;
     }
     return [];
   }


### PR DESCRIPTION
## Summary

This PR fixes an issue where discovered tools from an MCP server are erroneously wiped from the `ToolRegistry` if a background refresh operation fails due to network latency or an idle timeout.

## Details

When an MCP server's background connection is dropped (e.g. idle timeout during a long API request), an attempted background `discoverTools` could fail with a generic network error. Previously, `discoverTools` caught this error and returned an empty array `[]` instead of throwing. `refreshTools` interpreted this empty array as 0 tools on the server and aggressively removed the server's tools from the CLI's registry using `removeMcpToolsByServer()`.

This PR updates `discoverTools` to correctly re-throw the error when it is not a `MethodNotFound` error. This preserves the existing tools in the `ToolRegistry` and avoids the confusing "tool could no longer be found" error when the session later tries to use the registered tool. A regression test case was also added to ensure this behavior is enforced.

## Related Issues

Fixes https://github.com/google-gemini/maintainers-gemini-cli/issues/1635

## How to Validate

- Inspect the unit test in `packages/core/src/tools/mcp-client.test.ts` for handling graceful tool refresh errors.
- Confirm tests pass: `npm run test -w @google/gemini-cli-core -- src/tools/mcp-client.test.ts`
- Confirm lints and types: `npm run lint` and `npm run typecheck`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker