### PR TITLE
Allow non-https proxy urls to support container environments

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -862,7 +862,7 @@ describe('createContentGenerator', () => {
         },
         mockConfig,
       ),
-    ).rejects.toThrow('Custom base URL must use HTTPS unless it is localhost.');
+    );
   });
 });
 

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -852,13 +852,13 @@ describe('createContentGenerator', () => {
     ).rejects.toThrow('Invalid custom base URL: not-a-url');
   });
 
-  it('should reject non-https remote custom baseUrl values', async () => {
+  it('should allow non-https remote custom baseUrl values for container environments', async () => {
     await expect(
       createContentGenerator(
         {
           apiKey: 'test-api-key',
           authType: AuthType.USE_GEMINI,
-          baseUrl: 'http://example.com',
+          baseUrl: 'http://host.containers.internal',
         },
         mockConfig,
       ),

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -851,19 +851,6 @@ describe('createContentGenerator', () => {
       ),
     ).rejects.toThrow('Invalid custom base URL: not-a-url');
   });
-
-  it('should allow non-https remote custom baseUrl values for container environments', async () => {
-    await expect(
-      createContentGenerator(
-        {
-          apiKey: 'test-api-key',
-          authType: AuthType.USE_GEMINI,
-          baseUrl: 'http://host.containers.internal',
-        },
-        mockConfig,
-      ),
-    );
-  });
 });
 
 describe('createContentGeneratorConfig', () => {

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -110,7 +110,6 @@ export interface VertexAiRoutingConfig {
   sharedRequestType?: VertexAiSharedRequestType;
 }
 
-const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 const VERTEX_AI_REQUEST_TYPE_HEADER = 'X-Vertex-AI-LLM-Request-Type';
 const VERTEX_AI_SHARED_REQUEST_TYPE_HEADER =
   'X-Vertex-AI-LLM-Shared-Request-Type';
@@ -121,10 +120,6 @@ function validateBaseUrl(baseUrl: string): void {
     url = new URL(baseUrl);
   } catch {
     throw new Error(`Invalid custom base URL: ${baseUrl}`);
-  }
-
-  if (url.protocol !== 'https:' && !LOCAL_HOSTNAMES.includes(url.hostname)) {
-    throw new Error('Custom base URL must use HTTPS unless it is localhost.');
   }
 }
 

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -115,9 +115,8 @@ const VERTEX_AI_SHARED_REQUEST_TYPE_HEADER =
   'X-Vertex-AI-LLM-Shared-Request-Type';
 
 function validateBaseUrl(baseUrl: string): void {
-  let url: URL;
   try {
-    url = new URL(baseUrl);
+    new URL(baseUrl);
   } catch {
     throw new Error(`Invalid custom base URL: ${baseUrl}`);
   }


### PR DESCRIPTION
## Summary
Reverts new restriction that auth urls require https on non-localhost. This prior change breaks valid enterprise auth proxy configurations in container environments, and is now fixed. See https://github.com/google-gemini/gemini-cli/pull/25357#issuecomment-4347454432

## Related Issues
A prior change like this was done in https://github.com/google-gemini/gemini-cli/pull/23976 but re-added recently in https://github.com/google-gemini/gemini-cli/pull/25357

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
