### PR TITLE
fix(core): fail fast in MessageBus.request() on publish failure

### DIFF
--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -609,13 +609,15 @@ export class AppRig {
         this.removeToolPolicy(pending.toolName);
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      messageBus.publish({
+      const p = messageBus.publish({
         type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
         correlationId: pending.correlationId,
         confirmed: outcome !== ToolConfirmationOutcome.Cancel,
         outcome,
       });
+      if (p instanceof Promise) {
+        p.catch(() => {});
+      }
     });
 
     await act(async () => {

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -90,11 +90,13 @@ export class LocalSubagentInvocation extends BaseToolInvocation<
   }
 
   private publishActivity(activity: SubagentActivityItem): void {
-    void this.messageBus.publish({
-      type: MessageBusType.SUBAGENT_ACTIVITY,
-      subagentName: this.definition.displayName ?? this.definition.name,
-      activity,
-    });
+    void this.messageBus
+      .publish({
+        type: MessageBusType.SUBAGENT_ACTIVITY,
+        subagentName: this.definition.displayName ?? this.definition.name,
+        activity,
+      })
+      .catch(() => {});
   }
 
   /**

--- a/packages/core/src/agents/local-invocation.ts
+++ b/packages/core/src/agents/local-invocation.ts
@@ -90,13 +90,18 @@ export class LocalSubagentInvocation extends BaseToolInvocation<
   }
 
   private publishActivity(activity: SubagentActivityItem): void {
-    void this.messageBus
-      .publish({
+    try {
+      const p = this.messageBus.publish({
         type: MessageBusType.SUBAGENT_ACTIVITY,
         subagentName: this.definition.displayName ?? this.definition.name,
         activity,
-      })
-      .catch(() => {});
+      });
+      if (p instanceof Promise) {
+        p.catch(() => {});
+      }
+    } catch {
+      // Ignore errors in fire-and-forget activity update
+    }
   }
 
   /**

--- a/packages/core/src/confirmation-bus/message-bus.test.ts
+++ b/packages/core/src/confirmation-bus/message-bus.test.ts
@@ -10,6 +10,7 @@ import { PolicyEngine } from '../policy/policy-engine.js';
 import { PolicyDecision } from '../policy/types.js';
 import {
   MessageBusType,
+  type Message,
   type ToolConfirmationRequest,
   type ToolConfirmationResponse,
   type ToolPolicyRejection,
@@ -30,8 +31,9 @@ describe('MessageBus', () => {
       const errorHandler = vi.fn();
       messageBus.on('error', errorHandler);
 
-      // @ts-expect-error - Testing invalid message
-      await messageBus.publish({ invalid: 'message' });
+      await expect(
+        messageBus.publish({ invalid: 'message' } as unknown as Message),
+      ).rejects.toThrow('Invalid message structure');
 
       expect(errorHandler).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -44,11 +46,12 @@ describe('MessageBus', () => {
       const errorHandler = vi.fn();
       messageBus.on('error', errorHandler);
 
-      // @ts-expect-error - Testing missing correlationId
-      await messageBus.publish({
-        type: MessageBusType.TOOL_CONFIRMATION_REQUEST,
-        toolCall: { name: 'test' },
-      });
+      await expect(
+        messageBus.publish({
+          type: MessageBusType.TOOL_CONFIRMATION_REQUEST,
+          toolCall: { name: 'test' },
+        } as unknown as Message),
+      ).rejects.toThrow('Invalid message structure');
 
       expect(errorHandler).toHaveBeenCalled();
     });
@@ -251,8 +254,10 @@ describe('MessageBus', () => {
         correlationId: '123',
       };
 
-      // Should not throw
-      await expect(messageBus.publish(request)).resolves.not.toThrow();
+      // Should throw
+      await expect(messageBus.publish(request)).rejects.toThrow(
+        'Policy check failed',
+      );
 
       // Should emit error
       expect(errorHandler).toHaveBeenCalledWith(
@@ -288,11 +293,13 @@ describe('MessageBus', () => {
           MessageBusType.TOOL_CONFIRMATION_REQUEST,
           (msg) => {
             if (msg.subagent === subagentName) {
-              void messageBus.publish({
-                type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-                correlationId: msg.correlationId,
-                confirmed: true,
-              });
+              void messageBus
+                .publish({
+                  type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+                  correlationId: msg.correlationId,
+                  confirmed: true,
+                })
+                .catch(() => {});
               resolve();
             }
           },
@@ -330,11 +337,13 @@ describe('MessageBus', () => {
           MessageBusType.TOOL_CONFIRMATION_REQUEST,
           (msg) => {
             if (msg.subagent === 'agent1/agent2') {
-              void messageBus.publish({
-                type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-                correlationId: msg.correlationId,
-                confirmed: true,
-              });
+              void messageBus
+                .publish({
+                  type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+                  correlationId: msg.correlationId,
+                  confirmed: true,
+                })
+                .catch(() => {});
               resolve();
             }
           },

--- a/packages/core/src/confirmation-bus/message-bus.test.ts
+++ b/packages/core/src/confirmation-bus/message-bus.test.ts
@@ -293,13 +293,14 @@ describe('MessageBus', () => {
           MessageBusType.TOOL_CONFIRMATION_REQUEST,
           (msg) => {
             if (msg.subagent === subagentName) {
-              void messageBus
-                .publish({
-                  type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-                  correlationId: msg.correlationId,
-                  confirmed: true,
-                })
-                .catch(() => {});
+              const p = messageBus.publish({
+                type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+                correlationId: msg.correlationId,
+                confirmed: true,
+              });
+              if (p instanceof Promise) {
+                p.catch(() => {});
+              }
               resolve();
             }
           },
@@ -337,13 +338,14 @@ describe('MessageBus', () => {
           MessageBusType.TOOL_CONFIRMATION_REQUEST,
           (msg) => {
             if (msg.subagent === 'agent1/agent2') {
-              void messageBus
-                .publish({
-                  type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-                  correlationId: msg.correlationId,
-                  confirmed: true,
-                })
-                .catch(() => {});
+              const p = messageBus.publish({
+                type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+                correlationId: msg.correlationId,
+                confirmed: true,
+              });
+              if (p instanceof Promise) {
+                p.catch(() => {});
+              }
               resolve();
             }
           },

--- a/packages/core/src/confirmation-bus/message-bus.test.ts
+++ b/packages/core/src/confirmation-bus/message-bus.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MessageBus } from './message-bus.js';
 import { PolicyEngine } from '../policy/policy-engine.js';
 import { PolicyDecision } from '../policy/types.js';
+import { debugLogger } from '../utils/debugLogger.js';
 import {
   MessageBusType,
   type Message,
@@ -167,6 +168,62 @@ describe('MessageBus', () => {
       );
     });
 
+    it('should sanitize sensitive data in error messages', async () => {
+      const errorHandler = vi.fn();
+      messageBus.on('error', errorHandler);
+
+      const invalidMessage = {
+        type: MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        toolCall: {
+          name: 'test-tool',
+          args: { password: 'secret-password' },
+        },
+        // missing correlationId makes it invalid
+      } as unknown as Message;
+
+      await expect(messageBus.publish(invalidMessage)).rejects.toThrow(
+        /\[REDACTED\]/,
+      );
+      await expect(messageBus.publish(invalidMessage)).rejects.not.toThrow(
+        /secret-password/,
+      );
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('[REDACTED]'),
+        }),
+      );
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.not.stringContaining('secret-password'),
+        }),
+      );
+    });
+
+    it('should sanitize sensitive data in debug logs', async () => {
+      const debugSpy = vi.spyOn(debugLogger, 'debug');
+      // @ts-expect-error - access private member for test
+      messageBus.debug = true;
+
+      const message: ToolExecutionSuccess<string> = {
+        type: MessageBusType.TOOL_EXECUTION_SUCCESS as const,
+        toolCall: {
+          name: 'test-tool',
+          args: { api_key: 'my-api-key' },
+        },
+        result: 'success',
+      };
+
+      await messageBus.publish(message);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[REDACTED]'),
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.not.stringContaining('my-api-key'),
+      );
+    });
+
     it('should emit other message types directly', async () => {
       const successHandler = vi.fn();
       messageBus.subscribe(
@@ -265,6 +322,101 @@ describe('MessageBus', () => {
           message: 'Policy check failed',
         }),
       );
+    });
+  });
+
+  describe('request', () => {
+    it('should fail fast if publish fails', async () => {
+      // Mock publish to throw
+      vi.spyOn(messageBus, 'publish').mockRejectedValue(
+        new Error('Publish failed'),
+      );
+
+      const request: Omit<ToolConfirmationRequest, 'correlationId'> = {
+        type: MessageBusType.TOOL_CONFIRMATION_REQUEST,
+        toolCall: { name: 'test-tool', args: {} },
+      };
+
+      const start = Date.now();
+      const requestPromise = messageBus.request(
+        request,
+        MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        60000,
+      );
+
+      await expect(requestPromise).rejects.toThrow('Publish failed');
+      const duration = Date.now() - start;
+
+      // Should have failed way before the 60s timeout
+      expect(duration).toBeLessThan(1000);
+    });
+
+    it('should handle timeout if no response is received', async () => {
+      const request: Message = {
+        type: MessageBusType.SUBAGENT_ACTIVITY,
+        subagentName: 'test',
+        activity: {
+          id: '1',
+          type: 'thought',
+          status: 'running',
+          content: 'thinking',
+        },
+      };
+
+      const requestPromise = messageBus.request(
+        request,
+        MessageBusType.ASK_USER_RESPONSE,
+        10, // 10ms timeout
+      );
+
+      await expect(requestPromise).rejects.toThrow(
+        /Request timed out waiting for ask-user-response/,
+      );
+    });
+  });
+
+  describe('pattern resiliency', () => {
+    it('should handle publish returning non-promise (mock behavior)', () => {
+      // @ts-expect-error - mock returning undefined
+      vi.spyOn(messageBus, 'publish').mockReturnValue(undefined);
+
+      const publishAndCatch = () => {
+        const p = messageBus.publish({
+          type: MessageBusType.TOOL_CALLS_UPDATE,
+          toolCalls: [],
+          schedulerId: 'test',
+        } as Message);
+
+        if (p instanceof Promise) {
+          p.catch(() => {});
+        }
+      };
+
+      expect(publishAndCatch).not.toThrow();
+    });
+
+    it('should handle publish throwing synchronously (mock behavior)', () => {
+      vi.spyOn(messageBus, 'publish').mockImplementation(() => {
+        throw new Error('Sync throw');
+      });
+
+      const publishAndCatch = () => {
+        try {
+          const p = messageBus.publish({
+            type: MessageBusType.TOOL_CALLS_UPDATE,
+            toolCalls: [],
+            schedulerId: 'test',
+          } as Message);
+
+          if (p instanceof Promise) {
+            p.catch(() => {});
+          }
+        } catch {
+          // handled
+        }
+      };
+
+      expect(publishAndCatch).not.toThrow();
     });
   });
 

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -11,6 +11,7 @@ import { PolicyDecision } from '../policy/types.js';
 import { MessageBusType, type Message } from './types.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { sanitizeToolArgs } from '../utils/agent-sanitization-utils.js';
 
 export class MessageBus extends EventEmitter {
   private listenerToAbortCleanup = new WeakMap<
@@ -78,12 +79,16 @@ export class MessageBus extends EventEmitter {
 
   async publish(message: Message): Promise<void> {
     if (this.debug) {
-      debugLogger.debug(`[MESSAGE_BUS] publish: ${safeJsonStringify(message)}`);
+      debugLogger.debug(
+        `[MESSAGE_BUS] publish: ${safeJsonStringify(sanitizeToolArgs(message))}`,
+      );
     }
     try {
       if (!this.isValidMessage(message)) {
         throw new Error(
-          `Invalid message structure: ${safeJsonStringify(message)}`,
+          `Invalid message structure: ${safeJsonStringify(
+            sanitizeToolArgs(message),
+          )}`,
         );
       }
 

--- a/packages/core/src/confirmation-bus/message-bus.ts
+++ b/packages/core/src/confirmation-bus/message-bus.ts
@@ -144,6 +144,7 @@ export class MessageBus extends EventEmitter {
       }
     } catch (error) {
       this.emit('error', error);
+      throw error;
     }
   }
 
@@ -239,8 +240,11 @@ export class MessageBus extends EventEmitter {
       this.subscribe<TResponse>(responseType, responseHandler);
 
       // Publish the request with correlation ID
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-type-assertion
-      this.publish({ ...request, correlationId } as TRequest);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      this.publish({ ...request, correlationId } as TRequest).catch((error) => {
+        cleanup();
+        reject(error);
+      });
     });
   }
 }

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -13,6 +13,7 @@ import { checkPolicy, updatePolicy, getPolicyDenialError } from './policy.js';
 import { evaluateBeforeToolHook } from './hook-utils.js';
 import { ToolExecutor } from './tool-executor.js';
 import { ToolModificationHandler } from './tool-modifier.js';
+import { debugLogger } from '../utils/debugLogger.js';
 import {
   type ToolCallRequestInfo,
   type ToolCall,
@@ -166,12 +167,16 @@ export class Scheduler {
   private readonly handleToolConfirmationRequest = async (
     request: ToolConfirmationRequest,
   ) => {
-    await this.messageBus.publish({
-      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
-      correlationId: request.correlationId,
-      confirmed: false,
-      requiresUserConfirmation: true,
-    });
+    try {
+      await this.messageBus.publish({
+        type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+        correlationId: request.correlationId,
+        confirmed: false,
+        requiresUserConfirmation: true,
+      });
+    } catch (error) {
+      debugLogger.error('Failed to publish confirmation response', error);
+    }
   };
 
   private setupMessageBusListener(messageBus: MessageBus): void {

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -244,13 +244,18 @@ export class SchedulerStateManager {
     const snapshot = this.getSnapshot();
 
     // Fire and forget - The message bus handles the publish and error handling.
-    void this.messageBus
-      .publish({
+    try {
+      const p = this.messageBus.publish({
         type: MessageBusType.TOOL_CALLS_UPDATE,
         toolCalls: snapshot,
         schedulerId: this.schedulerId,
-      })
-      .catch(() => {});
+      });
+      if (p instanceof Promise) {
+        p.catch(() => {});
+      }
+    } catch {
+      // Ignore errors in fire-and-forget update
+    }
   }
 
   private isTerminalCall(call: ToolCall): call is CompletedToolCall {

--- a/packages/core/src/scheduler/state-manager.ts
+++ b/packages/core/src/scheduler/state-manager.ts
@@ -244,11 +244,13 @@ export class SchedulerStateManager {
     const snapshot = this.getSnapshot();
 
     // Fire and forget - The message bus handles the publish and error handling.
-    void this.messageBus.publish({
-      type: MessageBusType.TOOL_CALLS_UPDATE,
-      toolCalls: snapshot,
-      schedulerId: this.schedulerId,
-    });
+    void this.messageBus
+      .publish({
+        type: MessageBusType.TOOL_CALLS_UPDATE,
+        toolCalls: snapshot,
+        schedulerId: this.schedulerId,
+      })
+      .catch(() => {});
   }
 
   private isTerminalCall(call: ToolCall): call is CompletedToolCall {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -242,12 +242,14 @@ export abstract class BaseToolInvocation<
     ) {
       if (this._toolName) {
         const options = this.getPolicyUpdateOptions(outcome);
-        void this.messageBus.publish({
-          type: MessageBusType.UPDATE_POLICY,
-          toolName: this._toolName,
-          persist: outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave,
-          ...options,
-        });
+        void this.messageBus
+          .publish({
+            type: MessageBusType.UPDATE_POLICY,
+            toolName: this._toolName,
+            persist: outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave,
+            ...options,
+          })
+          .catch(() => {});
       }
     }
   }
@@ -361,12 +363,10 @@ export abstract class BaseToolInvocation<
         );
       };
 
-      try {
-        void this.messageBus.publish(request);
-      } catch {
+      this.messageBus.publish(request).catch(() => {
         cleanup();
         resolve('allow');
-      }
+      });
     });
   }
 

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -242,14 +242,19 @@ export abstract class BaseToolInvocation<
     ) {
       if (this._toolName) {
         const options = this.getPolicyUpdateOptions(outcome);
-        void this.messageBus
-          .publish({
+        try {
+          const p = this.messageBus.publish({
             type: MessageBusType.UPDATE_POLICY,
             toolName: this._toolName,
             persist: outcome === ToolConfirmationOutcome.ProceedAlwaysAndSave,
             ...options,
-          })
-          .catch(() => {});
+          });
+          if (p instanceof Promise) {
+            p.catch(() => {});
+          }
+        } catch {
+          // Ignore errors in fire-and-forget update
+        }
       }
     }
   }
@@ -363,10 +368,18 @@ export abstract class BaseToolInvocation<
         );
       };
 
-      this.messageBus.publish(request).catch(() => {
+      try {
+        const p = this.messageBus.publish(request);
+        if (p instanceof Promise) {
+          p.catch(() => {
+            cleanup();
+            resolve('allow');
+          });
+        }
+      } catch {
         cleanup();
         resolve('allow');
-      });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where MessageBus.request() would silently hang for 60 seconds if publish() failed. It also fixes a potential process crash caused by unhandled rejections from floating publish() calls, and addresses security concerns regarding sensitive data in logs.

## Details

- **Fail fast in request()**: Added a .catch() block to the publish() call inside MessageBus.request() to immediately reject the request and clean up listeners/timeouts if publication fails.
- **Rethrow in publish()**: Modified MessageBus.publish() to re-throw errors after emitting them on the 'error' event, ensuring callers get explicit failures.
- **Security Sanitization**: Integrated sanitizeToolArgs into MessageBus.publish() to redact sensitive information (passwords, tokens, etc.) from debug logs and error messages, preventing accidental secret leakage.
- **Resilient Floating Promises**: Refactored all floating publish() calls to use a type-safe pattern (instanceof Promise) that gracefully handles test mocks returning undefined or throwing synchronously, while still providing robust error handling in production.
- **Test Alignment & Coverage**: Updated unit tests to expect rejections on invalid input and added 6 new test cases to verify fail-fast behavior, sanitization, and pattern resiliency.

## Related Issues

Fixes #22588

## How to Validate

Run unit tests for the core package:
```bash
npm test -w @google/gemini-cli-core -- src/confirmation-bus/message-bus.test.ts
```
Verify that all 22 tests pass. Also run other affected tests:
```bash
npm test -w @google/gemini-cli-core -- src/scheduler/policy.test.ts src/tools/message-bus-integration.test.ts src/tools/web-fetch.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run