### PR TITLE
fix: suppress duplicate extension warnings during startup

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -660,7 +660,7 @@ export async function loadCliConfig(
 
   const extensionPlanSettings = extensionManager
     ?.getExtensions()
-    .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
+    ?.find((ext) => ext.isActive && ext.plan?.directory)?.plan;
 
   const experimentalJitContext = settings.experimental.jitContext ?? true;
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -37,6 +37,7 @@ import {
   getAdminErrorMessage,
   isHeadlessMode,
   Config,
+  SimpleExtensionLoader,
   resolveToRealPath,
   applyAdminAllowlist,
   applyRequiredServers,
@@ -558,6 +559,7 @@ export interface LoadCliConfigOptions {
     disabled?: string[];
   };
   worktreeSettings?: WorktreeSettings;
+  skipExtensions?: boolean;
 }
 
 export async function loadCliConfig(
@@ -566,7 +568,7 @@ export async function loadCliConfig(
   argv: CliArgs,
   options: LoadCliConfigOptions = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks } = options;
+  const { cwd = process.cwd(), projectHooks, skipExtensions = false } = options;
   const debugMode = isDebugMode(argv);
 
   const worktreeSettings =
@@ -641,20 +643,23 @@ export async function loadCliConfig(
     includeDirectories.push(...ideFolders);
   }
 
-  const extensionManager = new ExtensionManager({
-    settings,
-    requestConsent: requestConsentNonInteractive,
-    requestSetting: promptForSetting,
-    workspaceDir: cwd,
-    enabledExtensionOverrides: argv.extensions,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    eventEmitter: coreEvents as EventEmitter<ExtensionEvents>,
-    clientVersion: await getVersion(),
-  });
-  await extensionManager.loadExtensions();
+  let extensionManager: ExtensionManager | undefined;
+  if (!skipExtensions) {
+    extensionManager = new ExtensionManager({
+      settings,
+      requestConsent: requestConsentNonInteractive,
+      requestSetting: promptForSetting,
+      workspaceDir: cwd,
+      enabledExtensionOverrides: argv.extensions,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      eventEmitter: coreEvents as EventEmitter<ExtensionEvents>,
+      clientVersion: await getVersion(),
+    });
+    await extensionManager.loadExtensions();
+  }
 
   const extensionPlanSettings = extensionManager
-    .getExtensions()
+    ?.getExtensions()
     .find((ext) => ext.isActive && ext.plan?.directory)?.plan;
 
   const experimentalJitContext = settings.experimental.jitContext ?? true;
@@ -673,6 +678,9 @@ export async function loadCliConfig(
   let fileCount = 0;
   let filePaths: string[] = [];
 
+  const finalExtensionLoader =
+    extensionManager ?? new SimpleExtensionLoader([]);
+
   if (!experimentalJitContext) {
     // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
     const result = await loadServerHierarchicalMemory(
@@ -681,7 +689,7 @@ export async function loadCliConfig(
         ? includeDirectories
         : [],
       fileService,
-      extensionManager,
+      finalExtensionLoader,
       trustedFolder,
       memoryImportFormat,
       memoryFileFiltering,
@@ -1031,7 +1039,7 @@ export async function loadCliConfig(
     listSessions: argv.listSessions || false,
     deleteSession: argv.deleteSession,
     enabledExtensions: argv.extensions,
-    extensionLoader: extensionManager,
+    extensionLoader: finalExtensionLoader,
     extensionRegistryURI,
     enableExtensionReloading: settings.experimental?.extensionReloading,
     enableAgents: settings.experimental?.enableAgents,

--- a/packages/cli/src/config/skipExtensions.test.ts
+++ b/packages/cli/src/config/skipExtensions.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadCliConfig, type CliArgs } from './config.js';
+import { ExtensionManager } from './extension-manager.js';
+import { createTestMergedSettings } from './settings.js';
+
+vi.mock('./extension-manager.js', () => ({
+  ExtensionManager: vi.fn().mockImplementation(() => ({
+    loadExtensions: vi.fn().mockResolvedValue([]),
+    getExtensions: vi.fn().mockReturnValue([]),
+  })),
+}));
+
+describe('loadCliConfig skipExtensions', () => {
+  const settings = createTestMergedSettings();
+  const argv = {
+    query: undefined,
+    model: undefined,
+    sandbox: undefined,
+    debug: undefined,
+    prompt: undefined,
+    promptInteractive: undefined,
+    yolo: undefined,
+    approvalMode: undefined,
+    policy: undefined,
+    adminPolicy: undefined,
+    allowedMcpServerNames: undefined,
+    allowedTools: undefined,
+    extensions: undefined,
+    listExtensions: undefined,
+    resume: undefined,
+    sessionId: undefined,
+    listSessions: undefined,
+  } as unknown as CliArgs;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should load extensions by default', async () => {
+    await loadCliConfig(settings, 'session-id', argv);
+    expect(ExtensionManager).toHaveBeenCalled();
+  });
+
+  it('should skip extensions when skipExtensions is true', async () => {
+    await loadCliConfig(settings, 'session-id', argv, { skipExtensions: true });
+    expect(ExtensionManager).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -409,6 +409,7 @@ export async function main() {
 
   const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
+    skipExtensions: true,
   });
 
   adminControlsListner.setConfig(partialConfig);


### PR DESCRIPTION
## Summary

This PR fixes an issue where extension-related warnings (missing settings, MCP server deprecations, etc.) were displayed twice during CLI startup.

## Details

The CLI startup flow in `gemini.tsx` calls `loadCliConfig` twice—first to establish a minimal `partialConfig` for authentication/sandbox setup, and then for the full interactive session. Both calls were unconditionally loading all extensions. 

I've added a `skipExtensions` option to `loadCliConfig` and set it to `true` for the first call. When skipped, a `SimpleExtensionLoader([])` is used as a fallback to ensure the `Config` object remains valid and type-safe for downstream components.

## Related Issues

Fixes #23172

## How to Validate

1. Install an extension that has missing settings or triggers an MCP deprecation warning.
2. Run `gemini`.
3. Verify that the warning bubble appears only once during startup.
4. Verify that extensions are still correctly loaded and functional once the interactive session starts.

Alternatively, run the included unit test (manual steps if not using the repo's test runner):
```bash
# Create a test file in packages/cli/src/config/skipExtensions.test.ts
# and verify ExtensionManager is not instantiated when skipExtensions is true.
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
