### PR TITLE
fix: shell configuration executable and args not taking effect (especially on Windows)

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1068,6 +1068,8 @@ export async function loadCliConfig(
     useRenderProcess: settings.ui?.renderProcess,
     useRipgrep: settings.tools?.useRipgrep,
     enableInteractiveShell: settings.tools?.shell?.enableInteractiveShell,
+    shellExecutable: settings.tools?.shell?.executable,
+    shellArgs: settings.tools?.shell?.args,
     shellBackgroundCompletionBehavior: settings.tools?.shell
       ?.backgroundCompletionBehavior as string | undefined,
     shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1637,6 +1637,27 @@ const SETTINGS_SCHEMA = {
               'Enable shell output efficiency optimizations for better performance.',
             showInDialog: false,
           },
+          executable: {
+            type: 'string',
+            label: 'Shell Executable',
+            category: 'Tools',
+            requiresRestart: true,
+            default: undefined as string | undefined,
+            description:
+              'The executable for the shell (e.g., "pwsh", "bash", "zsh"). If not specified, the system default is used.',
+            showInDialog: true,
+          },
+          args: {
+            type: 'array',
+            label: 'Shell Arguments',
+            category: 'Tools',
+            requiresRestart: true,
+            default: [] as string[],
+            description:
+              'Arguments to pass to the shell executable (e.g., ["-c"]).',
+            showInDialog: true,
+            items: { type: 'string' },
+          },
         },
       },
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -722,6 +722,8 @@ export interface ConfigParameters {
   topicUpdateNarration?: boolean;
 
   disableLLMCorrection?: boolean;
+  shellExecutable?: string;
+  shellArgs?: string[];
   plan?: boolean;
   tracker?: boolean;
   planSettings?: PlanSettings;
@@ -875,6 +877,8 @@ export class Config implements McpContext, AgentLoopContext {
   readonly interactive: boolean;
   private readonly ptyInfo: string;
   private readonly trustedFolder: boolean | undefined;
+  private readonly shellExecutable: string | undefined;
+  private readonly shellArgs: string[] | undefined;
   private readonly directWebFetch: boolean;
   private readonly useRipgrep: boolean;
   private readonly enableInteractiveShell: boolean;
@@ -1248,6 +1252,8 @@ export class Config implements McpContext, AgentLoopContext {
     this.compressionThreshold = params.compressionThreshold;
     this.interactive = params.interactive ?? false;
     this.ptyInfo = params.ptyInfo ?? 'child_process';
+    this.shellExecutable = params.shellExecutable;
+    this.shellArgs = params.shellArgs;
     this.trustedFolder = params.trustedFolder;
     this.directWebFetch = params.directWebFetch ?? false;
     this.useRipgrep = params.useRipgrep ?? true;
@@ -1270,6 +1276,8 @@ export class Config implements McpContext, AgentLoopContext {
       terminalHeight: params.shellExecutionConfig?.terminalHeight ?? 24,
       showColor: params.shellExecutionConfig?.showColor ?? false,
       pager: params.shellExecutionConfig?.pager ?? 'cat',
+      shellExecutable: this.shellExecutable,
+      shellArgs: this.shellArgs,
       sanitizationConfig: this.sanitizationConfig,
       sandboxManager: this._sandboxManager,
       sandboxConfig: this.sandbox,
@@ -3467,6 +3475,14 @@ export class Config implements McpContext, AgentLoopContext {
 
   getShellToolInactivityTimeout(): number {
     return this.shellToolInactivityTimeout;
+  }
+
+  getShellExecutable(): string | undefined {
+    return this.shellExecutable;
+  }
+
+  getShellArgs(): string[] | undefined {
+    return this.shellArgs;
   }
 
   getShellExecutionConfig(): ShellExecutionConfig {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -103,6 +103,8 @@ export interface ShellExecutionConfig {
   maxSerializedLines?: number;
   sandboxConfig?: SandboxConfig;
   backgroundCompletionBehavior?: 'inject' | 'notify' | 'silent';
+  shellExecutable?: string;
+  shellArgs?: string[];
   originalCommand?: string;
   sessionId?: string;
 }
@@ -407,7 +409,10 @@ export class ShellExecutionService {
       shellExecutionConfig.sandboxConfig?.command === 'windows-native' &&
       !shellExecutionConfig.sandboxConfig?.networkAccess;
 
-    let { executable, argsPrefix, shell } = getShellConfiguration();
+    let { executable, argsPrefix, shell } = getShellConfiguration(
+      shellExecutionConfig.shellExecutable,
+      shellExecutionConfig.shellArgs,
+    );
     if (isStrictSandbox) {
       shell = 'cmd';
       argsPrefix = ['/c'];

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -646,7 +646,26 @@ export function parseCommandDetails(
  *
  * @returns The ShellConfiguration for the current environment.
  */
-export function getShellConfiguration(): ShellConfiguration {
+export function getShellConfiguration(
+  overrideExecutable?: string,
+  overrideArgs?: string[],
+): ShellConfiguration {
+  if (overrideExecutable) {
+    const executable = overrideExecutable.toLowerCase();
+    const isPowerShell =
+      executable.endsWith('powershell.exe') ||
+      executable.endsWith('pwsh.exe') ||
+      executable === 'powershell' ||
+      executable === 'pwsh';
+
+    return {
+      executable: overrideExecutable,
+      argsPrefix:
+        overrideArgs || (isPowerShell ? ['-NoProfile', '-Command'] : ['-c']),
+      shell: isPowerShell ? 'powershell' : 'bash',
+    };
+  }
+
   if (isWindows()) {
     const comSpec = process.env['ComSpec'];
     if (comSpec) {


### PR DESCRIPTION

## Summary

This PR fixes a bug where `tools.shell.executable` and `tools.shell.args` settings in `settings.json` were completely ignored. It resolves a critical limitation where the shell was hardcoded, preventing users from using modern shells or loading custom profiles despite these options being documented/expected.

## Details

Currently, while users might attempt to configure their shell in `settings.json`, the implementation fails to respect these settings because:
1. The `Config` class in `packages/core` is missing the internal fields to hold these values.
2. The `getShellConfiguration` utility relies on hardcoded logic that overrides any user preference.

This PR aligns the implementation with the expected configuration behavior:
- **Pipeline Fixed:** Established the missing mapping from `settings.json` to the `Config` class and `ShellExecutionService`.
- **Logic Corrected:** Refactored `getShellConfiguration` to properly prioritize user-defined overrides while maintaining safe defaults (`-NoProfile`) for PowerShell when args are omitted.
- **Cross-Platform Fix:** Ensures that Linux/macOS users can also successfully switch shells (e.g., to `zsh` or `fish`) via config.

## Related Issues

N/A (Fixes broken configuration pipeline for shell settings).

## How to Validate

1. Build the project: `npm run build`.
2. Open/Create `~/.gemini/settings.json`.
3. Add a custom shell configuration:
   ```json
   "tools": {
     "shell": {
       "executable": "pwsh",
       "args": ["-Command"]
     }
   }
   ```
4. Run a command that relies on your PowerShell profile (e.g., a custom alias or environment variable defined in `$PROFILE`).
5. Observe that the command now succeeds, whereas previously it would fail due to `-NoProfile`.
6. Remove the config and verify it falls back to `powershell.exe -NoProfile` (Windows) or `bash -c` (others).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (Updated `settingsSchema.ts` with docs).
- [ ] Added/updated tests (Verified manually via local builds).
- [x] Noted breaking changes (None. Default behavior is preserved).
- [ ] Validated on required platforms/methods:
  - [x] Windows (npm run)
  - [ ] MacOS
  - [ ] Linux
