### PR TITLE
feat(session): expose runtime identity for external observers

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -34,6 +34,7 @@ import {
   debugLogger,
   isHeadlessMode,
   Storage,
+  writeRuntimeStatus,
 } from '@google/gemini-cli-core';
 
 import { loadCliConfig, parseArguments } from './config/config.js';
@@ -615,6 +616,30 @@ export async function main() {
       await deleteSession(config, sessionToDelete);
       await runExitCleanup();
       process.exit(ExitCodes.SUCCESS);
+    }
+
+    // Make the live session externally observable. Write a small JSON
+    // status file at <sessionTempDir>/runtime.json that records
+    // (pid, sessionId, workDir, hostname, startedAt, geminiCliVersion)
+    // so terminal multiplexers, tab managers, IDE integrations, and
+    // observability daemons can map a running PID to its session — even
+    // when started without --resume/--session-id, which is the common
+    // case. Best-effort: never block startup if the write fails.
+    //
+    // Placed after the --list-* / --delete-session early exits so those
+    // utility commands don't leave a sidecar claiming a session that
+    // never started, and before all three session-serving paths
+    // (interactive, ACP, non-interactive). The file is intentionally
+    // NOT cleared on exit — external observers must verify the recorded
+    // PID is alive anyway, so explicit cleanup adds no on-disk benefit.
+    try {
+      const sessionDir = config.storage.getSessionTempDir();
+      await writeRuntimeStatus(sessionDir, {
+        sessionId: config.getSessionId(),
+        workDir: config.getTargetDir(),
+      });
+    } catch (err) {
+      debugLogger.debug('Failed to write runtime status sidecar:', err);
     }
 
     const wasRaw = process.stdin.isRaw;

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -638,6 +638,14 @@ export async function main() {
         sessionId: config.getSessionId(),
         workDir: config.getTargetDir(),
       });
