### PR TITLE
fix: windows backspace & allow HTTP custom base URL

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -655,7 +655,12 @@ function* emitKeys(
     } else if (ch === '\b' || ch === '\x7f') {
       // backspace or ctrl+h
       name = 'backspace';
-      alt = escaped;
+      // On Windows terminals (Git Bash, MSYS2), backspace may be sent as
+      // ESC + \x7f (\x1b\x7f), which would incorrectly set alt=true
+      // and trigger DELETE_WORD_BACKWARD instead of DELETE_CHAR_LEFT.
+      // Only set alt=true for \b with ESC prefix (genuine Alt+Backspace),
+      // not for \x7f which is the standard backspace sequence.
+      alt = escaped && ch === '\b';
     } else if (ch === ESC) {
       // escape key
       name = 'escape';

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -851,7 +851,7 @@ describe('createContentGenerator', () => {
     ).rejects.toThrow('Invalid custom base URL: not-a-url');
   });
 
-  it('should reject non-https remote custom baseUrl values', async () => {
+  it('should allow http remote custom baseUrl values', async () => {
     await expect(
       createContentGenerator(
         {
@@ -861,7 +861,7 @@ describe('createContentGenerator', () => {
         },
         mockConfig,
       ),
-    ).rejects.toThrow('Custom base URL must use HTTPS unless it is localhost.');
+    ).resolves.toBeDefined();
   });
 });
 

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -123,8 +123,13 @@ function validateBaseUrl(baseUrl: string): void {
     throw new Error(`Invalid custom base URL: ${baseUrl}`);
   }
 
-  if (url.protocol !== 'https:' && !LOCAL_HOSTNAMES.includes(url.hostname)) {
-    throw new Error('Custom base URL must use HTTPS unless it is localhost.');
+  // Allow both HTTP and HTTPS for custom base URLs (e.g. local/private proxies)
+  if (
+    url.protocol !== 'https:' &&
+    url.protocol !== 'http:' &&
+    !LOCAL_HOSTNAMES.includes(url.hostname)
+  ) {
+    throw new Error('Custom base URL must use HTTP or HTTPS.');
   }
 }
 


### PR DESCRIPTION
## Changes in this PR

1. **Windows Backspace Fix**: Corrects incorrect backspace behavior on Windows terminals (Git Bash/MSYS2) by distinguishing between ESC+DEL and ESC+BS.
2. **HTTP Base URL Support**: Removes the HTTPS-only restriction for custom base URLs (`GOOGLE_GEMINI_BASE_URL`) to support local/private proxies.

Closes #25867