### PR TITLE
fix(cli): support Vietnamese IME input on Windows

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,11 +6,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
 import os from 'node:os';
 import v8 from 'node:v8';
 
 // --- Global Entry Point ---
+
+// Set terminal code page to UTF-8 on Windows
+if (process.platform === 'win32') {
+  try {
+    execSync('chcp 65001', { stdio: 'ignore' });
+  } catch {
+    // Ignore errors if chcp is not available
+  }
+}
 
 // Suppress known race condition error in node-pty on Windows
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -463,7 +463,7 @@ describe('KeypressContext', () => {
       );
     });
 
-    it('should treat \\b as ctrl when WT_SESSION IS present (even if not Windows_NT)', async () => {
+    it('should NOT treat \\b as ctrl when WT_SESSION IS present (even if not Windows_NT)', async () => {
       vi.stubEnv('WT_SESSION', 'some-id');
       vi.stubEnv('OS', 'Linux');
       const { keyHandler } = await setupKeypressTest();
@@ -475,12 +475,12 @@ describe('KeypressContext', () => {
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'backspace',
-          ctrl: true,
+          ctrl: false,
         }),
       );
     });
 
-    it('should treat \\b as ctrl when OS is Windows_NT', async () => {
+    it('should NOT treat \\b as ctrl when OS is Windows_NT', async () => {
       vi.stubEnv('WT_SESSION', '');
       vi.stubEnv('OS', 'Windows_NT');
       const { keyHandler } = await setupKeypressTest();
@@ -492,7 +492,7 @@ describe('KeypressContext', () => {
       expect(keyHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'backspace',
-          ctrl: true,
+          ctrl: false,
         }),
       );
     });

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -652,16 +652,8 @@ function* emitKeys(
       name = 'tab';
       alt = escaped;
     } else if (ch === '\b') {
-      // ctrl+h / ctrl+backspace (windows terminals send \x08 for ctrl+backspace)
+      // backspace
       name = 'backspace';
-      // In Windows environments, \b is sent for Ctrl+Backspace (standard backspace is translated to \x7f).
-      // We scope this to Windows/WT_SESSION to avoid breaking other unixes where \b is a plain backspace.
-      if (
-        typeof process !== 'undefined' &&
-        (process.env?.['OS'] === 'Windows_NT' || !!process.env?.['WT_SESSION'])
-      ) {
-        ctrl = true;
-      }
       alt = escaped;
     } else if (ch === '\x7f') {
       // backspace


### PR DESCRIPTION
## Summary

Vietnamese (and other diacritic-using) IME input was being garbled or silently dropped in the interactive prompt on Windows. This PR fixes two underlying causes so users can type Vietnamese with UniKey / EVKey without character loss.

## Details

Two issues, addressed together:

1. **Console code page wasn't UTF-8.** Multibyte input from stdin was decoded with the host's default code page, garbling diacritics. Run `chcp 65001` at startup on Windows so stdin/stdout are UTF-8.

2. **`\b` was treated as Ctrl+Backspace on Windows.** `KeypressContext` forced `ctrl=true` whenever it saw a raw `\b` (0x08) and either `OS=Windows_NT` or `WT_SESSION` was set. Vietnamese IMEs emit `\b` while composing diacritics; the CLI then interpreted those bytes as Ctrl+Backspace and ate the in-progress character. Treat `\b` as a plain backspace on all platforms.

**Trade-off:** users who relied on Ctrl+Backspace deleting a whole word in Windows Terminal will lose that shortcut, since at this layer the CLI can no longer distinguish it from a plain Backspace. Happy to gate the change behind a setting (e.g. `ui.windowsCtrlBackspace`) if maintainers prefer keeping the shortcut for non-IME users.

Tests in `KeypressContext.test.tsx` were updated to match the new behavior.

## Related Issues

Fixes #25851
Related to #1984, #10157

## How to Validate

1. On Windows 11 with Windows Terminal + UniKey (or EVKey) running, install this branch locally:
   ```
   git fetch origin pull/<this-PR-number>/head:fix-vn-ime
   git checkout fix-vn-ime
   npm install && npm run bundle && npm link --force
   gemini
   ```
2. In the prompt, type a Vietnamese sentence with diacritics, e.g. `chào bạn, hôm nay trời đẹp quá`.
3. Expected: full sentence appears, no character drops while composing `à`, `ạ`, `ô`, `ờ`, `ẹ`, `á`, etc.
4. Run unit tests: `npm test --workspace=@google/gemini-cli` — `KeypressContext` suite should pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — N/A
- [x] Added/updated tests
- [x] Noted breaking changes (Ctrl+Backspace shortcut on Windows Terminal — see Details)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run (via local `npm link`)
    - [ ] npx
    - [ ] Docker
  - [ ] Linux