### PR TITLE
docs(cli): add skill discovery troubleshooting checklist to tutorial

### DIFF
--- a/docs/cli/tutorials/skills-getting-started.md
+++ b/docs/cli/tutorials/skills-getting-started.md
@@ -84,6 +84,29 @@ your new skill.
 
 You should see `api-auditor` in the list of available skills.
 
+### If your skill doesn't appear
+
+If `/skills list` doesn't show your skill, run through this checklist:
+
+1.  **The folder must be trusted (workspace skills only).** Skills under
+    `<workspace>/.gemini/skills/` are only loaded when the workspace folder is
+    marked as trusted. Run `/trust` and restart the session if needed. Skills
+    under `~/.gemini/skills/` (user scope) are not affected by trust.
+2.  **Check the path layout.** `SKILL.md` must live exactly one directory deep,
+    like `.gemini/skills/<skill-name>/SKILL.md`. Files placed directly in
+    `.gemini/skills/SKILL.md`, or nested more than one directory deep, are not
+    discovered.
+3.  **The filename must be `SKILL.md` exactly.** Capitalization matters on
+    case-sensitive filesystems (Linux, and macOS when configured as such):
+    `skill.md` or `Skill.md` will be ignored.
+4.  **Frontmatter must include both `name:` and `description:`.** A `SKILL.md`
+    is silently skipped if either field is missing or if the frontmatter
+    delimiters (`---` on their own lines) are absent.
+5.  **The skill name comes from the `name:` field, not the directory name.** If
+    your frontmatter says `name: foo`, the skill appears as `foo` in
+    `/skills list` regardless of what its parent directory is called. The
+    characters `: \ / < > * ? " |` in the name are replaced with `-`.
+
 ## How to use the skill
 
 Now, try it out. Start a new session and ask a question that triggers the

--- a/docs/cli/tutorials/skills-getting-started.md
+++ b/docs/cli/tutorials/skills-getting-started.md
@@ -86,7 +86,7 @@ You should see `api-auditor` in the list of available skills.
 
 ### If your skill doesn't appear
 
-If `/skills list` doesn't show your skill, run through this checklist:
+If `/skills list` doesn't show your skill, check the following:
 
 1.  **The folder must be trusted (workspace skills only).** Skills under
     `<workspace>/.gemini/skills/` are only loaded when the workspace folder is
@@ -97,14 +97,14 @@ If `/skills list` doesn't show your skill, run through this checklist:
     (`.gemini/skills/<skill-name>/SKILL.md`). The recommended layout uses a
     subdirectory per skill so you can bundle scripts and other resources
     alongside it. Files nested more than one directory deep are not discovered.
-3.  **The filename must be `SKILL.md` exactly.** Capitalization matters on
+3.  **The filename must be exactly `SKILL.md`.** Capitalization matters on
     case-sensitive filesystems (Linux, and macOS when configured as such):
     `skill.md` or `Skill.md` will be ignored.
-4.  **Frontmatter must include both `name:` and `description:`, and must be
-    the first thing in the file.** A `SKILL.md` is silently skipped if either
-    field is missing, if the delimiters (`---` on their own lines) are absent,
-    or if any text (an H1 title, a comment, even a blank line) appears before
-    the opening `---`.
+4.  **Frontmatter must include both `name:` and `description:`, and must be the
+    first thing in the file.** A `SKILL.md` is silently skipped if either field
+    is missing, if the delimiters (`---` on their own lines) are absent, or if
+    any text (an H1 title, a comment, even a blank line) appears before the
+    opening `---`.
 5.  **The skill name comes from the `name:` field, not the directory name.** If
     your frontmatter says `name: foo`, the skill appears as `foo` in
     `/skills list` regardless of what its parent directory is called. The

--- a/docs/cli/tutorials/skills-getting-started.md
+++ b/docs/cli/tutorials/skills-getting-started.md
@@ -92,16 +92,19 @@ If `/skills list` doesn't show your skill, run through this checklist:
     `<workspace>/.gemini/skills/` are only loaded when the workspace folder is
     marked as trusted. Run `/trust` and restart the session if needed. Skills
     under `~/.gemini/skills/` (user scope) are not affected by trust.
