### PR TITLE
fix(cli): propagate TLS env vars from .gemini/.env in parent process

### DIFF
--- a/packages/cli/index.test.ts
+++ b/packages/cli/index.test.ts
@@ -11,7 +11,6 @@ import * as os from 'node:os';
 import {
   PARENT_PROCESS_TLS_ENV_ALLOWLIST,
   parseSimpleEnv,
-  findProjectGeminiEnvFile,
   loadTlsEnvFromGemini,
 } from './index.js';
 
@@ -75,115 +74,57 @@ describe('parseSimpleEnv', () => {
   });
 });
 
-describe('findProjectGeminiEnvFile', () => {
-  let tmpRoot: string;
-  beforeEach(() => {
-    tmpRoot = fs.realpathSync(
-      fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-cli-find-env-')),
-    );
-  });
-  afterEach(() => {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  });
-
-  it('returns the file when .gemini/.env exists in the start dir', () => {
-    const geminiDir = path.join(tmpRoot, '.gemini');
-    fs.mkdirSync(geminiDir);
-    const envPath = path.join(geminiDir, '.env');
-    fs.writeFileSync(envPath, 'FOO=bar\n');
-    const found = findProjectGeminiEnvFile(tmpRoot, fs, path);
-    expect(found).toBe(envPath);
-  });
-
-  it('walks up to parent directories to find .gemini/.env', () => {
-    const parentGemini = path.join(tmpRoot, '.gemini');
-    fs.mkdirSync(parentGemini);
-    const envPath = path.join(parentGemini, '.env');
-    fs.writeFileSync(envPath, '');
-    const child = path.join(tmpRoot, 'a', 'b', 'c');
-    fs.mkdirSync(child, { recursive: true });
-    const found = findProjectGeminiEnvFile(child, fs, path);
-    expect(found).toBe(envPath);
-  });
-
-  it('does not match anything inside tmpRoot when no .env is written', () => {
-    const deep = path.join(tmpRoot, 'deep', 'empty');
-    fs.mkdirSync(deep, { recursive: true });
-    const found = findProjectGeminiEnvFile(deep, fs, path);
-    // A parent dir *outside* tmpRoot may have its own .gemini/.env on this
-    // host; we only assert that nothing inside tmpRoot was picked up.
-    if (found !== null) {
-      expect(found.startsWith(tmpRoot)).toBe(false);
-    }
-  });
-});
-
 describe('loadTlsEnvFromGemini', () => {
   let tmpRoot: string;
   let fakeHome: string;
-  let fakeCwd: string;
 
   beforeEach(() => {
     tmpRoot = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-cli-tls-env-')),
     );
     fakeHome = path.join(tmpRoot, 'home');
-    fakeCwd = path.join(tmpRoot, 'project');
     fs.mkdirSync(fakeHome, { recursive: true });
-    fs.mkdirSync(fakeCwd, { recursive: true });
   });
   afterEach(() => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  function writeEnv(dir: string, contents: string) {
-    const geminiDir = path.join(dir, '.gemini');
+  function writeHomeEnv(contents: string) {
+    const geminiDir = path.join(fakeHome, '.gemini');
     fs.mkdirSync(geminiDir, { recursive: true });
     fs.writeFileSync(path.join(geminiDir, '.env'), contents);
   }
 
   it('reads NODE_EXTRA_CA_CERTS from $HOME/.gemini/.env', async () => {
-    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/corp/ca.pem\n');
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
+    writeHomeEnv('NODE_EXTRA_CA_CERTS=/corp/ca.pem\n');
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
     expect(injected).toEqual({ NODE_EXTRA_CA_CERTS: '/corp/ca.pem' });
   });
 
-  it('prefers project .gemini/.env over home', async () => {
-    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/home/ca.pem\n');
-    writeEnv(fakeCwd, 'NODE_EXTRA_CA_CERTS=/project/ca.pem\n');
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
+  it('reads multiple allowlisted vars from the same file', async () => {
+    writeHomeEnv(
+      [
+        'NODE_EXTRA_CA_CERTS=/corp/ca.pem',
+        'HTTPS_PROXY=http://proxy.example:8080',
+        '',
+      ].join('\n'),
     );
-    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/project/ca.pem');
-  });
-
-  it('falls back to home for keys missing in project file', async () => {
-    writeEnv(fakeHome, 'HTTPS_PROXY=http://home-proxy:8080\n');
-    writeEnv(fakeCwd, 'NODE_EXTRA_CA_CERTS=/project/ca.pem\n');
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
-    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/project/ca.pem');
-    expect(injected.HTTPS_PROXY).toBe('http://home-proxy:8080');
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
+    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/corp/ca.pem');
+    expect(injected.HTTPS_PROXY).toBe('http://proxy.example:8080');
   });
 
   it('does NOT override keys already set in currentEnv (shell wins)', async () => {
-    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/home/ca.pem\n');
+    writeHomeEnv('NODE_EXTRA_CA_CERTS=/home/ca.pem\n');
     const injected = await loadTlsEnvFromGemini(
       { NODE_EXTRA_CA_CERTS: '/shell/ca.pem' },
-      { cwd: fakeCwd, homeDir: fakeHome },
+      { homeDir: fakeHome },
     );
     expect(injected).toEqual({});
   });
 
-  it('skips non-allowlisted keys', async () => {
-    writeEnv(
-      fakeHome,
+  it('skips non-allowlisted keys (e.g. GEMINI_API_KEY, FOO)', async () => {
+    writeHomeEnv(
       [
         'NODE_EXTRA_CA_CERTS=/corp/ca.pem',
         'FOO=bar',
@@ -191,41 +132,51 @@ describe('loadTlsEnvFromGemini', () => {
         '',
       ].join('\n'),
     );
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
     expect(injected).toEqual({ NODE_EXTRA_CA_CERTS: '/corp/ca.pem' });
     expect(injected).not.toHaveProperty('FOO');
     expect(injected).not.toHaveProperty('GEMINI_API_KEY');
   });
 
-  it('returns empty object when no .env files exist', async () => {
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
+  it('returns empty object when no home .env file exists', async () => {
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
     expect(injected).toEqual({});
   });
 
+  it('does NOT read project-local .gemini/.env (trust-gated; child handles it)', async () => {
+    // Create a project .gemini/.env with a TLS var; the parent must NOT
+    // load it (because the parent cannot cheaply verify workspace trust).
+    // The child's loadEnvironment() picks up project files under its full
+    // trust model — we only assert the parent helper stays HOME-only.
+    const fakeCwd = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(fakeCwd, '.gemini'), { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeCwd, '.gemini', '.env'),
+      'NODE_EXTRA_CA_CERTS=/project/ca.pem\n',
+    );
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(fakeCwd);
+      const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
+      expect(injected).toEqual({});
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
   it('tolerates malformed .env content without throwing', async () => {
-    writeEnv(
-      fakeHome,
+    writeHomeEnv(
       'this is not valid dotenv content !@#$\nNODE_EXTRA_CA_CERTS=/corp/ca.pem\n',
     );
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
     expect(injected.NODE_EXTRA_CA_CERTS).toBe('/corp/ca.pem');
   });
 
-  it('supports custom allowlist for injecting other keys', async () => {
-    writeEnv(fakeHome, 'CUSTOM_KEY=custom_value\nFOO=bar\n');
+  it('supports custom allowlist', async () => {
+    writeHomeEnv('CUSTOM_KEY=custom_value\nFOO=bar\n');
     const injected = await loadTlsEnvFromGemini(
       {},
       {
-        cwd: fakeCwd,
         homeDir: fakeHome,
         allowlist: ['CUSTOM_KEY'],
       },
@@ -237,11 +188,8 @@ describe('loadTlsEnvFromGemini', () => {
     const lines = PARENT_PROCESS_TLS_ENV_ALLOWLIST.map(
       (k) => `${k}=value_for_${k}`,
     );
-    writeEnv(fakeHome, lines.join('\n') + '\n');
-    const injected = await loadTlsEnvFromGemini(
-      {},
-      { cwd: fakeCwd, homeDir: fakeHome },
-    );
+    writeHomeEnv(lines.join('\n') + '\n');
+    const injected = await loadTlsEnvFromGemini({}, { homeDir: fakeHome });
     for (const key of PARENT_PROCESS_TLS_ENV_ALLOWLIST) {
       expect(injected[key]).toBe(`value_for_${key}`);
     }

--- a/packages/cli/index.test.ts
+++ b/packages/cli/index.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  PARENT_PROCESS_TLS_ENV_ALLOWLIST,
+  parseSimpleEnv,
+  findProjectGeminiEnvFile,
+  loadTlsEnvFromGemini,
+} from './index.js';
+
+describe('parseSimpleEnv', () => {
+  it('parses simple KEY=VALUE lines', () => {
+    const parsed = parseSimpleEnv('FOO=bar\nBAZ=qux\n');
+    expect(parsed).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('strips matching double and single quotes', () => {
+    const parsed = parseSimpleEnv(
+      ['FOO="hello world"', "BAR='spaced value'", 'BAZ=raw'].join('\n'),
+    );
+    expect(parsed).toEqual({
+      FOO: 'hello world',
+      BAR: 'spaced value',
+      BAZ: 'raw',
+    });
+  });
+
+  it('ignores blank lines and # comments', () => {
+    const parsed = parseSimpleEnv(
+      ['# top comment', '', 'FOO=bar', 'BAZ=qux'].join('\n'),
+    );
+    expect(parsed.FOO).toBe('bar');
+    expect(parsed.BAZ).toBe('qux');
+  });
+
+  it('supports the optional `export` prefix', () => {
+    const parsed = parseSimpleEnv(
+      'export NODE_EXTRA_CA_CERTS=/etc/ssl/cert.pem',
+    );
+    expect(parsed).toEqual({
+      NODE_EXTRA_CA_CERTS: '/etc/ssl/cert.pem',
+    });
+  });
+
+  it('strips inline `#` comments on unquoted values only', () => {
+    const parsed = parseSimpleEnv(
+      ['FOO=bar # trailing', 'BAZ="quoted # stays"'].join('\n'),
+    );
+    expect(parsed.FOO).toBe('bar');
+    expect(parsed.BAZ).toBe('quoted # stays');
+  });
+
+  it('silently drops malformed lines', () => {
+    const parsed = parseSimpleEnv(
+      ['=novalue', 'no equals sign', '9BAD_KEY=nope', 'GOOD=yes'].join('\n'),
+    );
+    expect(parsed).toEqual({ GOOD: 'yes' });
+  });
+
+  it('handles CRLF line endings', () => {
+    const parsed = parseSimpleEnv('FOO=bar\r\nBAZ=qux\r\n');
+    expect(parsed).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('preserves `=` inside values', () => {
+    const parsed = parseSimpleEnv('URL=https://example.com/?a=1&b=2');
+    expect(parsed.URL).toBe('https://example.com/?a=1&b=2');
+  });
+});
+
+describe('findProjectGeminiEnvFile', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-cli-find-env-')),
+    );
+  });
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the file when .gemini/.env exists in the start dir', () => {
+    const geminiDir = path.join(tmpRoot, '.gemini');
+    fs.mkdirSync(geminiDir);
+    const envPath = path.join(geminiDir, '.env');
+    fs.writeFileSync(envPath, 'FOO=bar\n');
+    const found = findProjectGeminiEnvFile(tmpRoot, fs, path);
+    expect(found).toBe(envPath);
+  });
+
+  it('walks up to parent directories to find .gemini/.env', () => {
+    const parentGemini = path.join(tmpRoot, '.gemini');
+    fs.mkdirSync(parentGemini);
+    const envPath = path.join(parentGemini, '.env');
+    fs.writeFileSync(envPath, '');
+    const child = path.join(tmpRoot, 'a', 'b', 'c');
+    fs.mkdirSync(child, { recursive: true });
+    const found = findProjectGeminiEnvFile(child, fs, path);
+    expect(found).toBe(envPath);
+  });
+
+  it('does not match anything inside tmpRoot when no .env is written', () => {
+    const deep = path.join(tmpRoot, 'deep', 'empty');
+    fs.mkdirSync(deep, { recursive: true });
+    const found = findProjectGeminiEnvFile(deep, fs, path);
+    // A parent dir *outside* tmpRoot may have its own .gemini/.env on this
+    // host; we only assert that nothing inside tmpRoot was picked up.
+    if (found !== null) {
+      expect(found.startsWith(tmpRoot)).toBe(false);
+    }
+  });
+});
+
+describe('loadTlsEnvFromGemini', () => {
+  let tmpRoot: string;
+  let fakeHome: string;
+  let fakeCwd: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-cli-tls-env-')),
+    );
+    fakeHome = path.join(tmpRoot, 'home');
+    fakeCwd = path.join(tmpRoot, 'project');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    fs.mkdirSync(fakeCwd, { recursive: true });
+  });
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeEnv(dir: string, contents: string) {
+    const geminiDir = path.join(dir, '.gemini');
+    fs.mkdirSync(geminiDir, { recursive: true });
+    fs.writeFileSync(path.join(geminiDir, '.env'), contents);
+  }
+
+  it('reads NODE_EXTRA_CA_CERTS from $HOME/.gemini/.env', async () => {
+    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/corp/ca.pem\n');
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected).toEqual({ NODE_EXTRA_CA_CERTS: '/corp/ca.pem' });
+  });
+
+  it('prefers project .gemini/.env over home', async () => {
+    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/home/ca.pem\n');
+    writeEnv(fakeCwd, 'NODE_EXTRA_CA_CERTS=/project/ca.pem\n');
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/project/ca.pem');
+  });
+
+  it('falls back to home for keys missing in project file', async () => {
+    writeEnv(fakeHome, 'HTTPS_PROXY=http://home-proxy:8080\n');
+    writeEnv(fakeCwd, 'NODE_EXTRA_CA_CERTS=/project/ca.pem\n');
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/project/ca.pem');
+    expect(injected.HTTPS_PROXY).toBe('http://home-proxy:8080');
+  });
+
+  it('does NOT override keys already set in currentEnv (shell wins)', async () => {
+    writeEnv(fakeHome, 'NODE_EXTRA_CA_CERTS=/home/ca.pem\n');
+    const injected = await loadTlsEnvFromGemini(
+      { NODE_EXTRA_CA_CERTS: '/shell/ca.pem' },
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected).toEqual({});
+  });
+
+  it('skips non-allowlisted keys', async () => {
+    writeEnv(
+      fakeHome,
+      [
+        'NODE_EXTRA_CA_CERTS=/corp/ca.pem',
+        'FOO=bar',
+        'GEMINI_API_KEY=sekret',
+        '',
+      ].join('\n'),
+    );
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected).toEqual({ NODE_EXTRA_CA_CERTS: '/corp/ca.pem' });
+    expect(injected).not.toHaveProperty('FOO');
+    expect(injected).not.toHaveProperty('GEMINI_API_KEY');
+  });
+
+  it('returns empty object when no .env files exist', async () => {
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected).toEqual({});
+  });
+
+  it('tolerates malformed .env content without throwing', async () => {
+    writeEnv(
+      fakeHome,
+      'this is not valid dotenv content !@#$\nNODE_EXTRA_CA_CERTS=/corp/ca.pem\n',
+    );
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    expect(injected.NODE_EXTRA_CA_CERTS).toBe('/corp/ca.pem');
+  });
+
+  it('supports custom allowlist for injecting other keys', async () => {
+    writeEnv(fakeHome, 'CUSTOM_KEY=custom_value\nFOO=bar\n');
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      {
+        cwd: fakeCwd,
+        homeDir: fakeHome,
+        allowlist: ['CUSTOM_KEY'],
+      },
+    );
+    expect(injected).toEqual({ CUSTOM_KEY: 'custom_value' });
+  });
+
+  it('respects the entire PARENT_PROCESS_TLS_ENV_ALLOWLIST', async () => {
+    const lines = PARENT_PROCESS_TLS_ENV_ALLOWLIST.map(
+      (k) => `${k}=value_for_${k}`,
+    );
+    writeEnv(fakeHome, lines.join('\n') + '\n');
+    const injected = await loadTlsEnvFromGemini(
+      {},
+      { cwd: fakeCwd, homeDir: fakeHome },
+    );
+    for (const key of PARENT_PROCESS_TLS_ENV_ALLOWLIST) {
+      expect(injected[key]).toBe(`value_for_${key}`);
+    }
+  });
+});

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -76,37 +76,25 @@ export function parseSimpleEnv(content: string): Record<string, string> {
 }
 
 /**
- * Walk up from `startDir` looking for `<dir>/.gemini/.env`. Returns the first
- * hit, or `null` if none is found before the filesystem root.
- */
-export function findProjectGeminiEnvFile(
-  startDir: string,
-  fsImpl: { existsSync: (p: string) => boolean },
-  pathImpl: {
-    resolve: (p: string) => string;
-    join: (...parts: string[]) => string;
-    dirname: (p: string) => string;
-  },
-): string | null {
-  let currentDir = pathImpl.resolve(startDir);
-  for (;;) {
-    const candidate = pathImpl.join(currentDir, GEMINI_DIR_NAME, ENV_FILE_NAME);
-    if (fsImpl.existsSync(candidate)) return candidate;
-    const parent = pathImpl.dirname(currentDir);
-    if (!parent || parent === currentDir) return null;
-    currentDir = parent;
-  }
-}
-
-/**
- * Read TLS-init-critical environment variables from `.gemini/.env` (project
- * first, then home) and return the subset that is both in the allowlist and
- * NOT already set in `currentEnv`. Never throws.
+ * Read TLS-init-critical environment variables from the user's
+ * `$HOME/.gemini/.env` and return the subset that is both in the allowlist
+ * and NOT already set in `currentEnv`. Never throws.
+ *
+ * This is deliberately scoped to the HOME-level file only. Project-local
+ * `<cwd>/.gemini/.env` is gated by the child's full workspace-trust check
+ * in `loadEnvironment()`, and reproducing that trust logic in the
+ * lightweight parent process would require either duplicating the
+ * longest-match + TRUST_PARENT resolution or importing heavy modules
+ * (which defeats the purpose of PR #24667). Extending this helper to
+ * project-local files after factoring the trust check into a shared
+ * standalone helper is a planned follow-up.
+ *
+ * The reporter's use case on #25987 (enterprise CA cert for an entire
+ * machine) is satisfied by the HOME-level path.
  */
 export async function loadTlsEnvFromGemini(
   currentEnv: NodeJS.ProcessEnv,
   options?: {
-    cwd?: string;
     homeDir?: string;
     allowlist?: readonly string[];
   },
@@ -116,43 +104,22 @@ export async function loadTlsEnvFromGemini(
     const { readFileSync, existsSync } = await import('node:fs');
     const pathMod = await import('node:path');
     const allowlist = options?.allowlist ?? PARENT_PROCESS_TLS_ENV_ALLOWLIST;
-    const cwd = options?.cwd ?? process.cwd();
     const homeDir = options?.homeDir ?? os.homedir();
 
-    const candidates: string[] = [];
-    const projectFile = findProjectGeminiEnvFile(
-      cwd,
-      { existsSync },
-      {
-        resolve: pathMod.resolve,
-        join: pathMod.join,
-        dirname: pathMod.dirname,
-      },
-    );
-    if (projectFile) candidates.push(projectFile);
-
     const homeFile = pathMod.join(homeDir, GEMINI_DIR_NAME, ENV_FILE_NAME);
-    if (homeFile !== projectFile && existsSync(homeFile)) {
-      candidates.push(homeFile);
-    }
+    if (!existsSync(homeFile)) return injected;
 
-    for (const file of candidates) {
-      let parsed: Record<string, string>;
-      try {
-        const content = readFileSync(file, 'utf-8');
-        parsed = parseSimpleEnv(content);
-      } catch {
-        // Ignore unreadable files (EACCES, ENOENT after race, etc.)
-        continue;
-      }
-      for (const key of allowlist) {
-        if (
-          Object.hasOwn(parsed, key) &&
-          !Object.hasOwn(injected, key) &&
-          !Object.hasOwn(currentEnv, key)
-        ) {
-          injected[key] = parsed[key];
-        }
+    let parsed: Record<string, string>;
+    try {
+      const content = readFileSync(homeFile, 'utf-8');
+      parsed = parseSimpleEnv(content);
+    } catch {
+      // Unreadable (EACCES, race on ENOENT, etc.) — silently skip.
+      return injected;
+    }
+    for (const key of allowlist) {
+      if (Object.hasOwn(parsed, key) && !Object.hasOwn(currentEnv, key)) {
+        injected[key] = parsed[key];
       }
     }
   } catch {

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -12,6 +12,155 @@ import v8 from 'node:v8';
 
 // --- Global Entry Point ---
 
+/**
+ * Whitelist of environment variables that Node.js and libcurl read during
+ * process initialization (before user JS code runs), and therefore must be
+ * present in the child process's initial environment for its TLS / proxy /
+ * certificate-trust layer to pick them up. See:
+ *   - https://nodejs.org/api/cli.html#node_extra_ca_certsfile
+ *   - https://nodejs.org/api/cli.html#node_tls_reject_unauthorizedvalue
+ *   - https://curl.se/docs/manpage.html (SSL_CERT_FILE, SSL_CERT_DIR)
+ *
+ * Any other variables defined in .gemini/.env continue to be loaded by the
+ * child via loadEnvironment() in src/config/settings.ts, which applies the
+ * full workspace-trust and exclusion logic.
+ */
+export const PARENT_PROCESS_TLS_ENV_ALLOWLIST: readonly string[] = [
+  'NODE_EXTRA_CA_CERTS',
+  'NODE_TLS_REJECT_UNAUTHORIZED',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+];
+
+const GEMINI_DIR_NAME = '.gemini';
+const ENV_FILE_NAME = '.env';
+
+/**
+ * Minimal KEY=VALUE parser used only by the lightweight parent process.
+ * Deliberately avoids importing `dotenv` (which would pull heavy deps into
+ * the parent and defeat the purpose of PR #24667). Supports:
+ *   - KEY=value
+ *   - KEY="value" / KEY='value' (quotes stripped if balanced)
+ *   - blank lines and `#` comments (including inline, when value is unquoted)
+ *   - optional `export ` prefix
+ * Malformed lines are silently ignored.
+ */
+export function parseSimpleEnv(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = content.split(/\r?\n/);
+  for (const raw of lines) {
+    let line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line.startsWith('export ')) line = line.slice(7).trimStart();
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let value = line.slice(eq + 1).trim();
+    const isQuoted =
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")));
+    if (!isQuoted) {
+      const hashIdx = value.indexOf(' #');
+      if (hashIdx !== -1) value = value.slice(0, hashIdx).trimEnd();
+    } else {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Walk up from `startDir` looking for `<dir>/.gemini/.env`. Returns the first
+ * hit, or `null` if none is found before the filesystem root.
+ */
+export function findProjectGeminiEnvFile(
+  startDir: string,
+  fsImpl: { existsSync: (p: string) => boolean },
+  pathImpl: {
+    resolve: (p: string) => string;
+    join: (...parts: string[]) => string;
+    dirname: (p: string) => string;
+  },
+): string | null {
+  let currentDir = pathImpl.resolve(startDir);
+  for (;;) {
+    const candidate = pathImpl.join(currentDir, GEMINI_DIR_NAME, ENV_FILE_NAME);
+    if (fsImpl.existsSync(candidate)) return candidate;
+    const parent = pathImpl.dirname(currentDir);
+    if (!parent || parent === currentDir) return null;
+    currentDir = parent;
+  }
+}
+
+/**
+ * Read TLS-init-critical environment variables from `.gemini/.env` (project
+ * first, then home) and return the subset that is both in the allowlist and
+ * NOT already set in `currentEnv`. Never throws.
+ */
+export async function loadTlsEnvFromGemini(
+  currentEnv: NodeJS.ProcessEnv,
+  options?: {
+    cwd?: string;
+    homeDir?: string;
+    allowlist?: readonly string[];
+  },
+): Promise<Record<string, string>> {
+  const injected: Record<string, string> = {};
+  try {
+    const { readFileSync, existsSync } = await import('node:fs');
+    const pathMod = await import('node:path');
+    const allowlist = options?.allowlist ?? PARENT_PROCESS_TLS_ENV_ALLOWLIST;
+    const cwd = options?.cwd ?? process.cwd();
+    const homeDir = options?.homeDir ?? os.homedir();
+
+    const candidates: string[] = [];
+    const projectFile = findProjectGeminiEnvFile(
+      cwd,
+      { existsSync },
+      {
+        resolve: pathMod.resolve,
+        join: pathMod.join,
+        dirname: pathMod.dirname,
+      },
+    );
+    if (projectFile) candidates.push(projectFile);
+
+    const homeFile = pathMod.join(homeDir, GEMINI_DIR_NAME, ENV_FILE_NAME);
+    if (homeFile !== projectFile && existsSync(homeFile)) {
+      candidates.push(homeFile);
+    }
+
+    for (const file of candidates) {
+      let parsed: Record<string, string>;
+      try {
+        const content = readFileSync(file, 'utf-8');
+        parsed = parseSimpleEnv(content);
+      } catch {
+        // Ignore unreadable files (EACCES, ENOENT after race, etc.)
+        continue;
+      }
+      for (const key of allowlist) {
+        if (
+          Object.hasOwn(parsed, key) &&
+          !Object.hasOwn(injected, key) &&
+          !Object.hasOwn(currentEnv, key)
+        ) {
+          injected[key] = parsed[key];
+        }
+      }
+    }
+  } catch {
+    // Defensive: never block startup on a parent-env helper failure.
+  }
+  return injected;
+}
+
 // Suppress known race condition error in node-pty on Windows
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827
 process.on('uncaughtException', (error) => {
@@ -84,7 +233,18 @@ async function run() {
     nodeArgs.push(script);
     nodeArgs.push(...scriptArgs);
 
-    const newEnv = { ...process.env, GEMINI_CLI_NO_RELAUNCH: 'true' };
+    // Propagate TLS-initialization env vars from `.gemini/.env` into the
+    // child's initial environment. Node reads these once at process start
+    // (before any JS runs), so they must be set on the spawn env rather
+    // than loaded later by the child's loadEnvironment(). Fixes #25987.
+    // Keys already present in process.env take precedence — matching the
+    // "shell env wins" rule enforced in loadEnvironment().
+    const tlsEnvFromFile = await loadTlsEnvFromGemini(process.env);
+    const newEnv = {
+      ...tlsEnvFromFile,
+      ...process.env,
+      GEMINI_CLI_NO_RELAUNCH: 'true',
+    };
     const RELAUNCH_EXIT_CODE = 199;
     let latestAdminSettings: unknown = undefined;
 
@@ -186,4 +346,23 @@ async function run() {
   }
 }
 
-run();
+// Only bootstrap when this module is the executed entrypoint. This lets
+// unit tests import the helpers above without triggering a child spawn.
+// Uses the standard Node ESM "is-main-module" idiom: compare the script
+// path Node was launched with (process.argv[1]) against this module's URL.
+async function isEntrypointModule(): Promise<boolean> {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    const { pathToFileURL } = await import('node:url');
+    return pathToFileURL(entry).href === import.meta.url;
+  } catch {
+    // On any failure, preserve historical behavior and run — the CLI
+    // binary must start even if this check misbehaves.
+    return true;
+  }
+}
+
+if (await isEntrypointModule()) {
+  await run();
+}


### PR DESCRIPTION
## Summary
Fixes #25987. `NODE_EXTRA_CA_CERTS` and other TLS-initialization env
vars defined in `.gemini/.env` were ignored after PR #24667 introduced
the lightweight parent / heavy child process model, because the
child's Node TLS layer initializes from `process.env` *before* its
`loadEnvironment()` call ever runs.

## Details
Node reads `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `HTTPS_PROXY`, etc.
once at process start, in C++ before any user JS runs. Pre-#24667 the
CLI ran as a single process, so there was no observable ordering
problem — no outbound TLS happened until after `.env` was loaded.
After #24667 the child is spawned with a pre-built env, and by the
time the child's JS gets around to parsing `.env` the TLS layer is
already initialized without the cert.

This PR keeps the parent lightweight (no `dotenv` import, no heavy
module loads) by hand-parsing `.gemini/.env` for a small allowlist of
env vars that Node and libcurl require at init time:

- \`NODE_EXTRA_CA_CERTS\`
- \`NODE_TLS_REJECT_UNAUTHORIZED\`
- \`SSL_CERT_FILE\`, \`SSL_CERT_DIR\`
- \`HTTPS_PROXY\`, \`HTTP_PROXY\`, \`NO_PROXY\`

Values from \`.gemini/.env\` are injected into the child's spawn env
**only when the key is not already set in the shell env**, preserving
the existing \"shell env wins\" rule from \`loadEnvironment()\`.

Lookup order (matches \`findEnvFile\` in \`settings.ts\`):
1. Nearest \`<cwd>/.gemini/.env\` walking up parent directories
2. \`\$HOME/.gemini/.env\`

Scope is deliberately narrow: seven well-known network/TLS vars, and
only the \`.gemini/.env\` path (not arbitrary \`.env\`). Non-TLS vars
continue to flow through the child's full \`loadEnvironment()\` path
with its trust checks unchanged.

The PR also adds a small is-main-module guard around \`run()\` so the
new helpers (\`parseSimpleEnv\`, \`findProjectGeminiEnvFile\`,
\`loadTlsEnvFromGemini\`) can be imported from unit tests without
triggering a child spawn.

## Related Issues
Fixes #25987
Related to #24667 (introduced the regression)

## How to Validate
1. Create \`~/.gemini/.env\` with
   \`NODE_EXTRA_CA_CERTS=/path/to/cert.pem\`.
2. Ensure \`NODE_EXTRA_CA_CERTS\` is NOT set in your shell env.
3. Run any command that makes an HTTPS request through a CA covered by
   that cert (e.g. \`gemini mcp list\` against an internal MCP server).
4. **Before this PR:** \`TypeError: fetch failed\`.
5. **After this PR:** succeeds.

Also verified:
- \`npm run typecheck --workspace @google/gemini-cli\` — clean
- \`npx eslint packages/cli/index.ts packages/cli/index.test.ts --max-warnings 0\` — clean
- \`npx vitest run index.test.ts\` — **20/20 new tests pass**
- Full \`npm run test --workspace @google/gemini-cli\` — the 6 unrelated
  failures on my machine (\`extension_integrity.json\` local-state
  issue) also fail on stock \`main\`, so they are not regressions
  from this PR.

## Pre-Merge Checklist
- [x] Tests added (packages/cli/index.test.ts, 20 cases covering the parser, the dir walker, and the orchestrator helper)
- [x] No breaking changes (helper is additive; existing \`newEnv\` spread order preserves \`process.env\` precedence)
- [x] No docs changes needed
- [ ] Validated on required platforms/methods:
  - [x] MacOS — npm run, vitest
  - [ ] Windows — not available locally (reporter is on win32; reporter steps apply)
  - [ ] Linux — not available locally