### PR TITLE
fix(cli): correct alternate buffer warning logic for JetBrains

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -85,7 +85,6 @@ import { relaunchOnExitCode } from './utils/relaunch.js';
 import { loadSandboxConfig } from './config/sandboxConfig.js';
 import { deleteSession, listSessions } from './utils/sessions.js';
 import { createPolicyUpdater } from './config/policy.js';
-import { isAlternateBufferEnabled } from './ui/hooks/useAlternateBuffer.js';
 
 import { setupTerminalAndTheme } from './utils/terminalTheme.js';
 import { runDeferredCommand } from './deferred.js';
@@ -644,7 +643,7 @@ export async function main() {
 
     let input = config.getQuestion();
     const useAlternateBuffer = shouldEnterAlternateScreen(
-      isAlternateBufferEnabled(config),
+      config.getUseAlternateBuffer(),
       config.getScreenReader(),
     );
     const rawStartupWarnings = await rawStartupWarningsPromise;

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -230,7 +230,9 @@ describe('getUserStartupWarnings', () => {
         isAlternateBuffer: true,
       });
 
-      await getUserStartupWarnings({}, projectDir, { isAlternateBuffer: false });
+      await getUserStartupWarnings({}, projectDir, {
+        isAlternateBuffer: false,
+      });
       expect(getCompatibilityWarnings).toHaveBeenCalledWith({
         isAlternateBuffer: false,
       });

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -220,5 +220,20 @@ describe('getUserStartupWarnings', () => {
       );
       expect(warnings).not.toContainEqual(compWarning);
     });
+
+    it('should correctly pass isAlternateBuffer option to getCompatibilityWarnings', async () => {
+      const projectDir = path.join(testRootDir, 'project-alt');
+      await fs.mkdir(projectDir);
+
+      await getUserStartupWarnings({}, projectDir, { isAlternateBuffer: true });
+      expect(getCompatibilityWarnings).toHaveBeenCalledWith({
+        isAlternateBuffer: true,
+      });
+
+      await getUserStartupWarnings({}, projectDir, { isAlternateBuffer: false });
+      expect(getCompatibilityWarnings).toHaveBeenCalledWith({
+        isAlternateBuffer: false,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes issue #24790 where the JetBrains alternate buffer warning was incorrectly firing when the user had `terminalBuffer` mode enabled but `alternateBuffer` mode disabled.

## Details

The `isAlternateBufferEnabled(config)` helper returns `true` if *either* `alternateBuffer` or `terminalBuffer` is enabled. However, the terminal's physical alternate screen buffer is only entered when `alternateBuffer` is enabled. The scrolling and rendering issues specific to JetBrains are tied to the actual terminal alternate screen, so the warning should not fire for `terminalBuffer` mode.

Changed `packages/cli/src/gemini.tsx` to use `config.getUseAlternateBuffer()` for computing the `useAlternateBuffer` flag used in startup warnings.

## Related Issues

Fixes #24790

## How to Validate

1. Open Gemini CLI settings.
2. Enable `terminalBuffer` but ensure `Use Alternate Screen Buffer` is disabled.
3. Run the CLI in a JetBrains IDE terminal.
4. Verify that the JetBrains compatibility warning is NOT displayed at startup.
5. Enable `Use Alternate Screen Buffer` and verify that the warning IS displayed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (Verified existing core compatibility tests)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
