### PR TITLE
fix: remove instruction to combine shell commands with &&

### DIFF
--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -369,7 +369,6 @@ export function renderGitRepo(options?: GitRepoOptions): string {
     - \`git diff --staged\` to review only staged changes when a partial commit makes sense or was requested by the user.
   - \`git log -n 3\` to review recent commit messages and match their style (verbosity, formatting, signature line, etc.)
 - Do not use \`git add .\` or \`git add -A\` unprompted as this can stage unwanted or untracked files. Instead, stage only the specific files that were changed or created as part of the task.
-- Combine shell commands whenever possible to save time/steps, e.g. \`git status && git diff HEAD && git log -n 3\`.
 - Always propose a draft commit message. Never just ask the user to give you the full commit message.
 - Prefer commit messages that are clear, concise, and focused more on "why" and less on "what".${gitRepoKeepUserInformed(options.interactive)}
 - After each commit, confirm that it was successful by running \`git status\`.

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -510,7 +510,6 @@ export function renderGitRepo(options?: GitRepoOptions): string {
     - \`git diff --staged\` to review only staged changes when a partial commit makes sense or was requested by the user.
   - \`git log -n 3\` to review recent commit messages and match their style (verbosity, formatting, signature line, etc.)
 - Do not use \`git add .\` or \`git add -A\` unprompted as this can stage unwanted or untracked files. Instead, stage only the specific files that were changed or created as part of the task.
-- Combine shell commands whenever possible to save time/steps, e.g. \`git status && git diff HEAD && git log -n 3\`.
 - Always propose a draft commit message. Never just ask the user to give you the full commit message.
 - Prefer commit messages that are clear, concise, and focused more on "why" and less on "what".${gitRepoKeepUserInformed(options.interactive)}
 - After each commit, confirm that it was successful by running \`git status\`.


### PR DESCRIPTION
The system prompt instructed the agent to combine shell commands using "&&" (e.g., "git status && git diff HEAD && git log -n 3"). This syntax doesn't work in PowerShell on Windows, causing the agent to fail and have to retry commands.

Removed the "Combine shell commands whenever possible" instruction from both `snippets.ts` and `snippets.legacy.ts` to fix issue #18022.

## Details

According to my experience (and reading issue #18022, it might not be just me) the gemini models have trouble sorting out conflicting instructions. No amount of additional prompting can make the model forget something it has in its context. Removing the instruction from the system prompt was the only way that worked reliably.

## Related Issues

Fixes #18022.

## How to Validate

Just keep using it for a while on Windows. I did use it for my day to day work for one whole workday and not once has the model used `&&` to combine shell commands. It did combine commands even without the instructions and it used `;` to do so.

One example:
<img width="678" height="129" alt="image" src="https://github.com/user-attachments/assets/214f0b31-4527-43e2-8ee6-27807b151b53" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
