### PR TITLE
fix(cli): refine platform-specific undo/redo and smart bubbling for WSL

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -499,12 +499,13 @@ the dedicated [Custom Commands documentation](../cli/custom-commands.md).
 These shortcuts apply directly to the input prompt for text manipulation.
 
 - **Undo:**
-  - **Keyboard shortcut:** Press **Alt+z** or **Cmd+z** to undo the last action
-    in the input prompt.
+  - **Keyboard shortcut:** Press **Ctrl+z** (Windows), **Cmd+z** (macOS), or
+    **Alt+z** (Linux/WSL) to undo the last action in the input prompt.
 
 - **Redo:**
-  - **Keyboard shortcut:** Press **Shift+Alt+Z** or **Shift+Cmd+Z** to redo the
-    last undone action in the input prompt.
+  - **Keyboard shortcut:** Press **Ctrl+y** (Windows), **Shift+Cmd+Z** (macOS),
+    or **Shift+Alt+Z** (Linux/WSL) to redo the last undone action in the input
+    prompt.
 
 ## At commands (`@`)
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -503,9 +503,8 @@ These shortcuts apply directly to the input prompt for text manipulation.
     **Alt+z** (Linux/WSL) to undo the last action in the input prompt.
 
 - **Redo:**
-  - **Keyboard shortcut:** Press **Ctrl+y** (Windows), **Shift+Cmd+Z** (macOS),
-    or **Shift+Alt+Z** (Linux/WSL) to redo the last undone action in the input
-    prompt.
+  - **Keyboard shortcut:** Press **Shift+Cmd+Z** (macOS), or **Shift+Alt+Z**
+    (Linux/WSL) to redo the last undone action in the input prompt.
 
 ## At commands (`@`)
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -40,7 +40,7 @@ available combinations.
 | `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                              |
 | `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                                 |
 | `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                                 |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y`<br />`Ctrl+Shift+Z`<br />`Shift+Cmd/Win+Z`<br />`Alt+Shift+Z` |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y`<br />`Ctrl+Shift+Z`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
 
 #### Scrolling
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -40,7 +40,7 @@ available combinations.
 | `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                |
 | `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                   |
 | `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                   |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Shift+Cmd/Win+Z`<br />`Alt+Shift+Z` |
 
 #### Scrolling
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -30,17 +30,17 @@ available combinations.
 
 #### Editing
 
-| Command                | Action                                           | Keys                                                                   |
-| ---------------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
-| `edit.deleteRightAll`  | Delete from the cursor to the end of the line.   | `Ctrl+K`                                                               |
-| `edit.deleteLeftAll`   | Delete from the cursor to the start of the line. | `Ctrl+U`                                                               |
-| `edit.clear`           | Clear all text in the input field.               | `Ctrl+C`                                                               |
-| `edit.deleteWordLeft`  | Delete the previous word.                        | `Ctrl+Backspace`<br />`Alt+Backspace`<br />`Ctrl+W`                    |
-| `edit.deleteWordRight` | Delete the next word.                            | `Ctrl+Delete`<br />`Alt+Delete`<br />`Alt+D`                           |
-| `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                              |
-| `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                                 |
-| `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                                 |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Ctrl+Y`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
+| Command                | Action                                           | Keys                                                     |
+| ---------------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| `edit.deleteRightAll`  | Delete from the cursor to the end of the line.   | `Ctrl+K`                                                 |
+| `edit.deleteLeftAll`   | Delete from the cursor to the start of the line. | `Ctrl+U`                                                 |
+| `edit.clear`           | Clear all text in the input field.               | `Ctrl+C`                                                 |
+| `edit.deleteWordLeft`  | Delete the previous word.                        | `Ctrl+Backspace`<br />`Alt+Backspace`<br />`Ctrl+W`      |
+| `edit.deleteWordRight` | Delete the next word.                            | `Ctrl+Delete`<br />`Alt+Delete`<br />`Alt+D`             |
+| `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                |
+| `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                   |
+| `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                   |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
 
 #### Scrolling
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -39,8 +39,8 @@ available combinations.
 | `edit.deleteWordRight` | Delete the next word.                            | `Ctrl+Delete`<br />`Alt+Delete`<br />`Alt+D`             |
 | `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                |
 | `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                   |
