### PR TITLE
feat(cli): support boolean and number casting for env vars in settings.json

### DIFF
--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -325,6 +325,68 @@ describe('settings-validation', () => {
       const result = validateSettings(validSettings);
       expect(result.success).toBe(true);
     });
+
+    describe('type casting', () => {
+      it('should cast "true" and "false" strings to booleans', () => {
+        const settings = {
+          ui: {
+            autoThemeSwitching: 'true',
+            hideWindowTitle: 'false',
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.success).toBe(true);
+        const data = result.data as any;
+        expect(data.ui.autoThemeSwitching).toBe(true);
+        expect(data.ui.hideWindowTitle).toBe(false);
+      });
+
+      it('should cast boolean strings case-insensitively', () => {
+        const settings = {
+          ui: {
+            autoThemeSwitching: 'TRUE',
+            hideWindowTitle: 'fAlSe',
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.success).toBe(true);
+        const data = result.data as any;
+        expect(data.ui.autoThemeSwitching).toBe(true);
+        expect(data.ui.hideWindowTitle).toBe(false);
+      });
+
+      it('should cast numeric strings to numbers', () => {
+        const settings = {
+          model: {
+            maxSessionTurns: '42',
+            compressionThreshold: '0.5',
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.success).toBe(true);
+        const data = result.data as any;
+        expect(data.model.maxSessionTurns).toBe(42);
+        expect(data.model.compressionThreshold).toBe(0.5);
+      });
+
+      it('should reject invalid castable strings', () => {
+        const settings = {
+          ui: {
+            autoThemeSwitching: 'not-a-boolean',
+          },
+          model: {
+            maxSessionTurns: 'not-a-number',
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues).toHaveLength(2);
+      });
+    });
   });
 
   describe('formatValidationError', () => {

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -337,6 +337,7 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = result.data as any;
         expect(data.ui.autoThemeSwitching).toBe(true);
         expect(data.ui.hideWindowTitle).toBe(false);
@@ -352,6 +353,7 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = result.data as any;
         expect(data.ui.autoThemeSwitching).toBe(true);
         expect(data.ui.hideWindowTitle).toBe(false);
@@ -367,6 +369,7 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = result.data as any;
         expect(data.model.maxSessionTurns).toBe(42);
         expect(data.model.compressionThreshold).toBe(0.5);

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -386,6 +386,28 @@ describe('settings-validation', () => {
         const result = validateSettings(settings);
         expect(result.success).toBe(false);
         expect(result.error?.issues).toHaveLength(2);
+        expect(result.error?.issues[0].message).toContain(
+          'Expected boolean, received string',
+        );
+        expect(result.error?.issues[1].message).toContain(
+          'Expected number, received string',
+        );
+      });
+
+      it('should cast strings to booleans/numbers in shared definitions (refs)', () => {
+        const settings = {
+          mcpServers: {
+            'test-server': {
+              command: 'node',
+              trust: 'true', // from boolean ref
+            },
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.success).toBe(true);
+        const data = result.data as Settings;
+        expect(data.mcpServers?.['test-server'].trust).toBe(true);
       });
     });
   });

--- a/packages/cli/src/config/settings-validation.test.ts
+++ b/packages/cli/src/config/settings-validation.test.ts
@@ -13,6 +13,7 @@ import {
   settingsZodSchema,
 } from './settings-validation.js';
 import { z } from 'zod';
+import { type Settings } from './settingsSchema.js';
 
 describe('settings-validation', () => {
   describe('validateSettings', () => {
@@ -337,10 +338,9 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data = result.data as any;
-        expect(data.ui.autoThemeSwitching).toBe(true);
-        expect(data.ui.hideWindowTitle).toBe(false);
+        const data = result.data as Settings;
+        expect(data.ui?.autoThemeSwitching).toBe(true);
+        expect(data.ui?.hideWindowTitle).toBe(false);
       });
 
       it('should cast boolean strings case-insensitively', () => {
@@ -353,10 +353,9 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data = result.data as any;
-        expect(data.ui.autoThemeSwitching).toBe(true);
-        expect(data.ui.hideWindowTitle).toBe(false);
+        const data = result.data as Settings;
+        expect(data.ui?.autoThemeSwitching).toBe(true);
+        expect(data.ui?.hideWindowTitle).toBe(false);
       });
 
       it('should cast numeric strings to numbers', () => {
@@ -369,10 +368,9 @@ describe('settings-validation', () => {
 
         const result = validateSettings(settings);
         expect(result.success).toBe(true);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data = result.data as any;
-        expect(data.model.maxSessionTurns).toBe(42);
-        expect(data.model.compressionThreshold).toBe(0.5);
+        const data = result.data as Settings;
+        expect(data.model?.maxSessionTurns).toBe(42);
+        expect(data.model?.compressionThreshold).toBe(0.5);
       });
 
       it('should reject invalid castable strings', () => {

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -133,9 +133,22 @@ function buildPrimitiveSchema(
     case 'string':
       return z.string();
     case 'number':
-      return z.number();
+      return z.preprocess((val) => {
+        if (typeof val === 'string' && val.trim() !== '') {
+          const num = Number(val);
+          if (!isNaN(num)) return num;
+        }
+        return val;
+      }, z.number());
     case 'boolean':
-      return z.boolean();
+      return z.preprocess((val) => {
+        if (typeof val === 'string') {
+          const lower = val.toLowerCase();
+          if (lower === 'true') return true;
+          if (lower === 'false') return false;
+        }
+        return val;
+      }, z.boolean());
     default:
       return z.unknown();
   }

--- a/packages/cli/src/config/settings-validation.ts
+++ b/packages/cli/src/config/settings-validation.ts
@@ -25,10 +25,10 @@ function buildZodSchemaFromJsonSchema(def: any): z.ZodTypeAny {
   if (def.type === 'string') {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     if (def.enum) return z.enum(def.enum as [string, ...string[]]);
-    return z.string();
+    return buildPrimitiveSchema('string');
   }
-  if (def.type === 'number') return z.number();
-  if (def.type === 'boolean') return z.boolean();
+  if (def.type === 'number') return buildPrimitiveSchema('number');
+  if (def.type === 'boolean') return buildPrimitiveSchema('boolean');
 
   if (def.type === 'array') {
     if (def.items) {
@@ -173,7 +173,9 @@ function buildZodSchemaFromDefinition(
   if (definition.ref === 'TelemetrySettings') {
     const objectSchema = REF_SCHEMAS['TelemetrySettings'];
     if (objectSchema) {
-      return z.union([z.boolean(), objectSchema]).optional();
+      return z
+        .union([buildPrimitiveSchema('boolean'), objectSchema])
+        .optional();
     }
   }
 

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -565,6 +565,51 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged.model.maxSessionTurns).toBe('not-a-number');
     });
 
+    it('should preserve environment variable placeholders on save', () => {
+      vi.stubEnv('TEST_AUTO_THEME', 'true');
+      const placeholder = '${TEST_AUTO_THEME:-false}';
+
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (
+            path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)
+          ) {
+            return JSON.stringify({
+              ui: { autoThemeSwitching: placeholder },
+            });
+          }
+          return '{}';
+        },
+      );
+
+      // Load settings - this will expand the placeholder for runtime use
+      const loaded = loadSettings(MOCK_WORKSPACE_DIR);
+      expect(loaded.merged.ui.autoThemeSwitching).toBe(true);
+
+      // Verify that the original settings for the user scope still have the placeholder
+      const userFile = loaded.forScope(SettingScope.User);
+      expect(userFile.originalSettings.ui?.autoThemeSwitching).toBe(
+        placeholder,
+      );
+
+      // Save settings - this should use the originalSettings (with placeholders)
+      const mockUpdate = vi.mocked(updateSettingsFilePreservingFormat);
+      saveSettings(userFile);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        USER_SETTINGS_PATH,
+        expect.objectContaining({
+          ui: expect.objectContaining({
+            autoThemeSwitching: placeholder,
+          }),
+        }),
+      );
+    });
+
     it('should use system folderTrust over user setting', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       const userSettingsContent = {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -479,6 +479,84 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged.security?.folderTrust?.enabled).toBe(false); // Workspace setting should be used
     });
 
+    it('should resolve environment variables and cast them to correct types before validation', () => {
+      vi.stubEnv('TEST_AUTO_THEME', 'false');
+      vi.stubEnv('TEST_MAX_TURNS', '15');
+
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+            return JSON.stringify({
+              ui: { autoThemeSwitching: '$TEST_AUTO_THEME' },
+              model: { maxSessionTurns: '$TEST_MAX_TURNS' },
+            });
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.ui.autoThemeSwitching).toBe(false);
+      expect(settings.merged.model.maxSessionTurns).toBe(15);
+      expect(settings.errors).toHaveLength(0);
+    });
+
+    it('should use default values from environment variable placeholders', () => {
+      vi.stubEnv('TEST_AUTO_THEME', ''); // Should trigger default
+      delete process.env.TEST_AUTO_THEME;
+
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+            return JSON.stringify({
+              ui: { autoThemeSwitching: '${TEST_AUTO_THEME:-true}' },
+            });
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.merged.ui.autoThemeSwitching).toBe(true);
+      expect(settings.errors).toHaveLength(0);
+    });
+
+    it('should record validation errors if expansion result is invalid', () => {
+      vi.stubEnv('TEST_MAX_TURNS', 'not-a-number');
+
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH),
+      );
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+            return JSON.stringify({
+              model: { maxSessionTurns: '$TEST_MAX_TURNS' },
+            });
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(settings.errors.length).toBeGreaterThan(0);
+      expect(settings.errors[0].message).toContain('Expected number, received string');
+      // Should fall back to the expanded string value
+      expect(settings.merged.model.maxSessionTurns).toBe('not-a-number');
+    });
+
     it('should use system folderTrust over user setting', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       const userSettingsContent = {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -535,7 +535,7 @@ describe('Settings Loading and Merging', () => {
       expect(settings.errors).toHaveLength(0);
     });
 
-    it('should record validation errors if expansion result is invalid', () => {
+    it('should throw FatalConfigError if expansion result is invalid', () => {
       vi.stubEnv('TEST_MAX_TURNS', 'not-a-number');
 
       (mockFsExistsSync as Mock).mockImplementation(
@@ -555,14 +555,9 @@ describe('Settings Loading and Merging', () => {
         },
       );
 
-      const settings = loadSettings(MOCK_WORKSPACE_DIR);
-
-      expect(settings.errors.length).toBeGreaterThan(0);
-      expect(settings.errors[0].message).toContain(
-        'Expected number, received string',
+      expect(() => loadSettings(MOCK_WORKSPACE_DIR)).toThrow(
+        /Expected number, received string/,
       );
-      // Should fall back to the schema default (since we return {} on validation failure for that scope)
-      expect(settings.merged.model.maxSessionTurns).toBe(-1);
     });
 
     it('should use system folderTrust over user setting', () => {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -561,8 +561,8 @@ describe('Settings Loading and Merging', () => {
       expect(settings.errors[0].message).toContain(
         'Expected number, received string',
       );
-      // Should fall back to the expanded string value
-      expect(settings.merged.model.maxSessionTurns).toBe('not-a-number');
+      // Should fall back to the schema default (since we return {} on validation failure for that scope)
+      expect(settings.merged.model.maxSessionTurns).toBe(-1);
     });
 
     it('should use system folderTrust over user setting', () => {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -535,7 +535,7 @@ describe('Settings Loading and Merging', () => {
       expect(settings.errors).toHaveLength(0);
     });
 
-    it('should throw FatalConfigError if expansion result is invalid', () => {
+    it('should record validation errors if expansion result is invalid', () => {
       vi.stubEnv('TEST_MAX_TURNS', 'not-a-number');
 
       (mockFsExistsSync as Mock).mockImplementation(
@@ -555,14 +555,14 @@ describe('Settings Loading and Merging', () => {
         },
       );
 
-      // Should throw FatalConfigError
-      expect(() => loadSettings(MOCK_WORKSPACE_DIR)).toThrow(
-        /Expected number, received string/,
-      );
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
 
-      // Verify that if we bypass the throw (internal check), we still have the original values
-      // This is a bit tricky since loadSettings is cached and throws.
-      // But we can clear cache and use a non-throwing mock for coreEvents if needed.
+      expect(settings.errors.length).toBeGreaterThan(0);
+      expect(settings.errors[0].message).toContain(
+        'Expected number, received string',
+      );
+      // Should fall back to the expanded string value
+      expect(settings.merged.model.maxSessionTurns).toBe('not-a-number');
     });
 
     it('should use system folderTrust over user setting', () => {

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -489,7 +489,9 @@ describe('Settings Loading and Merging', () => {
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+          if (
+            path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)
+          ) {
             return JSON.stringify({
               ui: { autoThemeSwitching: '$TEST_AUTO_THEME' },
               model: { maxSessionTurns: '$TEST_MAX_TURNS' },
@@ -508,7 +510,7 @@ describe('Settings Loading and Merging', () => {
 
     it('should use default values from environment variable placeholders', () => {
       vi.stubEnv('TEST_AUTO_THEME', ''); // Should trigger default
-      delete process.env.TEST_AUTO_THEME;
+      delete process.env['TEST_AUTO_THEME'];
 
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) =>
@@ -516,7 +518,9 @@ describe('Settings Loading and Merging', () => {
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+          if (
+            path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)
+          ) {
             return JSON.stringify({
               ui: { autoThemeSwitching: '${TEST_AUTO_THEME:-true}' },
             });
@@ -540,7 +544,9 @@ describe('Settings Loading and Merging', () => {
       );
       (fs.readFileSync as Mock).mockImplementation(
         (p: fs.PathOrFileDescriptor) => {
-          if (path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)) {
+          if (
+            path.normalize(p.toString()) === path.normalize(USER_SETTINGS_PATH)
+          ) {
             return JSON.stringify({
               model: { maxSessionTurns: '$TEST_MAX_TURNS' },
             });
@@ -552,7 +558,9 @@ describe('Settings Loading and Merging', () => {
       const settings = loadSettings(MOCK_WORKSPACE_DIR);
 
       expect(settings.errors.length).toBeGreaterThan(0);
-      expect(settings.errors[0].message).toContain('Expected number, received string');
+      expect(settings.errors[0].message).toContain(
+        'Expected number, received string',
+      );
       // Should fall back to the expanded string value
       expect(settings.merged.model.maxSessionTurns).toBe('not-a-number');
     });

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -555,9 +555,14 @@ describe('Settings Loading and Merging', () => {
         },
       );
 
+      // Should throw FatalConfigError
       expect(() => loadSettings(MOCK_WORKSPACE_DIR)).toThrow(
         /Expected number, received string/,
       );
+
+      // Verify that if we bypass the throw (internal check), we still have the original values
+      // This is a bit tricky since loadSettings is cached and throws.
+      // But we can clear cache and use a non-throwing mock for coreEvents if needed.
     });
 
     it('should use system folderTrust over user setting', () => {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -673,7 +673,9 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   const storage = new Storage(workspaceDir);
   const workspaceSettingsPath = storage.getWorkspaceSettingsPath();
 
-  const load = (filePath: string): { settings: Settings; rawJson?: string } => {
+  const load = (
+    filePath: string,
+  ): { settings: Settings; rawSettings: Settings; rawJson?: string } => {
     try {
       if (fs.existsSync(filePath)) {
         const content = fs.readFileSync(filePath, 'utf-8');
@@ -689,7 +691,7 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
             path: filePath,
             severity: 'error',
           });
-          return { settings: {} };
+          return { settings: {}, rawSettings: {} };
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -712,7 +714,11 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
             path: filePath,
             severity: 'warning',
           });
-          return { settings: expandedSettings, rawJson: content };
+          return {
+            settings: expandedSettings,
+            rawSettings: settingsObject as Settings,
+            rawJson: content,
+          };
         }
 
         // Return the successfully cast and validated data
@@ -721,6 +727,7 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
           // it's safe to cast the resulting data to the Settings type.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           settings: (validationResult.data as Settings) ?? expandedSettings,
+          rawSettings: settingsObject as Settings,
           rawJson: content,
         };
       }
@@ -731,27 +738,34 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         severity: 'error',
       });
     }
-    return { settings: {} };
+    return { settings: {}, rawSettings: {} };
   };
 
   const systemResult = load(systemSettingsPath);
   const systemDefaultsResult = load(systemDefaultsPath);
   const userResult = load(USER_SETTINGS_PATH);
 
-  let workspaceResult: { settings: Settings; rawJson?: string } = {
+  let workspaceResult: {
+    settings: Settings;
+    rawSettings: Settings;
+    rawJson?: string;
+  } = {
     settings: {} as Settings,
+    rawSettings: {} as Settings,
     rawJson: undefined,
   };
   if (!storage.isWorkspaceHomeDir()) {
     workspaceResult = load(workspaceSettingsPath);
   }
 
-  const systemOriginalSettings = structuredClone(systemResult.settings);
+  const systemOriginalSettings = structuredClone(systemResult.rawSettings);
   const systemDefaultsOriginalSettings = structuredClone(
-    systemDefaultsResult.settings,
+    systemDefaultsResult.rawSettings,
   );
-  const userOriginalSettings = structuredClone(userResult.settings);
-  const workspaceOriginalSettings = structuredClone(workspaceResult.settings);
+  const userOriginalSettings = structuredClone(userResult.rawSettings);
+  const workspaceOriginalSettings = structuredClone(
+    workspaceResult.rawSettings,
+  );
 
   // Environment variables for runtime use are already resolved and validated in load()
   systemSettings = systemResult.settings;

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -726,37 +726,67 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   const userOriginalSettings = structuredClone(userResult.settings);
   const workspaceOriginalSettings = structuredClone(workspaceResult.settings);
 
-    // Environment variables for runtime use
+  // Environment variables for runtime use
   systemSettings = resolveEnvVarsInObject(systemResult.settings);
   systemDefaultSettings = resolveEnvVarsInObject(systemDefaultsResult.settings);
   userSettings = resolveEnvVarsInObject(userResult.settings);
   workspaceSettings = resolveEnvVarsInObject(workspaceResult.settings);
 
-  // Validate settings structure with Zod after environment variable expansion
-  const validateAndRecordErrors = (settings: Settings, filePath: string): Settings => {
-    if (Object.keys(settings).length === 0) return settings;
+  // Validate settings structure with Zod after environment variable expansion.
+  // We use a functional approach to avoid mutating outer state, and "fail closed"
+  // by returning an empty object if validation fails to prevent insecure configurations.
+  const validate = (
+    settings: Settings,
+    filePath: string,
+  ): { settings: Settings; errors: SettingsError[] } => {
+    if (Object.keys(settings).length === 0) return { settings, errors: [] };
     const validationResult = validateSettings(settings);
     if (!validationResult.success && validationResult.error) {
       const errorMessage = formatValidationError(
         validationResult.error,
         filePath,
       );
-      settingsErrors.push({
-        message: errorMessage,
-        path: filePath,
-        severity: 'warning',
-      });
-      return settings;
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        settings: {} as unknown as Settings,
+        errors: [
+          {
+            message: errorMessage,
+            path: filePath,
+            severity: 'warning',
+          },
+        ],
+      };
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    return (validationResult.data as Settings) ?? settings;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      settings: (validationResult.data as Settings) ?? settings,
+      errors: [],
+    };
   };
 
-  systemSettings = validateAndRecordErrors(systemSettings, systemSettingsPath);
-  systemDefaultSettings = validateAndRecordErrors(systemDefaultSettings, systemDefaultsPath);
-  userSettings = validateAndRecordErrors(userSettings, USER_SETTINGS_PATH);
+  const systemValidation = validate(systemSettings, systemSettingsPath);
+  systemSettings = systemValidation.settings;
+  settingsErrors.push(...systemValidation.errors);
+
+  const systemDefaultsValidation = validate(
+    systemDefaultSettings,
+    systemDefaultsPath,
+  );
+  systemDefaultSettings = systemDefaultsValidation.settings;
+  settingsErrors.push(...systemDefaultsValidation.errors);
+
+  const userValidation = validate(userSettings, USER_SETTINGS_PATH);
+  userSettings = userValidation.settings;
+  settingsErrors.push(...userValidation.errors);
+
   if (!storage.isWorkspaceHomeDir()) {
-    workspaceSettings = validateAndRecordErrors(workspaceSettings, workspaceSettingsPath);
+    const workspaceValidation = validate(
+      workspaceSettings,
+      workspaceSettingsPath,
+    );
+    workspaceSettings = workspaceValidation.settings;
+    settingsErrors.push(...workspaceValidation.errors);
   }
 
   // Support legacy theme names

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -747,10 +747,9 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         filePath,
       );
       return {
-        // If validation fails, we return an empty object for this layer.
+        // If validation fails, we return the original settings.
         // Since we also return a fatal 'error', the app will stop anyway.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        settings: {} as unknown as Settings,
+        settings,
         errors: [
           {
             message: errorMessage,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -734,7 +734,7 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
 
   // Validate settings structure with Zod after environment variable expansion.
   // We use a functional approach to avoid mutating outer state, and "fail closed"
-  // by returning an empty object if validation fails to prevent insecure configurations.
+  // by marking errors as 'error' (fatal) if validation fails to prevent insecure configurations.
   const validate = (
     settings: Settings,
     filePath: string,
@@ -747,13 +747,15 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         filePath,
       );
       return {
+        // If validation fails, we return an empty object for this layer.
+        // Since we also return a fatal 'error', the app will stop anyway.
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         settings: {} as unknown as Settings,
         errors: [
           {
             message: errorMessage,
             path: filePath,
-            severity: 'warning',
+            severity: 'error',
           },
         ],
       };

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -733,8 +733,9 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   workspaceSettings = resolveEnvVarsInObject(workspaceResult.settings);
 
   // Validate settings structure with Zod after environment variable expansion.
-  // We use a functional approach to avoid mutating outer state, and "fail closed"
-  // by marking errors as 'error' (fatal) if validation fails to prevent insecure configurations.
+  // We use a functional approach to avoid mutating outer state.
+  // If validation fails, we mark it as a 'warning' and return the original settings
+  // (instead of an empty object) to avoid "ignoring" the file (fail-open).
   const validate = (
     settings: Settings,
     filePath: string,
@@ -747,14 +748,14 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         filePath,
       );
       return {
-        // If validation fails, we return the original settings.
-        // Since we also return a fatal 'error', the app will stop anyway.
+        // If validation fails, we return the original settings (unvalidated/uncast).
+        // This ensures the file is NOT ignored during merging, while still reporting the error.
         settings,
         errors: [
           {
             message: errorMessage,
             path: filePath,
-            severity: 'error',
+            severity: 'warning',
           },
         ],
       };

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -695,20 +695,6 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const settingsObject = rawSettings as Record<string, unknown>;
 
-        // Validate settings structure with Zod
-        const validationResult = validateSettings(settingsObject);
-        if (!validationResult.success && validationResult.error) {
-          const errorMessage = formatValidationError(
-            validationResult.error,
-            filePath,
-          );
-          settingsErrors.push({
-            message: errorMessage,
-            path: filePath,
-            severity: 'warning',
-          });
-        }
-
         return { settings: settingsObject as Settings, rawJson: content };
       }
     } catch (error: unknown) {
@@ -740,11 +726,38 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   const userOriginalSettings = structuredClone(userResult.settings);
   const workspaceOriginalSettings = structuredClone(workspaceResult.settings);
 
-  // Environment variables for runtime use
+    // Environment variables for runtime use
   systemSettings = resolveEnvVarsInObject(systemResult.settings);
   systemDefaultSettings = resolveEnvVarsInObject(systemDefaultsResult.settings);
   userSettings = resolveEnvVarsInObject(userResult.settings);
   workspaceSettings = resolveEnvVarsInObject(workspaceResult.settings);
+
+  // Validate settings structure with Zod after environment variable expansion
+  const validateAndRecordErrors = (settings: Settings, filePath: string): Settings => {
+    if (Object.keys(settings).length === 0) return settings;
+    const validationResult = validateSettings(settings);
+    if (!validationResult.success && validationResult.error) {
+      const errorMessage = formatValidationError(
+        validationResult.error,
+        filePath,
+      );
+      settingsErrors.push({
+        message: errorMessage,
+        path: filePath,
+        severity: 'warning',
+      });
+      return settings;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return (validationResult.data as Settings) ?? settings;
+  };
+
+  systemSettings = validateAndRecordErrors(systemSettings, systemSettingsPath);
+  systemDefaultSettings = validateAndRecordErrors(systemDefaultSettings, systemDefaultsPath);
+  userSettings = validateAndRecordErrors(userSettings, USER_SETTINGS_PATH);
+  if (!storage.isWorkspaceHomeDir()) {
+    workspaceSettings = validateAndRecordErrors(workspaceSettings, workspaceSettingsPath);
+  }
 
   // Support legacy theme names
   if (userSettings.ui?.theme === 'VS') {

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -717,6 +717,8 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
 
         // Return the successfully cast and validated data
         return {
+          // Since we've successfully validated expandedSettings against settingsZodSchema,
+          // it's safe to cast the resulting data to the Settings type.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           settings: (validationResult.data as Settings) ?? expandedSettings,
           rawJson: content,

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -695,7 +695,32 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const settingsObject = rawSettings as Record<string, unknown>;
 
-        return { settings: settingsObject as Settings, rawJson: content };
+        // Expand environment variables
+        const expandedSettings = resolveEnvVarsInObject(
+          settingsObject as Settings,
+        );
+
+        // Validate settings structure with Zod after environment variable expansion
+        const validationResult = validateSettings(expandedSettings);
+        if (!validationResult.success && validationResult.error) {
+          const errorMessage = formatValidationError(
+            validationResult.error,
+            filePath,
+          );
+          settingsErrors.push({
+            message: errorMessage,
+            path: filePath,
+            severity: 'warning',
+          });
+          return { settings: expandedSettings, rawJson: content };
+        }
+
+        // Return the successfully cast and validated data
+        return {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          settings: (validationResult.data as Settings) ?? expandedSettings,
+          rawJson: content,
+        };
       }
     } catch (error: unknown) {
       settingsErrors.push({
@@ -726,70 +751,11 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   const userOriginalSettings = structuredClone(userResult.settings);
   const workspaceOriginalSettings = structuredClone(workspaceResult.settings);
 
-  // Environment variables for runtime use
-  systemSettings = resolveEnvVarsInObject(systemResult.settings);
-  systemDefaultSettings = resolveEnvVarsInObject(systemDefaultsResult.settings);
-  userSettings = resolveEnvVarsInObject(userResult.settings);
-  workspaceSettings = resolveEnvVarsInObject(workspaceResult.settings);
-
-  // Validate settings structure with Zod after environment variable expansion.
-  // We use a functional approach to avoid mutating outer state.
-  // If validation fails, we mark it as a 'warning' and return the original settings
-  // (instead of an empty object) to avoid "ignoring" the file (fail-open).
-  const validate = (
-    settings: Settings,
-    filePath: string,
-  ): { settings: Settings; errors: SettingsError[] } => {
-    if (Object.keys(settings).length === 0) return { settings, errors: [] };
-    const validationResult = validateSettings(settings);
-    if (!validationResult.success && validationResult.error) {
-      const errorMessage = formatValidationError(
-        validationResult.error,
-        filePath,
-      );
-      return {
-        // If validation fails, we return the original settings (unvalidated/uncast).
-        // This ensures the file is NOT ignored during merging, while still reporting the error.
-        settings,
-        errors: [
-          {
-            message: errorMessage,
-            path: filePath,
-            severity: 'warning',
-          },
-        ],
-      };
-    }
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      settings: (validationResult.data as Settings) ?? settings,
-      errors: [],
-    };
-  };
-
-  const systemValidation = validate(systemSettings, systemSettingsPath);
-  systemSettings = systemValidation.settings;
-  settingsErrors.push(...systemValidation.errors);
-
-  const systemDefaultsValidation = validate(
-    systemDefaultSettings,
-    systemDefaultsPath,
-  );
-  systemDefaultSettings = systemDefaultsValidation.settings;
-  settingsErrors.push(...systemDefaultsValidation.errors);
-
-  const userValidation = validate(userSettings, USER_SETTINGS_PATH);
-  userSettings = userValidation.settings;
-  settingsErrors.push(...userValidation.errors);
-
-  if (!storage.isWorkspaceHomeDir()) {
-    const workspaceValidation = validate(
-      workspaceSettings,
-      workspaceSettingsPath,
-    );
-    workspaceSettings = workspaceValidation.settings;
-    settingsErrors.push(...workspaceValidation.errors);
-  }
+  // Environment variables for runtime use are already resolved and validated in load()
+  systemSettings = systemResult.settings;
+  systemDefaultSettings = systemDefaultsResult.settings;
+  userSettings = userResult.settings;
+  workspaceSettings = workspaceResult.settings;
 
   // Support legacy theme names
   if (userSettings.ui?.theme === 'VS') {

--- a/packages/cli/src/config/settings_validation_warning.test.ts
+++ b/packages/cli/src/config/settings_validation_warning.test.ts
@@ -80,7 +80,6 @@ vi.mock('fs', async (importOriginal) => {
 import {
   loadSettings,
   USER_SETTINGS_PATH,
-  type LoadedSettings,
   resetSettingsCacheForTesting,
 } from './settings.js';
 
@@ -94,20 +93,14 @@ describe('Settings Validation Warning', () => {
     (fs.existsSync as Mock).mockReturnValue(false);
   });
 
-  it('should emit a warning and NOT throw when settings are invalid', () => {
+  it('should throw a fatal error when settings have invalid types (fail-closed)', () => {
     (fs.existsSync as Mock).mockImplementation(
       (p: string) => p === USER_SETTINGS_PATH,
     );
 
     const invalidSettingsContent = {
       ui: {
-        customThemes: {
-          terafox: {
-            name: 'terafox',
-            type: 'custom',
-            DiffModified: '#ffffff', // Invalid key
-          },
-        },
+        autoThemeSwitching: 'not-a-boolean',
       },
     };
 
@@ -117,18 +110,10 @@ describe('Settings Validation Warning', () => {
       return '{}';
     });
 
-    // Should NOT throw
-    let settings: LoadedSettings | undefined;
+    // Should throw FatalConfigError
     expect(() => {
-      settings = loadSettings(MOCK_WORKSPACE_DIR);
-    }).not.toThrow();
-
-    // Should have recorded a warning in the settings object
-    expect(
-      settings?.errors.some((e) =>
-        e.message.includes("Unrecognized key(s) in object: 'DiffModified'"),
-      ),
-    ).toBe(true);
+      loadSettings(MOCK_WORKSPACE_DIR);
+    }).toThrow(/Expected boolean, received string/);
   });
 
   it('should throw a fatal error when settings file is not a valid JSON object', () => {

--- a/packages/cli/src/config/settings_validation_warning.test.ts
+++ b/packages/cli/src/config/settings_validation_warning.test.ts
@@ -80,6 +80,7 @@ vi.mock('fs', async (importOriginal) => {
 import {
   loadSettings,
   USER_SETTINGS_PATH,
+  type LoadedSettings,
   resetSettingsCacheForTesting,
 } from './settings.js';
 
@@ -93,14 +94,20 @@ describe('Settings Validation Warning', () => {
     (fs.existsSync as Mock).mockReturnValue(false);
   });
 
-  it('should throw a fatal error when settings have invalid types (fail-closed)', () => {
+  it('should emit a warning and NOT throw when settings are invalid', () => {
     (fs.existsSync as Mock).mockImplementation(
       (p: string) => p === USER_SETTINGS_PATH,
     );
 
     const invalidSettingsContent = {
       ui: {
-        autoThemeSwitching: 'not-a-boolean',
+        customThemes: {
+          terafox: {
+            name: 'terafox',
+            type: 'custom',
+            DiffModified: '#ffffff', // Invalid key
+          },
+        },
       },
     };
 
@@ -110,10 +117,19 @@ describe('Settings Validation Warning', () => {
       return '{}';
     });
 
-    // Should throw FatalConfigError
+    // Should NOT throw
+    let settings: LoadedSettings | undefined;
     expect(() => {
-      loadSettings(MOCK_WORKSPACE_DIR);
-    }).toThrow(/Expected boolean, received string/);
+      settings = loadSettings(MOCK_WORKSPACE_DIR);
+    }).not.toThrow();
+
+    // Should have recorded a warning in the settings object
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings?.errors.some((e: any) =>
+        e.message.includes("Unrecognized key(s) in object: 'DiffModified'"),
+      ),
+    ).toBe(true);
   });
 
   it('should throw a fatal error when settings file is not a valid JSON object', () => {

--- a/packages/cli/src/config/settings_validation_warning.test.ts
+++ b/packages/cli/src/config/settings_validation_warning.test.ts
@@ -125,8 +125,7 @@ describe('Settings Validation Warning', () => {
 
     // Should have recorded a warning in the settings object
     expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      settings?.errors.some((e: any) =>
+      settings?.errors.some((e) =>
         e.message.includes("Unrecognized key(s) in object: 'DiffModified'"),
       ),
     ).toBe(true);


### PR DESCRIPTION
## Summary

Support boolean and number types when configuring `settings.json` via environment variables.

## Details

Currently, environment variables in `settings.json` are expanded as strings. This causes validation errors for settings that expect boolean or number types (e.g., `ui.autoThemeSwitching` or `model.maxSessionTurns`).

This PR:
- Uses `z.preprocess` in `settings-validation.ts` to automatically cast strings like `"true"`, `"false"`, or numeric strings to their respective types during validation.
- Delays configuration validation in `settings.ts` until after environment variable expansion has occurred.
- Ensures that the successfully cast and validated data is preserved and used by the application.

## Related Issues

Fixes #25573

## How to Validate

### Manual Verification:
1. Update `~/.gemini/settings.json` to use placeholders:
   ```json
   {
     "ui": { "autoThemeSwitching": "${GEMINI_AUTO_THEME:-false}" },
     "model": { "maxSessionTurns": "${GEMINI_MAX_TURNS:-7}" }
   }
   ```
2. Run `gemini` and check `/settings`:
   - No env vars: Should show `false` and `7`.
   - `GEMINI_AUTO_THEME=true GEMINI_MAX_TURNS=42 gemini`: Should show `true` and `42`.
3. Verify case-insensitivity: `GEMINI_AUTO_THEME=TRUE gemini` should result in `true`.
4. Verify invalid types: `GEMINI_MAX_TURNS=not-a-number gemini` should show a validation warning and fall back to default.

### Automated Tests:
Run the configuration tests:
```bash
npm test -w @google/gemini-cli -- src/config/settings.test.ts src/config/settings-validation.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
