### PR TITLE
fix(core): expand env vars in mcp server args

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2128,11 +2128,10 @@ describe('mcp-client', () => {
         .spyOn(SdkClientStdioLib, 'StdioClientTransport')
         .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
 
-      const originalEnv = process.env;
-      process.env = {
-        ...originalEnv,
-        GEMINI_TEST_VAR: 'expanded-value',
-      };
+      MOCK_CONTEXT.sanitizationConfig.allowedEnvironmentVariables = [
+        'GEMINI_TEST_VAR',
+      ];
+      vi.stubEnv('GEMINI_TEST_VAR', 'expanded-value');
 
       try {
         await createTransport(
@@ -2153,7 +2152,45 @@ describe('mcp-client', () => {
         expect(callArgs.env!['TEST_EXPANDED']).toBe('Value is expanded-value');
         expect(callArgs.env!['SECRET_KEY']).toBe('intentional-secret-123');
       } finally {
-        process.env = originalEnv;
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should expand environment variables in args', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      MOCK_CONTEXT.sanitizationConfig.allowedEnvironmentVariables = [
+        'GEMINI_TEST_VAR',
+      ];
+      vi.stubEnv('GEMINI_TEST_VAR', 'expanded-value');
+
+      try {
+        await createTransport(
+          'test-server',
+          {
+            command: 'test-command',
+            args: [
+              '--arg1',
+              '$GEMINI_TEST_VAR',
+              '--arg2=value-$GEMINI_TEST_VAR',
+            ],
+            env: {},
+          },
+          false,
+          MOCK_CONTEXT,
+        );
+
+        const callArgs = mockedTransport.mock.calls[0][0];
+        expect(callArgs.args).toBeDefined();
+        expect(callArgs.args).toEqual([
+          '--arg1',
+          'expanded-value',
+          '--arg2=value-expanded-value',
+        ]);
+      } finally {
+        vi.unstubAllEnvs();
       }
     });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2128,9 +2128,13 @@ describe('mcp-client', () => {
         .spyOn(SdkClientStdioLib, 'StdioClientTransport')
         .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
 
-      MOCK_CONTEXT.sanitizationConfig.allowedEnvironmentVariables = [
-        'GEMINI_TEST_VAR',
-      ];
+      const localContext = {
+        ...MOCK_CONTEXT,
+        sanitizationConfig: {
+          ...MOCK_CONTEXT.sanitizationConfig,
+          allowedEnvironmentVariables: ['GEMINI_TEST_VAR'],
+        },
+      };
       vi.stubEnv('GEMINI_TEST_VAR', 'expanded-value');
 
       try {
@@ -2144,7 +2148,7 @@ describe('mcp-client', () => {
             },
           },
           false,
-          MOCK_CONTEXT,
+          localContext,
         );
 
         const callArgs = mockedTransport.mock.calls[0][0];
@@ -2161,9 +2165,13 @@ describe('mcp-client', () => {
         .spyOn(SdkClientStdioLib, 'StdioClientTransport')
         .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
 
-      MOCK_CONTEXT.sanitizationConfig.allowedEnvironmentVariables = [
-        'GEMINI_TEST_VAR',
-      ];
+      const localContext = {
+        ...MOCK_CONTEXT,
+        sanitizationConfig: {
+          ...MOCK_CONTEXT.sanitizationConfig,
+          allowedEnvironmentVariables: ['GEMINI_TEST_VAR'],
+        },
+      };
       vi.stubEnv('GEMINI_TEST_VAR', 'expanded-value');
 
       try {
@@ -2179,7 +2187,7 @@ describe('mcp-client', () => {
             env: {},
           },
           false,
-          MOCK_CONTEXT,
+          localContext,
         );
 
         const callArgs = mockedTransport.mock.calls[0][0];
@@ -2189,6 +2197,77 @@ describe('mcp-client', () => {
           'expanded-value',
           '--arg2=value-expanded-value',
         ]);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should expand environment variables in command and cwd', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      const localContext = {
+        ...MOCK_CONTEXT,
+        sanitizationConfig: {
+          ...MOCK_CONTEXT.sanitizationConfig,
+          allowedEnvironmentVariables: ['TEST_HOME', 'TEST_CWD'],
+        },
+      };
+
+      vi.stubEnv('TEST_HOME', '/home/user');
+      vi.stubEnv('TEST_CWD', '/path/to/project');
+
+      try {
+        await createTransport(
+          'test-server',
+          {
+            command: '$TEST_HOME/bin/server',
+            cwd: '$TEST_CWD/src',
+            env: {},
+          },
+          false,
+          localContext,
+        );
+
+        const callArgs = mockedTransport.mock.calls[0][0];
+        expect(callArgs.command).toBe('/home/user/bin/server');
+        expect(callArgs.cwd).toBe('/path/to/project/src');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should support sequential/multiple variable expansion', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      const localContext = {
+        ...MOCK_CONTEXT,
+        sanitizationConfig: {
+          ...MOCK_CONTEXT.sanitizationConfig,
+          allowedEnvironmentVariables: ['VAR1', 'VAR2'],
+        },
+      };
+
+      vi.stubEnv('VAR1', 'foo');
+      vi.stubEnv('VAR2', 'bar');
+
+      try {
+        await createTransport(
+          'test-server',
+          {
+            command: 'test',
+            args: ['$VAR1-$VAR2', '${VAR1}_${VAR2}'],
+            env: {},
+          },
+          false,
+          localContext,
+        );
+
+        const callArgs = mockedTransport.mock.calls[0][0];
+        expect(callArgs.args).toEqual(['foo-bar', 'foo_bar']);
       } finally {
         vi.unstubAllEnvs();
       }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -2274,15 +2274,22 @@ export async function createTransport(
       }
     }
 
+    const expandedCommand = expandEnvVars(
+      mcpServerConfig.command,
+      sanitizedEnv,
+    );
     const expandedArgs = (mcpServerConfig.args || []).map((arg) =>
       expandEnvVars(arg, sanitizedEnv),
     );
+    const expandedCwd = mcpServerConfig.cwd
+      ? expandEnvVars(mcpServerConfig.cwd, sanitizedEnv)
+      : undefined;
 
     let transport: Transport = new StdioClientTransport({
-      command: mcpServerConfig.command,
+      command: expandedCommand,
       args: expandedArgs,
       env: finalEnv,
-      cwd: mcpServerConfig.cwd,
+      cwd: expandedCwd,
       stderr: 'pipe',
     });
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -2270,13 +2270,17 @@ export async function createTransport(
     // Expand and merge explicit environment variables from the MCP configuration.
     if (mcpServerConfig.env) {
       for (const [key, value] of Object.entries(mcpServerConfig.env)) {
-        finalEnv[key] = expandEnvVars(value, expansionEnv);
+        finalEnv[key] = expandEnvVars(value, sanitizedEnv);
       }
     }
 
+    const expandedArgs = (mcpServerConfig.args || []).map((arg) =>
+      expandEnvVars(arg, sanitizedEnv),
+    );
+
     let transport: Transport = new StdioClientTransport({
       command: mcpServerConfig.command,
-      args: mcpServerConfig.args || [],
+      args: expandedArgs,
       env: finalEnv,
       cwd: mcpServerConfig.cwd,
       stderr: 'pipe',


### PR DESCRIPTION
## Summary

Fixed a bug where environment variables (e.g., `${VARIABLE_NAME}`) in the `args` array of MCP server configurations were not being expanded before process execution. This update expands the feature to `command` and `cwd` fields for consistency and improves test isolation.

## Details

- **Expanded Scope**: Environment variable expansion is now applied to `command`, `args`, and `cwd` fields in the MCP server configuration.
- **Security**: Continues to use a sanitized environment for all expansions to prevent leaking sensitive system-wide secrets.
- **Robustness**: Verified that sequential and multiple variable expansion in a single string is supported via the underlying `dotenv-expand` utility.
- **Test Quality**:
    - Refactored tests to use Vitest's `vi.stubEnv` for environment variable mocking.
    - Improved test isolation by avoiding direct mutation of shared mock objects (`MOCK_CONTEXT`), using local context copies instead.
    - Added new test cases for `command`/`cwd` expansion and multiple variable resolution.

## Related Issues

Fixes #25939

## How to Validate

1. Run the updated unit tests in `packages/core/src/tools/mcp-client.test.ts`:
   `npm test -w @google/gemini-cli-core -- src/tools/mcp-client.test.ts`
2. Configure an MCP server in `settings.json` using environment variables in `command`, `args`, or `cwd`:
   ```json
   "mcpServers": {
     "test": {
       "command": "${HOME}/bin/mcp-server",
       "args": ["--path=${PROJECT_ROOT}/data"],
       "cwd": "${PROJECT_ROOT}"
     }
   }
   ```
3. Verify that all fields are correctly expanded when the process starts.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
