### PR TITLE
Respect logPrompts flag for logging sensitive fields

### DIFF
--- a/packages/core/src/telemetry/conseca-logger.test.ts
+++ b/packages/core/src/telemetry/conseca-logger.test.ts
@@ -144,4 +144,106 @@ describe('conseca-logger', () => {
 
     expect(mockLogger.emit).not.toHaveBeenCalled();
   });
+
+  it('should omit user_prompt/trusted_content/policy from OTEL when logPrompts is disabled', () => {
+    const configNoPrompts = {
+      getTelemetryEnabled: vi.fn().mockReturnValue(true),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getTelemetryTracesEnabled: vi.fn().mockReturnValue(false),
+      isInteractive: vi.fn().mockReturnValue(true),
+      getExperiments: vi.fn().mockReturnValue({ experimentIds: [] }),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({ authType: 'oauth' }),
+    } as unknown as Config;
+
+    const event = new ConsecaPolicyGenerationEvent(
+      'sensitive prompt',
+      'sensitive content',
+      'sensitive policy',
+    );
+
+    logConsecaPolicyGeneration(configNoPrompts, event);
+
+    const attrs = mockLogger.emit.mock.calls[0][0].attributes as Record<
+      string,
+      unknown
+    >;
+    expect(attrs['user_prompt']).toBeUndefined();
+    expect(attrs['trusted_content']).toBeUndefined();
+    expect(attrs['policy']).toBeUndefined();
+    expect(attrs['event.name']).toBe(EVENT_CONSECA_POLICY_GENERATION);
+  });
+
+  it('should include user_prompt/trusted_content/policy in OTEL when logPrompts is enabled', () => {
+    const event = new ConsecaPolicyGenerationEvent(
+      'visible prompt',
+      'visible content',
+      'visible policy',
+    );
+
+    logConsecaPolicyGeneration(mockConfig, event);
+
+    const attrs = mockLogger.emit.mock.calls[0][0].attributes as Record<
+      string,
+      unknown
+    >;
+    expect(attrs['user_prompt']).toBe('visible prompt');
+    expect(attrs['trusted_content']).toBe('visible content');
+    expect(attrs['policy']).toBe('visible policy');
+  });
+
+  it('should omit sensitive fields from verdict OTEL when logPrompts is disabled', () => {
+    const configNoPrompts = {
+      getTelemetryEnabled: vi.fn().mockReturnValue(true),
+      getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getTelemetryLogPromptsEnabled: vi.fn().mockReturnValue(false),
+      getTelemetryTracesEnabled: vi.fn().mockReturnValue(false),
+      isInteractive: vi.fn().mockReturnValue(true),
+      getExperiments: vi.fn().mockReturnValue({ experimentIds: [] }),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({ authType: 'oauth' }),
+    } as unknown as Config;
+
+    const event = new ConsecaVerdictEvent(
+      'sensitive prompt',
+      'sensitive policy',
+      'sensitive tool call',
+      'allow',
+      'sensitive rationale',
+    );
+
+    logConsecaVerdict(configNoPrompts, event);
+
+    const attrs = mockLogger.emit.mock.calls[0][0].attributes as Record<
+      string,
+      unknown
+    >;
+    expect(attrs['user_prompt']).toBeUndefined();
+    expect(attrs['policy']).toBeUndefined();
+    expect(attrs['tool_call']).toBeUndefined();
+    expect(attrs['verdict_rationale']).toBeUndefined();
+    // verdict (the allow/deny result) is not sensitive and should be present
+    expect(attrs['verdict']).toBe('allow');
+  });
+
+  it('should include sensitive fields in verdict OTEL when logPrompts is enabled', () => {
+    const event = new ConsecaVerdictEvent(
+      'visible prompt',
+      'visible policy',
+      'visible tool call',
+      'deny',
+      'visible rationale',
+    );
+
+    logConsecaVerdict(mockConfig, event);
+
+    const attrs = mockLogger.emit.mock.calls[0][0].attributes as Record<
+      string,
+      unknown
+    >;
+    expect(attrs['user_prompt']).toBe('visible prompt');
+    expect(attrs['policy']).toBe('visible policy');
+    expect(attrs['tool_call']).toBe('visible tool call');
+    expect(attrs['verdict_rationale']).toBe('visible rationale');
+    expect(attrs['verdict']).toBe('deny');
+  });
 });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1919,6 +1919,99 @@ describe('loggers', () => {
     });
   });
 
