### PR TITLE
fix(cli): clear pending steering hints upon cancellation

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1204,6 +1204,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
         onCancelSubmit,
         isShellFocused: embeddedShellFocused,
         logger,
+        consumeUserHint: consumePendingHints,
       })
     : // eslint-disable-next-line react-hooks/rules-of-hooks
       useGeminiStream(

--- a/packages/cli/src/ui/hooks/useAgentStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useAgentStream.test.tsx
@@ -204,4 +204,23 @@ describe('useAgentStream', () => {
     expect(mockLegacyAgentProtocol.abort).toHaveBeenCalled();
     expect(mockOnCancelSubmit).toHaveBeenCalledWith(false);
   });
+
+  it('should clear pending user hints when cancelOngoingRequest is called', async () => {
+    const consumeUserHintSpy = vi.fn().mockReturnValue('some hint');
+    const { result } = await renderHookWithProviders(() =>
+      useAgentStream({
+        agent: mockLegacyAgentProtocol as unknown as LegacyAgentProtocol,
+        addItem: mockAddItem,
+        onCancelSubmit: mockOnCancelSubmit,
+        isShellFocused: false,
+        consumeUserHint: consumeUserHintSpy,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.cancelOngoingRequest();
+    });
+
+    expect(consumeUserHintSpy).toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/ui/hooks/useAgentStream.ts
+++ b/packages/cli/src/ui/hooks/useAgentStream.ts
@@ -43,6 +43,7 @@ export interface UseAgentStreamOptions {
   onCancelSubmit: (shouldRestorePrompt?: boolean) => void;
   isShellFocused?: boolean;
   logger?: Logger | null;
+  consumeUserHint?: () => string | null;
 }
 
 /**
@@ -55,6 +56,7 @@ export const useAgentStream = ({
   onCancelSubmit,
   isShellFocused,
   logger,
+  consumeUserHint,
 }: UseAgentStreamOptions) => {
   const [initError] = useState<string | null>(null);
   const [retryStatus] = useState<RetryAttemptPayload | null>(null);
@@ -125,8 +127,9 @@ export const useAgentStream = ({
       await agent.abort();
       setStreamingState(StreamingState.Idle);
       onCancelSubmit(false);
+      consumeUserHint?.();
     }
-  }, [agent, onCancelSubmit]);
+  }, [agent, onCancelSubmit, consumeUserHint]);
 
   // TODO: Support native handleApprovalModeChange for Plan Mode
   const handleApprovalModeChange = useCallback(

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1681,6 +1681,49 @@ describe('useGeminiStream', () => {
       expect(setShellInputFocusedSpy).toHaveBeenCalledWith(false);
     });
 
+    it('should clear pending user hints when escape is pressed', async () => {
+      const consumeUserHintSpy = vi.fn().mockReturnValue('some hint');
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Part 1' };
+        await new Promise(() => {}); // Keep stream open
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = await renderHookWithProviders(() =>
+        useGeminiStream(
+          mockConfig.getGeminiClient(),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+          false,
+          consumeUserHintSpy,
+        ),
+      );
+
+      // Start a query
+      await act(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        result.current.submitQuery('test query');
+      });
+
+      simulateEscapeKeyPress();
+
+      expect(consumeUserHintSpy).toHaveBeenCalled();
+    });
+
     it('should not do anything if escape is pressed when not responding', async () => {
       const { result } = await renderTestHook();
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -880,9 +880,6 @@ export const useGeminiStream = (
     onCancelSubmit(false);
     setShellInputFocused(false);
     consumeUserHint?.();
-    onCancelSubmit(false);
-    setShellInputFocused(false);
-  }, [
   }, [
     streamingState,
     addItem,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -879,6 +879,7 @@ export const useGeminiStream = (
 
     onCancelSubmit(false);
     setShellInputFocused(false);
+    consumeUserHint?.();
   }, [
     streamingState,
     addItem,
@@ -890,6 +891,7 @@ export const useGeminiStream = (
     toolCalls,
     activeShellPtyId,
     setIsResponding,
+    consumeUserHint,
   ]);
 
   useKeypress(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -880,6 +880,9 @@ export const useGeminiStream = (
     onCancelSubmit(false);
     setShellInputFocused(false);
     consumeUserHint?.();
+    onCancelSubmit(false);
+    setShellInputFocused(false);
+  }, [
   }, [
     streamingState,
     addItem,


### PR DESCRIPTION
## Summary

This PR fixes a bug where cancelling a turn (via `ESC` or `Ctrl+C`) would immediately resubmit any pending user steering hints as a new turn.

## Details

The `AppContainer` maintains a buffer of pending steering hints that have not yet been submitted. When a turn is active, these hints are queued. If the turn is cancelled, the state returns to `Idle`. A `useEffect` in `AppContainer` monitors the `Idle` state and, if it finds pending hints, automatically submits them.

This change updates the `cancelOngoingRequest` handler in both `useGeminiStream` and `useAgentStream` to consume (clear) the pending hint buffer during cancellation, preventing the unwanted automatic resubmission.

## Related Issues

Fixes #26133

## How to Validate

1. Run the CLI in a mode where you can trigger a long-running tool (e.g., `sleep 10` in a shell).
2. While the tool is running, type a steering hint and press Enter.
3. Press `ESC` or `Ctrl+C` to cancel the turn.
4. **Expected**: The turn cancels, and you are returned to a clean prompt.
5. **Observed (before fix)**: The turn cancels, but then immediately a new turn starts with your steering hint.

Automated tests:
`npm test -w @google/gemini-cli -- src/ui/hooks/useGeminiStream.test.tsx src/ui/hooks/useAgentStream.test.tsx`

## Meme

![ZomboMeme 28042026234311.jpg](https://github.com/user-attachments/assets/885a4565-aa9f-4469-9fde-3036b606b198)



## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