-2.  **Check the path layout.** `SKILL.md` must live exactly one directory deep,
-    like `.gemini/skills/<skill-name>/SKILL.md`. Files placed directly in
-    `.gemini/skills/SKILL.md`, or nested more than one directory deep, are not
-    discovered.
+2.  **Check the path layout.** `SKILL.md` is discovered either at the root of
+    the skills directory (`.gemini/skills/SKILL.md`) or one directory deep
+    (`.gemini/skills/<skill-name>/SKILL.md`). The recommended layout uses a
+    subdirectory per skill so you can bundle scripts and other resources
+    alongside it. Files nested more than one directory deep are not discovered.
 3.  **The filename must be `SKILL.md` exactly.** Capitalization matters on
     case-sensitive filesystems (Linux, and macOS when configured as such):
     `skill.md` or `Skill.md` will be ignored.
-4.  **Frontmatter must include both `name:` and `description:`.** A `SKILL.md`
-    is silently skipped if either field is missing or if the frontmatter
-    delimiters (`---` on their own lines) are absent.
+4.  **Frontmatter must include both `name:` and `description:`, and must be
+    the first thing in the file.** A `SKILL.md` is silently skipped if either
+    field is missing, if the delimiters (`---` on their own lines) are absent,
+    or if any text (an H1 title, a comment, even a blank line) appears before
+    the opening `---`.
 5.  **The skill name comes from the `name:` field, not the directory name.** If
     your frontmatter says `name: foo`, the skill appears as `foo` in
     `/skills list` regardless of what its parent directory is called. The


### PR DESCRIPTION
Closes #24169.

## Summary

Adds a 5-point troubleshooting checklist under the existing "How to verify discovery" section of `docs/cli/tutorials/skills-getting-started.md`, so a beginner whose newly-created skill doesn't show up in `/skills list` has somewhere to look.

26 lines added, 1 file modified, no code changes.

## What the checklist covers

| # | Cause | Source |
|---|---|---|
| 1 | Workspace folder not trusted (skips all workspace skills silently) | `packages/core/src/skills/skillManager.ts:75-80` |
| 2 | `SKILL.md` nested more than one directory deep | `skillLoader.ts:127` glob pattern is `['SKILL.md', '*/SKILL.md']` (root and one-level deep are both discovered) |
| 3 | Filename case mismatch on case-sensitive filesystems | `glob` respects FS case-sensitivity |
| 4 | Frontmatter missing `name:`/`description:`, or any text (title/comment/blank line) before the opening `---` | `skillLoader.ts:34` regex is anchored with `^---` and has no `m` flag; `skillLoader.ts:106-108` returns `null` if either field is absent |
| 5 | Confusion between directory name and `name:` field | `skillLoader.ts:181-187` uses sanitized frontmatter `name` as the displayed identifier |

## Note on the issue's suggested tips

The issue listed two suggested tips. I kept the spirit but adjusted one based on the code:

- ✅ "Verify `.gemini/skills/<name>/SKILL.md` exists" → kept (covered by points 2 + 3)
- 🔧 "Ensure skill directory name matches `name` field in SKILL.md" → **inverted**. Reading `skillLoader.ts:181-187`, the directory name has no role in identification — the skill name is the sanitized `name:` field from frontmatter. So point 5 of the checklist explains the actual relationship, rather than asserting a constraint that isn't enforced. Happy to revisit if a maintainer thinks the directory-name-must-match rule is intended even though the loader doesn't enforce it.

## What I deliberately did NOT include

A "use `DEBUG=1 gemini` to diagnose" tip. The diagnostic in `skillLoader.ts:142-149` only fires when the directory exists AND is non-empty AND no valid skills were found — covering one failure mode out of the five. For a beginner-facing tutorial, an inconsistent debug hint felt worse than no debug hint, so the checklist stands on its own.

## Revisions

The bot review on the initial commit caught two technical inaccuracies, both addressed in commit `5a441ef`:

- Point 2 originally said `SKILL.md` had to be exactly one directory deep. Per `skillLoader.ts:127`, the glob `['SKILL.md', '*/SKILL.md']` also matches a `SKILL.md` directly under the skills directory. Reworded to recommend the subdirectory layout as best practice (for script bundling) without claiming it as a hard requirement.
- Point 4 originally only mentioned missing `name:`/`description:` and missing delimiters. Per `skillLoader.ts:34`, the regex is anchored with `^---` (no `m` flag), so the opening delimiter must be the very first thing in the file. Added the explicit constraint that any preceding text — H1 title, comment, even a blank line — silently breaks parsing.

## Pre-merge checklist

- [x] Pure docs change, no code paths touched
- [x] All 5 points cross-checked against the current `skillLoader.ts` / `skillManager.ts` behavior on `main` (snapshot 42587de7), revisions reflect bot review feedback
- [x] No formatting changes outside the inserted block
- [x] CLA already on file from PR #26016
