### PR TITLE
Update documentation workflows with workspace trust

### DIFF
--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -28,6 +28,8 @@ jobs:
       - name: 'Run Docs Audit with Gemini'
         id: 'run_gemini'
         uses: 'google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31'
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: true
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           prompt: |

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -70,6 +70,8 @@ jobs:
       - name: 'Generate Changelog with Gemini'
         if: "steps.validate_version.outputs.CONTINUE == 'true'"
         uses: 'google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31' # ratchet:google-github-actions/run-gemini-cli@v0
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: true
         with:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           prompt: |


### PR DESCRIPTION
## Summary

This PR addresses a recent CI failure affecting automated documentation tasks (`docs-audit.yml` and `release-notes.yml` for generating changelogs). The Gemini CLI workflows were failing with an untrusted directory error.

Fixes #26151

## Changes

*   **Workflow Updates:** Added the `GEMINI_CLI_TRUST_WORKSPACE: true` environment variable to the `google-github-actions/run-gemini-cli` action step in both `.github/workflows/docs-audit.yml` and `.github/workflows/release-notes.yml`. This explicitly bypasses the untrusted workspace block for headless environments, allowing the automated documentation and changelog generation to proceed normally.

## Validation

*   Verified that the `GEMINI_CLI_TRUST_WORKSPACE` convention matches the usage in existing successful workflows (like `ci.yml`).