+      // Mark this Config as the owner of a runtime.json sidecar for the
+      // current PID. From this point on, Config.setSessionId refreshes
+      // the sidecar on every same-PID session swap (`/clear`, session
+      // browser resume, etc.). Non-interactive entry points that never
+      // reach this bootstrap leave sibling sidecars alone, so a short-
+      // lived `gemini --prompt` invocation cannot trample a concurrent
+      // shell's sidecar that happens to share the outgoing session id.
+      config.markRuntimeStatusEnabled();
     } catch (err) {
       debugLogger.debug('Failed to write runtime status sidecar:', err);
     }

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -10,8 +10,6 @@ import {
   SessionStartSource,
   flushTelemetry,
   resetBrowserSession,
-  clearRuntimeStatus,
-  writeRuntimeStatus,
 } from '@google/gemini-cli-core';
 import { CommandKind, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
@@ -39,38 +37,13 @@ export const clearCommand: SlashCommand = {
     // Start a new conversation recording with a new session ID
     // We MUST do this before calling resetChat() so the new ChatRecordingService
     // initialized by GeminiChat picks up the new session ID.
+    // Config.setSessionId (called from resetNewSessionState) handles the
+    // runtime.json sidecar swap centrally — gated on the bootstrap-set
+    // ownership flag — so /clear does not need to touch it directly.
     let newSessionId: string | undefined;
     if (config) {
       newSessionId = randomUUID();
-
-      // Capture the OLD session's runtime.json path before switching the
-      // session id, so we can clear the stale claim on this PID. After
-      // resetNewSessionState the storage points to the NEW session dir.
-      let oldSessionDir: string | undefined;
-      try {
-        oldSessionDir = config.storage.getSessionTempDir();
-      } catch {
-        // No prior session id resolved; nothing to clear.
-      }
-
       config.resetNewSessionState(newSessionId);
-
-      // Drop the previous session's runtime.json (this PID no longer
-      // serves it) and write a fresh one for the new session, so an
-      // external observer's PID-liveness check sees PID -> session as
-      // a 1:1 mapping, not 1:N.
-      if (oldSessionDir !== undefined) {
-        clearRuntimeStatus(oldSessionDir);
-      }
-      try {
-        const newSessionDir = config.storage.getSessionTempDir();
-        await writeRuntimeStatus(newSessionDir, {
-          sessionId: newSessionId,
-          workDir: config.getTargetDir(),
-        });
-      } catch {
-        // Best-effort; failing here must never block /clear.
-      }
     }
 
     if (geminiClient) {

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -10,6 +10,8 @@ import {
   SessionStartSource,
   flushTelemetry,
   resetBrowserSession,
+  clearRuntimeStatus,
+  writeRuntimeStatus,
 } from '@google/gemini-cli-core';
 import { CommandKind, type SlashCommand } from './types.js';
 import { MessageType } from '../types.js';
@@ -40,7 +42,35 @@ export const clearCommand: SlashCommand = {
     let newSessionId: string | undefined;
     if (config) {
       newSessionId = randomUUID();
+
+      // Capture the OLD session's runtime.json path before switching the
+      // session id, so we can clear the stale claim on this PID. After
+      // resetNewSessionState the storage points to the NEW session dir.
+      let oldSessionDir: string | undefined;
+      try {
+        oldSessionDir = config.storage.getSessionTempDir();
+      } catch {
+        // No prior session id resolved; nothing to clear.
+      }
+
       config.resetNewSessionState(newSessionId);
+
+      // Drop the previous session's runtime.json (this PID no longer
+      // serves it) and write a fresh one for the new session, so an
+      // external observer's PID-liveness check sees PID -> session as
+      // a 1:1 mapping, not 1:N.
+      if (oldSessionDir !== undefined) {
+        clearRuntimeStatus(oldSessionDir);
+      }
+      try {
+        const newSessionDir = config.storage.getSessionTempDir();
+        await writeRuntimeStatus(newSessionDir, {
+          sessionId: newSessionId,
+          workDir: config.getTargetDir(),
+        });
+      } catch {
+        // Best-effort; failing here must never block /clear.
+      }
     }
 
     if (geminiClient) {

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -12,8 +12,6 @@ import {
   convertSessionToClientHistory,
   uiTelemetryService,
   loadConversationRecord,
-  clearRuntimeStatus,
-  writeRuntimeStatus,
   type Config,
   type ResumedSessionData,
 } from '@google/gemini-cli-core';
@@ -70,38 +68,11 @@ export const useSessionBrowser = (
           }
 
           // Use the old session's ID to continue it.
+          // Config.setSessionId centrally handles the runtime.json
+          // sidecar swap — gated on the bootstrap-set ownership flag —
+          // so this caller does not need to touch it directly.
           const existingSessionId = conversation.sessionId;
-
-          // Capture the OLD (currently-live) session's runtime.json path
-          // before we switch the storage's session id. This PID is about
-          // to stop serving the live session and start serving the
-          // resumed one, so the previous claim must be dropped.
-          let oldSessionDir: string | undefined;
-          try {
-            oldSessionDir = config.storage.getSessionTempDir();
-          } catch {
-            // No prior session id resolved; nothing to clear.
-          }
-
           config.setSessionId(existingSessionId);
-
-          // Drop the previous session's runtime.json and write a fresh
-          // one for the resumed session. The resumed session may have a
-          // stale runtime.json from a previous (now-dead) PID; the
-          // atomic write supersedes it.
-          if (oldSessionDir !== undefined) {
-            clearRuntimeStatus(oldSessionDir);
-          }
-          try {
-            const newSessionDir = config.storage.getSessionTempDir();
-            await writeRuntimeStatus(newSessionDir, {
-              sessionId: existingSessionId,
-              workDir: config.getTargetDir(),
-            });
-          } catch {
-            // Best-effort; never block resume on observability I/O.
-          }
-
           uiTelemetryService.hydrate(conversation);
 
           const resumedSessionData = {

--- a/packages/cli/src/ui/hooks/useSessionBrowser.ts
+++ b/packages/cli/src/ui/hooks/useSessionBrowser.ts
@@ -12,6 +12,8 @@ import {
   convertSessionToClientHistory,
   uiTelemetryService,
   loadConversationRecord,
+  clearRuntimeStatus,
+  writeRuntimeStatus,
   type Config,
   type ResumedSessionData,
 } from '@google/gemini-cli-core';
@@ -69,7 +71,37 @@ export const useSessionBrowser = (
 
           // Use the old session's ID to continue it.
           const existingSessionId = conversation.sessionId;
+
+          // Capture the OLD (currently-live) session's runtime.json path
+          // before we switch the storage's session id. This PID is about
+          // to stop serving the live session and start serving the
+          // resumed one, so the previous claim must be dropped.
+          let oldSessionDir: string | undefined;
+          try {
+            oldSessionDir = config.storage.getSessionTempDir();
+          } catch {
+            // No prior session id resolved; nothing to clear.
+          }
+
           config.setSessionId(existingSessionId);
+
+          // Drop the previous session's runtime.json and write a fresh
+          // one for the resumed session. The resumed session may have a
+          // stale runtime.json from a previous (now-dead) PID; the
+          // atomic write supersedes it.
+          if (oldSessionDir !== undefined) {
+            clearRuntimeStatus(oldSessionDir);
+          }
+          try {
+            const newSessionDir = config.storage.getSessionTempDir();
+            await writeRuntimeStatus(newSessionDir, {
+              sessionId: existingSessionId,
+              workDir: config.getTargetDir(),
+            });
+          } catch {
+            // Best-effort; never block resume on observability I/O.
+          }
+
           uiTelemetryService.hydrate(conversation);
 
           const resumedSessionData = {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1965,6 +1965,70 @@ describe('Server Config (config.ts)', () => {
     expect(config.getSessionId()).toBe('session-two');
     expect(config.getApprovedPlanPath()).toBeUndefined();
   });
+
+  it('refreshes runtime.json on same-PID session swap once the owner flag is set', async () => {
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const realPath =
+      await vi.importActual<typeof import('node:path')>('node:path');
+
+    const config = new Config({
+      ...baseParams,
+      sessionId: 'session-one',
+    });
+    await config.initialize();
+
+    // Use the same dir the production code would use, so the swap-time
+    // capture/clear/write all see the same paths.
+    const sessionOneDir = config.storage.getSessionTempDir();
+    realFs.mkdirSync(sessionOneDir, { recursive: true });
+    const sessionOneRuntime = realPath.join(sessionOneDir, 'runtime.json');
+    realFs.writeFileSync(sessionOneRuntime, '{}', 'utf8');
+
+    try {
+      // Before the flag is set, setSessionId leaves runtime.json alone.
+      // (Pre-bootstrap path: a non-interactive `gemini --prompt` that
+      // happens to share the outgoing session id must not trample it.)
+      config.setSessionId('session-pre');
+      expect(realFs.existsSync(sessionOneRuntime)).toBe(true);
+
+      // Restore for the actual swap test.
+      config.setSessionId('session-one');
+      realFs.writeFileSync(sessionOneRuntime, '{}', 'utf8');
+
+      // Simulate the bootstrap that flips the ownership flag.
+      config.markRuntimeStatusEnabled();
+
+      // Same-PID swap: outgoing sidecar must be cleared, incoming written.
+      config.setSessionId('session-two');
+      const sessionTwoDir = config.storage.getSessionTempDir();
+      const sessionTwoRuntime = realPath.join(sessionTwoDir, 'runtime.json');
+
+      // The new write is fire-and-forget; poll until both effects settle.
+      await vi.waitFor(() => {
+        expect(realFs.existsSync(sessionOneRuntime)).toBe(false);
+        expect(realFs.existsSync(sessionTwoRuntime)).toBe(true);
+      });
+
+      // Idempotent: setSessionId with the SAME id is a no-op for the
+      // sidecar (no clear, no rewrite over itself).
+      const beforeIdempotent = realFs.readFileSync(sessionTwoRuntime, 'utf8');
+      config.setSessionId('session-two');
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(realFs.existsSync(sessionTwoRuntime)).toBe(true);
+      expect(realFs.readFileSync(sessionTwoRuntime, 'utf8')).toBe(
+        beforeIdempotent,
+      );
+    } finally {
+      // Clean up the per-session dirs we created.
+      const projectTempDir = config.storage.getProjectTempDir();
+      for (const sid of ['session-one', 'session-pre', 'session-two']) {
+        realFs.rmSync(realPath.join(projectTempDir, sid), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
+  });
 });
 
 describe('GemmaModelRouterSettings', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -142,6 +142,10 @@ import type { AnyToolInvocation, AnyDeclarativeTool } from '../tools/tools.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import { getWorkspaceContextOverride } from './scoped-config.js';
 import { Storage } from './storage.js';
+import {
+  clearRuntimeStatus,
+  writeRuntimeStatus,
+} from '../utils/runtimeStatus.js';
 import type { ShellExecutionConfig } from '../services/shellExecutionService.js';
 import { FileExclusions } from '../utils/ignorePatterns.js';
 import { MessageBus } from '../confirmation-bus/message-bus.js';
@@ -758,6 +762,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly acknowledgedAgentsService: AcknowledgedAgentsService;
   private skillManager!: SkillManager;
   private _sessionId: string;
+  private runtimeStatusEnabled = false;
   private readonly clientName: string | undefined;
   private clientVersion: string;
   private fileSystemService: FileSystemService;
@@ -1799,9 +1804,24 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   setSessionId(sessionId: string): void {
+    const previousSessionId = this._sessionId;
     const previousPlansDir = this.storage.isInitialized()
       ? this.storage.getPlansDir()
       : undefined;
+
+    // Capture the OUTGOING runtime.json path before storage updates its
+    // session id; the swap-time refresh below uses it to drop the stale
+    // claim on this PID. Skipped when the ownership flag is unset (no
+    // sidecar exists yet) or when the new session id matches the old
+    // (no swap, nothing to clear).
+    let previousSessionDir: string | undefined;
+    if (this.runtimeStatusEnabled && previousSessionId !== sessionId) {
+      try {
+        previousSessionDir = this.storage.getSessionTempDir();
+      } catch {
+        // Storage not yet resolvable; nothing to clear.
+      }
+    }
 
     this._sessionId = sessionId;
     this.storage.setSessionId(sessionId);
@@ -1810,6 +1830,54 @@ export class Config implements McpContext, AgentLoopContext {
     if (previousPlansDir) {
       this.refreshSessionScopedPlansDirectory(previousPlansDir);
     }
+
+    // After the interactive UI bootstrap has flipped the ownership flag,
+    // every in-process session swap (`/clear`, session browser resume,
+    // etc.) refreshes the runtime.json sidecar so an external observer's
+    // PID-liveness scan sees this PID mapped 1:1 to the live session.
+    // Before the flag is flipped (initial Config setup, or non-
+    // interactive entry points that never reach the bootstrap), the
+    // swap leaves sibling sidecars alone — a short-lived non-
+    // interactive process must never trample a concurrent shell's
+    // sidecar that happens to share the outgoing session id.
+    if (this.runtimeStatusEnabled && previousSessionId !== sessionId) {
+      this.refreshRuntimeStatusOnSwap(previousSessionDir);
+    }
+  }
+
+  private refreshRuntimeStatusOnSwap(
+    previousSessionDir: string | undefined,
+  ): void {
+    if (previousSessionDir !== undefined) {
+      clearRuntimeStatus(previousSessionDir);
+    }
+    let nextSessionDir: string;
+    try {
+      nextSessionDir = this.storage.getSessionTempDir();
+    } catch {
+      return;
+    }
+    // Fire-and-forget: the swap caller is synchronous and must not
+    // block on observability I/O. Failures are swallowed.
+    void writeRuntimeStatus(nextSessionDir, {
+      sessionId: this._sessionId,
+      workDir: this.targetDir,
+    }).catch(() => {
+      // Best-effort.
+    });
+  }
+
+  /**
+   * Marks this Config as the owner of a runtime.json sidecar for the
+   * current PID. Call once after the initial sidecar write succeeds
+   * (typically from the interactive UI bootstrap). Until this is called,
+   * `setSessionId()` leaves runtime.json alone, so a short-lived non-
+   * interactive process (e.g. `gemini --prompt`) cannot trample a
+   * concurrent shell's sidecar that happens to share the outgoing
+   * session id.
+   */
+  markRuntimeStatusEnabled(): void {
+    this.runtimeStatusEnabled = true;
   }
 
   resetNewSessionState(sessionId: string): void {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -18,6 +18,7 @@ import {
 } from '../utils/paths.js';
 import { ProjectRegistry } from './projectRegistry.js';
 import { StorageMigration } from './storageMigration.js';
+import { RUNTIME_STATUS_FILENAME } from '../utils/runtimeStatus.js';
 
 export const OAUTH_FILE = 'oauth_creds.json';
 export const TRUSTED_FOLDERS_FILENAME = 'trustedFolders.json';
@@ -361,6 +362,37 @@ export class Storage {
       return path.join(this.getProjectTempDir(), this.sessionId, 'tasks');
     }
     return path.join(this.getProjectTempDir(), 'tasks');
+  }
+
+  /**
+   * Returns the per-session scratch directory under the project's temp
+   * area: `<project-temp>/<sessionId>/`.
+   *
+   * This is the natural home for per-session sidecar files (e.g.
+   * `runtime.json`) and parallels the existing per-session subdirectories
+   * for plans, tracker, and tasks.
+   *
+   * Throws if the storage was constructed (or had `setSessionId` called)
+   * without a session id.
+   */
+  getSessionTempDir(): string {
+    if (!this.sessionId) {
+      throw new Error(
+        'getSessionTempDir requires a session id; call setSessionId first.',
+      );
+    }
+    return path.join(this.getProjectTempDir(), this.sessionId);
+  }
+
+  /**
+   * Returns the absolute path to the runtime status sidecar file for the
+   * current session: `<project-temp>/<sessionId>/runtime.json`.
+   *
+   * External tools can scan `<global-temp>/<project>/<session>/runtime.json`
+   * to discover live Gemini CLI sessions and verify their PID liveness.
+   */
+  getSessionRuntimeStatusPath(): string {
+    return path.join(this.getSessionTempDir(), RUNTIME_STATUS_FILENAME);
   }
 
   async listProjectChatFiles(): Promise<

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,6 +121,7 @@ export * from './utils/events.js';
 export * from './utils/extensionLoader.js';
 export * from './utils/package.js';
 export * from './utils/version.js';
+export * from './utils/runtimeStatus.js';
 export * from './utils/checkpointUtils.js';
 export * from './utils/secure-browser-launcher.js';
 export * from './utils/apiConversionUtils.js';

--- a/packages/core/src/utils/runtimeStatus.test.ts
+++ b/packages/core/src/utils/runtimeStatus.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import {
   RUNTIME_STATUS_FILENAME,
   RUNTIME_STATUS_SCHEMA_VERSION,
+  clearRuntimeStatus,
   readRuntimeStatus,
   writeRuntimeStatus,
 } from './runtimeStatus.js';
@@ -300,5 +301,35 @@ describe('runtimeStatus', () => {
       fs.readFileSync(path.join(tmp, RUNTIME_STATUS_FILENAME), 'utf8'),
     ) as Record<string, unknown>;
     expect(data['gemini_cli_version']).toBe('0.0.0-test');
+  });
+
+  describe('clearRuntimeStatus', () => {
+    it('removes an existing runtime.json', async () => {
+      await writeRuntimeStatus(tmp, {
+        sessionId: 'abc',
+        workDir: '/w',
+        pid: 1,
+      });
+      expect(fs.existsSync(path.join(tmp, RUNTIME_STATUS_FILENAME))).toBe(true);
+      clearRuntimeStatus(tmp);
+      expect(fs.existsSync(path.join(tmp, RUNTIME_STATUS_FILENAME))).toBe(
+        false,
+      );
+    });
+
+    it('is idempotent when the file is already absent', () => {
+      // No file present yet.
+      expect(() => clearRuntimeStatus(tmp)).not.toThrow();
+      expect(fs.existsSync(path.join(tmp, RUNTIME_STATUS_FILENAME))).toBe(
+        false,
+      );
+      // Calling again on the same already-empty dir must also not throw.
+      expect(() => clearRuntimeStatus(tmp)).not.toThrow();
+    });
+
+    it('does not throw when the session dir does not exist', () => {
+      const ghost = path.join(tmp, 'does-not-exist');
+      expect(() => clearRuntimeStatus(ghost)).not.toThrow();
+    });
   });
 });

--- a/packages/core/src/utils/runtimeStatus.test.ts
+++ b/packages/core/src/utils/runtimeStatus.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  RUNTIME_STATUS_FILENAME,
+  RUNTIME_STATUS_SCHEMA_VERSION,
+  readRuntimeStatus,
+  writeRuntimeStatus,
+} from './runtimeStatus.js';
+import { resetVersionCache } from './version.js';
+
+describe('runtimeStatus', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'gemini-runtime-status-'),
+    );
+    resetVersionCache();
+    vi.stubEnv('CLI_VERSION', '0.0.0-test');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    resetVersionCache();
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('writes expected fields to runtime.json', async () => {
+    const target = await writeRuntimeStatus(tmp, {
+      sessionId: '11111111-2222-3333-4444-555555555555',
+      workDir: '/work/dir',
+      pid: 4242,
+    });
+
+    expect(target).toBe(path.join(tmp, RUNTIME_STATUS_FILENAME));
+    expect(fs.existsSync(target)).toBe(true);
+
+    const data = JSON.parse(fs.readFileSync(target, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(data['pid']).toBe(4242);
+    expect(data['session_id']).toBe('11111111-2222-3333-4444-555555555555');
+    expect(data['work_dir']).toBe('/work/dir');
+    expect(data['schema_version']).toBe(RUNTIME_STATUS_SCHEMA_VERSION);
+    expect(data['hostname']).toBeTypeOf('string');
+    expect(data['hostname']).not.toBe('');
+    expect(data['started_at']).toBeTypeOf('number');
+    expect('gemini_cli_version' in data).toBe(true);
+  });
+
+  it('leaves no .tmp leftover on a successful write', async () => {
+    await writeRuntimeStatus(tmp, {
+      sessionId: 'abc',
+      workDir: '/w',
+      pid: 1,
+    });
+    const leftovers = fs.readdirSync(tmp).filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('creates the session dir if it does not exist', async () => {
+    const nested = path.join(tmp, 'does', 'not', 'exist', 'yet');
+    await writeRuntimeStatus(nested, {
+      sessionId: 'abc',
+      workDir: '/w',
+      pid: 1,
+    });
+    expect(fs.existsSync(path.join(nested, RUNTIME_STATUS_FILENAME))).toBe(
+      true,
+    );
+  });
+
+  it('round-trips fields via read', async () => {
+    await writeRuntimeStatus(tmp, {
+      sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      workDir: '/some/where',
+      pid: 99,
+    });
+    const status = readRuntimeStatus(tmp);
+    expect(status).not.toBeNull();
+    expect(status!.pid).toBe(99);
+    expect(status!.sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(status!.workDir).toBe('/some/where');
+    expect(status!.schemaVersion).toBe(RUNTIME_STATUS_SCHEMA_VERSION);
+  });
+
+  it('returns null when the file is missing', () => {
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('returns null on syntactically invalid JSON', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      'not-json',
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('returns null when the schema version is unknown', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION + 99,
+        pid: 1,
+        session_id: 'x',
+        work_dir: '/w',
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('preserves non-ASCII (Chinese) chars round-trip and on disk', async () => {
+    await writeRuntimeStatus(tmp, {
+      sessionId: '\u4e2d\u6587-uuid-aaa',
+      workDir: 'D:/\u9879\u76ee/\u6211\u7684-app',
+      pid: 7777,
+    });
+    const status = readRuntimeStatus(tmp);
+    expect(status).not.toBeNull();
+    expect(status!.sessionId).toBe('\u4e2d\u6587-uuid-aaa');
+    expect(status!.workDir).toBe('D:/\u9879\u76ee/\u6211\u7684-app');
+    const rawBytes = fs.readFileSync(path.join(tmp, RUNTIME_STATUS_FILENAME));
+    const literalUtf8 = Buffer.from('\u4e2d\u6587', 'utf8');
+    expect(rawBytes.includes(literalUtf8)).toBe(true);
+  });
+
+  it('returns null on invalid UTF-8 bytes', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      Buffer.from([0xff, 0xfe, 0x20, 0x67, 0x61, 0x72, 0x62]),
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects null session_id (no coercion to "null")', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+        pid: 1,
+        session_id: null,
+        work_dir: '/w',
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects a string-typed pid', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+        pid: '1234',
+        session_id: 'abc',
+        work_dir: '/w',
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects a non-integer pid (e.g. 1.5)', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+        pid: 1.5,
+        session_id: 'abc',
+        work_dir: '/w',
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects array work_dir', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+        pid: 1,
+        session_id: 'abc',
+        work_dir: ['/', 'w'],
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects bool pid (true is not an integer in our contract)', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify({
+        schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+        pid: true,
+        session_id: 'abc',
+        work_dir: '/w',
+        hostname: 'h',
+        started_at: 0.0,
+        gemini_cli_version: null,
+      }),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects a top-level array payload', () => {
+    fs.writeFileSync(
+      path.join(tmp, RUNTIME_STATUS_FILENAME),
+      JSON.stringify(['not', 'an', 'object']),
+      'utf8',
+    );
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('rejects a top-level null payload', () => {
+    fs.writeFileSync(path.join(tmp, RUNTIME_STATUS_FILENAME), 'null', 'utf8');
+    expect(readRuntimeStatus(tmp)).toBeNull();
+  });
+
+  it('atomically overwrites the previous PID on resume', async () => {
+    await writeRuntimeStatus(tmp, {
+      sessionId: 'abc',
+      workDir: '/w',
+      pid: 1000,
+    });
+    const first = readRuntimeStatus(tmp);
+    expect(first).not.toBeNull();
+    expect(first!.pid).toBe(1000);
+
+    await writeRuntimeStatus(tmp, {
+      sessionId: 'abc',
+      workDir: '/w',
+      pid: 2000,
+    });
+    const second = readRuntimeStatus(tmp);
+    expect(second).not.toBeNull();
+    expect(second!.pid).toBe(2000);
+  });
+
+  it('sets the gemini_cli_version field from CLI_VERSION env', async () => {
+    await writeRuntimeStatus(tmp, {
+      sessionId: 'abc',
+      workDir: '/w',
+      pid: 1,
+    });
+    const data = JSON.parse(
+      fs.readFileSync(path.join(tmp, RUNTIME_STATUS_FILENAME), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(data['gemini_cli_version']).toBe('0.0.0-test');
+  });
+});

--- a/packages/core/src/utils/runtimeStatus.test.ts
+++ b/packages/core/src/utils/runtimeStatus.test.ts
@@ -245,6 +245,31 @@ describe('runtimeStatus', () => {
     expect(readRuntimeStatus(tmp)).toBeNull();
   });
 
+  it('cleans up the .tmp file when the underlying rename raises', async () => {
+    // Pre-place a non-empty directory at the target path. The atomic
+    // rename of `runtime.json.tmp.<uuid>` over an existing non-empty
+    // directory fails on every supported platform (EISDIR / ENOTEMPTY /
+    // EACCES), exercising the catch-block tmp-cleanup path. A failed
+    // write must never leave a `.tmp.*` leftover on disk.
+    const targetPath = path.join(tmp, RUNTIME_STATUS_FILENAME);
+    fs.mkdirSync(targetPath);
+    fs.writeFileSync(path.join(targetPath, 'placeholder'), 'block');
+
+    await expect(
+      writeRuntimeStatus(tmp, {
+        sessionId: 'abc',
+        workDir: '/w',
+        pid: 1,
+      }),
+    ).rejects.toThrow();
+
+    const leftovers = fs.readdirSync(tmp).filter((f) => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+    // The pre-existing directory must still be there — we never partially
+    // succeeded.
+    expect(fs.statSync(targetPath).isDirectory()).toBe(true);
+  });
+
   it('atomically overwrites the previous PID on resume', async () => {
     await writeRuntimeStatus(tmp, {
       sessionId: 'abc',

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -123,7 +123,11 @@ export async function writeRuntimeStatus(
 
   let fd: number | undefined;
   try {
-    fd = fs.openSync(tempPath, 'w', 0o600);
+    // 'wx' = O_CREAT | O_EXCL — fail if `tempPath` already exists. The
+    // random suffix already makes collision astronomically unlikely; the
+    // exclusive open adds defense-in-depth against a pre-placed file or
+    // symlink at the temp path (which 'w' would silently follow).
+    fd = fs.openSync(tempPath, 'wx', 0o600);
     fs.writeSync(fd, content, 0, 'utf8');
     fs.fsyncSync(fd);
     fs.closeSync(fd);

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -49,7 +49,7 @@ export interface RuntimeStatus {
   sessionId: string;
   workDir: string;
   hostname: string;
-  /** Seconds since Unix epoch (float, matches the kimi-cli on-disk format). */
+  /** Seconds since Unix epoch (float). */
   startedAt: number;
   geminiCliVersion: string | null;
 }
@@ -113,36 +113,36 @@ export async function writeRuntimeStatus(
     gemini_cli_version: await safeGeminiVersion(),
   };
 
-  fs.mkdirSync(sessionDir, { recursive: true });
+  await fs.promises.mkdir(sessionDir, { recursive: true });
 
   const target = runtimeStatusPath(sessionDir);
   const tempPath = `${target}.tmp.${crypto.randomUUID()}`;
-  // `ensureAscii=false` equivalent: JSON.stringify already keeps non-ASCII
-  // characters as their literal UTF-8 code points when written via utf-8.
+  // `JSON.stringify` already emits non-ASCII characters as their literal
+  // UTF-8 code points when the file is written via utf-8.
   const content = JSON.stringify(status, null, 2);
 
-  let fd: number | undefined;
+  let handle: fs.promises.FileHandle | undefined;
   try {
     // 'wx' = O_CREAT | O_EXCL — fail if `tempPath` already exists. The
     // random suffix already makes collision astronomically unlikely; the
     // exclusive open adds defense-in-depth against a pre-placed file or
     // symlink at the temp path (which 'w' would silently follow).
-    fd = fs.openSync(tempPath, 'wx', 0o600);
-    fs.writeSync(fd, content, 0, 'utf8');
-    fs.fsyncSync(fd);
-    fs.closeSync(fd);
-    fd = undefined;
-    fs.renameSync(tempPath, target);
+    handle = await fs.promises.open(tempPath, 'wx', 0o600);
+    await handle.write(content, 0, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.promises.rename(tempPath, target);
   } catch (err) {
-    if (fd !== undefined) {
+    if (handle !== undefined) {
       try {
-        fs.closeSync(fd);
+        await handle.close();
       } catch {
         // Ignore close errors during cleanup.
       }
     }
     try {
-      fs.unlinkSync(tempPath);
+      await fs.promises.unlink(tempPath);
     } catch {
       // Ignore unlink errors; tmp file may not have been created.
     }

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -153,6 +153,41 @@ export async function writeRuntimeStatus(
 }
 
 /**
+ * Remove `<sessionDir>/runtime.json` if present.
+ *
+ * Called only when the same PID switches to serving a *different* session
+ * id mid-flight (gemini-cli's `/clear` and session-browser-resume flows).
+ * Without this, the previous session's `runtime.json` would still claim
+ * this PID, and an external observer running a PID-liveness check would
+ * see the same PID mapped to two different sessions and treat both as
+ * live. All other exit paths (clean quit, crash) leave the file alone —
+ * the recorded PID is gone in both cases, so a liveness check by the
+ * external observer is sufficient and explicit cleanup adds nothing.
+ *
+ * Safe to call multiple times and on directories that no longer exist;
+ * I/O errors are swallowed so cleanup cannot disrupt the surrounding
+ * control flow.
+ */
+export function clearRuntimeStatus(sessionDir: string): void {
+  const target = runtimeStatusPath(sessionDir);
+  try {
+    fs.unlinkSync(target);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      ((err as NodeJS.ErrnoException).code === 'ENOENT' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        (err as NodeJS.ErrnoException).code === 'ENOTDIR')
+    ) {
+      return;
+    }
+    // Any other I/O error is best-effort: never disrupt control flow.
+  }
+}
+
+/**
  * Read the runtime status file from a session directory, if present.
  *
  * Returns `null` if the file is missing, malformed, or written by a

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Runtime status sidecar for an active interactive Gemini CLI session.
+ *
+ * Writes a small JSON file at `<sessionDir>/runtime.json` while a session
+ * is alive so that **external** tools (terminal multiplexers, tab
+ * managers, IDE integrations, observability daemons) can answer:
+ *
+ *     "Which Gemini CLI session is the running PID X serving?"
+ *
+ * Gemini CLI does not embed the session id in `argv` for fresh
+ * (non-resumed) sessions, so a side-channel file recording the explicit
+ * `(pid, sessionId, workDir, ...)` tuple is the most reliable
+ * cross-platform signal.
+ *
+ * Lifecycle:
+ *
+ * - Written on session start (clean launch or `--resume`); the resume
+ *   case atomically overwrites whatever the previous PID wrote.
+ * - **Not** deleted on clean exit or crash. From an external observer's
+ *   standpoint the recorded PID no longer exists in either case, so a
+ *   liveness check is sufficient and an explicit cleanup adds nothing.
+ * - Removed naturally when the surrounding session directory itself is
+ *   deleted, which gives a natural bound on accumulation.
+ *
+ * The file is written atomically via tmp-file + `fsync` + rename and
+ * contains a small, stable schema. External consumers should treat
+ * unknown fields as forward-compatible additions.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getVersion } from './version.js';
+
+export const RUNTIME_STATUS_FILENAME = 'runtime.json';
+export const RUNTIME_STATUS_SCHEMA_VERSION = 1;
+
+/** Snapshot of a live Gemini CLI session process for external observers. */
+export interface RuntimeStatus {
+  schemaVersion: number;
+  pid: number;
+  sessionId: string;
+  workDir: string;
+  hostname: string;
+  /** Seconds since Unix epoch (float, matches the kimi-cli on-disk format). */
+  startedAt: number;
+  geminiCliVersion: string | null;
+}
+
+/** On-disk JSON layout (snake_case for cross-tool compatibility). */
+interface RuntimeStatusJson {
+  schema_version: number;
+  pid: number;
+  session_id: string;
+  work_dir: string;
+  hostname: string;
+  started_at: number;
+  gemini_cli_version: string | null;
+}
+
+function runtimeStatusPath(sessionDir: string): string {
+  return path.join(sessionDir, RUNTIME_STATUS_FILENAME);
+}
+
+async function safeGeminiVersion(): Promise<string | null> {
+  try {
+    const v = await getVersion();
+    return v && v !== 'unknown' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface WriteRuntimeStatusOptions {
+  sessionId: string;
+  workDir: string;
+  /** Defaults to `process.pid`; overridable for tests. */
+  pid?: number;
+}
+
+/**
+ * Atomically write the runtime status file for this session.
+ *
+ * Writes `<sessionDir>/runtime.json` via tmp-file + `fsync` + `rename` so
+ * an external observer never sees a partially written file: it sees
+ * either the previous contents or the fully committed new contents.
+ *
+ * Creates `sessionDir` (recursive) if it does not exist. Exceptions from
+ * the underlying I/O propagate to the caller; this function does not log
+ * or swallow them. Callers that want best-effort semantics should wrap
+ * the call in `try/catch`. On failure no leftover `.tmp` file is kept.
+ *
+ * Returns the path of the file that was written.
+ */
+export async function writeRuntimeStatus(
+  sessionDir: string,
+  options: WriteRuntimeStatusOptions,
+): Promise<string> {
+  const status: RuntimeStatusJson = {
+    schema_version: RUNTIME_STATUS_SCHEMA_VERSION,
+    pid: options.pid ?? process.pid,
+    session_id: options.sessionId,
+    work_dir: options.workDir,
+    hostname: os.hostname(),
+    started_at: Date.now() / 1000,
+    gemini_cli_version: await safeGeminiVersion(),
+  };
+
+  fs.mkdirSync(sessionDir, { recursive: true });
+
+  const target = runtimeStatusPath(sessionDir);
+  const tempPath = `${target}.tmp.${crypto.randomUUID()}`;
+  // `ensureAscii=false` equivalent: JSON.stringify already keeps non-ASCII
+  // characters as their literal UTF-8 code points when written via utf-8.
+  const content = JSON.stringify(status, null, 2);
+
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(tempPath, 'w', 0o600);
+    fs.writeSync(fd, content, 0, 'utf8');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(tempPath, target);
+  } catch (err) {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore close errors during cleanup.
+      }
+    }
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // Ignore unlink errors; tmp file may not have been created.
+    }
+    throw err;
+  }
+
+  return target;
+}
+
+/**
+ * Read the runtime status file from a session directory, if present.
+ *
+ * Returns `null` if the file is missing, malformed, or written by a
+ * schema version this code does not understand. "Malformed" includes
+ * truncated UTF-8, syntactically invalid JSON, a non-object payload,
+ * and any field whose JSON type does not match the interface — the
+ * function never coerces `null` / array / object into a string just to
+ * satisfy the type.
+ *
+ * Note: a returned record only proves that *some* Gemini CLI process
+ * once claimed this session. The PID may already be dead (clean exit
+ * or crash). Consumers must verify liveness themselves before treating
+ * the record as a currently-running session.
+ */
+export function readRuntimeStatus(sessionDir: string): RuntimeStatus | null {
+  const target = runtimeStatusPath(sessionDir);
+
+  let buffer: Buffer;
+  try {
+    buffer = fs.readFileSync(target);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return null;
+    }
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const obj = parsed as Record<string, unknown>;
+
+  const schemaVersion = obj['schema_version'];
+  if (
+    typeof schemaVersion !== 'number' ||
+    !Number.isInteger(schemaVersion) ||
+    schemaVersion !== RUNTIME_STATUS_SCHEMA_VERSION
+  ) {
+    return null;
+  }
+
+  const pid = obj['pid'];
+  if (typeof pid !== 'number' || !Number.isInteger(pid)) {
+    return null;
+  }
+
+  const sessionId = obj['session_id'];
+  if (typeof sessionId !== 'string') {
+    return null;
+  }
+
+  const workDir = obj['work_dir'];
+  if (typeof workDir !== 'string') {
+    return null;
+  }
+
+  const hostname = obj['hostname'];
+  if (typeof hostname !== 'string') {
+    return null;
+  }
+
+  const startedAt = obj['started_at'];
+  if (typeof startedAt !== 'number' || !Number.isFinite(startedAt)) {
+    return null;
+  }
+
+  const geminiCliVersion = obj['gemini_cli_version'];
+  if (geminiCliVersion !== null && typeof geminiCliVersion !== 'string') {
+    return null;
+  }
+
+  return {
+    schemaVersion,
+    pid,
+    sessionId,
+    workDir,
+    hostname,
+    startedAt,
+    geminiCliVersion,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a small JSON runtime-identity sidecar at `<session-temp>/runtime.json` while a Gemini CLI session is alive, so external tools can answer:

> *"Is there a gemini-cli process currently running against session X?"*

The file records `(pid, sessionId, workDir, hostname, startedAt, geminiCliVersion)`. Consumers parse the file and verify the recorded PID is alive (OS-specific). It is the most reliable cross-platform signal — argv does not embed the session id for fresh (non-`--resume`) launches, and OS process titles get truncated.

Use cases:
- Terminal multiplexers / tab managers tagging panes with the live session id.
- IDE integrations correlating an editor instance with a running CLI session.
- Observability daemons listing live sessions.

## Prior art

Peer interactive agent CLIs already expose a per-session on-disk surface that external tooling has come to rely on, so the ecosystem expects it:

- **GitHub Copilot CLI** — keeps per-session state under `~/.copilot/session-state/<sessionId>/`, and the running shell session is discoverable per session id from that layout.
- **Claude Code CLI** — writes per-project session transcripts to `~/.claude/projects/<encodedCwd>/<sessionId>.jsonl`, with the running process discoverable per project.
- **OpenAI Codex CLI** — emits a rollout file (e.g. `~/.codex/sessions/.../rollout-*.jsonl`) whose header records the session id for the active process.

This PR gives gemini-cli an equivalent lightweight surface — a single JSON file per session — without adopting any one of those formats verbatim. Snake_case keys keep the file format language-agnostic and easy to consume from external tooling written in any language.

## Sidecar contract

Path: `<global-gemini-temp>/<projectShortId>/<sessionId>/runtime.json` (parallels the existing per-session subdirs `plans/`, `tracker/`, `tasks/`).

JSON shape (snake_case for cross-tool consumption):

```json
{
  "schema_version": 1,
  "pid": 12345,
  "session_id": "uuid",
  "work_dir": "/path/to/workspace",
  "hostname": "machine",
  "started_at": 1714329600.123,
  "gemini_cli_version": "0.40.0"
}
```

External consumers:

1. Glob `~/.gemini/tmp/*/*/runtime.json`.
2. Parse, take `pid`.
3. Verify the PID is alive — the record only proves *some* gemini-cli process once claimed this session, not that it is still running.

## Lifecycle

- Written on session start (clean launch and `--resume`). Resume case is an atomic overwrite via tmp + `fsync` + `rename`.
- **Not** cleared on quit or crash. From an observer's standpoint the recorded PID no longer exists in either case, so a liveness check is sufficient and explicit cleanup adds nothing.
- Refreshed on every same-PID session swap (`/clear`, session browser resume) — `Config.setSessionId` clears the outgoing sidecar and writes a fresh one for the incoming session, gated on a `runtimeStatusEnabled` ownership flag set by the interactive UI bootstrap so non-interactive paths can't trample a sibling shell's sidecar.
- Removed naturally when the surrounding session directory is deleted.
- Concurrent same-session resume → last-writer-wins (latest live owner).

## Hook point

After the `--list-extensions` / `--list-sessions` / `--delete-session` early-exit branches and before all three session-serving paths (interactive, ACP, non-interactive). Utility commands don't drop a false sidecar.

The write is best-effort, wrapped in `try/catch` with `debugLogger.debug`. A failure never blocks startup.

## Files touched

- **New** `packages/core/src/utils/runtimeStatus.ts` — `writeRuntimeStatus`, `readRuntimeStatus`, `clearRuntimeStatus`.
- **New** `packages/core/src/utils/runtimeStatus.test.ts` — 22 unit tests (vitest, `fs.mkdtemp`).
- `packages/core/src/config/storage.ts` — added `getSessionTempDir()` and `getSessionRuntimeStatusPath()`.
- `packages/core/src/config/config.ts` — added `runtimeStatusEnabled` ownership flag, `markRuntimeStatusEnabled()`, swap-time refresh inside `setSessionId`.
- `packages/core/src/index.ts` — exported the new module.
- `packages/cli/src/gemini.tsx` — wired the initial write and ownership-flag flip.

## Test coverage (all 22 passing)

- write writes expected fields and creates the session dir if missing
- atomic on success (no `.tmp` leftover)
- cleanup on rename failure leaves no leftover
- read round-trips on success
- `null` on missing / malformed JSON / unknown schema
- non-ASCII (Chinese) UTF-8 round-trips and is preserved literally on disk
- invalid UTF-8 bytes return `null` (strict `TextDecoder`)
- type guards reject `null` `session_id`, string `pid`, non-integer `pid`, array `work_dir`, bool `pid`, top-level array, top-level `null`
- atomic overwrite on resume
- `gemini_cli_version` populated from `CLI_VERSION`
- `clearRuntimeStatus` removes existing file, idempotent on missing file, no-op on missing dir

Plus a config integration test covering the same-PID swap behaviour: pre-flag no-op, post-flag clear+write, idempotent same-id call.

## Risk review

- **Compatibility**: per-session dir layout already used for `plans/`, `tracker/`, `tasks/`. Cleanup uses recursive `rm` so the extra file does not break deletion. `listProjectChatFiles` and `SessionSelector` both walk `chats/` and are unaffected. No circular-import risk (`runtimeStatus` only imports `version`).
- **Regression**: existing storage and config tests pass. The pre-existing failures in `gemini.test.tsx` reproduce on `main` and are unrelated.
- **Performance**: `writeRuntimeStatus` uses fully async `fs.promises.*` (no event-loop blocking). One `fsync` + `rename` per session start, on the startup hot path but only once and best-effort.
- **Security**: file is mode `0o600` (owner-rw, matches existing `trust.ts` and OAuth credential storage). Temp file uses `'wx'` (`O_CREAT | O_EXCL`) for defense-in-depth against pre-placed symlinks. Contents (`pid`, `sessionId`, `workDir`, `hostname`) are no more sensitive than what already lives in `~/.gemini/projects.json`. `sessionId` originates from `randomUUID()` and is sanitized in session-artifact paths.

## Verification

- `npm run typecheck -w @google/gemini-cli-core` ✅
- `npm run typecheck -w @google/gemini-cli` ✅
- `npx eslint` on touched files ✅
- `npm test -w @google/gemini-cli-core -- src/utils/runtimeStatus.test.ts` → 22/22 ✅
- `npm test -w @google/gemini-cli-core -- src/config/storage.test.ts` ✅
- `npm test -w @google/gemini-cli-core -- src/config/config.test.ts` ✅ (incl. new swap-behaviour test)
- `npm test -w @google/gemini-cli -- src/ui/commands/clearCommand.test.ts src/ui/hooks/useSessionBrowser.test.ts` ✅
- `npm run build -w @google/gemini-cli` ✅
