### PR TITLE
fix(ui): fix issue with box edges

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -368,6 +368,39 @@ describe('<ToolGroupMessage />', () => {
       unmount();
     });
 
+    it('renders update_topic in the middle of other tools', async () => {
+      const toolCalls = [
+        createToolCall({
+          callId: 'tool-1',
+          name: 'read_file',
+          status: CoreToolCallStatus.Success,
+        }),
+        createToolCall({
+          callId: 'topic-tool-middle',
+          name: UPDATE_TOPIC_TOOL_NAME,
+          args: {
+            [TOPIC_PARAM_TITLE]: 'Middle Topic',
+          },
+        }),
+        createToolCall({
+          callId: 'tool-2',
+          name: 'write_file',
+          status: CoreToolCallStatus.Success,
+        }),
+      ];
+      const item = createItem(toolCalls);
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <ToolGroupMessage {...baseProps} item={item} toolCalls={toolCalls} />,
+        {
+          config: baseMockConfig,
+          settings: fullVerbositySettings,
+        },
+      );
+      expect(lastFrame()).toMatchSnapshot('update_topic_middle');
+      unmount();
+    });
+
     it('renders with limited terminal height', async () => {
       const toolCalls = [
         createToolCall({

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -192,6 +192,9 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         !Array.isArray(prevGroup) &&
         isCompactTool(prevGroup, isCompactModeEnabled);
 
+      const prevIsTopic =
+        prevGroup && !Array.isArray(prevGroup) && isTopicTool(prevGroup.name);
+
       const nextGroup = !isLast ? groupedTools[i + 1] : null;
       const nextIsCompact =
         nextGroup &&
@@ -226,7 +229,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
       const isFirstProp = !!(isFirst
         ? (borderTopOverride ?? true)
-        : prevIsCompact);
+        : prevIsCompact || prevIsTopic);
 
       const showClosingBorder =
         !isCompact &&
@@ -363,6 +366,8 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           prevGroup &&
           !Array.isArray(prevGroup) &&
           isCompactTool(prevGroup, isCompactModeEnabled);
+        const prevIsTopic =
+          prevGroup && !Array.isArray(prevGroup) && isTopicTool(prevGroup.name);
 
         const nextGroup = !isLast ? groupedTools[index + 1] : null;
         const nextIsCompact =
@@ -379,7 +384,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
         const isFirstProp = !!(isFirst
           ? (borderTopOverride ?? true)
-          : prevIsCompact);
+          : prevIsCompact || prevIsTopic);
 
         const showClosingBorder =
           !isCompact &&

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -141,6 +141,22 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders two tool groups where
 "
 `;
 
+exports[`<ToolGroupMessage /> > Golden Snapshots > renders update_topic in the middle of other tools > update_topic_middle 1`] = `
+"╭──────────────────────────────────────────────────────────────────────────╮
+│ ✓  read_file A tool for testing                                          │
+│                                                                          │
+│ Test result                                                              │
+╰──────────────────────────────────────────────────────────────────────────╯
+  Middle Topic
+
+╭──────────────────────────────────────────────────────────────────────────╮
+│ ✓  write_file A tool for testing                                         │
+│                                                                          │
+│ Test result                                                              │
+╰──────────────────────────────────────────────────────────────────────────╯
+"
+`;
+
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders update_topic tool call using TopicMessage > update_topic_tool 1`] = `
 "  Testing Topic: This is the description
 "


### PR DESCRIPTION
## Summary

Fixes an issue with box edges in `ToolGroupMessage` where a tool appearing immediately after an `update_topic` tool would be missing its top border.

## Details

Added `prevIsTopic` check to ensure the top border is drawn when the previous tool group was a topic tool, correctly separating the new tool group from the topic message. Included a new snapshot test `renders update_topic in the middle of other tools` to prevent regressions.

## Related Issues

None

## How to Validate

1. Run the test suite: `npm test -w @google/gemini-cli -- src/ui/components/messages/ToolGroupMessage.test.tsx`
2. Ensure the new snapshot tests pass and demonstrate correct border rendering.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
