### PR TITLE
fix(mcp): handle hyphenated server names consistently in tool dispatch

### DIFF
--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -289,6 +289,37 @@ describe('ToolRegistry', () => {
     });
   });
 
+  describe('getTool with hyphenated MCP server names', () => {
+    it('should resolve a hallucinated snake_case name to the registered hyphenated MCP tool', () => {
+      // Server registers as "mcp_hyphen-server_test-tool", but the model
+      // commonly emits the function call as "mcp_hyphen_server_test_tool"
+      // (hyphens collapsed to underscores). Lookup should still resolve.
+      const mcpTool = createMCPTool('hyphen-server', 'test-tool', 'desc');
+      toolRegistry.registerTool(mcpTool);
+
+      expect(mcpTool.name).toBe('mcp_hyphen-server_test-tool');
+      expect(toolRegistry.getTool('mcp_hyphen-server_test-tool')).toBe(mcpTool);
+      expect(toolRegistry.getTool('mcp_hyphen_server_test_tool')).toBe(mcpTool);
+    });
+
+    it('should return undefined when two MCP tools collapse to the same name', () => {
+      // mcp_a-b_c and mcp_a_b-c both collapse to mcp_a_b_c. Refuse to guess.
+      const ambiguousA = createMCPTool('a-b', 'c', 'desc');
+      const ambiguousB = createMCPTool('a', 'b-c', 'desc');
+      toolRegistry.registerTool(ambiguousA);
+      toolRegistry.registerTool(ambiguousB);
+
+      expect(toolRegistry.getTool('mcp_a_b_c')).toBeUndefined();
+    });
+
+    it('should leave non-MCP tools alone', () => {
+      const regular = new MockTool({ name: 'mock-tool' });
+      toolRegistry.registerTool(regular);
+
+      expect(toolRegistry.getTool('mock_tool')).toBeUndefined();
+    });
+  });
+
   describe('removeMcpToolsByServer', () => {
     it('should remove all tools from a specific server', () => {
       const serverName = 'test-server';

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -18,7 +18,7 @@ import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
-import { DiscoveredMCPTool } from './mcp-tool.js';
+import { DiscoveredMCPTool, MCP_TOOL_PREFIX } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { ToolErrorType } from './tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
@@ -800,9 +800,65 @@ export class ToolRegistry {
       }
     }
 
+    // Fallback for MCP tools whose registered names contain hyphens. Models
+    // sometimes return the function name with hyphens normalized to
+    // underscores (snake_case), causing a literal lookup miss. Try a
+    // hyphen/underscore-tolerant match against registered MCP tool names,
+    // but only if it resolves to a single registered tool.
+    if (!tool && name.startsWith(MCP_TOOL_PREFIX)) {
+      const resolved = this.resolveMcpToolNameLoose(name);
+      if (resolved) {
+        debugLogger.debug(
+          `Resolved hyphen-insensitive MCP tool name "${name}" to "${resolved.name}"`,
+        );
+        tool = resolved;
+      }
+    }
+
     if (tool && this.isActiveTool(tool)) {
       return tool;
     }
     return;
   }
+
+  /**
+   * Looks up an MCP tool by collapsing hyphens and underscores in the name
+   * past the `mcp_` prefix. Returns the registered tool when exactly one
+   * registered MCP tool name matches; returns undefined on no match or on
+   * ambiguity (multiple registered names collapse to the same key).
+   *
+   * This recovers from a known model behavior where the model emits the
+   * tool name with hyphens replaced by underscores (e.g.
+   * `mcp_my-server_my-tool` -> `mcp_my_server_my_tool`).
+   */
+  private resolveMcpToolNameLoose(
+    name: string,
+  ): AnyDeclarativeTool | undefined {
+    const target = collapseMcpSeparators(name);
+    let match: AnyDeclarativeTool | undefined;
+    for (const [registeredName, registeredTool] of this.allKnownTools) {
+      if (
+        registeredTool instanceof DiscoveredMCPTool &&
+        collapseMcpSeparators(registeredName) === target
+      ) {
+        if (match) {
+          // Ambiguous: refuse to guess.
+          return undefined;
+        }
+        match = registeredTool;
+      }
+    }
+    return match;
+  }
+}
+
+/**
+ * Normalizes both `-` and `_` to a single sentinel after the `mcp_` prefix
+ * so that callers can compare names tolerant to hyphen/underscore swaps.
+ */
+function collapseMcpSeparators(name: string): string {
+  if (!name.startsWith(MCP_TOOL_PREFIX)) {
+    return name;
+  }
+  return MCP_TOOL_PREFIX + name.slice(MCP_TOOL_PREFIX.length).replace(/-/g, '_');
 }


### PR DESCRIPTION
Closes #25952.

MCP tools register with their literal hyphenated names (e.g. `mcp_hyphen-server_test-tool`), but Gemini models frequently emit the function-call name with hyphens collapsed to underscores (`mcp_hyphen_server_test_tool`), so `ToolRegistry.getTool` missed and the call surfaced "tool not found" even when the right tool existed.

After the literal and legacy-alias lookups miss, fall back to a hyphen/underscore-tolerant match for `mcp_`-prefixed names. The fallback only resolves when exactly one registered MCP tool collapses to the same normalized form, so we never silently dispatch on an ambiguous match.

Test in `packages/core/src/tools/tool-registry.test.ts`.