-| `edit.undo`            | Undo the most recent text edit.                  | `Cmd/Win+Z`<br />`Alt+Z`                                 |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Shift+Cmd/Win+Z`<br />`Alt+Shift+Z` |
+| `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z` (Windows)<br />`Cmd+Z` (macOS)<br />`Alt+Z` (Linux/WSL) |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y` (Windows)<br />`Ctrl+Shift+Z`<br />`Shift+Cmd+Z`<br />`Alt+Shift+Z` |
 
 #### Scrolling
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -40,7 +40,7 @@ available combinations.
 | `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                              |
 | `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                                 |
 | `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                                 |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y`<br />`Ctrl+Shift+Z`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Shift+Z`<br />`Ctrl+Y`<br />`Alt+Shift+Z`<br />`Shift+Cmd/Win+Z` |
 
 #### Scrolling
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -30,17 +30,17 @@ available combinations.
 
 #### Editing
 
-| Command                | Action                                           | Keys                                                     |
-| ---------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| `edit.deleteRightAll`  | Delete from the cursor to the end of the line.   | `Ctrl+K`                                                 |
-| `edit.deleteLeftAll`   | Delete from the cursor to the start of the line. | `Ctrl+U`                                                 |
-| `edit.clear`           | Clear all text in the input field.               | `Ctrl+C`                                                 |
-| `edit.deleteWordLeft`  | Delete the previous word.                        | `Ctrl+Backspace`<br />`Alt+Backspace`<br />`Ctrl+W`      |
-| `edit.deleteWordRight` | Delete the next word.                            | `Ctrl+Delete`<br />`Alt+Delete`<br />`Alt+D`             |
-| `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                |
-| `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                   |
-| `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z` (Windows)<br />`Cmd+Z` (macOS)<br />`Alt+Z` (Linux/WSL) |
-| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y` (Windows)<br />`Ctrl+Shift+Z`<br />`Shift+Cmd+Z`<br />`Alt+Shift+Z` |
+| Command                | Action                                           | Keys                                                                   |
+| ---------------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
+| `edit.deleteRightAll`  | Delete from the cursor to the end of the line.   | `Ctrl+K`                                                               |
+| `edit.deleteLeftAll`   | Delete from the cursor to the start of the line. | `Ctrl+U`                                                               |
+| `edit.clear`           | Clear all text in the input field.               | `Ctrl+C`                                                               |
+| `edit.deleteWordLeft`  | Delete the previous word.                        | `Ctrl+Backspace`<br />`Alt+Backspace`<br />`Ctrl+W`                    |
+| `edit.deleteWordRight` | Delete the next word.                            | `Ctrl+Delete`<br />`Alt+Delete`<br />`Alt+D`                           |
+| `edit.deleteLeft`      | Delete the character to the left.                | `Backspace`<br />`Ctrl+H`                                              |
+| `edit.deleteRight`     | Delete the character to the right.               | `Delete`<br />`Ctrl+D`                                                 |
+| `edit.undo`            | Undo the most recent text edit.                  | `Ctrl+Z`<br />`Alt+Z`<br />`Cmd/Win+Z`                                 |
+| `edit.redo`            | Redo the most recent undone text edit.           | `Ctrl+Y`<br />`Ctrl+Shift+Z`<br />`Shift+Cmd/Win+Z`<br />`Alt+Shift+Z` |
 
 #### Scrolling
 

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1926,13 +1926,13 @@ describe('useTextBuffer', () => {
       const redoKey: Key =
         process.platform === 'win32'
           ? {
-              name: 'y',
+              name: 'z',
               ctrl: true,
-              shift: false,
+              shift: true,
               alt: false,
               cmd: false,
               insertable: false,
-              sequence: '\x19',
+              sequence: '\x1a',
             }
           : process.platform === 'darwin'
             ? {

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -1870,6 +1870,55 @@ describe('useTextBuffer', () => {
       expect(handled).toBe(false);
     });
 
+    if (process.platform === 'linux') {
+      it('should handle "Ctrl+Z" for smart bubbling on Linux/WSL', async () => {
+        const { result } = await renderHook(() => useTextBuffer({ viewport }));
+
+        const ctrlZ: Key = {
+          name: 'z',
+          ctrl: true,
+          shift: false,
+          alt: false,
+          cmd: false,
+          insertable: false,
+          sequence: '\x1a',
+        };
+
+        // 1. Empty buffer: should NOT handle (bubble up to Suspend)
+        let handled = true;
+        act(() => {
+          handled = result.current.handleInput(ctrlZ);
+        });
+        expect(handled).toBe(false);
+
+        // 2. Add text
+        act(() => {
+          result.current.handleInput({
+            name: 'x',
+            insertable: true,
+            sequence: 'x',
+            shift: false,
+            alt: false,
+            ctrl: false,
+            cmd: false,
+          });
+        });
+
+        // 3. Has history: should handle (perform Undo)
+        act(() => {
+          handled = result.current.handleInput(ctrlZ);
+        });
+        expect(handled).toBe(true);
+        expect(getBufferState(result).text).toBe('');
+
+        // 4. Empty again: should NOT handle
+        act(() => {
+          handled = result.current.handleInput(ctrlZ);
+        });
+        expect(handled).toBe(false);
+      });
+    }
+
     it('should only handle Redo if there is something to redo', async () => {
       const { result } = await renderHook(() => useTextBuffer({ viewport }));
 

--- a/packages/cli/src/ui/components/shared/text-buffer.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.test.ts
@@ -41,6 +41,7 @@ import {
   getTransformedImagePath,
 } from './text-buffer.js';
 import { cpLen } from '../../utils/textUtils.js';
+import { type Key } from '../../hooks/useKeypress.js';
 import { escapePath } from '@google/gemini-cli-core';
 
 const defaultVisualLayout: VisualLayout = {
@@ -1797,6 +1798,180 @@ describe('useTextBuffer', () => {
         });
       });
       expect(getBufferState(result).text).toBe('');
+    });
+
+    it('should only handle Undo if there is something to undo', async () => {
+      const { result } = await renderHook(() => useTextBuffer({ viewport }));
+
+      // Platform-specific undo key
+      const undoKey: Key =
+        process.platform === 'win32'
+          ? {
+              name: 'z',
+              ctrl: true,
+              shift: false,
+              alt: false,
+              cmd: false,
+              insertable: false,
+              sequence: '\x1a',
+            }
+          : process.platform === 'darwin'
+            ? {
+                name: 'z',
+                ctrl: false,
+                shift: false,
+                alt: false,
+                cmd: true,
+                insertable: false,
+                sequence: '\u001b[122;D',
+              }
+            : {
+                name: 'z',
+                ctrl: false,
+                shift: false,
+                alt: true,
+                cmd: false,
+                insertable: false,
+                sequence: '\u001bz',
+              };
+
+      // 1. Initial state: nothing to undo
+      let handled = true;
+      act(() => {
+        handled = result.current.handleInput(undoKey);
+      });
+      expect(handled).toBe(false);
+
+      // 2. Insert something
+      act(() => {
+        result.current.handleInput({
+          name: 'a',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          insertable: true,
+          sequence: 'a',
+        });
+      });
+      expect(getBufferState(result).text).toBe('a');
+
+      // 3. Now undo should work
+      act(() => {
+        handled = result.current.handleInput(undoKey);
+      });
+      expect(handled).toBe(true);
+      expect(getBufferState(result).text).toBe('');
+
+      // 4. Undo again: nothing left to undo
+      act(() => {
+        handled = result.current.handleInput(undoKey);
+      });
+      expect(handled).toBe(false);
+    });
+
+    it('should only handle Redo if there is something to redo', async () => {
+      const { result } = await renderHook(() => useTextBuffer({ viewport }));
+
+      // Platform-specific redo key (first in list)
+      const redoKey: Key =
+        process.platform === 'win32'
+          ? {
+              name: 'y',
+              ctrl: true,
+              shift: false,
+              alt: false,
+              cmd: false,
+              insertable: false,
+              sequence: '\x19',
+            }
+          : process.platform === 'darwin'
+            ? {
+                name: 'z',
+                ctrl: false,
+                shift: true,
+                alt: false,
+                cmd: true,
+                insertable: false,
+                sequence: '\u001b[122;2D',
+              }
+            : {
+                name: 'z',
+                ctrl: false,
+                shift: true,
+                alt: true,
+                cmd: false,
+                insertable: false,
+                sequence: '\u001bZ',
+              };
+
+      const undoKey: Key =
+        process.platform === 'win32'
+          ? {
+              name: 'z',
+              ctrl: true,
+              shift: false,
+              alt: false,
+              cmd: false,
+              insertable: false,
+              sequence: '\x1a',
+            }
+          : process.platform === 'darwin'
+            ? {
+                name: 'z',
+                ctrl: false,
+                shift: false,
+                alt: false,
+                cmd: true,
+                insertable: false,
+                sequence: '\u001b[122;D',
+              }
+            : {
+                name: 'z',
+                ctrl: false,
+                shift: false,
+                alt: true,
+                cmd: false,
+                insertable: false,
+                sequence: '\u001bz',
+              };
+
+      // 1. Initial state: nothing to redo
+      let handled = true;
+      act(() => {
+        handled = result.current.handleInput(redoKey);
+      });
+      expect(handled).toBe(false);
+
+      // 2. Insert and Undo
+      act(() => {
+        result.current.handleInput({
+          name: 'a',
+          shift: false,
+          alt: false,
+          ctrl: false,
+          cmd: false,
+          insertable: true,
+          sequence: 'a',
+        });
+      });
+      act(() => {
+        result.current.handleInput(undoKey);
+      });
+      expect(getBufferState(result).text).toBe('');
+
+      // 3. Now redo should work
+      act(() => {
+        handled = result.current.handleInput(redoKey);
+      });
+      expect(handled).toBe(true);
+      expect(getBufferState(result).text).toBe('a');
+
+      // 4. Redo again: nothing left to redo
+      act(() => {
+        handled = result.current.handleInput(redoKey);
+      });
+      expect(handled).toBe(false);
     });
 
     it('should handle multiple delete characters in one input', async () => {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2889,6 +2889,8 @@ export function useTextBuffer({
     transformationsByLine,
     pastedContent,
     expandedPaste,
+    undoStack,
+    redoStack,
   } = state;
 
   const text = useMemo(() => lines.join('\n'), [lines]);
@@ -3454,10 +3456,16 @@ export function useTextBuffer({
         return true;
       }
       if (keyMatchers[Command.UNDO](key)) {
+        if (undoStack.length === 0) {
+          return false;
+        }
         undo();
         return true;
       }
       if (keyMatchers[Command.REDO](key)) {
+        if (redoStack.length === 0) {
+          return false;
+        }
         redo();
         return true;
       }
@@ -3486,6 +3494,8 @@ export function useTextBuffer({
       visualCursor,
       visualLines,
       keyMatchers,
+      undoStack.length,
+      redoStack.length,
     ],
   );
 

--- a/packages/cli/src/ui/key/keyBindings.test.ts
+++ b/packages/cli/src/ui/key/keyBindings.test.ts
@@ -126,19 +126,10 @@ describe('keyBindings config', () => {
 
   it('should have platform-specific REDO bindings', () => {
     const redoBindings = defaultKeyBindingConfig.get(Command.REDO);
-    if (process.platform === 'win32') {
-      expect(redoBindings?.[0].name).toBe('z');
-      expect(redoBindings?.[0].shift).toBe(true);
-      expect(redoBindings?.[0].ctrl).toBe(true);
-    } else if (process.platform === 'darwin') {
-      expect(redoBindings?.[0].name).toBe('z');
-      expect(redoBindings?.[0].shift).toBe(true);
-      expect(redoBindings?.[0].cmd).toBe(true);
-    } else {
-      expect(redoBindings?.[0].name).toBe('z');
-      expect(redoBindings?.[0].shift).toBe(true);
-      expect(redoBindings?.[0].alt).toBe(true);
-    }
+    // Ctrl+Shift+Z is now the universal primary to avoid conflict with YOLO (Ctrl+Y)
+    expect(redoBindings?.[0].name).toBe('z');
+    expect(redoBindings?.[0].shift).toBe(true);
+    expect(redoBindings?.[0].ctrl).toBe(true);
   });
 
   describe('command metadata', () => {

--- a/packages/cli/src/ui/key/keyBindings.test.ts
+++ b/packages/cli/src/ui/key/keyBindings.test.ts
@@ -108,6 +108,36 @@ describe('keyBindings config', () => {
     }
   });
 
+  it('should have platform-specific UNDO bindings', () => {
+    const undoBindings = defaultKeyBindingConfig.get(Command.UNDO);
+    if (process.platform === 'win32') {
+      expect(undoBindings?.[0].name).toBe('z');
+      expect(undoBindings?.[0].ctrl).toBe(true);
+    } else if (process.platform === 'darwin') {
+      expect(undoBindings?.[0].name).toBe('z');
+      expect(undoBindings?.[0].cmd).toBe(true);
+    } else {
+      expect(undoBindings?.[0].name).toBe('z');
+      expect(undoBindings?.[0].alt).toBe(true);
+    }
+  });
+
+  it('should have platform-specific REDO bindings', () => {
+    const redoBindings = defaultKeyBindingConfig.get(Command.REDO);
+    if (process.platform === 'win32') {
+      expect(redoBindings?.[0].name).toBe('y');
+      expect(redoBindings?.[0].ctrl).toBe(true);
+    } else if (process.platform === 'darwin') {
+      expect(redoBindings?.[0].name).toBe('z');
+      expect(redoBindings?.[0].shift).toBe(true);
+      expect(redoBindings?.[0].cmd).toBe(true);
+    } else {
+      expect(redoBindings?.[0].name).toBe('z');
+      expect(redoBindings?.[0].shift).toBe(true);
+      expect(redoBindings?.[0].alt).toBe(true);
+    }
+  });
+
   describe('command metadata', () => {
     const commandValues = Object.values(Command);
 

--- a/packages/cli/src/ui/key/keyBindings.test.ts
+++ b/packages/cli/src/ui/key/keyBindings.test.ts
@@ -127,7 +127,8 @@ describe('keyBindings config', () => {
   it('should have platform-specific REDO bindings', () => {
     const redoBindings = defaultKeyBindingConfig.get(Command.REDO);
     if (process.platform === 'win32') {
-      expect(redoBindings?.[0].name).toBe('y');
+      expect(redoBindings?.[0].name).toBe('z');
+      expect(redoBindings?.[0].shift).toBe(true);
       expect(redoBindings?.[0].ctrl).toBe(true);
     } else if (process.platform === 'darwin') {
       expect(redoBindings?.[0].name).toBe('z');

--- a/packages/cli/src/ui/key/keyBindings.test.ts
+++ b/packages/cli/src/ui/key/keyBindings.test.ts
@@ -119,6 +119,8 @@ describe('keyBindings config', () => {
     } else {
       expect(undoBindings?.[0].name).toBe('z');
       expect(undoBindings?.[0].alt).toBe(true);
+      // Ensure ctrl+z is also present for smart bubbling
+      expect(undoBindings?.some((b) => b.name === 'z' && b.ctrl)).toBe(true);
     }
   });
 

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -312,14 +312,21 @@ export const defaultKeyBindingConfig: KeyBindingConfig = new Map([
     Command.DELETE_CHAR_RIGHT,
     [new KeyBinding('delete'), new KeyBinding('ctrl+d')],
   ],
-  [Command.UNDO, [new KeyBinding('cmd+z'), new KeyBinding('alt+z')]],
+  [
+    Command.UNDO,
+    process.platform === 'win32'
+      ? [new KeyBinding('ctrl+z'), new KeyBinding('alt+z')]
+      : process.platform === 'darwin'
+        ? [new KeyBinding('cmd+z'), new KeyBinding('alt+z')]
+        : [new KeyBinding('alt+z'), new KeyBinding('cmd+z')],
+  ],
   [
     Command.REDO,
-    [
-      new KeyBinding('ctrl+shift+z'),
-      new KeyBinding('cmd+shift+z'),
-      new KeyBinding('alt+shift+z'),
-    ],
+    process.platform === 'win32'
+      ? [new KeyBinding('ctrl+y'), new KeyBinding('ctrl+shift+z')]
+      : process.platform === 'darwin'
+        ? [new KeyBinding('cmd+shift+z'), new KeyBinding('alt+shift+z')]
+        : [new KeyBinding('alt+shift+z'), new KeyBinding('cmd+shift+z')],
   ],
 
   // Scrolling

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -312,22 +312,8 @@ export const defaultKeyBindingConfig: KeyBindingConfig = new Map([
     Command.DELETE_CHAR_RIGHT,
     [new KeyBinding('delete'), new KeyBinding('ctrl+d')],
   ],
-  [
-    Command.UNDO,
-    process.platform === 'win32'
-      ? [new KeyBinding('ctrl+z'), new KeyBinding('alt+z')]
-      : process.platform === 'darwin'
-        ? [new KeyBinding('cmd+z'), new KeyBinding('alt+z')]
-        : [new KeyBinding('alt+z'), new KeyBinding('cmd+z')],
-  ],
-  [
-    Command.REDO,
-    process.platform === 'win32'
-      ? [new KeyBinding('ctrl+y'), new KeyBinding('ctrl+shift+z')]
-      : process.platform === 'darwin'
-        ? [new KeyBinding('cmd+shift+z'), new KeyBinding('alt+shift+z')]
-        : [new KeyBinding('alt+shift+z'), new KeyBinding('cmd+shift+z')],
-  ],
+  [Command.UNDO, getPlatformUndoBindings(process.platform)],
+  [Command.REDO, getPlatformRedoBindings(process.platform)],
 
   // Scrolling
   [Command.SCROLL_UP, [new KeyBinding('shift+up')]],
@@ -788,4 +774,28 @@ export async function loadCustomKeybindings(): Promise<{
   }
 
   return { config, errors };
+}
+
+export function getPlatformUndoBindings(
+  platform: string,
+): readonly KeyBinding[] {
+  if (platform === 'win32') {
+    return [new KeyBinding('ctrl+z'), new KeyBinding('alt+z')];
+  }
+  if (platform === 'darwin') {
+    return [new KeyBinding('cmd+z'), new KeyBinding('alt+z')];
+  }
+  return [new KeyBinding('alt+z'), new KeyBinding('cmd+z')];
+}
+
+export function getPlatformRedoBindings(
+  platform: string,
+): readonly KeyBinding[] {
+  if (platform === 'win32') {
+    return [new KeyBinding('ctrl+y'), new KeyBinding('ctrl+shift+z')];
+  }
+  if (platform === 'darwin') {
+    return [new KeyBinding('cmd+shift+z'), new KeyBinding('alt+shift+z')];
+  }
+  return [new KeyBinding('alt+shift+z'), new KeyBinding('cmd+shift+z')];
 }

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -798,11 +798,7 @@ export function getPlatformRedoBindings(
   platform: string,
 ): readonly KeyBinding[] {
   if (platform === 'win32') {
-    return [
-      new KeyBinding('ctrl+shift+z'),
-      new KeyBinding('ctrl+y'),
-      new KeyBinding('alt+shift+z'),
-    ];
+    return [new KeyBinding('ctrl+shift+z'), new KeyBinding('alt+shift+z')];
   }
   if (platform === 'darwin') {
     return [
@@ -811,11 +807,10 @@ export function getPlatformRedoBindings(
       new KeyBinding('ctrl+shift+z'),
     ];
   }
-  // Linux / WSL: Prioritize Ctrl+Shift+Z, keep Ctrl+Y as secondary for smart bubbling.
+  // Linux / WSL: Keep only shift-based redo to avoid conflict with YOLO (ctrl+y)
   return [
     new KeyBinding('ctrl+shift+z'),
     new KeyBinding('alt+shift+z'),
     new KeyBinding('cmd+shift+z'),
-    new KeyBinding('ctrl+y'),
   ];
 }

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -795,22 +795,13 @@ export function getPlatformUndoBindings(
 }
 
 export function getPlatformRedoBindings(
-  platform: string,
+  _platform: string,
 ): readonly KeyBinding[] {
-  if (platform === 'win32') {
-    return [new KeyBinding('ctrl+shift+z'), new KeyBinding('alt+shift+z')];
-  }
-  if (platform === 'darwin') {
-    return [
-      new KeyBinding('cmd+shift+z'),
-      new KeyBinding('alt+shift+z'),
-      new KeyBinding('ctrl+shift+z'),
-    ];
-  }
-  // Linux / WSL: Keep only shift-based redo to avoid conflict with YOLO (ctrl+y)
+  // Use a stable order for all platforms to minimize churn.
+  // Ctrl+Shift+Z is the universal primary.
   return [
     new KeyBinding('ctrl+shift+z'),
-    new KeyBinding('alt+shift+z'),
     new KeyBinding('cmd+shift+z'),
+    new KeyBinding('alt+shift+z'),
   ];
 }

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -785,7 +785,13 @@ export function getPlatformUndoBindings(
   if (platform === 'darwin') {
     return [new KeyBinding('cmd+z'), new KeyBinding('alt+z')];
   }
-  return [new KeyBinding('alt+z'), new KeyBinding('cmd+z')];
+  // Linux / WSL: Promote Alt+Z to avoid Windows interception,
+  // but keep Ctrl+Z for smart bubbling.
+  return [
+    new KeyBinding('alt+z'),
+    new KeyBinding('cmd+z'),
+    new KeyBinding('ctrl+z'),
+  ];
 }
 
 export function getPlatformRedoBindings(
@@ -793,8 +799,8 @@ export function getPlatformRedoBindings(
 ): readonly KeyBinding[] {
   if (platform === 'win32') {
     return [
-      new KeyBinding('ctrl+y'),
       new KeyBinding('ctrl+shift+z'),
+      new KeyBinding('ctrl+y'),
       new KeyBinding('alt+shift+z'),
     ];
   }
@@ -805,9 +811,11 @@ export function getPlatformRedoBindings(
       new KeyBinding('ctrl+shift+z'),
     ];
   }
+  // Linux / WSL: Prioritize Ctrl+Shift+Z, keep Ctrl+Y as secondary for smart bubbling.
   return [
+    new KeyBinding('ctrl+shift+z'),
     new KeyBinding('alt+shift+z'),
     new KeyBinding('cmd+shift+z'),
-    new KeyBinding('ctrl+shift+z'),
+    new KeyBinding('ctrl+y'),
   ];
 }

--- a/packages/cli/src/ui/key/keyBindings.ts
+++ b/packages/cli/src/ui/key/keyBindings.ts
@@ -792,10 +792,22 @@ export function getPlatformRedoBindings(
   platform: string,
 ): readonly KeyBinding[] {
   if (platform === 'win32') {
-    return [new KeyBinding('ctrl+y'), new KeyBinding('ctrl+shift+z')];
+    return [
+      new KeyBinding('ctrl+y'),
+      new KeyBinding('ctrl+shift+z'),
+      new KeyBinding('alt+shift+z'),
+    ];
   }
   if (platform === 'darwin') {
-    return [new KeyBinding('cmd+shift+z'), new KeyBinding('alt+shift+z')];
+    return [
+      new KeyBinding('cmd+shift+z'),
+      new KeyBinding('alt+shift+z'),
+      new KeyBinding('ctrl+shift+z'),
+    ];
   }
-  return [new KeyBinding('alt+shift+z'), new KeyBinding('cmd+shift+z')];
+  return [
+    new KeyBinding('alt+shift+z'),
+    new KeyBinding('cmd+shift+z'),
+    new KeyBinding('ctrl+shift+z'),
+  ];
 }

--- a/packages/cli/src/ui/key/keyMatchers.test.ts
+++ b/packages/cli/src/ui/key/keyMatchers.test.ts
@@ -166,12 +166,16 @@ describe('keyMatchers', () => {
       command: Command.REDO,
       positive: [
         ...(process.platform === 'win32'
-          ? [createKey('y', { shift: false, ctrl: true })]
+          ? []
           : [createKey('z', { shift: true, cmd: true })]),
         createKey('z', { shift: true, alt: true }),
         createKey('z', { shift: true, ctrl: true }),
       ],
-      negative: [createKey('z'), createKey('z', { shift: false, cmd: true })],
+      negative: [
+        createKey('z'),
+        createKey('z', { shift: false, cmd: true }),
+        createKey('y', { shift: false, ctrl: true }),
+      ],
     },
 
     // Screen control

--- a/packages/cli/src/ui/key/keyMatchers.test.ts
+++ b/packages/cli/src/ui/key/keyMatchers.test.ts
@@ -151,14 +151,25 @@ describe('keyMatchers', () => {
       positive: [
         ...(process.platform === 'win32'
           ? [createKey('z', { shift: false, ctrl: true })]
-          : [createKey('z', { shift: false, cmd: true })]),
-        createKey('z', { shift: false, alt: true }),
+          : process.platform === 'darwin'
+            ? [createKey('z', { shift: false, cmd: true })]
+            : [
+                createKey('z', { shift: false, alt: true }),
+                createKey('z', { shift: false, cmd: true }),
+                createKey('z', { shift: false, ctrl: true }),
+              ]),
+        ...(process.platform !== 'linux'
+          ? [createKey('z', { shift: false, alt: true })]
+          : []),
       ],
       negative: [
         createKey('z'),
         createKey('z', { shift: true, cmd: true }),
-        ...(process.platform !== 'win32'
+        ...(process.platform === 'darwin'
           ? [createKey('z', { shift: false, ctrl: true })]
+          : []),
+        ...(process.platform === 'win32'
+          ? [createKey('z', { shift: false, cmd: true })]
           : []),
       ],
     },

--- a/packages/cli/src/ui/key/keyMatchers.test.ts
+++ b/packages/cli/src/ui/key/keyMatchers.test.ts
@@ -149,19 +149,25 @@ describe('keyMatchers', () => {
     {
       command: Command.UNDO,
       positive: [
-        createKey('z', { shift: false, cmd: true }),
+        ...(process.platform === 'win32'
+          ? [createKey('z', { shift: false, ctrl: true })]
+          : [createKey('z', { shift: false, cmd: true })]),
         createKey('z', { shift: false, alt: true }),
       ],
       negative: [
         createKey('z'),
         createKey('z', { shift: true, cmd: true }),
-        createKey('z', { shift: false, ctrl: true }),
+        ...(process.platform !== 'win32'
+          ? [createKey('z', { shift: false, ctrl: true })]
+          : []),
       ],
     },
     {
       command: Command.REDO,
       positive: [
-        createKey('z', { shift: true, cmd: true }),
+        ...(process.platform === 'win32'
+          ? [createKey('y', { shift: false, ctrl: true })]
+          : [createKey('z', { shift: true, cmd: true })]),
         createKey('z', { shift: true, alt: true }),
         createKey('z', { shift: true, ctrl: true }),
       ],

--- a/scripts/generate-keybindings-doc.ts
+++ b/scripts/generate-keybindings-doc.ts
@@ -13,6 +13,9 @@ import {
   commandCategories,
   commandDescriptions,
   defaultKeyBindingConfig,
+  Command,
+  getPlatformUndoBindings,
+  getPlatformRedoBindings,
 } from '../packages/cli/src/ui/key/keyBindings.js';
 import {
   formatWithPrettier,
@@ -81,12 +84,52 @@ export async function main(argv = process.argv.slice(2)) {
 export function buildDefaultDocSections(): readonly KeybindingDocSection[] {
   return commandCategories.map((category) => ({
     title: category.title,
-    commands: category.commands.map((command) => ({
-      command: command,
-      description: commandDescriptions[command],
-      bindings: defaultKeyBindingConfig.get(command) ?? [],
-    })),
+    commands: category.commands.map((command) => {
+      // For UNDO and REDO, we want to show all platform variants in the docs
+      if (command === Command.UNDO) {
+        return {
+          command: command,
+          description: commandDescriptions[command],
+          bindings: getMergedPlatformBindings(getPlatformUndoBindings),
+        };
+      }
+      if (command === Command.REDO) {
+        return {
+          command: command,
+          description: commandDescriptions[command],
+          bindings: getMergedPlatformBindings(getPlatformRedoBindings),
+        };
+      }
+
+      return {
+        command: command,
+        description: commandDescriptions[command],
+        bindings: defaultKeyBindingConfig.get(command) ?? [],
+      };
+    }),
   }));
+}
+
+function getMergedPlatformBindings(
+  getBindings: (platform: string) => readonly KeyBinding[],
+): readonly KeyBinding[] {
+  const win32 = getBindings('win32');
+  const darwin = getBindings('darwin');
+  const linux = getBindings('linux');
+
+  const all = [...win32, ...darwin, ...linux];
+  const seen = new Set<string>();
+  const unique: KeyBinding[] = [];
+
+  for (const b of all) {
+    const key = `${b.name}-${b.ctrl}-${b.shift}-${b.alt}-${b.cmd}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(b);
+    }
+  }
+
+  return unique;
 }
 
 export function renderDocumentation(


### PR DESCRIPTION
## Summary

This PR refines the platform-specific Undo/Redo shortcuts to specifically address WSL users on Windows 11 while ensuring no regressions for other platforms.

## Details

- **WSL/Linux Optimization:** Promoted 'Alt+Z' (Undo) and 'Alt+Shift+Z' (Redo) as primary shortcuts on Linux/WSL. This avoids the OS-level interception of 'Win+Z' (Snap Layouts) on Windows 11.
- **Smart Bubbling:** Enhanced the text buffer input handler to only consume 'Ctrl+Z' when there is actual text to undo. This allows WSL users to use 'Ctrl+Z' for undoing text (natural behavior) while still being able to use it for terminal suspension when the buffer is empty.
- **Native Windows/Mac:** Restored 'Ctrl+Z' for native Windows and kept 'Cmd+Z' for macOS, following platform standards.
- **Documentation:** Updated references to explicitly mention WSL support for 'Alt+Z'.

## Related Issues

Fixes #23648

## How to Validate

1. Run unit tests for keybindings:
   `npm test -w @google/gemini-cli -- src/ui/key/keyBindings.test.ts`
2. Run functional tests for the text buffer:
   `npm test -w @google/gemini-cli -- src/ui/components/shared/text-buffer.test.ts`
3. Verify that on Linux/WSL, 'Alt+Z' is the primary suggested shortcut.