### PR TITLE
fix(core): fail session deletion when file is missing

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -728,10 +728,13 @@ describe('ChatRecordingService', () => {
       expect(fs.existsSync(logFile)).toBe(false);
     });
 
-    it('should not throw if session file does not exist', async () => {
+    it('should throw if session file does not exist', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+
       await expect(
         chatRecordingService.deleteSession('non-existent'),
-      ).resolves.not.toThrow();
+      ).rejects.toThrow('No session file found for non-existent');
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -695,6 +695,10 @@ export class ChatRecordingService {
         chatsDir,
         shortId,
       );
+      if (matchingFiles.length === 0) {
+        throw new Error(`No session file found for ${sessionIdOrBasename}`);
+      }
+
       for (const file of matchingFiles) {
         await this.deleteSessionAndArtifacts(chatsDir, file, tempDir);
       }


### PR DESCRIPTION
## Summary

Fixes #26113.

When session deletion cannot find a matching session file, `ChatRecordingService.deleteSession()` currently resolves successfully. The interactive `/resume` browser treats that as a successful deletion and removes the row from UI state even though the `.jsonl` file remains on disk.

This changes deletion to fail fast when the chats directory exists but no matching session file is found, so callers can surface the error instead of optimistically hiding the session.

## Test plan

- `npm test --workspace @google/gemini-cli-core -- chatRecordingService.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx prettier --check packages/core/src/services/chatRecordingService.ts packages/core/src/services/chatRecordingService.test.ts`
