### PR TITLE
fix(ui): better error messages for ECONNRESET and ETIMEDOUT

### DIFF
--- a/packages/core/src/utils/fsErrorMessages.test.ts
+++ b/packages/core/src/utils/fsErrorMessages.test.ts
@@ -146,6 +146,12 @@ describe('getFsErrorMessage', () => {
         expected:
           'Connection reset by peer. The network connection was unexpectedly closed.',
       },
+      {
+        code: 'ETIMEDOUT',
+        message: 'ETIMEDOUT: operation timed out',
+        expected:
+          'Operation timed out. The network connection or filesystem operation took too long.',
+      },
     ];
 
     it.each(testCases)(

--- a/packages/core/src/utils/fsErrorMessages.test.ts
+++ b/packages/core/src/utils/fsErrorMessages.test.ts
@@ -140,6 +140,12 @@ describe('getFsErrorMessage', () => {
         expected:
           'Too many open files in system. Close some unused files or applications.',
       },
+      {
+        code: 'ECONNRESET',
+        message: 'ECONNRESET: connection reset by peer',
+        expected:
+          'Connection reset by peer. The network connection was unexpectedly closed.',
+      },
     ];
 
     it.each(testCases)(

--- a/packages/core/src/utils/fsErrorMessages.ts
+++ b/packages/core/src/utils/fsErrorMessages.ts
@@ -48,6 +48,8 @@ const errorMessageGenerators: Record<string, (path?: string) => string> = {
   EMFILE: () => 'Too many open files. Close some unused files or applications.',
   ENFILE: () =>
     'Too many open files in system. Close some unused files or applications.',
+  ECONNRESET: () =>
+    'Connection reset by peer. The network connection was unexpectedly closed.',
 };
 
 /**

--- a/packages/core/src/utils/fsErrorMessages.ts
+++ b/packages/core/src/utils/fsErrorMessages.ts
@@ -50,6 +50,8 @@ const errorMessageGenerators: Record<string, (path?: string) => string> = {
     'Too many open files in system. Close some unused files or applications.',
   ECONNRESET: () =>
     'Connection reset by peer. The network connection was unexpectedly closed.',
+  ETIMEDOUT: () =>
+    'Operation timed out. The network connection or filesystem operation took too long.',
 };
 
 /**


### PR DESCRIPTION
## Summary

Added better error messages for ECONNRESET and ETIMEDOUT in `fsErrorMessages.ts`.

## Details

Updated `fsErrorMessages.ts` to include user-friendly messages for both ECONNRESET and ETIMEDOUT.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

Closes #23874 and #23861

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Run the unit tests.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
