### PR TITLE
test: fix failures due to antigravity environment leakage

### DIFF
--- a/packages/cli/src/config/extension-manager-agents.test.ts
+++ b/packages/cli/src/config/extension-manager-agents.test.ts
@@ -42,10 +42,12 @@ describe('ExtensionManager agents loading', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', '');
     vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
 
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-test-agents-'));
     mockHomedir.mockReturnValue(tempDir);
+    vi.stubEnv('GEMINI_CLI_HOME', tempDir);
 
     // Create the extensions directory that ExtensionManager expects
     extensionsDir = path.join(tempDir, '.gemini', EXTENSIONS_DIRECTORY_NAME);

--- a/packages/cli/src/config/extension-manager-hydration.test.ts
+++ b/packages/cli/src/config/extension-manager-hydration.test.ts
@@ -48,11 +48,13 @@ describe('ExtensionManager hydration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', '');
     vi.spyOn(coreEvents, 'emitFeedback');
     vi.spyOn(debugLogger, 'debug').mockImplementation(() => {});
 
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-test-'));
     mockHomedir.mockReturnValue(tempDir);
+    vi.stubEnv('GEMINI_CLI_HOME', tempDir);
 
     // Create the extensions directory that ExtensionManager expects
     extensionsDir = path.join(tempDir, '.gemini', EXTENSIONS_DIRECTORY_NAME);

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -39,6 +39,7 @@ describe('createContentGenerator', () => {
   beforeEach(() => {
     resetVersionCache();
     vi.clearAllMocks();
+    vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', '');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes test failures in `contentGenerator.test.ts` and `ExtensionManager` suites caused by environment leakage (specifically `ANTIGRAVITY_CLI_ALIAS` and home directory leakage).

## Details

- **Mocked `ANTIGRAVITY_CLI_ALIAS`**: In `contentGenerator.test.ts`, `extension-manager-agents.test.ts`, and `extension-manager-hydration.test.ts`, I added `vi.stubEnv('ANTIGRAVITY_CLI_ALIAS', '')` to ensures that the `User-Agent` generated during tests is consistent and doesn't include unexpected "antigravity" tags from the host environment.
- **Isolated `ExtensionManager` Tests**: Updated the `beforeEach` blocks in `extension-manager-agents.test.ts` and `extension-manager-hydration.test.ts` to set `GEMINI_CLI_HOME` to a temporary directory. This correctly redirects all file operations (including settings and integrity stores) to a sandbox environment, preventing "Extension integrity store cannot be verified" errors.

## Related Issues

N/A

## How to Validate

Run the targeted tests:
```bash
npx vitest run packages/core/src/core/contentGenerator.test.ts packages/cli/src/config/extension-manager-agents.test.ts packages/cli/src/config/extension-manager-hydration.test.ts
```
Or run the full preflight:
```bash
npm run preflight
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
