### PR TITLE
fix(agent): prevent exit_plan_mode from being called via shell

### DIFF
--- a/evals/plan_mode.eval.ts
+++ b/evals/plan_mode.eval.ts
@@ -420,4 +420,62 @@ describe('plan_mode', () => {
       assertModelHasOutput(result);
     },
   });
+
+  evalTest('USUALLY_PASSES', {
+    suiteName: 'plan_mode',
+    suiteType: 'behavioral',
+    name: 'should invoke exit_plan_mode as a tool instead of a shell command',
+    approvalMode: ApprovalMode.PLAN,
+    params: {
+      settings: {
+        general: {
+          plan: { enabled: true },
+        },
+        tools: {
+          core: [
+            'run_shell_command',
+            'exit_plan_mode',
+            'write_file',
+            'read_file',
+          ],
+        },
+      },
+    },
+    files: {
+      'plans/my-plan.md': '# My Plan\n\n1. Step one',
+    },
+    prompt:
+      'I agree with the plan in plans/my-plan.md. Please exit plan mode and then run `echo "Starting implementation"`',
+    assert: async (rig) => {
+      await rig.waitForTelemetryReady();
+      const toolLogs = rig.readToolLogs();
+
+      // Check if exit_plan_mode was called as a tool
+      const exitPlanToolCall = toolLogs.find(
+        (log) => log.toolRequest.name === 'exit_plan_mode',
+      );
+
+      // Check if exit_plan_mode was called via shell
+      const shellCalls = toolLogs.filter(
+        (log) => log.toolRequest.name === 'run_shell_command',
+      );
+      const exitPlanViaShell = shellCalls.find((log) => {
+        try {
+          const args = JSON.parse(log.toolRequest.args);
+          return args.command.includes('exit_plan_mode');
+        } catch {
+          return false;
+        }
+      });
+
+      expect(
+        exitPlanViaShell,
+        'Should NOT call exit_plan_mode via run_shell_command',
+      ).toBeUndefined();
+      expect(
+        exitPlanToolCall,
+        'Should call exit_plan_mode tool directly',
+      ).toBeDefined();
+    },
+  });
 });

