### PR TITLE
fix(core): better error message for failed cloudshell-gca auth

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -644,6 +644,28 @@ describe('CodeAssistServer', () => {
     );
   });
 
+  it('should throw friendly error for 403 on cloudshell-gca project', async () => {
+    const { server } = createTestServer();
+    const mock403Error = {
+      response: {
+        status: 403,
+        data: {
+          error: {
+            message: 'Permission denied',
+          },
+        },
+      },
+    };
+    vi.spyOn(server, 'requestPost').mockRejectedValue(mock403Error);
+
+    await expect(
+      server.loadCodeAssist({
+        cloudaicompanionProject: 'cloudshell-gca',
+        metadata: {},
+      }),
+    ).rejects.toThrow(/Access to the default Cloud Shell Gemini project/);
+  });
+
   it('should call the listExperiments endpoint with metadata', async () => {
     const { server } = createTestServer();
     const mockResponse = {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -273,6 +273,16 @@ export class CodeAssistServer implements ContentGenerator {
         return {
           currentTier: { id: UserTierId.STANDARD },
         };
+      } else if (
+        isPermissionDeniedError(e) &&
+        req.cloudaicompanionProject === 'cloudshell-gca'
+      ) {
+        throw new Error(
+          'Access to the default Cloud Shell Gemini project was denied.\n' +
+            'Please set your own Google Cloud project by running:\n' +
+            'gcloud config set project [PROJECT_ID]\n' +
+            'or setting export GOOGLE_CLOUD_PROJECT=...',
+        );
       } else {
         throw e;
       }
@@ -571,4 +581,16 @@ function isVpcScAffectedUser(error: unknown): boolean {
     );
   }
   return false;
+}
+
+function isPermissionDeniedError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    !!error.response &&
+    typeof error.response === 'object' &&
+    'status' in error.response &&
+    error.response.status === 403
+  );
 }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Added better error message for failed cloudshell-gca auth

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
When the cloudshell-gca project wouldn't work for users on the Cloud Shell, it would just give them 403 errors. This PR improves the error message to let users know how to fix the issue.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Addresses #25946

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Added test case to check the new error message.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
