### PR TITLE
fix(core): handle ENAMETOOLONG/ENOTDIR in robustRealpath (#26010)

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -561,6 +561,36 @@ describe('resolveToRealPath', () => {
     expect(resolveToRealPath(input)).toBe(expected);
   });
 
+  it('should return input path even if fs.realpathSync fails with ENAMETOOLONG', () => {
+    // Regression test for #26010: pasting long strings that the at-mention
+    // regex misinterprets as a path must not throw an unhandled ENAMETOOLONG
+    // up to the caller.
+    vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
+      const err = new Error('name too long') as NodeJS.ErrnoException;
+      err.code = 'ENAMETOOLONG';
+      throw err;
+    });
+
+    const longInput = path.resolve('/tmp', 'a'.repeat(4096));
+
+    expect(resolveToRealPath(longInput)).toBe(longInput);
+  });
+
+  it('should return input path even if fs.realpathSync fails with ENOTDIR', () => {
+    // Regression test for #26010: an intermediate path component being a
+    // regular file (e.g. @path/to/file.json/extra) surfaces ENOTDIR from
+    // realpathSync — handle it the same way as a non-existent path.
+    vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
+      const err = new Error('not a directory') as NodeJS.ErrnoException;
+      err.code = 'ENOTDIR';
+      throw err;
+    });
+
+    const input = path.resolve('/tmp', 'file.json', 'extra');
+
+    expect(resolveToRealPath(input)).toBe(input);
+  });
+
   it('should recursively resolve symlinks for non-existent child paths', () => {
     const parentPath = path.resolve('/some/parent/path');
     const resolvedParentPath = path.resolve('/resolved/parent/path');

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -412,6 +412,14 @@ export function resolveToRealPath(pathStr: string): string {
   return robustRealpath(path.resolve(resolvedPath));
 }
 
+function hasErrorCode(e: unknown, codes: readonly string[]): boolean {
+  if (!e || typeof e !== 'object' || !('code' in e)) {
+    return false;
+  }
+  const code = e.code;
+  return typeof code === 'string' && codes.includes(code);
+}
+
 function robustRealpath(p: string, visited = new Set<string>()): string {
   const key = process.platform === 'win32' ? p.toLowerCase() : p;
   if (visited.has(key)) {
@@ -421,12 +429,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
   try {
     return fs.realpathSync(p);
   } catch (e: unknown) {
-    if (
-      e &&
-      typeof e === 'object' &&
-      'code' in e &&
-      (e.code === 'ENOENT' || e.code === 'EISDIR')
-    ) {
+    if (hasErrorCode(e, ['ENOENT', 'EISDIR'])) {
       try {
         const stat = fs.lstatSync(p);
         if (stat.isSymbolicLink()) {
@@ -437,20 +440,21 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       } catch (lstatError: unknown) {
         // Not a symlink, or lstat failed. Re-throw if it's not an expected
         // ENOENT (e.g., a permissions error), otherwise resolve parent.
-        if (
-          !(
-            lstatError &&
-            typeof lstatError === 'object' &&
-            'code' in lstatError &&
-            (lstatError.code === 'ENOENT' || lstatError.code === 'EISDIR')
-          )
-        ) {
+        if (!hasErrorCode(lstatError, ['ENOENT', 'EISDIR'])) {
           throw lstatError;
         }
       }
       const parent = path.dirname(p);
       if (parent === p) return p;
       return path.join(robustRealpath(parent, visited), path.basename(p));
+    }
+    if (hasErrorCode(e, ['ENAMETOOLONG', 'ENOTDIR'])) {
+      // The input is not a resolvable real path — for example a caller
+      // is probing whether a pasted string is a file reference (see the
+      // @-mention path parsing in atCommandProcessor). Returning the
+      // input unchanged lets downstream fileExists / fs.stat calls
+      // reject it normally instead of surfacing an unhandled rejection.
+      return p;
     }
     throw e;
   }


### PR DESCRIPTION
## Summary
Stops the CLI from crashing with `CRITICAL: Unhandled Promise Rejection: ENAMETOOLONG: name too long, lstat '...'` when pasting text that the at-mention regex recognizes as a path but that the OS cannot resolve.

## Details
`packages/core/src/utils/paths.ts::robustRealpath` wraps `fs.realpathSync(p)` and only special-cased `ENOENT` / `EISDIR`; every other error code was rethrown unhandled.

The crash path:

1. User pastes a JSON blob containing a long hex string or an `@email.com`-style token.
2. `atCommandProcessor.parseAllAtCommands` matches it as an `atPath` (the regex is intentionally generous).
3. `checkPermissions` calls `resolveToRealPath(path.resolve(targetDir, pathName))`.
4. `robustRealpath` -> `fs.realpathSync(p)` -> `ENAMETOOLONG` -> rethrown -> unhandled promise rejection in the UI layer -> CRITICAL crash banner.

This PR extends the catch branch to treat two additional error codes as non-fatal:

- `ENAMETOOLONG` — path component exceeds `NAME_MAX` / `PATH_MAX`.
- `ENOTDIR` — an intermediate component is a regular file (e.g. `@path/to/file.json/extra`).

Both semantically mean "this is not a resolvable real path", same as `ENOENT`. The correct fallback is to return the input unchanged so downstream `fileExists` / `fs.stat` callers (which already handle `ENOENT` gracefully, see `atCommandProcessor.ts:301`) can reject it normally. Walking up the parent chain (as the existing `ENOENT` branch does for symlink-aware resolution) would be wrong here because the basename is garbage.

Also factors the repeated `typeof e === 'object' && 'code' in e && ...` checks into a local `hasErrorCode(e, codes)` helper. Semantics of the existing `ENOENT`/`EISDIR` branch are unchanged.

## Related Issues
Closes #26010

## How to Validate
Unit tests covering the new branches:

```bash
npx vitest run packages/core/src/utils/paths.test.ts
```

End-to-end: paste a large JSON blob containing strings longer than 255 chars into the prompt — prior to this patch the CLI panics with an unhandled ENAMETOOLONG; after this patch the string is treated as plain text and no path resolution error surfaces.

Full local CI allowlist (all green on this branch):

```bash
npm run lint
npm run typecheck
npm run test -w @google/gemini-cli-core    # 7082 passed
```

(Two pre-existing failures in `packages/cli/src/config/extension-manager-*.test.ts` reproduce on unmodified upstream `main` and are unrelated to this change.)

## Pre-Merge Checklist
- [x] Conventional-commit title with scope
- [x] Closes #N syntax
- [x] Tests added covering the new branches (ENAMETOOLONG + ENOTDIR)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `@google/gemini-cli-core` test suite clean
- [x] No public API changes; `resolveToRealPath` signature unchanged
- [x] No behaviour change for valid paths or for the existing ENOENT/EISDIR error branch
- [x] Cross-platform: both error codes are standard on POSIX and Windows