### PR TITLE
fix(cli): resolve file-loaded custom theme lookup by internal name

### DIFF
--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -152,6 +152,20 @@ describe('ThemeManager', () => {
       );
     });
 
+    it('should find a file-loaded theme by its internal name', () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(mockTheme));
+
+      // First load the theme via path
+      themeManager.setActiveTheme('/home/user/my-theme.json');
+
+      // Then try to find it by its internal name
+      const foundTheme = themeManager.findThemeByName('My File Theme');
+
+      expect(foundTheme).toBeDefined();
+      expect(foundTheme?.name).toBe('My File Theme');
+    });
+
     it('should not load a theme if the file does not exist', () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -655,6 +655,13 @@ class ThemeManager {
       return this.fileThemes.get(themeName);
     }
 
+    // Support looking up a file-loaded theme by its internal name
+    for (const theme of this.fileThemes.values()) {
+      if (theme.name === themeName) {
+        return theme;
+      }
+    }
+
     // If it's not a built-in, not in cache, and not a valid file path,
     // it's not a valid theme.
     return undefined;


### PR DESCRIPTION
## Summary

Fixes a bug where file-loaded custom themes cannot be selected from the `/theme` menu using their internal name.

## Details

The `findThemeByName` method was only checking `this.fileThemes.has(themeName)`, which uses the canonical file path as the key. This update iterates over the values of `this.fileThemes` to also match against the `name` property.

## Related Issues

Fixes #25961

## How to Validate

1. Configure a custom theme in `~/.gemini/config.json` via file path (e.g. `"theme": "/path/to/theme.json"`).
2. Start the CLI and run `/theme`.
3. Select the custom theme from the list (which displays its internal name).
4. Verify the theme is successfully applied instead of throwing "Theme not found".
Alternatively, run `npm test -w @google/gemini-cli -- src/ui/themes/theme-manager.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
