### PR TITLE
feat(core): experimental.windowsBash — route shell commands through bash on Windows

### DIFF
--- a/integration-tests/windows-bash.test.ts
+++ b/integration-tests/windows-bash.test.ts
@@ -1,0 +1,276 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for experimental.windowsBash — verifies that Unix-syntax
+ * commands execute correctly through a real bash binary on any OS.
+ *
+ * Tests are skipped automatically when bash is not on PATH (e.g. Windows
+ * without Git for Windows).  On Linux and macOS bash is always present, so
+ * all tests run unconditionally on those platforms.
+ *
+ * Run: npm run test:integration:sandbox:none -- windows-bash.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import { tmpdir } from 'node:os';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  ShellExecutionService,
+  type ShellExecutionConfig,
+} from '../packages/core/src/services/shellExecutionService.js';
+import { NoopSandboxManager } from '../packages/core/src/services/sandboxManager.js';
+import {
+  resolveBashOnPath,
+  clearBashPathCache,
+} from '../packages/core/src/utils/shell-utils.js';
+
+// ---------------------------------------------------------------------------
+// Resolve bash path once at module load time so that it.skipIf() predicates
+// can use it.  Top-level await is valid in ESM test files.
+// ---------------------------------------------------------------------------
+clearBashPathCache();
+const bashPath = await resolveBashOnPath();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_CONFIG: ShellExecutionConfig = {
+  sanitizationConfig: {
+    enableEnvironmentVariableRedaction: false,
+    allowedEnvironmentVariables: [],
+    blockedEnvironmentVariables: [],
+  },
+  sandboxManager: new NoopSandboxManager(),
+  disableDynamicLineTrimming: true,
+};
+
+async function runCmd(
+  command: string,
+  config: Partial<ShellExecutionConfig> = {},
+  cwd = process.cwd(),
+): Promise<{ output: string; exitCode: number | null }> {
+  ShellExecutionService.resetForTest();
+  const handle = await ShellExecutionService.execute(
+    command,
+    cwd,
+    () => {},
+    new AbortController().signal,
+    false,
+    { ...BASE_CONFIG, ...config },
+  );
+  const result = await handle.result;
+  return { output: result.output.trim(), exitCode: result.exitCode };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('windowsBash integration', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gemini-bash-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ---- Platform-agnostic sanity ----------------------------------------
+
+  it('resolveBashOnPath returns a path string or undefined', () => {
+    expect(bashPath === undefined || typeof bashPath === 'string').toBe(true);
+  });
+
+  // ---- Tests that require bash on PATH ---------------------------------
+  //
+  // On Linux/macOS bash is always available; on Windows it requires Git Bash,
+  // MSYS2, WSL, or another bash provider in PATH.
+
+  it.skipIf(bashPath === undefined)(
+    'executes a simple echo command through bash',
+    async () => {
+      const { output, exitCode } = await runCmd('echo hello-from-bash', {
+        enableWindowsBash: true,
+      });
+      expect(exitCode).toBe(0);
+      expect(output).toContain('hello-from-bash');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'supports && operator — both commands run on success',
+    async () => {
+      const { output, exitCode } = await runCmd('echo first && echo second', {
+        enableWindowsBash: true,
+      });
+      expect(exitCode).toBe(0);
+      expect(output).toContain('first');
+      expect(output).toContain('second');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    '&& short-circuits — second command does not run after failure',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'false && echo should-not-appear',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).not.toBe(0);
+      expect(output).not.toContain('should-not-appear');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'supports || — fallback command runs when first fails',
+    async () => {
+      const { output, exitCode } = await runCmd('false || echo fallback-ran', {
+        enableWindowsBash: true,
+      });
+      expect(exitCode).toBe(0);
+      expect(output).toContain('fallback-ran');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'supports pipes — stdout of one command feeds stdin of next',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'printf "alpha\\nbeta\\ngamma" | grep beta',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('beta');
+      expect(output).not.toContain('alpha');
+      expect(output).not.toContain('gamma');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'redirects stdout to /dev/null without error',
+    async () => {
+      const { exitCode } = await runCmd(
+        'echo discard > /dev/null && echo still-runs',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'supports unix-style variable assignment and expansion',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'GREETING=hello-bash; echo $GREETING',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('hello-bash');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'ls -la lists directory contents',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        `ls -la "${tmpDir}"`,
+        { enableWindowsBash: true },
+        tmpDir,
+      );
+      expect(exitCode).toBe(0);
+      // ls -la always shows . and .. entries
+      expect(output).toMatch(/\./);
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'semicolon-separated commands all execute',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'echo line1; echo line2; echo line3',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('line1');
+      expect(output).toContain('line2');
+      expect(output).toContain('line3');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'exit code is correctly propagated',
+    async () => {
+      const { exitCode } = await runCmd('exit 42', {
+        enableWindowsBash: true,
+      });
+      expect(exitCode).toBe(42);
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'subshell command substitution works',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'echo "result: $(echo inner)"',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('result: inner');
+    },
+  );
+
+  it.skipIf(bashPath === undefined)(
+    'writes a file and reads it back with cat',
+    async () => {
+      const filePath = join(tmpDir, 'test.txt').replaceAll('\\', '/');
+      const { output, exitCode } = await runCmd(
+        `echo "file-content" > "${filePath}" && cat "${filePath}"`,
+        { enableWindowsBash: true },
+        tmpDir,
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('file-content');
+    },
+  );
+
+  // ---- Windows-specific: verify the bash binary path is actually used ----
+
+  it.skipIf(bashPath === undefined || os.platform() !== 'win32')(
+    'on Windows, enableWindowsBash routes through the resolved bash binary',
+    async () => {
+      const { output, exitCode } = await runCmd(
+        'echo windows-bash-active && printf "done\\n"',
+        { enableWindowsBash: true },
+      );
+      expect(exitCode).toBe(0);
+      expect(output).toContain('windows-bash-active');
+      expect(output).toContain('done');
+    },
+  );
+
+  // ---- Control: windowsBash disabled uses the platform default shell ------
+
+  it('without windowsBash, plain echo works on the default shell', async () => {
+    const command =
+      os.platform() === 'win32'
+        ? 'Write-Output "powershell-echo"'
+        : 'echo native-echo';
+    const expected =
+      os.platform() === 'win32' ? 'powershell-echo' : 'native-echo';
+
+    const { output, exitCode } = await runCmd(command, {
+      enableWindowsBash: false,
+    });
+    expect(exitCode).toBe(0);
+    expect(output).toContain(expected);
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -998,6 +998,7 @@ export async function loadCliConfig(
     extensionLoader: extensionManager,
     extensionRegistryURI,
     enableExtensionReloading: settings.experimental?.extensionReloading,
+    enableWindowsBash: settings.experimental?.windowsBash,
     enableAgents: settings.experimental?.enableAgents,
     plan: settings.general?.plan?.enabled ?? true,
     voiceMode: settings.experimental?.voiceMode,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2287,6 +2287,21 @@ const SETTINGS_SCHEMA = {
           'Enable model steering (user hints) to guide the model during tool execution.',
         showInDialog: true,
       },
+      windowsBash: {
+        type: 'boolean',
+        label: 'Windows Bash',
+        category: 'Experimental',
+        requiresRestart: false,
+        default: false,
+        description:
+          'On Windows, route all shell commands through a bash binary on PATH so ' +
+          'the model can use Unix syntax (&&, ||, /dev/null, rm -rf, …) without ' +
+          'translation. Requires Git for Windows (recommended): ' +
+          'https://git-scm.com/download/win. Other bash variants on PATH (WSL, ' +
+          'MSYS2, Cygwin) also work. No-op on non-Windows. Falls back to ' +
+          'PowerShell with a warning if no bash is found on PATH.',
+        showInDialog: true,
+      },
       directWebFetch: {
         type: 'boolean',
         label: 'Direct Web Fetch',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -643,6 +643,7 @@ export interface ConfigParameters {
   extensionLoader?: ExtensionLoader;
   enabledExtensions?: string[];
   enableExtensionReloading?: boolean;
+  enableWindowsBash?: boolean;
   allowedMcpServers?: string[];
   blockedMcpServers?: string[];
   allowedEnvironmentVariables?: string[];
@@ -835,6 +836,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly _extensionLoader: ExtensionLoader;
   private readonly _enabledExtensions: string[];
   private readonly enableExtensionReloading: boolean;
+  private readonly enableWindowsBash: boolean;
   fallbackModelHandler?: FallbackModelHandler;
   validationHandler?: ValidationHandler;
   private quotaErrorOccurred: boolean = false;
@@ -1296,6 +1298,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.extensionManagement = params.extensionManagement ?? true;
     this.extensionRegistryURI = params.extensionRegistryURI;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
+    this.enableWindowsBash = params.enableWindowsBash ?? false;
     this.storage = new Storage(this.targetDir, this._sessionId);
     this.storage.setCustomPlansDir(params.planSettings?.directory);
 
@@ -2962,6 +2965,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getEnableExtensionReloading(): boolean {
     return this.enableExtensionReloading;
+  }
+
+  getEnableWindowsBash(): boolean {
+    return this.enableWindowsBash;
   }
 
   getDisableLLMCorrection(): boolean {

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -37,9 +37,10 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
     const powershellCommand =
       'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress';
     // Increase maxBuffer to handle large process lists (default is 1MB)
-    const { stdout } = await execAsync(`powershell "${powershellCommand}"`, {
-      maxBuffer: 10 * 1024 * 1024,
-    });
+    const { stdout } = await execAsync(
+      `powershell -NoProfile -NoLogo "${powershellCommand}"`,
+      { maxBuffer: 10 * 1024 * 1024 },
+    );
 
     if (!stdout.trim()) {
       return processMap;

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -228,6 +228,7 @@ export class PromptProvider {
             interactiveShellEnabled: context.config.isInteractiveShellEnabled(),
             topicUpdateNarration: isTopicUpdateNarrationEnabled,
             memoryV2Enabled: context.config.isMemoryV2Enabled(),
+            windowsBashActive: context.config.getEnableWindowsBash(),
             userProjectMemoryPath: context.config.isMemoryV2Enabled()
               ? getProjectMemoryIndexFilePath(context.config.storage)
               : undefined,

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -278,6 +278,13 @@ ${newApplicationSteps(options)}
 `.trim();
 }
 
+function shellEnvironmentNote(windowsBashActive?: boolean): string {
+  if (!windowsBashActive) return '';
+  return `## Shell Environment
+Shell: bash (Git for Windows / MSYS2 / WSL). Use Unix syntax for all shell commands: \`&&\`, \`||\`, pipes, \`/dev/null\`, \`grep\`, \`awk\`, \`sed\`, \`find\`, etc. Do not use PowerShell syntax or cmdlets.
+`;
+}
+
 export function renderOperationalGuidelines(
   options?: OperationalGuidelinesOptions,
 ): string {
@@ -285,7 +292,7 @@ export function renderOperationalGuidelines(
   return `
 # Operational Guidelines
 
-${shellEfficiencyGuidelines(options.enableShellEfficiency, options.windowsBashActive)}
+${shellEnvironmentNote(options.windowsBashActive)}${shellEfficiencyGuidelines(options.enableShellEfficiency, options.windowsBashActive)}
 
 ## Tone and Style (CLI Interaction)
 - **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -75,6 +75,7 @@ export interface OperationalGuidelinesOptions {
   interactiveShellEnabled: boolean;
   topicUpdateNarration?: boolean;
   memoryV2Enabled: boolean;
+  windowsBashActive?: boolean;
   /**
    * Absolute path to the user's per-project private memory index. See
    * snippets.ts for full semantics.
@@ -284,7 +285,7 @@ export function renderOperationalGuidelines(
   return `
 # Operational Guidelines
 
-${shellEfficiencyGuidelines(options.enableShellEfficiency)}
+${shellEfficiencyGuidelines(options.enableShellEfficiency, options.windowsBashActive)}
 
 ## Tone and Style (CLI Interaction)
 - **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.
@@ -655,12 +656,17 @@ function planningPhaseSuggestion(options: PrimaryWorkflowsOptions): string {
   return '';
 }
 
-function shellEfficiencyGuidelines(enabled: boolean): string {
+function shellEfficiencyGuidelines(
+  enabled: boolean,
+  windowsBashActive?: boolean,
+): string {
   if (!enabled) return '';
-  const isWindows = process.platform === 'win32';
-  const inspectExample = isWindows
-    ? "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)"
-    : "using commands like 'grep', 'tail', 'head'";
+  const usePosixShell =
+    process.platform !== 'win32' ||
+    (process.platform === 'win32' && windowsBashActive);
+  const inspectExample = usePosixShell
+    ? "using commands like 'grep', 'tail', 'head'"
+    : "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)";
   return `
 ## Shell tool output token efficiency:
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -84,6 +84,7 @@ export interface OperationalGuidelinesOptions {
   interactiveShellEnabled: boolean;
   topicUpdateNarration: boolean;
   memoryV2Enabled: boolean;
+  windowsBashActive?: boolean;
   /**
    * Absolute path to the user's per-project private memory index
    * (e.g. ~/.gemini/tmp/<project-hash>/memory/MEMORY.md). Surfaced to the
@@ -378,6 +379,13 @@ ${newApplicationSteps(options)}
 `.trim();
 }
 
+function shellEnvironmentNote(windowsBashActive?: boolean): string {
+  if (!windowsBashActive) return '';
+  return `## Shell Environment
+Shell: bash (Git for Windows / MSYS2 / WSL). Use Unix syntax for all shell commands: \`&&\`, \`||\`, pipes, \`/dev/null\`, \`grep\`, \`awk\`, \`sed\`, \`find\`, etc. Do not use PowerShell syntax or cmdlets.
+`;
+}
+
 export function renderOperationalGuidelines(
   options?: OperationalGuidelinesOptions,
 ): string {
@@ -385,7 +393,7 @@ export function renderOperationalGuidelines(
   return `
 # Operational Guidelines
 
-## Tone and Style
+${shellEnvironmentNote(options.windowsBashActive)}## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
 - **High-Signal Output:** Focus exclusively on **intent** and **technical rationale**. Avoid conversational filler, apologies, and ${

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -37,6 +37,7 @@ const mockCreateWriteStream = vi.hoisted(() => vi.fn());
 const mockGetPty = vi.hoisted(() => vi.fn());
 const mockSerializeTerminalToObject = vi.hoisted(() => vi.fn());
 const mockResolveExecutable = vi.hoisted(() => vi.fn());
+const mockResolveBashOnPath = vi.hoisted(() => vi.fn());
 const mockDebugLogger = vi.hoisted(() => ({
   log: vi.fn(),
   warn: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
   return {
     ...actual,
     resolveExecutable: mockResolveExecutable,
+    resolveBashOnPath: mockResolveBashOnPath,
     spawnAsync: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
   };
 });
@@ -2185,5 +2187,136 @@ describe('ShellExecutionService environment variables', () => {
     await new Promise(process.nextTick);
 
     vi.unstubAllEnvs();
+  });
+});
+
+describe('ShellExecutionService windowsBash', () => {
+  let mockChildProcess: EventEmitter & Partial<ChildProcess>;
+  let onOutputEventMock: Mock<(event: ShellOutputEvent) => void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ExecutionLifecycleService.resetForTest();
+    ShellExecutionService.resetForTest();
+
+    mockIsBinary.mockReturnValue(false);
+    mockPlatform.mockReturnValue('win32');
+    mockGetPty.mockResolvedValue(null);
+    mockResolveExecutable.mockImplementation(async (exe: string) => exe);
+    mockResolveBashOnPath.mockResolvedValue(undefined);
+
+    onOutputEventMock = vi.fn();
+
+    mockChildProcess = new EventEmitter() as EventEmitter &
+      Partial<ChildProcess>;
+    mockChildProcess.stdout = new EventEmitter() as Readable;
+    mockChildProcess.stderr = new EventEmitter() as Readable;
+    mockChildProcess.kill = vi.fn();
+
+    Object.defineProperty(mockChildProcess, 'pid', {
+      value: 99999,
+      configurable: true,
+    });
+
+    mockCpSpawn.mockReturnValue(mockChildProcess);
+  });
+
+  const runCommand = async (
+    command: string,
+    config: ShellExecutionConfig,
+  ): Promise<void> => {
+    const abortController = new AbortController();
+    const handle = await ShellExecutionService.execute(
+      command,
+      '/test/dir',
+      onOutputEventMock,
+      abortController.signal,
+      false,
+      config,
+    );
+    await new Promise((resolve) => process.nextTick(resolve));
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await handle.result;
+  };
+
+  it('uses PowerShell when enableWindowsBash is off (default) on Windows', async () => {
+    await runCommand('dir', { ...shellExecutionConfig });
+
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-Command', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
+  it('uses bash when enableWindowsBash is on and bash is found on PATH', async () => {
+    mockResolveBashOnPath.mockResolvedValue('/usr/bin/bash');
+
+    await runCommand('ls -la', {
+      ...shellExecutionConfig,
+      enableWindowsBash: true,
+    });
+
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      '/usr/bin/bash',
+      ['-c', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to PowerShell with a warning when enableWindowsBash is on but bash is not on PATH', async () => {
+    mockResolveBashOnPath.mockResolvedValue(undefined);
+
+    await runCommand('ls -la', {
+      ...shellExecutionConfig,
+      enableWindowsBash: true,
+    });
+
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      'powershell.exe',
+      ['-NoProfile', '-Command', expect.any(String)],
+      expect.any(Object),
+    );
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('experimental.windowsBash'),
+    );
+  });
+
+  it('uses cmd.exe (sandbox) even when enableWindowsBash is on with strict sandbox', async () => {
+    mockResolveBashOnPath.mockResolvedValue('/usr/bin/bash');
+
+    await runCommand('dir', {
+      ...shellExecutionConfig,
+      enableWindowsBash: true,
+      sandboxConfig: {
+        enabled: true,
+        command: 'windows-native',
+        networkAccess: false,
+      },
+    });
+
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/c', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
+  it('ignores enableWindowsBash on non-Windows platforms', async () => {
+    mockPlatform.mockReturnValue('linux');
+    mockResolveBashOnPath.mockResolvedValue('/usr/bin/bash');
+
+    await runCommand('ls -la', {
+      ...shellExecutionConfig,
+      enableWindowsBash: true,
+    });
+
+    expect(mockCpSpawn).toHaveBeenCalledWith(
+      'bash',
+      ['-c', expect.any(String)],
+      expect.any(Object),
+    );
+    expect(mockResolveBashOnPath).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -17,6 +17,7 @@ import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import {
   getShellConfiguration,
   resolveExecutable,
+  resolveBashOnPath,
   type ShellType,
 } from '../utils/shell-utils.js';
 import { isBinary, truncateString } from '../utils/textUtils.js';
@@ -105,6 +106,7 @@ export interface ShellExecutionConfig {
   backgroundCompletionBehavior?: 'inject' | 'notify' | 'silent';
   originalCommand?: string;
   sessionId?: string;
+  enableWindowsBash?: boolean;
 }
 
 /**
@@ -408,6 +410,25 @@ export class ShellExecutionService {
       !shellExecutionConfig.sandboxConfig?.networkAccess;
 
     let { executable, argsPrefix, shell } = getShellConfiguration();
+
+    if (
+      shellExecutionConfig.enableWindowsBash &&
+      isWindows &&
+      !isStrictSandbox
+    ) {
+      const bashOnPath = await resolveBashOnPath();
+      if (bashOnPath) {
+        executable = bashOnPath;
+        argsPrefix = ['-c'];
+        shell = 'bash';
+      } else {
+        debugLogger.warn(
+          '[shell] experimental.windowsBash is enabled but bash was not found ' +
+            'on PATH. Falling back to PowerShell.',
+        );
+      }
+    }
+
     if (isStrictSandbox) {
       shell = 'cmd';
       argsPrefix = ['/c'];

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -256,6 +256,7 @@ export type BackgroundProcessRecord = Omit<BackgroundProcess, 'pid'> & {
 export class ShellExecutionService {
   private static activePtys = new Map<number, ActivePty>();
   private static activeChildProcesses = new Map<number, ActiveChildProcess>();
+  private static windowsBashNotFoundWarned = false;
   private static backgroundLogPids = new Set<number>();
   private static backgroundLogStreams = new Map<number, fs.WriteStream>();
   private static backgroundProcessHistory = new Map<
@@ -422,9 +423,16 @@ export class ShellExecutionService {
         argsPrefix = ['-c'];
         shell = 'bash';
       } else {
+        if (!ShellExecutionService.windowsBashNotFoundWarned) {
+          ShellExecutionService.windowsBashNotFoundWarned = true;
+          process.stderr.write(
+            'Warning: experimental.windowsBash is enabled but no bash binary was found.\n' +
+              'Install Git for Windows (https://git-scm.com/download/win) or add bash to PATH.\n' +
+              'Falling back to PowerShell for this session.\n',
+          );
+        }
         debugLogger.warn(
-          '[shell] experimental.windowsBash is enabled but bash was not found ' +
-            'on PATH. Falling back to PowerShell.',
+          '[shell] experimental.windowsBash is enabled but bash was not found. Falling back to PowerShell.',
         );
       }
     }
@@ -470,6 +478,12 @@ export class ShellExecutionService {
       PAGER: shellExecutionConfig.pager ?? 'cat',
       GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
     };
+
+    if (shell === 'bash' && isWindows) {
+      if (!baseEnv['MSYS_NO_PATHCONV']) baseEnv['MSYS_NO_PATHCONV'] = '1';
+      if (!baseEnv['LANG']) baseEnv['LANG'] = 'C.UTF-8';
+      if (!baseEnv['LC_ALL']) baseEnv['LC_ALL'] = 'C.UTF-8';
+    }
 
     if (!isInteractive) {
       // Ensure all GIT_CONFIG_* variables are preserved even if they were redacted

--- a/packages/core/src/tools/definitions/coreTools.ts
+++ b/packages/core/src/tools/definitions/coreTools.ts
@@ -251,18 +251,21 @@ export function getShellDefinition(
   enableInteractiveShell: boolean,
   enableEfficiency: boolean,
   enableToolSandboxing: boolean = false,
+  enableWindowsBash: boolean = false,
 ): ToolDefinition {
   return {
     base: getShellDeclaration(
       enableInteractiveShell,
       enableEfficiency,
       enableToolSandboxing,
+      enableWindowsBash,
     ),
     overrides: (modelId) =>
       getToolSet(modelId).run_shell_command(
         enableInteractiveShell,
         enableEfficiency,
         enableToolSandboxing,
+        enableWindowsBash,
       ),
   };
 }

--- a/packages/core/src/tools/definitions/dynamic-declaration-helpers.ts
+++ b/packages/core/src/tools/definitions/dynamic-declaration-helpers.ts
@@ -36,6 +36,7 @@ import {
 export function getShellToolDescription(
   enableInteractiveShell: boolean,
   enableEfficiency: boolean,
+  enableWindowsBash: boolean = false,
 ): string {
   const efficiencyGuidelines = enableEfficiency
     ? `
@@ -56,7 +57,7 @@ export function getShellToolDescription(
       Background PIDs: Only included if background processes were started.
       Process Group PGID: Only included if available.`;
 
-  if (os.platform() === 'win32') {
+  if (os.platform() === 'win32' && !enableWindowsBash) {
     const backgroundInstructions = enableInteractiveShell
       ? `To run a command in the background, set the \`${SHELL_PARAM_IS_BACKGROUND}\` parameter to true. Do NOT use PowerShell background constructs.`
       : 'Command can start background processes using PowerShell constructs such as `Start-Process -NoNewWindow` or `Start-Job`.';
@@ -72,8 +73,10 @@ export function getShellToolDescription(
 /**
  * Returns the platform-specific description for the 'command' parameter.
  */
-export function getCommandDescription(): string {
-  if (os.platform() === 'win32') {
+export function getCommandDescription(
+  enableWindowsBash: boolean = false,
+): string {
+  if (os.platform() === 'win32' && !enableWindowsBash) {
     return 'Exact command to execute as `powershell.exe -NoProfile -Command <command>`';
   }
   return 'Exact bash command to execute as `bash -c <command>`';
@@ -86,19 +89,21 @@ export function getShellDeclaration(
   enableInteractiveShell: boolean,
   enableEfficiency: boolean,
   enableToolSandboxing: boolean = false,
+  enableWindowsBash: boolean = false,
 ): FunctionDeclaration {
   return {
     name: SHELL_TOOL_NAME,
     description: getShellToolDescription(
       enableInteractiveShell,
       enableEfficiency,
+      enableWindowsBash,
     ),
     parametersJsonSchema: {
       type: 'object',
       properties: {
         [SHELL_PARAM_COMMAND]: {
           type: 'string',
-          description: getCommandDescription(),
+          description: getCommandDescription(enableWindowsBash),
         },
         [PARAM_DESCRIPTION]: {
           type: 'string',

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -339,11 +339,13 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
     enableInteractiveShell,
     enableEfficiency,
     enableToolSandboxing,
+    enableWindowsBash,
   ) =>
     getShellDeclaration(
       enableInteractiveShell,
       enableEfficiency,
       enableToolSandboxing,
+      enableWindowsBash,
     ),
 
   replace: {

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -346,11 +346,13 @@ export const GEMINI_3_SET: CoreToolSet = {
     enableInteractiveShell,
     enableEfficiency,
     enableToolSandboxing,
+    enableWindowsBash,
   ) =>
     getShellDeclaration(
       enableInteractiveShell,
       enableEfficiency,
       enableToolSandboxing,
+      enableWindowsBash,
     ),
 
   replace: {

--- a/packages/core/src/tools/definitions/types.ts
+++ b/packages/core/src/tools/definitions/types.ts
@@ -38,6 +38,7 @@ export interface CoreToolSet {
     enableInteractiveShell: boolean,
     enableEfficiency: boolean,
     enableToolSandboxing: boolean,
+    enableWindowsBash?: boolean,
   ) => FunctionDeclaration;
   replace: FunctionDeclaration;
   google_web_search: FunctionDeclaration;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -600,6 +600,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             backgroundCompletionBehavior:
               this.context.config.getShellBackgroundCompletionBehavior(),
             originalCommand: strippedCommand,
+            enableWindowsBash: this.context.config.getEnableWindowsBash(),
           },
         );
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -988,6 +988,7 @@ export class ShellTool extends BaseDeclarativeTool<
       context.config.getEnableInteractiveShell(),
       context.config.getEnableShellOutputEfficiency(),
       context.config.getSandboxEnabled(),
+      context.config.getEnableWindowsBash(),
     );
     super(
       ShellTool.Name,
@@ -1038,6 +1039,7 @@ export class ShellTool extends BaseDeclarativeTool<
       this.context.config.getEnableInteractiveShell(),
       this.context.config.getEnableShellOutputEfficiency(),
       this.context.config.getSandboxEnabled(),
+      this.context.config.getEnableWindowsBash(),
     );
     return resolveToolDeclaration(definition, modelId);
   }

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -13,6 +13,7 @@ import {
   spawnSync,
   type SpawnOptionsWithoutStdio,
 } from 'node:child_process';
+import type { Config } from '../config/config.js';
 
 /**
  * Extracts the primary command name from a potentially wrapped shell command.
@@ -679,6 +680,24 @@ export function getShellConfiguration(): ShellConfiguration {
  * Export the platform detection constant for use in process management (e.g., killing processes).
  */
 export const isWindows = () => os.platform() === 'win32';
+
+let cachedBashPath: string | null | undefined;
+
+export async function resolveBashOnPath(): Promise<string | undefined> {
+  if (cachedBashPath !== undefined) return cachedBashPath ?? undefined;
+  const found = await resolveExecutable('bash');
+  cachedBashPath = found ?? null;
+  return found;
+}
+
+export function clearBashPathCache(): void {
+  cachedBashPath = undefined;
+}
+
+export function isPosixShellEffective(config: Config): boolean {
+  if (!isWindows()) return true;
+  return config.getEnableWindowsBash() && !!cachedBashPath;
+}
 
 /**
  * Escapes a string so that it can be safely used as a single argument

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -683,11 +683,71 @@ export const isWindows = () => os.platform() === 'win32';
 
 let cachedBashPath: string | null | undefined;
 
+function resolveGitForWindowsBash(): string | undefined {
+  if (os.platform() !== 'win32') return undefined;
+
+  // Registry probe: Git for Windows always writes its install path here, even
+  // when the installer is configured not to add bash to PATH.
+  try {
+    const result = spawnSync(
+      'reg',
+      ['query', 'HKLM\\SOFTWARE\\GitForWindows', '/v', 'InstallPath'],
+      { encoding: 'utf8', windowsHide: true, timeout: 3000 },
+    );
+    if (result.status === 0 && result.stdout) {
+      const match = /InstallPath\s+REG_SZ\s+(.+)/i.exec(result.stdout);
+      if (match) {
+        const candidate = path.join(match[1].trim(), 'bin', 'bash.exe');
+        if (fs.existsSync(candidate)) return candidate;
+      }
+    }
+  } catch {
+    // Registry unavailable; fall through to filesystem probes.
+  }
+
+  // Filesystem probes for well-known default install locations.
+  const probes = [
+    path.join(
+      process.env['ProgramFiles'] ?? 'C:\\Program Files',
+      'Git',
+      'bin',
+      'bash.exe',
+    ),
+    path.join(
+      process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+      'Git',
+      'bin',
+      'bash.exe',
+    ),
+    path.join(
+      process.env['LOCALAPPDATA'] ?? '',
+      'Programs',
+      'Git',
+      'bin',
+      'bash.exe',
+    ),
+  ];
+  for (const candidate of probes) {
+    if (candidate && fs.existsSync(candidate)) return candidate;
+  }
+
+  return undefined;
+}
+
 export async function resolveBashOnPath(): Promise<string | undefined> {
   if (cachedBashPath !== undefined) return cachedBashPath ?? undefined;
+
+  // 1. PATH search.
   const found = await resolveExecutable('bash');
-  cachedBashPath = found ?? null;
-  return found;
+  if (found) {
+    cachedBashPath = found;
+    return found;
+  }
+
+  // 2. Windows-specific: registry + filesystem probes.
+  const gitBash = resolveGitForWindowsBash();
+  cachedBashPath = gitBash ?? null;
+  return gitBash;
 }
 
 export function clearBashPathCache(): void {


### PR DESCRIPTION
## Problem

On Windows, `run_shell_command` is hardcoded to PowerShell. Foundation models are trained overwhelmingly on Unix shell syntax — they naturally emit `&&`, `grep`, `awk`, `sed`, `find -name`, pipes, and `/dev/null` regardless of what the system prompt says. Patching the prompt does not hold: the model's training prior always wins over a few lines of context. This is the structural root cause behind a long tail of Windows compatibility issues, most visibly tracked in #21340.

## Solution

Add an `experimental.windowsBash` setting that routes `run_shell_command` through bash when enabled. Meet the model where its training is rather than fighting it.

```jsonc
// settings.json
{
  "experimental": {
    "windowsBash": true
  }
}
```

When enabled, every shell command runs as `bash -c "<command>"` instead of `powershell.exe -Command "<command>"`.

## What this PR includes

**Core setting and routing** (`experimental.windowsBash`)
- New setting in `settingsSchema.ts` / `config.ts`
- `ShellExecutionService` uses bash when the setting is active on Windows

**Robust bash detection** (`shell-utils.ts`)
- PATH lookup (covers explicit installs)
- Windows registry probe: `HKLM\SOFTWARE\GitForWindows\InstallPath` — Git for Windows writes this key even when the installer is configured *not* to add bash to PATH (the default option), so PATH-only detection misses most installs
- Filesystem fallbacks: `%ProgramFiles%\Git`, `%ProgramFiles(x86)%\Git`, `%LOCALAPPDATA%\Programs\Git`
- If no bash is found: one-time warning to stderr, transparent fallback to PowerShell

**MSYS/encoding environment** (`shellExecutionService.ts`)
- `MSYS_NO_PATHCONV=1` — prevents Git Bash from silently rewriting argument paths
- `LANG=C.UTF-8` / `LC_ALL=C.UTF-8` — fixes CJK and non-ASCII output garbling

**Model awareness** (tool description + system prompt)
- Shell tool description says `bash -c <command>` instead of `powershell.exe` when bash is active, so the model's tool schema matches reality
- Explicit `## Shell Environment` section injected into operational guidelines (both legacy and Gemini-3 prompt paths) stating "use Unix syntax" — prevents mid-session drift back to PowerShell syntax

**Process table fix** (`process-utils.ts`)
- Add `-NoProfile -NoLogo` to the PowerShell invocation in `getProcessTableWindows` to prevent slow profile loads on startup (addresses the class of issue reported in #23870)

**Tests**
- `shellExecutionService.test.ts`: bash routing, MSYS env vars, UTF-8 locale, once-per-session warning, PowerShell fallback when bash absent
- `integration-tests/windows-bash.test.ts`: end-to-end bash command execution on Windows

## Why not improve the PowerShell path instead?

PowerShell 7 fixes `&&`/`||`, but the model also emits `grep`, `tail`, `head`, `sed`, `awk`, `find -name`, and similar tools that have no PowerShell equivalent by the same name. Bash gives both the operator semantics and the tool surface the model was trained on. The opt-in nature of the setting means zero regression risk for existing users.

## Relates to

Closes #21340
Related: #20773, #21997, #18022, #20545, #23870