### PR TITLE
fix(cli): prevent last-char clip on input lines matching prompt width

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -5332,6 +5332,34 @@ describe('InputPrompt', () => {
       });
     });
   });
+
+  describe('terminal buffer rendering', () => {
+    it('does not clip the last char of a visual line whose width equals inputWidth', async () => {
+      const fullLine = '1234567890'; // 10 chars, exactly props.inputWidth
+      props.inputWidth = 10;
+      props.suggestionsWidth = 10;
+      vi.spyOn(props.config, 'getUseTerminalBuffer').mockReturnValue(true);
+      mockBuffer.text = fullLine;
+      mockBuffer.lines = [fullLine];
+      mockBuffer.allVisualLines = [fullLine];
+      mockBuffer.viewportVisualLines = [fullLine];
+      mockBuffer.visualToLogicalMap = [[0, 0]];
+      mockBuffer.visualToTransformedMap = [0];
+      mockBuffer.transformationsByLine = [[]];
+      mockBuffer.cursor = [0, fullLine.length];
+      mockBuffer.visualCursor = [0, fullLine.length];
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} />,
+        { uiActions },
+      );
+
+      await waitFor(() => {
+        expect(clean(lastFrame())).toContain(fullLine);
+      });
+      unmount();
+    });
+  });
 });
 
 function clean(str: string | undefined): string {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1862,7 +1862,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                         ? `line-${item.absoluteVisualIdx}`
                         : `ghost-${item.index}`
                     }
-                    width={inputWidth}
+                    // VirtualizedList applies paddingRight=1 for its scroll
+                    // gutter, so a visual line exactly inputWidth chars wide
+                    // would have its last char clipped. Add 1 so the inner
+                    // content area equals inputWidth.
+                    width={inputWidth + 1}
                     backgroundColor={listBackgroundColor}
                     containerHeight={Math.min(
                       buffer.viewportHeight,


### PR DESCRIPTION
## Summary

Fixes #26212.

`VirtualizedList` (the engine behind `ScrollableList`) renders with `paddingRight: 1` for its scroll gutter (`shared/VirtualizedList.tsx:738`). `InputPrompt` was passing `width={inputWidth}` to `ScrollableList`, so the inner content area was actually `inputWidth - 1`. A visual line exactly `inputWidth` chars wide had its last character clipped — at the wrap boundary the user saw the just-typed character and the cursor disappear, even though the buffer kept them.

Pass `width={inputWidth + 1}` so the inner content area equals the configured `inputWidth`.

Only the `ui.terminalBuffer: true` render path was affected; the fallback path renders directly through `Text`/`Fragment` and was already correct.

## Test plan

- [x] Added a regression test in `InputPrompt.test.tsx` (`describe('terminal buffer rendering')`) that mocks a buffer with a visual line of exactly `inputWidth` chars (`'1234567890'`, `inputWidth = 10`) and asserts the rendered frame contains the full string.
- [x] Verified the test fails on `main` (`lastFrame()` returns `'> 123456789'`, missing the trailing `0`) and passes with the fix applied.
- [x] Manually verified in PowerShell + Windows Terminal that the original repro (`parola ` × 7 + `par`) now wraps correctly.
- [x] Pre-commit hooks (prettier, eslint) green.