+  describe('logToolCall — logPrompts flag', () => {
+    it('should omit function_args when logPrompts is disabled', () => {
+      const mockConfigNoPrompts = {
+        getSessionId: () => 'test-session-id',
+        getTargetDir: () => 'target-dir',
+        getUsageStatisticsEnabled: () => true,
+        getTelemetryEnabled: () => true,
+        getTelemetryLogPromptsEnabled: () => false,
+        getTelemetryTracesEnabled: () => false,
+        isInteractive: () => false,
+        getExperiments: () => undefined,
+        getExperimentsAsync: async () => undefined,
+        getContentGeneratorConfig: () => undefined,
+      } as unknown as Config;
+
+      const call: CompletedToolCall = {
+        status: CoreToolCallStatus.Success,
+        request: {
+          name: 'run_bash',
+          args: { command: 'echo sensitive' },
+          callId: 'call-1',
+          isClientInitiated: false,
+          prompt_id: 'prompt-noprompts',
+        },
+        response: {
+          callId: 'call-1',
+          responseParts: [],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
+        tool: undefined as unknown as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        durationMs: 50,
+      };
+      const event = new ToolCallEvent(call);
+      logToolCall(mockConfigNoPrompts, event);
+
+      const emitted = mockLogger.emit.mock.calls[0][0] as {
+        attributes: Record<string, unknown>;
+      };
+      expect(emitted.attributes['function_args']).toBeUndefined();
+      expect(emitted.attributes['function_name']).toBe('run_bash');
+    });
+
+    it('should include function_args when logPrompts is enabled', () => {
+      const mockConfigWithPrompts = {
+        getSessionId: () => 'test-session-id',
+        getTargetDir: () => 'target-dir',
+        getUsageStatisticsEnabled: () => true,
+        getTelemetryEnabled: () => true,
+        getTelemetryLogPromptsEnabled: () => true,
+        getTelemetryTracesEnabled: () => false,
+        isInteractive: () => false,
+        getExperiments: () => undefined,
+        getExperimentsAsync: async () => undefined,
+        getContentGeneratorConfig: () => undefined,
+      } as unknown as Config;
+
+      const call: CompletedToolCall = {
+        status: CoreToolCallStatus.Success,
+        request: {
+          name: 'run_bash',
+          args: { command: 'echo visible' },
+          callId: 'call-2',
+          isClientInitiated: false,
+          prompt_id: 'prompt-withprompts',
+        },
+        response: {
+          callId: 'call-2',
+          responseParts: [],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+          contentLength: undefined,
+        },
+        tool: undefined as unknown as AnyDeclarativeTool,
+        invocation: {} as AnyToolInvocation,
+        durationMs: 50,
+      };
+      const event = new ToolCallEvent(call);
+      logToolCall(mockConfigWithPrompts, event);
+
+      const emitted = mockLogger.emit.mock.calls[0][0] as {
+        attributes: Record<string, unknown>;
+      };
+      expect(emitted.attributes['function_args']).toBe(
+        JSON.stringify({ command: 'echo visible' }, null, 2),
+      );
+    });
+  });
+
   describe('logMalformedJsonResponse', () => {
     beforeEach(() => {
       vi.spyOn(ClearcutLogger.prototype, 'logMalformedJsonResponseEvent');

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -642,6 +642,54 @@ describe('loggers', () => {
         }),
       });
     });
+    it('should not include response_text when logPrompts is disabled', () => {
+      const mockConfigNoPrompts = {
+        getSessionId: () => 'test-session-id',
+        getTargetDir: () => 'target-dir',
+        getUsageStatisticsEnabled: () => true,
+        getTelemetryEnabled: () => true,
+        getTelemetryLogPromptsEnabled: () => false,
+        getTelemetryTracesEnabled: () => false,
+        isInteractive: () => false,
+        getExperiments: () => undefined,
+        getExperimentsAsync: async () => undefined,
+        getContentGeneratorConfig: () => undefined,
+      } as unknown as Config;
+
+      const event = new ApiResponseEvent(
+        'test-model',
+        100,
+        { prompt_id: 'prompt-id-noprompts', contents: [] },
+        { candidates: [] },
+        AuthType.LOGIN_WITH_GOOGLE,
+        {},
+        'this response should be hidden',
+      );
+
+      logApiResponse(mockConfigNoPrompts, event);
+
+      const firstEmitCall = mockLogger.emit.mock.calls[0][0];
+      expect(firstEmitCall.attributes['response_text']).toBeUndefined();
+    });
+
+    it('should include response_text when logPrompts is enabled', () => {
+      const event = new ApiResponseEvent(
+        'test-model',
+        100,
+        { prompt_id: 'prompt-id-withprompts', contents: [] },
+        { candidates: [] },
+        AuthType.LOGIN_WITH_GOOGLE,
+        {},
+        'this response should be visible',
+      );
+
+      logApiResponse(mockConfig, event);
+
+      const firstEmitCall = mockLogger.emit.mock.calls[0][0];
+      expect(firstEmitCall.attributes['response_text']).toBe(
+        'this response should be visible',
+      );
+    });
   });
 
   describe('logApiError', () => {
@@ -1076,6 +1124,10 @@ describe('loggers', () => {
       expect(attributes['gen_ai.provider.name']).toBe('gcp.vertex_ai');
       // Ensure prompt messages are NOT included
       expect(attributes['gen_ai.input.messages']).toBeUndefined();
+
+      // Ensure request_text is also NOT included in the first (toLogRecord) log
+      const firstLogCall = mockLogger.emit.mock.calls[0][0];
+      expect(firstLogCall.attributes['request_text']).toBeUndefined();
     });
 
     it('should correctly derive model from prompt details if available in semantic log', () => {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -423,8 +423,10 @@ export class ApiRequestEvent implements BaseTelemetryEvent {
       'event.timestamp': this['event.timestamp'],
       model: this.model,
       prompt_id: this.prompt.prompt_id,
-      request_text: this.request_text,
     };
+    if (config.getTelemetryLogPromptsEnabled() && this.request_text) {
+      attributes['request_text'] = this.request_text;
+    }
     if (this.role) {
       attributes['role'] = this.role;
     }
@@ -692,7 +694,7 @@ export class ApiResponseEvent implements BaseTelemetryEvent {
     if (this.role) {
       attributes['role'] = this.role;
     }
-    if (this.response_text) {
+    if (config.getTelemetryLogPromptsEnabled() && this.response_text) {
       attributes['response_text'] = this.response_text;
     }
     if (this.status_code) {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -368,7 +368,7 @@ export class ToolCallEvent implements BaseTelemetryEvent {
       end_time: this.end_time,
       metadata: this.metadata,
     };
-    if (config.getTelemetryLogPromptsEnabled()) {
+    if (config.getTelemetryLogPromptsEnabled() && this.function_args) {
       attributes['function_args'] = safeJsonStringify(this.function_args, 2);
     }
 
@@ -961,9 +961,15 @@ export class ConsecaPolicyGenerationEvent implements BaseTelemetryEvent {
     };
 
     if (config.getTelemetryLogPromptsEnabled()) {
-      attributes['user_prompt'] = this.user_prompt;
-      attributes['trusted_content'] = this.trusted_content;
-      attributes['policy'] = this.policy;
+      if (this.user_prompt) {
+        attributes['user_prompt'] = this.user_prompt;
+      }
+      if (this.trusted_content) {
+        attributes['trusted_content'] = this.trusted_content;
+      }
+      if (this.policy) {
+        attributes['policy'] = this.policy;
+      }
     }
 
     if (this.error) {
@@ -1016,10 +1022,18 @@ export class ConsecaVerdictEvent implements BaseTelemetryEvent {
     };
 
     if (config.getTelemetryLogPromptsEnabled()) {
-      attributes['user_prompt'] = this.user_prompt;
-      attributes['policy'] = this.policy;
-      attributes['tool_call'] = this.tool_call;
-      attributes['verdict_rationale'] = this.verdict_rationale;
+      if (this.user_prompt) {
+        attributes['user_prompt'] = this.user_prompt;
+      }
+      if (this.policy) {
+        attributes['policy'] = this.policy;
+      }
+      if (this.tool_call) {
+        attributes['tool_call'] = this.tool_call;
+      }
+      if (this.verdict_rationale) {
+        attributes['verdict_rationale'] = this.verdict_rationale;
+      }
     }
 
     if (this.error) {

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -355,7 +355,6 @@ export class ToolCallEvent implements BaseTelemetryEvent {
       'event.name': EVENT_TOOL_CALL,
       'event.timestamp': this['event.timestamp'],
       function_name: this.function_name,
-      function_args: safeJsonStringify(this.function_args, 2),
       duration_ms: this.duration_ms,
       success: this.success,
       decision: this.decision,
@@ -369,6 +368,9 @@ export class ToolCallEvent implements BaseTelemetryEvent {
       end_time: this.end_time,
       metadata: this.metadata,
     };
+    if (config.getTelemetryLogPromptsEnabled()) {
+      attributes['function_args'] = safeJsonStringify(this.function_args, 2);
+    }
 
     if (this.error) {
       attributes[CoreToolCallStatus.Error] = this.error;
@@ -956,10 +958,13 @@ export class ConsecaPolicyGenerationEvent implements BaseTelemetryEvent {
       ...getCommonAttributes(config),
       'event.name': EVENT_CONSECA_POLICY_GENERATION,
       'event.timestamp': this['event.timestamp'],
-      user_prompt: this.user_prompt,
-      trusted_content: this.trusted_content,
-      policy: this.policy,
     };
+
+    if (config.getTelemetryLogPromptsEnabled()) {
+      attributes['user_prompt'] = this.user_prompt;
+      attributes['trusted_content'] = this.trusted_content;
+      attributes['policy'] = this.policy;
+    }
 
     if (this.error) {
       attributes['error'] = this.error;
@@ -1007,12 +1012,15 @@ export class ConsecaVerdictEvent implements BaseTelemetryEvent {
       ...getCommonAttributes(config),
       'event.name': EVENT_CONSECA_VERDICT,
       'event.timestamp': this['event.timestamp'],
-      user_prompt: this.user_prompt,
-      policy: this.policy,
-      tool_call: this.tool_call,
       verdict: this.verdict,
-      verdict_rationale: this.verdict_rationale,
     };
+
+    if (config.getTelemetryLogPromptsEnabled()) {
+      attributes['user_prompt'] = this.user_prompt;
+      attributes['policy'] = this.policy;
+      attributes['tool_call'] = this.tool_call;
+      attributes['verdict_rationale'] = this.verdict_rationale;
+    }
 
     if (this.error) {
       attributes['error'] = this.error;


### PR DESCRIPTION
## Summary

When `logPrompts: false`, several telemetry events were still emitting user-sensitive content to OpenTelemetry log records. This fixes fields across four event classes to gate on `getTelemetryLogPromptsEnabled()`, consistent with the existing pattern used by `UserPromptEvent`, `HookCallEvent`, and the `toSemanticLogRecord` paths. All conditionally-included fields also have existence checks, matching the `getTelemetryLogPromptsEnabled() && this.xxx` pattern used in `toLogRecord`.

## Details

**Fields fixed:**

- **`ApiRequestEvent.toLogRecord`** — `request_text` (full conversation history JSON) was unconditionally included
- **`ApiResponseEvent.toLogRecord`** — `response_text` was included whenever non-empty
- **`ToolCallEvent.toOpenTelemetryAttributes`** — `function_args` can contain file content, bash commands, search queries, etc.; guarded with both `logPrompts` check and `&& this.function_args` existence check
- **`ConsecaPolicyGenerationEvent.toOpenTelemetryAttributes`** — `user_prompt`, `trusted_content`, `policy` all derived from user input; each guarded with an individual existence check inside the `logPrompts` block
- **`ConsecaVerdictEvent.toOpenTelemetryAttributes`** — `user_prompt`, `policy`, `tool_call`, `verdict_rationale`; each guarded with an individual existence check inside the `logPrompts` block; `verdict` (the allow/deny classification) is kept unconditional as it contains no user content

The `toSemanticLogRecord` methods already guarded equivalent fields via `shouldIncludePayloads()`. This aligns `toLogRecord` / `toOpenTelemetryAttributes` with the same contract, including the existence-check idiom used in `toLogRecord` (e.g. `getTelemetryLogPromptsEnabled() && this.request_text`).

## Related Issues
#18979 

## How to Validate

Set `logPrompts: false` in telemetry config and run prompts with tool calls. Confirm in exported OTel logs:
- `gemini_cli.api_request` has no `request_text`
- `gemini_cli.api_response` has no `response_text`
- `gemini_cli.tool_call` has no `function_args`
- `gemini_cli.conseca.*` events have no `user_prompt`, `trusted_content`, `policy`, `tool_call`, `verdict_rationale`

With `logPrompts: true` all fields appear as before (and only when the field value is non-empty).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker