### PR TITLE
fix(core): quiet ripgrep fallback log

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2262,6 +2262,12 @@ describe('setApprovalMode with folder trust', () => {
 
     it('should register GrepTool as a fallback when useRipgrep is true but it is not available', async () => {
       vi.mocked(canUseRipgrep).mockResolvedValue(false);
+      const warnSpy = vi
+        .spyOn(debugLogger, 'warn')
+        .mockImplementation(() => {});
+      const debugSpy = vi
+        .spyOn(debugLogger, 'debug')
+        .mockImplementation(() => {});
       const config = new Config({ ...baseParams, useRipgrep: true });
       await config.initialize();
 
@@ -2281,11 +2287,23 @@ describe('setApprovalMode with folder trust', () => {
       );
       const event = vi.mocked(logRipgrepFallback).mock.calls[0][1];
       expect(event.error).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        'Ripgrep is not available. Falling back to GrepTool.',
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Ripgrep is not available. Falling back to GrepTool.',
+      );
     });
 
     it('should register GrepTool as a fallback when canUseRipgrep throws an error', async () => {
       const error = new Error('ripGrep check failed');
       vi.mocked(canUseRipgrep).mockRejectedValue(error);
+      const warnSpy = vi
+        .spyOn(debugLogger, 'warn')
+        .mockImplementation(() => {});
+      const debugSpy = vi
+        .spyOn(debugLogger, 'debug')
+        .mockImplementation(() => {});
       const config = new Config({ ...baseParams, useRipgrep: true });
       await config.initialize();
 
@@ -2305,6 +2323,12 @@ describe('setApprovalMode with folder trust', () => {
       );
       const event = vi.mocked(logRipgrepFallback).mock.calls[0][1];
       expect(event.error).toBe(String(error));
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        'Ripgrep is not available. Falling back to GrepTool.',
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Ripgrep is not available. Falling back to GrepTool.',
+      );
     });
 
     it('should register GrepTool when useRipgrep is false', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3680,7 +3680,9 @@ export class Config implements McpContext, AgentLoopContext {
           registry.registerTool(new RipGrepTool(this, this.messageBus)),
         );
       } else {
-        debugLogger.warn(`Ripgrep is not available. Falling back to GrepTool.`);
+        debugLogger.debug(
+          `Ripgrep is not available. Falling back to GrepTool.`,
+        );
         logRipgrepFallback(this, new RipgrepFallbackEvent(errorString));
         maybeRegister(GrepTool, () =>
           registry.registerTool(new GrepTool(this, this.messageBus)),


### PR DESCRIPTION
## Summary
- Move the ripgrep unavailable fallback message from warning to debug logging.
- Keep GrepTool fallback behavior and ripgrep fallback telemetry unchanged.
- Add regression coverage for both unavailable and erroring ripgrep detection paths.

Fixes #26193.

## Tests
- `npm test --workspace @google/gemini-cli-core -- config.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx prettier --check packages/core/src/config/config.ts packages/core/src/config/config.test.ts`