### PR TITLE
Fix infinite dialog loop and add ESC key support in the /skills link command

### DIFF
--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -115,10 +115,15 @@ async function linkAction(
           targetDir,
           true,
         );
-        return requestConsentInteractive(
-          consentString,
-          context.ui.setConfirmationRequest.bind(context.ui),
-        );
+        return requestConsentInteractive(consentString, (req) => {
+          context.ui.setConfirmationRequest({
+            prompt: req.prompt,
+            onConfirm: (confirmed) => {
+              context.ui.setConfirmationRequest(null);
+              req.onConfirm(confirmed);
+            },
+          });
+        });
       },
     );
 

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -89,7 +89,7 @@ export interface CommandContext {
      *
      * @param value The confirmation request details.
      */
-    setConfirmationRequest: (value: ConfirmationRequest) => void;
+    setConfirmationRequest: (value: ConfirmationRequest | null) => void;
     removeComponent: () => void;
     toggleBackgroundTasks: () => void;
     toggleShortcutsHelp: () => void;

--- a/packages/cli/src/ui/components/ConsentPrompt.test.tsx
+++ b/packages/cli/src/ui/components/ConsentPrompt.test.tsx
@@ -6,7 +6,7 @@
 
 import { Text } from 'ink';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '../../test-utils/render.js';
+import { renderWithProviders as render } from '../../test-utils/render.js';
 import { act } from 'react';
 import { ConsentPrompt } from './ConsentPrompt.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
@@ -126,6 +126,25 @@ describe('ConsentPrompt', () => {
       }),
       undefined,
     );
+    unmount();
+  });
+
+  it('calls onConfirm with false when ESC is pressed', async () => {
+    const prompt = 'Are you sure?';
+    const { stdin, waitUntilReady, unmount } = await render(
+      <ConsentPrompt
+        prompt={prompt}
+        onConfirm={onConfirm}
+        terminalWidth={terminalWidth}
+      />,
+    );
+
+    await act(async () => {
+      stdin.write('\x1b'); // ESC key
+    });
+    await waitUntilReady();
+
+    expect(onConfirm).toHaveBeenCalledWith(false);
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/ConsentPrompt.tsx
+++ b/packages/cli/src/ui/components/ConsentPrompt.tsx
@@ -10,6 +10,9 @@ import { theme } from '../semantic-colors.js';
 import { MarkdownDisplay } from '../utils/MarkdownDisplay.js';
 import { RadioButtonSelect } from './shared/RadioButtonSelect.js';
 import { DialogFooter } from './shared/DialogFooter.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { Command } from '../key/keyMatchers.js';
+import { useKeyMatchers } from '../hooks/useKeyMatchers.js';
 
 type ConsentPromptProps = {
   // If a simple string is given, it will render using markdown by default.
@@ -20,6 +23,18 @@ type ConsentPromptProps = {
 
 export const ConsentPrompt = (props: ConsentPromptProps) => {
   const { prompt, onConfirm, terminalWidth } = props;
+  const keyMatchers = useKeyMatchers();
+
+  useKeypress(
+    (key) => {
+      if (keyMatchers[Command.ESCAPE](key)) {
+        onConfirm(false);
+        return true;
+      }
+      return false;
+    },
+    { isActive: true },
+  );
 
   return (
     <Box

--- a/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
+++ b/packages/cli/src/ui/noninteractive/nonInteractiveUi.ts
@@ -6,6 +6,7 @@
 
 import type { CommandContext } from '../commands/types.js';
 import type { ExtensionUpdateAction } from '../state/extensions.js';
+import type { ConfirmationRequest } from '../types.js';
 
 /**
  * Creates a UI context object with no-op functions.
@@ -39,7 +40,7 @@ export function createNonInteractiveUI(): CommandContext['ui'] {
     extensionsUpdateState: new Map(),
     dispatchExtensionStateUpdate: (_action: ExtensionUpdateAction) => {},
     addConfirmUpdateExtensionRequest: (_request) => {},
-    setConfirmationRequest: (_request) => {},
+    setConfirmationRequest: (_request: ConfirmationRequest | null) => {},
     removeComponent: () => {},
     toggleBackgroundTasks: () => {},
     toggleShortcutsHelp: () => {},


### PR DESCRIPTION
 ## Summary

When running the `gemini skills link /path/to/my-skills-repo` command, a confirmation dialog appears to request user consent. However, after the user selects "Yes" or "No," the dialog would not disappear, blocking further interaction.
And I found the dialog shows it supports ESC to exit, but it didn't work.

Fixed an infinite dialog loop in the `/skills link` command and added ESC key support to the `ConsentPrompt` component.
       
## Details
       
- Updated `CommandUIContext` to allow `setConfirmationRequest(null)`.
- Modified `skillsCommand.ts` to clear the confirmation request state after the user responds.
- Added `useKeypress` handling to `ConsentPrompt.tsx` to handle the ESC key, which now triggers a cancellation (`onConfirm(false)`).
- Updated the `DialogFooter` in `ConsentPrompt` to include "Esc cancel" hint.
- Refactored `ConsentPrompt.test.tsx` to use `renderWithProviders` for proper context and added a test case for ESC key handling.
      
## Related Issues
      
N/A
      
## How to Validate
      
1. Run `npm run start`.
2. Execute `/skills link <any_path>`.
3. Verify the confirmation dialog appears.
4. Press `Esc` and verify the dialog disappears and focus returns to the input.
5. Execute the command again and select "Yes" or "No" using the keyboard/Enter, verify the dialog disappears and doesn't reappear in a loop.
6. Run `npm test --workspace @google/gemini-cli --src/ui/components/ConsentPrompt.test.tsx`.
      
## Pre-Merge Checklist
      
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker