### PR TITLE
fix(cli-ui): revert backspace handling to fix Windows regression

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -44,7 +44,7 @@ enum TerminalKeys {
   LEFT_ARROW = '\u001B[D',
   RIGHT_ARROW = '\u001B[C',
   ESCAPE = '\u001B',
-  BACKSPACE = '\x7f',
+  BACKSPACE = '\u0008',
   CTRL_P = '\u0010',
   CTRL_N = '\u000E',
 }

--- a/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/shared/BaseSettingsDialog.test.tsx
@@ -24,7 +24,7 @@ enum TerminalKeys {
   LEFT_ARROW = '\u001B[D',
   RIGHT_ARROW = '\u001B[C',
   ESCAPE = '\u001B',
-  BACKSPACE = '\x7f',
+  BACKSPACE = '\u0008',
   CTRL_L = '\u000C',
 }
 

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -9,17 +9,7 @@ import { act } from 'react';
 import { renderHookWithProviders } from '../../test-utils/render.js';
 import { createMockSettings } from '../../test-utils/settings.js';
 import { waitFor } from '../../test-utils/async.js';
-import type { Mock } from 'vitest';
-import {
-  vi,
-  afterAll,
-  beforeAll,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-} from 'vitest';
+import { vi, afterAll, beforeAll, type Mock } from 'vitest';
 import {
   useKeypressContext,
   ESC_TIMEOUT,
@@ -439,80 +429,6 @@ describe('KeypressContext', () => {
         );
       },
     );
-  });
-
-  describe('Windows Terminal Backspace handling', () => {
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
-
-    it('should NOT treat \\b as ctrl when WT_SESSION is NOT present and OS is not Windows_NT', async () => {
-      vi.stubEnv('WT_SESSION', '');
-      vi.stubEnv('OS', 'Linux');
-      const { keyHandler } = await setupKeypressTest();
-
-      act(() => {
-        stdin.write('\b');
-      });
-
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'backspace',
-          ctrl: false,
-        }),
-      );
-    });
-
-    it('should treat \\b as ctrl when WT_SESSION IS present (even if not Windows_NT)', async () => {
-      vi.stubEnv('WT_SESSION', 'some-id');
-      vi.stubEnv('OS', 'Linux');
-      const { keyHandler } = await setupKeypressTest();
-
-      act(() => {
-        stdin.write('\b');
-      });
-
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'backspace',
-          ctrl: true,
-        }),
-      );
-    });
-
-    it('should treat \\b as ctrl when OS is Windows_NT', async () => {
-      vi.stubEnv('WT_SESSION', '');
-      vi.stubEnv('OS', 'Windows_NT');
-      const { keyHandler } = await setupKeypressTest();
-
-      act(() => {
-        stdin.write('\b');
-      });
-
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'backspace',
-          ctrl: true,
-        }),
-      );
-    });
-
-    it('should treat \\x7f as regular backspace regardless of WT_SESSION or OS', async () => {
-      vi.stubEnv('WT_SESSION', 'some-id');
-      vi.stubEnv('OS', 'Windows_NT');
-      const { keyHandler } = await setupKeypressTest();
-
-      act(() => {
-        stdin.write('\x7f');
-      });
-
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'backspace',
-          ctrl: false,
-        }),
-      );
-    });
   });
 
   describe('paste mode', () => {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -651,20 +651,8 @@ function* emitKeys(
       // tab
       name = 'tab';
       alt = escaped;
-    } else if (ch === '\b') {
-      // ctrl+h / ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
-      name = 'backspace';
-      // In Windows environments, \b is sent for Ctrl+Backspace (standard backspace is translated to \x7f).
-      // We scope this to Windows/WT_SESSION to avoid breaking other unixes where \b is a plain backspace.
-      if (
-        typeof process !== 'undefined' &&
-        (process.env?.['OS'] === 'Windows_NT' || !!process.env?.['WT_SESSION'])
-      ) {
-        ctrl = true;
-      }
-      alt = escaped;
-    } else if (ch === '\x7f') {
-      // backspace
+    } else if (ch === '\b' || ch === '\x7f') {
+      // backspace or ctrl+h
       name = 'backspace';
       alt = escaped;
     } else if (ch === ESC) {


### PR DESCRIPTION
## Summary

This reverts commit 80764c8bb50017ed84072f10a90d8ff2c5368846.

## Details

The original PR (#21447) assumed that a plain backspace on Windows always sends \x7f and that \b is only sent for Ctrl+Backspace. This does not seem to be true for some windows users using node 22.

## Related Issues

Fixes #25856