### PR TITLE
fix(mcp): expand env vars in stdio args

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2157,6 +2157,39 @@ describe('mcp-client', () => {
       }
     });
 
+    it('should expand environment variables in mcpServerConfig.args before spawn', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        DISCORD_TOKEN: 'real-discord-token',
+      };
+
+      try {
+        await createTransport(
+          'test-server',
+          {
+            command: 'docker',
+            args: ['run', '--env', 'DISCORD_TOKEN=${DISCORD_TOKEN}'],
+          },
+          false,
+          MOCK_CONTEXT,
+        );
+
+        const callArgs = mockedTransport.mock.calls[0][0];
+        expect(callArgs.args).toEqual([
+          'run',
+          '--env',
+          'DISCORD_TOKEN=real-discord-token',
+        ]);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
     describe('useGoogleCredentialProvider', () => {
       beforeEach(() => {
         // Mock GoogleAuth client

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -2274,9 +2274,13 @@ export async function createTransport(
       }
     }
 
+    const expandedArgs = (mcpServerConfig.args || []).map((arg) =>
+      expandEnvVars(arg, expansionEnv),
+    );
+
     let transport: Transport = new StdioClientTransport({
       command: mcpServerConfig.command,
-      args: mcpServerConfig.args || [],
+      args: expandedArgs,
       env: finalEnv,
       cwd: mcpServerConfig.cwd,
       stderr: 'pipe',
@@ -2286,7 +2290,7 @@ export async function createTransport(
     // It returns JSON in `content` instead of `structuredContent`
     if (
       mcpServerConfig.command === 'xcrun' &&
-      mcpServerConfig.args?.includes('mcpbridge')
+      expandedArgs.includes('mcpbridge')
     ) {
       transport = new XcodeMcpBridgeFixTransport(transport);
     }


### PR DESCRIPTION
`mcpServers` stdio args were passed through to the child process without the env expansion already used for explicit `env` entries, so placeholders like `${DISCORD_TOKEN}` reached Docker unchanged.

This expands each arg against the same environment before spawning and keeps the Xcode `mcpbridge` special-case check aligned with the final args. Added a regression test covering `${DISCORD_TOKEN}` expansion in `args`.

Fixes #25939