### PR TITLE
test(core): add regression test for issue for ToolConfirmationResponse

### DIFF
--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -357,6 +357,45 @@ describe('confirmation.ts', () => {
       expect(mockState.updateArgs).toHaveBeenCalled();
     });
 
+    it('should pass payload to onConfirm callback (Regression for #22120)', async () => {
+      const details = {
+        type: 'ask_user' as const,
+        questions: [],
+        title: 'Title',
+        onConfirm: vi.fn(),
+      };
+      invocationMock.shouldConfirmExecute.mockResolvedValue(details);
+
+      const listenerPromise = waitForListener(
+        MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      );
+      const promise = resolveConfirmation(toolCall, signal, {
+        config: mockConfig,
+        messageBus: mockMessageBus,
+        state: mockState,
+        modifier: mockModifier,
+        getPreferredEditor,
+        schedulerId: ROOT_SCHEDULER_ID,
+      });
+
+      await listenerPromise;
+
+      const payload = { answers: { '0': 'user choice' } };
+      emitResponse({
+        type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        correlationId: '123e4567-e89b-12d3-a456-426614174000',
+        confirmed: true,
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+        payload,
+      });
+
+      await promise;
+      expect(details.onConfirm).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.ProceedOnce,
+        payload,
+      );
+    });
+
     it('should resolve immediately if IDE confirmation resolves first', async () => {
       const idePromise = Promise.resolve({
         status: 'accepted' as const,

--- a/packages/core/src/scheduler/confirmation.test.ts
+++ b/packages/core/src/scheduler/confirmation.test.ts
@@ -357,7 +357,7 @@ describe('confirmation.ts', () => {
       expect(mockState.updateArgs).toHaveBeenCalled();
     });
 
-    it('should pass payload to onConfirm callback (Regression for #22120)', async () => {
+    it('should pass payload to onConfirm callback', async () => {
       const details = {
         type: 'ask_user' as const,
         questions: [],


### PR DESCRIPTION
## Summary

Adds a regression test to ensure that the `payload` from a `ToolConfirmationResponse` is correctly passed to the `onConfirm` callback.

## Details

Issue #22120 reported that `CoreToolScheduler.handleConfirmationResponse` was dropping the `payload` parameter. This bug was fixed during the migration to the new event-driven scheduler (specifically in `packages/core/src/scheduler/confirmation.ts`), where the payload is correctly retrieved from the response message and passed to the callback. 

This PR adds a dedicated unit test in `packages/core/src/scheduler/confirmation.test.ts` to verify this behavior and prevent regressions.

## Related Issues

Fixes #22120

## How to Validate

Run the unit tests for the core package:
```bash
npm test -w @google/gemini-cli-core -- src/scheduler/confirmation.test.ts
```
The new test case "should pass payload to onConfirm callback (Regression for #22120)" should pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
