### PR TITLE
fix(core): clamp remaining context tokens

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1552,6 +1552,41 @@ ${JSON.stringify(
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
+    it('should not report negative remaining tokens when the current prompt already exceeds the limit', async () => {
+      const MOCKED_TOKEN_LIMIT = 1000;
+      vi.mocked(tokenLimit).mockReturnValue(MOCKED_TOKEN_LIMIT);
+
+      const mockChat: Partial<GeminiChat> = {
+        getLastPromptTokenCount: vi.fn().mockReturnValue(1200),
+        setTools: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      vi.spyOn(client, 'tryCompressChat').mockResolvedValue({
+        originalTokenCount: 1200,
+        newTokenCount: 1200,
+        compressionStatus: CompressionStatus.NOOP,
+      });
+
+      const request: Part[] = [{ text: 'short request' }];
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-overflow-negative-remaining',
+        ),
+      );
+
+      expect(events).toContainEqual({
+        type: GeminiEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount: 3,
+          remainingTokenCount: 0,
+        },
+      });
+    });
+
     it("should use the sticky model's token limit for the overflow check", async () => {
       // Arrange
       const STICKY_MODEL = 'gemini-1.5-flash';

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -643,8 +643,10 @@ export class GeminiClient {
       }
     }
 
-    const remainingTokenCount =
-      tokenLimit(modelForLimitCheck) - this.getChat().getLastPromptTokenCount();
+    const remainingTokenCount = Math.max(
+      0,
+      tokenLimit(modelForLimitCheck) - this.getChat().getLastPromptTokenCount(),
+    );
 
     await this.tryMaskToolOutputs(this.getHistory());
 


### PR DESCRIPTION
## Summary
- Clamp `remainingTokenCount` at zero before emitting `ContextWindowWillOverflow`.
- Prevent user-facing overflow warnings from showing impossible negative token counts when the current prompt already exceeds the model limit.
- Add a regression test for the over-limit current prompt case.

Fixes #26188.

## Tests
- `npm test --workspace @google/gemini-cli-core -- client.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx prettier --check packages/core/src/core/client.ts packages/core/src/core/client.test.ts`