--- a/evals/plan_mode.eval.ts
+++ b/evals/plan_mode.eval.ts
@@ -431,14 +431,6 @@ describe('plan_mode', () => {
         general: {
           plan: { enabled: true },
         },
-        tools: {
-          core: [
-            'run_shell_command',
-            'exit_plan_mode',
-            'write_file',
-            'read_file',
-          ],
-        },
       },
     },
     files: {

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -118,7 +118,7 @@ The following tools are available in Plan Mode:
    - **Inquiries:** If the request is an **Inquiry** (e.g., "How does X work?"), answer directly. DO NOT create a plan.
    - **Directives:** If the request is a **Directive** (e.g., "Fix bug Y"), follow the workflow below.
 5. **Plan Storage:** Save plans as Markdown (.md) using descriptive filenames.
-6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use \`exit_plan_mode\` to request approval.
+6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use the built-in \`exit_plan_mode\` tool to request approval. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.**
 7. **Presenting Plan:** When seeking informal agreement on a plan, or any time the user asks to see the plan, you MUST output the full content of the plan in the chat response. This overrides the "Minimal Output" guideline.
 
 ## Planning Workflow
@@ -143,7 +143,7 @@ Write the implementation plan to \`../plans/\`. The plan's structure adapts to t
 - **Alignment Check:** After drafting the plan, you MUST present it to the user in the chat (adhering to Rule 7 for presenting plans) to ensure alignment on the specific details. Ask for feedback or confirmation, and proceed to Step 4 (Review & Approval) once the user agrees with the detailed plan.
 
 ### 4. Review & Approval
-ONLY use the \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. When called, this tool will present the plan and formally request approval.
+ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.** When called, this tool will present the plan and formally request approval.
 
 # Operational Guidelines
 
@@ -298,7 +298,7 @@ The following tools are available in Plan Mode:
    - **Inquiries:** If the request is an **Inquiry** (e.g., "How does X work?"), answer directly. DO NOT create a plan.
    - **Directives:** If the request is a **Directive** (e.g., "Fix bug Y"), follow the workflow below.
 5. **Plan Storage:** Save plans as Markdown (.md) using descriptive filenames.
-6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use \`exit_plan_mode\` to request approval.
+6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use the built-in \`exit_plan_mode\` tool to request approval. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.**
 7. **Presenting Plan:** When seeking informal agreement on a plan, or any time the user asks to see the plan, you MUST output the full content of the plan in the chat response. This overrides the "Minimal Output" guideline.
 
 ## Planning Workflow
@@ -323,7 +323,7 @@ Write the implementation plan to \`../plans/\`. The plan's structure adapts to t
 - **Alignment Check:** After drafting the plan, you MUST present it to the user in the chat (adhering to Rule 7 for presenting plans) to ensure alignment on the specific details. Ask for feedback or confirmation, and proceed to Step 4 (Review & Approval) once the user agrees with the detailed plan.
 
 ### 4. Review & Approval
-ONLY use the \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. When called, this tool will present the plan and formally request approval.
+ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.** When called, this tool will present the plan and formally request approval.
 
 ## Approved Plan
 An approved plan is available for this task at \`../plans/feature-x.md\`.
@@ -599,7 +599,7 @@ The following tools are available in Plan Mode:
    - **Inquiries:** If the request is an **Inquiry** (e.g., "How does X work?"), answer directly. DO NOT create a plan.
    - **Directives:** If the request is a **Directive** (e.g., "Fix bug Y"), follow the workflow below.
 5. **Plan Storage:** Save plans as Markdown (.md) using descriptive filenames.
-6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use \`exit_plan_mode\` to request approval.
+6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use the built-in \`exit_plan_mode\` tool to request approval. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.**
 7. **Presenting Plan:** When seeking informal agreement on a plan, or any time the user asks to see the plan, you MUST output the full content of the plan in the chat response. This overrides the "Minimal Output" guideline.
 
 ## Planning Workflow
@@ -624,7 +624,7 @@ Write the implementation plan to \`plans/\`. The plan's structure adapts to the 
 - **Alignment Check:** After drafting the plan, you MUST present it to the user in the chat (adhering to Rule 7 for presenting plans) to ensure alignment on the specific details. Ask for feedback or confirmation, and proceed to Step 4 (Review & Approval) once the user agrees with the detailed plan.
 
 ### 4. Review & Approval
-ONLY use the \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. When called, this tool will present the plan and formally request approval.
+ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. **CRITICAL: NEVER attempt to call this tool via \`run_shell_command\`.** When called, this tool will present the plan and formally request approval.
 
 # Operational Guidelines
 

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -477,7 +477,7 @@ ${options.planModeToolsList}
 - Save the implementation plan to the designated plans directory
 
 ### Phase 4: Review & Approval
-- Present the plan and request approval for the finalized plan using the \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool
+- Present the plan and request approval for the finalized plan using the built-in \`${EXIT_PLAN_MODE_TOOL_NAME}\` tool. **CRITICAL: NEVER attempt to call this tool via \`${SHELL_TOOL_NAME}\`.**
 - If plan is approved, you can begin implementation
 - If plan is rejected, address the feedback and iterate on the plan
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -604,7 +604,7 @@ ${options.planModeToolsList}
    - **Inquiries:** If the request is an **Inquiry** (e.g., "How does X work?"), answer directly. DO NOT create a plan.
    - **Directives:** If the request is a **Directive** (e.g., "Fix bug Y"), follow the workflow below.
 5. **Plan Storage:** Save plans as Markdown (.md) using descriptive filenames.
-6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} to request approval.
+6. **Direct Modification:** If asked to modify code, explain you are in Plan Mode and use the built-in ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} tool to request approval. **CRITICAL: NEVER attempt to call this tool via ${formatToolName(SHELL_TOOL_NAME)}.**
 7. **Presenting Plan:** When seeking informal agreement on a plan, or any time the user asks to see the plan, you MUST output the full content of the plan in the chat response. This overrides the "Minimal Output" guideline.
 
 ## Planning Workflow
@@ -628,7 +628,7 @@ Write the implementation plan to \`${options.plansDir}/\`. The plan's structure 
 - **Complex Tasks:** Include **Background & Motivation**, **Scope & Impact**, **Proposed Solution**, **Alternatives Considered**, a phased **Implementation Plan**, **Verification**, and **Migration & Rollback** strategies.${options.interactive ? '\n- **Alignment Check:** After drafting the plan, you MUST present it to the user in the chat (adhering to Rule 7 for presenting plans) to ensure alignment on the specific details. Ask for feedback or confirmation, and proceed to Step 4 (Review & Approval) once the user agrees with the detailed plan.' : ''}
 
 ### 4. Review & Approval
-ONLY use the ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. When called, this tool will present the plan and ${options.interactive ? 'formally request approval.' : 'begin implementation.'}
+ONLY use the built-in ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. **CRITICAL: NEVER attempt to call this tool via ${formatToolName(SHELL_TOOL_NAME)}.** When called, this tool will present the plan and ${options.interactive ? 'formally request approval.' : 'begin implementation.'}
 
 ${renderApprovedPlanSection(options.approvedPlanPath)}`.trim();
 }


### PR DESCRIPTION
## Summary

This PR prevents the agent from erroneously attempting to call the `exit_plan_mode` tool via the `run_shell_command` tool when operating in Plan Mode.

## Details

In certain scenarios, the agent would hallucinate treating `exit_plan_mode` as a CLI command because the system prompts allowed generic shell execution. The core system prompts (`snippets.ts` and `snippets.legacy.ts`) have been updated with a strict, critical mandate explicitly forbidding the execution of `exit_plan_mode` via `run_shell_command`. Additionally, a behavioral evaluation was added to ensure the agent invokes the tool directly instead of using a shell subprocess.

## Related Issues

Fixes #25047

## How to Validate

1. Run the newly added behavioral evaluation test:
   ```bash
   npm exec cross-env -- RUN_EVALS=1 vitest run --config evals/vitest.config.ts evals/plan_mode.eval.ts -t "should invoke exit_plan_mode as a tool instead of a shell command"
   ```
2. Verify that the agent successfully uses the `exit_plan_mode` tool directly and does not attempt to invoke it via `run_shell_command`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
