### PR TITLE
fix(cli): sweep all projects for session retention

### DIFF
--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -280,6 +280,84 @@ describe('Session Cleanup (Refactored)', () => {
       expect(existsSync(path.join(chatsDir, sessions[1].id))).toBe(false); // Subagent chats directory should be deleted
     });
 
+    it('should apply retention across all project temp directories', async () => {
+      const globalTempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'gemini-cli-global-cleanup-test-'),
+      );
+      const currentProjectTempDir = path.join(globalTempDir, 'current-project');
+      const otherProjectTempDir = path.join(globalTempDir, 'other-project');
+      const currentChatsDir = path.join(currentProjectTempDir, 'chats');
+      const otherChatsDir = path.join(otherProjectTempDir, 'chats');
+      const otherLogsDir = path.join(otherProjectTempDir, 'logs');
+
+      await fs.mkdir(currentChatsDir, { recursive: true });
+      await fs.mkdir(otherChatsDir, { recursive: true });
+      await fs.mkdir(otherLogsDir, { recursive: true });
+
+      const now = new Date();
+      const oldDate = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+
+      await fs.writeFile(
+        path.join(currentChatsDir, 'session-20250120-current1.json'),
+        JSON.stringify({
+          sessionId: 'current123',
+          startTime: now.toISOString(),
+          lastUpdated: now.toISOString(),
+          messages: [{ type: 'user', content: 'hello' }],
+        }),
+      );
+
+      await fs.writeFile(
+        path.join(otherChatsDir, 'session-20250101-oldother.json'),
+        JSON.stringify({
+          sessionId: 'old-other-session',
+          startTime: oldDate.toISOString(),
+          lastUpdated: oldDate.toISOString(),
+          messages: [{ type: 'user', content: 'hello' }],
+        }),
+      );
+      await fs.writeFile(
+        path.join(otherLogsDir, 'session-old-other-session.jsonl'),
+        'log content',
+      );
+
+      vi.spyOn(Storage, 'getGlobalTempDir').mockReturnValue(globalTempDir);
+
+      const config = createMockConfig({
+        storage: {
+          getProjectTempDir: () => currentProjectTempDir,
+        },
+      } as unknown as Partial<Config>);
+      const settings: Settings = {
+        general: { sessionRetention: { enabled: true, maxAge: '10d' } },
+      };
+
+      try {
+        const result = await cleanupExpiredSessions(config, settings);
+
+        expect(result.scanned).toBe(2);
+        expect(result.deleted).toBe(1);
+        expect(result.skipped).toBe(1);
+        expect(
+          existsSync(
+            path.join(currentChatsDir, 'session-20250120-current1.json'),
+          ),
+        ).toBe(true);
+        expect(
+          existsSync(
+            path.join(otherChatsDir, 'session-20250101-oldother.json'),
+          ),
+        ).toBe(false);
+        expect(
+          existsSync(
+            path.join(otherLogsDir, 'session-old-other-session.jsonl'),
+          ),
+        ).toBe(false);
+      } finally {
+        await fs.rm(globalTempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should NOT delete sessions within the cutoff date', async () => {
       const sessions = await seedSessions(); // [current, 14d, 30d]
       const config = createMockConfig();

--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -46,6 +46,16 @@ export interface CleanupResult {
   failed: number;
 }
 
+interface CleanupRoot {
+  tempDir: string;
+  chatsDir: string;
+}
+
+interface CleanupSessionFileEntry extends SessionFileEntry {
+  tempDir: string;
+  chatsDir: string;
+}
+
 /**
  * Helpers for session cleanup.
  */
@@ -66,13 +76,37 @@ function deriveShortIdFromFileName(fileName: string): string | null {
  */
 async function cleanupSessionAndSubagentsAsync(
   sessionId: string,
-  config: Config,
+  tempDir: string,
 ): Promise<void> {
-  const tempDir = config.storage.getProjectTempDir();
   const chatsDir = path.join(tempDir, 'chats');
 
   await deleteSessionArtifactsAsync(sessionId, tempDir);
   await deleteSubagentSessionDirAndArtifactsAsync(sessionId, chatsDir, tempDir);
+}
+
+async function getCleanupRoots(projectTempDir: string): Promise<CleanupRoot[]> {
+  const globalTempDir = Storage.getGlobalTempDir();
+  const relativeProjectTemp = path.relative(globalTempDir, projectTempDir);
+  const isUnderGlobalTemp =
+    relativeProjectTemp &&
+    !relativeProjectTemp.startsWith('..') &&
+    !path.isAbsolute(relativeProjectTemp);
+
+  if (!isUnderGlobalTemp) {
+    return [
+      { tempDir: projectTempDir, chatsDir: path.join(projectTempDir, 'chats') },
+    ];
+  }
+
+  const entries = await fs
+    .readdir(globalTempDir, { withFileTypes: true })
+    .catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const tempDir = path.join(globalTempDir, entry.name);
+      return { tempDir, chatsDir: path.join(tempDir, 'chats') };
+    });
 }
 
 /**
@@ -97,7 +131,9 @@ export async function cleanupExpiredSessions(
     }
 
     const retentionConfig = settings.general.sessionRetention;
-    const chatsDir = path.join(config.storage.getProjectTempDir(), 'chats');
+    const cleanupRoots = await getCleanupRoots(
+      config.storage.getProjectTempDir(),
+    );
 
     // Validate retention configuration
     const validationErrorMessage = validateRetentionConfig(
@@ -110,7 +146,21 @@ export async function cleanupExpiredSessions(
       return { ...result, disabled: true };
     }
 
-    const allFiles = await getAllSessionFiles(chatsDir, config.getSessionId());
+    const allFiles: CleanupSessionFileEntry[] = (
+      await Promise.all(
+        cleanupRoots.map(async (root): Promise<CleanupSessionFileEntry[]> => {
+          const files = await getAllSessionFiles(
+            root.chatsDir,
+            config.getSessionId(),
+          );
+          return files.map((file) => ({
+            ...file,
+            tempDir: root.tempDir,
+            chatsDir: root.chatsDir,
+          }));
+        }),
+      )
+    ).flat();
     result.scanned = allFiles.length;
 
     if (allFiles.length === 0) {
@@ -131,21 +181,21 @@ export async function cleanupExpiredSessions(
         const shortId = deriveShortIdFromFileName(sessionToDelete.fileName);
 
         if (shortId) {
-          if (processedShortIds.has(shortId)) {
+          const processedShortIdKey = `${sessionToDelete.chatsDir}:${shortId}`;
+          if (processedShortIds.has(processedShortIdKey)) {
             continue;
           }
-          processedShortIds.add(shortId);
+          processedShortIds.add(processedShortIdKey);
 
-          const matchingFiles = allFiles
-            .map((f) => f.fileName)
-            .filter(
-              (f) =>
-                f.startsWith(SESSION_FILE_PREFIX) &&
-                f.endsWith(`-${shortId}.json`),
-            );
+          const matchingFiles = allFiles.filter(
+            (f) =>
+              f.chatsDir === sessionToDelete.chatsDir &&
+              f.fileName.startsWith(SESSION_FILE_PREFIX) &&
+              f.fileName.endsWith(`-${shortId}.json`),
+          );
 
           for (const file of matchingFiles) {
-            const filePath = path.join(chatsDir, file);
+            const filePath = path.join(file.chatsDir, file.fileName);
             let fullSessionId: string | undefined;
 
             try {
@@ -173,7 +223,10 @@ export async function cleanupExpiredSessions(
                 await fs.unlink(filePath);
 
                 if (fullSessionId) {
-                  await cleanupSessionAndSubagentsAsync(fullSessionId, config);
+                  await cleanupSessionAndSubagentsAsync(
+                    fullSessionId,
+                    file.tempDir,
+                  );
                 }
                 result.deleted++;
               } else {
@@ -189,7 +242,7 @@ export async function cleanupExpiredSessions(
                 // File already deleted, do nothing.
               } else {
                 debugLogger.warn(
-                  `Failed to delete matching file ${file}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                  `Failed to delete matching file ${file.fileName}: ${error instanceof Error ? error.message : 'Unknown error'}`,
                 );
                 result.failed++;
               }
@@ -197,12 +250,18 @@ export async function cleanupExpiredSessions(
           }
         } else {
           // Fallback to old logic
-          const sessionPath = path.join(chatsDir, sessionToDelete.fileName);
+          const sessionPath = path.join(
+            sessionToDelete.chatsDir,
+            sessionToDelete.fileName,
+          );
           await fs.unlink(sessionPath);
 
           const sessionId = sessionToDelete.sessionInfo?.id;
           if (sessionId) {
-            await cleanupSessionAndSubagentsAsync(sessionId, config);
+            await cleanupSessionAndSubagentsAsync(
+              sessionId,
+              sessionToDelete.tempDir,
+            );
           }
 
           if (config.getDebugMode()) {
@@ -254,11 +313,11 @@ export async function cleanupExpiredSessions(
 /**
  * Identifies sessions that should be deleted (corrupted or expired based on retention policy)
  */
-export async function identifySessionsToDelete(
-  allFiles: SessionFileEntry[],
+export async function identifySessionsToDelete<T extends SessionFileEntry>(
+  allFiles: T[],
   retentionConfig: SessionRetentionSettings,
-): Promise<SessionFileEntry[]> {
-  const sessionsToDelete: SessionFileEntry[] = [];
+): Promise<T[]> {
+  const sessionsToDelete: T[] = [];
 
   // All corrupted files should be deleted
   sessionsToDelete.push(


### PR DESCRIPTION
## Summary
- apply `sessionRetention` cleanup across all project temp directories under the global Gemini temp root
- delete session artifacts from the matching project temp directory instead of always using the active project's temp directory
- add regression coverage for pruning an expired session from an inactive project

Fixes #26094

## Testing
- `npm test --workspace @google/gemini-cli -- sessionCleanup.test.ts`
- `npm run typecheck --workspace @google/gemini-cli`
- `npm run lint --workspace @google/gemini-cli -- --quiet src/utils/sessionCleanup.ts src/utils/sessionCleanup.test.ts`
- `npx prettier --check packages/cli/src/utils/sessionCleanup.ts packages/cli/src/utils/sessionCleanup.test.ts`
