### PR TITLE
fix(core): reduce default API timeout to 60s and enable retries for undici timeouts

### DIFF
--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -209,7 +209,7 @@ describe('fetch utils', () => {
       expect(ProxyAgent).toHaveBeenCalledWith({
         uri: proxyUrl,
         headersTimeout: 45773134,
-        bodyTimeout: 45773134,
+        bodyTimeout: 300000,
       });
       expect(setGlobalDispatcher).toHaveBeenCalled();
     });

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -28,14 +28,15 @@ export class PrivateIpError extends Error {
   }
 }
 
-let defaultTimeout = 60000; // 60 seconds
+let defaultHeadersTimeout = 60000; // 60 seconds
+const defaultBodyTimeout = 300000; // 5 minutes
 let currentProxy: string | undefined = undefined;
 
 // Configure default global dispatcher with higher timeouts
 setGlobalDispatcher(
   new Agent({
-    headersTimeout: defaultTimeout,
-    bodyTimeout: defaultTimeout,
+    headersTimeout: defaultHeadersTimeout,
+    bodyTimeout: defaultBodyTimeout,
   }),
 );
 
@@ -45,14 +46,15 @@ export function updateGlobalFetchTimeouts(timeoutMs: number) {
       `Invalid timeout value: ${timeoutMs}. Must be a positive finite number.`,
     );
   }
-  defaultTimeout = timeoutMs;
+  defaultHeadersTimeout = timeoutMs;
+  // We keep body timeout high for LLM streaming responses
   if (currentProxy) {
     setGlobalProxy(currentProxy);
   } else {
     setGlobalDispatcher(
       new Agent({
-        headersTimeout: defaultTimeout,
-        bodyTimeout: defaultTimeout,
+        headersTimeout: defaultHeadersTimeout,
+        bodyTimeout: defaultBodyTimeout,
       }),
     );
   }
@@ -214,8 +216,8 @@ export function setGlobalProxy(proxy: string) {
   setGlobalDispatcher(
     new ProxyAgent({
       uri: proxy,
-      headersTimeout: defaultTimeout,
-      bodyTimeout: defaultTimeout,
+      headersTimeout: defaultHeadersTimeout,
+      bodyTimeout: defaultBodyTimeout,
     }),
   );
 }

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -28,7 +28,7 @@ export class PrivateIpError extends Error {
   }
 }
 
-let defaultTimeout = 300000; // 5 minutes
+let defaultTimeout = 60000; // 60 seconds
 let currentProxy: string | undefined = undefined;
 
 // Configure default global dispatcher with higher timeouts

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -451,6 +451,25 @@ describe('retryWithBackoff', () => {
       });
       await vi.runAllTimersAsync();
       await expect(promise).resolves.toBe('success');
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on undici timeout error codes (UND_ERR_HEADERS_TIMEOUT)', async () => {
+      const error = new Error('Headers timeout error');
+      (error as any).code = 'UND_ERR_HEADERS_TIMEOUT';
+      const mockFn = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue('success');
+
+      const promise = retryWithBackoff(mockFn, {
+        retryFetchErrors: false,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+      });
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe('success');
+      expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
     it('should retry on SSL error code (ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC)', async () => {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -55,6 +55,9 @@ const RETRYABLE_NETWORK_CODES = [
   'ECONNREFUSED',
   'ERR_SSL_WRONG_VERSION_NUMBER',
   'EPROTO', // Generic protocol error (often SSL-related)
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
 ];
 
 // Node.js builds SSL error codes by prepending ERR_SSL_ to the uppercased
@@ -84,15 +87,7 @@ function getNetworkErrorCode(error: unknown): string | undefined {
     }
     if ('code' in obj && typeof (obj as { code: unknown }).code === 'string') {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const code = (obj as { code: string }).code;
-      if (
-        code === 'UND_ERR_HEADERS_TIMEOUT' ||
-        code === 'UND_ERR_BODY_TIMEOUT' ||
-        code === 'UND_ERR_CONNECT_TIMEOUT'
-      ) {
-        return 'ETIMEDOUT';
-      }
-      return code;
+      return (obj as { code: string }).code;
     }
     return undefined;
   };

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -84,7 +84,15 @@ function getNetworkErrorCode(error: unknown): string | undefined {
     }
     if ('code' in obj && typeof (obj as { code: unknown }).code === 'string') {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      return (obj as { code: string }).code;
+      const code = (obj as { code: string }).code;
+      if (
+        code === 'UND_ERR_HEADERS_TIMEOUT' ||
+        code === 'UND_ERR_BODY_TIMEOUT' ||
+        code === 'UND_ERR_CONNECT_TIMEOUT'
+      ) {
+        return 'ETIMEDOUT';
+      }
+      return code;
     }
     return undefined;
   };


### PR DESCRIPTION
## Summary

API requests could hang for up to 5 minutes (default undici timeout) when the backend or local proxy was unresponsive. This PR reduces the default timeout to 60 seconds and ensures that these timeouts are automatically retried.

## Details

- Reduced `defaultTimeout` in `packages/core/src/utils/fetch.ts` from 300,000ms to 60,000ms.
- Updated `getNetworkErrorCode` in `packages/core/src/utils/retry.ts` to map Undici-specific timeout error codes (`UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, `UND_ERR_CONNECT_TIMEOUT`) to the standard `ETIMEDOUT` code.
- This mapping allows the existing backoff resilience logic to treat Undici timeouts as retryable network errors.

## Related Issues

Fixes #18030

## How to Validate

1. Run `npm test -w @google/gemini-cli-core -- src/utils/retry.test.ts` to verify the new test case for Undici timeouts.
2. Run `npm test -w @google/gemini-cli-core -- src/utils/fetch.test.ts` to ensure no regressions in fetch utilities.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker