### PR TITLE
fix(cli): make MCP ping optional in list command and use configured timeout

### DIFF
--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -260,6 +260,9 @@ describe('mcp list command', () => {
       expect.anything(),
       expect.objectContaining({ timeout: 12345 }),
     );
+    expect(mockClient.ping).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 12345 }),
+    );
   });
 
   it('should use default timeout for connection when not configured', async () => {
@@ -280,6 +283,9 @@ describe('mcp list command', () => {
 
     expect(mockClient.connect).toHaveBeenCalledWith(
       expect.anything(),
+      expect.objectContaining({ timeout: 600000 }),
+    );
+    expect(mockClient.ping).toHaveBeenCalledWith(
       expect.objectContaining({ timeout: 600000 }),
     );
   });

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -67,6 +67,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     GEMINI_DIR: '.gemini',
     getErrorMessage: (e: unknown) =>
       e instanceof Error ? e.message : String(e),
+    MCP_DEFAULT_TIMEOUT_MSEC: 600000,
   };
 });
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -214,6 +215,72 @@ describe('mcp list command', () => {
       expect.stringContaining(
         'test-server: /test/server  (stdio) - Disconnected',
       ),
+    );
+  });
+
+  it('should display connected status even if ping fails', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'test-server': { command: '/test/server' },
+        },
+      },
+      isTrusted: true,
+    });
+
+    mockClient.connect.mockResolvedValue(undefined);
+    mockClient.ping.mockRejectedValue(new Error('Ping failed'));
+
+    await listMcpServers();
+
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('test-server: /test/server  (stdio) - Connected'),
+    );
+  });
+
+  it('should use configured timeout for connection', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'test-server': { command: '/test/server', timeout: 12345 },
+        },
+      },
+      isTrusted: true,
+    });
+
+    mockClient.connect.mockResolvedValue(undefined);
+
+    await listMcpServers();
+
+    expect(mockClient.connect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 12345 }),
+    );
+  });
+
+  it('should use default timeout for connection when not configured', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'test-server': { command: '/test/server' },
+        },
+      },
+      isTrusted: true,
+    });
+
+    mockClient.connect.mockResolvedValue(undefined);
+
+    await listMcpServers();
+
+    expect(mockClient.connect).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ timeout: 600000 }),
     );
   });
 

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -67,7 +67,6 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     GEMINI_DIR: '.gemini',
     getErrorMessage: (e: unknown) =>
       e instanceof Error ? e.message : String(e),
-    MCP_DEFAULT_TIMEOUT_MSEC: 600000,
   };
 });
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -283,10 +282,10 @@ describe('mcp list command', () => {
 
     expect(mockClient.connect).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 600000 }),
+      expect.objectContaining({ timeout: 5000 }),
     );
     expect(mockClient.ping).toHaveBeenCalledWith(
-      expect.objectContaining({ timeout: 600000 }),
+      expect.objectContaining({ timeout: 5000 }),
     );
   });
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -17,7 +17,6 @@ import {
   debugLogger,
   applyAdminAllowlist,
   getAdminBlockedMcpServersMessage,
-  MCP_DEFAULT_TIMEOUT_MSEC,
 } from '@google/gemini-cli-core';
 import type { MCPServerConfig } from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -67,6 +66,8 @@ export async function getMcpServersFromConfig(
 
   return filteredResult;
 }
+
+const MCP_LIST_DEFAULT_TIMEOUT_MSEC = 5000;
 
 async function testMCPConnection(
   serverName: string,
@@ -128,8 +129,9 @@ async function testMCPConnection(
   }
 
   try {
-    // Attempt actual MCP connection with timeout from config or default
-    const timeout = config.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC;
+    // Attempt actual MCP connection with timeout from config or default to 5s.
+    // We use a short default for the list command to keep it responsive.
+    const timeout = config.timeout ?? MCP_LIST_DEFAULT_TIMEOUT_MSEC;
     await client.connect(transport, { timeout });
 
     // Test basic MCP protocol by pinging the server.

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -17,6 +17,7 @@ import {
   debugLogger,
   applyAdminAllowlist,
   getAdminBlockedMcpServersMessage,
+  MCP_DEFAULT_TIMEOUT_MSEC,
 } from '@google/gemini-cli-core';
 import type { MCPServerConfig } from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -127,11 +128,20 @@ async function testMCPConnection(
   }
 
   try {
-    // Attempt actual MCP connection with short timeout
-    await client.connect(transport, { timeout: 5000 }); // 5s timeout
+    // Attempt actual MCP connection with timeout from config or default
+    const timeout = config.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC;
+    await client.connect(transport, { timeout });
 
-    // Test basic MCP protocol by pinging the server
-    await client.ping();
+    // Test basic MCP protocol by pinging the server.
+    // Ping is optional per MCP spec - some servers (e.g. Google first-party)
+    // don't implement it. A successful connect() is sufficient proof of connectivity.
+    try {
+      await client.ping();
+    } catch (e) {
+      debugLogger.debug(
+        `MCP ping failed for ${serverName}, but connect succeeded: ${e}`,
+      );
+    }
 
     await client.close();
     return MCPServerStatus.CONNECTED;

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -136,10 +136,11 @@ async function testMCPConnection(
     // Ping is optional per MCP spec - some servers (e.g. Google first-party)
     // don't implement it. A successful connect() is sufficient proof of connectivity.
     try {
-      await client.ping();
+      await client.ping({ timeout });
     } catch (e) {
       debugLogger.debug(
-        `MCP ping failed for ${serverName}, but connect succeeded: ${e}`,
+        `MCP ping failed for ${serverName}, but connect succeeded:`,
+        e,
       );
     }
 


### PR DESCRIPTION
Fixes #25599.

### Changes:
- **Optional Ping**: The `ping()` call in `gemini mcp list` is now optional. If it fails but `connect()` succeeds, the server is reported as Connected. This fixes the "Disconnected" status for Google first-party MCP servers that don't implement ping.
- **Timeout Logic**: 
    - Connectivity checks now honor the server's explicit `timeout` configuration if provided.
    - If no timeout is configured, it defaults to **5 seconds** (maintaining the previous behavior for command responsiveness).
    - Both `connect()` and `ping()` now respect this timeout.
- **Improved Logging**: Updated `debugLogger.debug` to receive the error object separately, improving stack trace visibility in logs for easier troubleshooting.
- **Tests**: Added unit tests to verify Connected status on ping failure and correct timeout usage for both `connect` and `ping`.