### PR TITLE
fix: expand template vars in MCP stdio config

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -1993,6 +1993,45 @@ describe('mcp-client', () => {
       });
     });
 
+    it('should expand template variables in stdio MCP server config', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        HOME: '/home/test-user',
+      };
+
+      try {
+        await createTransport(
+          'test-server',
+          {
+            command: '{{HOME}}/.bun/bin/bun',
+            args: ['{{HOME}}/server.js', '$HOME/config.json'],
+            env: {
+              SERVER_ROOT: '{{HOME}}/mcp',
+            },
+            cwd: '{{HOME}}/workspace',
+          },
+          false,
+          MOCK_CONTEXT,
+        );
+
+        expect(mockedTransport).toHaveBeenCalledWith({
+          command: '/home/test-user/.bun/bin/bun',
+          args: ['/home/test-user/server.js', '/home/test-user/config.json'],
+          cwd: '/home/test-user/workspace',
+          env: expect.objectContaining({
+            SERVER_ROOT: '/home/test-user/mcp',
+          }),
+          stderr: 'pipe',
+        });
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
     it('sets an env variable GEMINI_CLI=1 for stdio MCP servers', async () => {
       const mockedTransport = vi
         .spyOn(SdkClientStdioLib, 'StdioClientTransport')

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1165,6 +1165,19 @@ export function populateMcpServerCommand(
   return mcpServers;
 }
 
+function expandMcpServerConfigValue(
+  value: string,
+  env: Record<string, string | undefined>,
+): string {
+  return expandEnvVars(
+    value.replace(
+      /\{\{(\w+)\}\}/g,
+      (match, name: string) => env[name] ?? match,
+    ),
+    env,
+  );
+}
+
 /**
  * Connects to an MCP server and discovers available tools, registering them with the tool registry.
  * This function handles the complete lifecycle of connecting to a server, discovering tools,
@@ -2270,15 +2283,26 @@ export async function createTransport(
     // Expand and merge explicit environment variables from the MCP configuration.
     if (mcpServerConfig.env) {
       for (const [key, value] of Object.entries(mcpServerConfig.env)) {
-        finalEnv[key] = expandEnvVars(value, expansionEnv);
+        finalEnv[key] = expandMcpServerConfigValue(value, expansionEnv);
       }
     }
 
+    const command = expandMcpServerConfigValue(
+      mcpServerConfig.command,
+      expansionEnv,
+    );
+    const args = mcpServerConfig.args?.map((arg) =>
+      expandMcpServerConfigValue(arg, expansionEnv),
+    );
+    const cwd = mcpServerConfig.cwd
+      ? expandMcpServerConfigValue(mcpServerConfig.cwd, expansionEnv)
+      : undefined;
+
     let transport: Transport = new StdioClientTransport({
-      command: mcpServerConfig.command,
-      args: mcpServerConfig.args || [],
+      command,
+      args: args || [],
       env: finalEnv,
-      cwd: mcpServerConfig.cwd,
+      cwd,
       stderr: 'pipe',
     });
 


### PR DESCRIPTION
## Summary
- expand `{{VAR}}` template placeholders in stdio MCP `command`, `args`, `cwd`, and explicit `env` values before creating the transport
- keep existing `$VAR` / `${VAR}` expansion behavior by routing through the existing env expansion helper
- add coverage for `{{HOME}}` in command, args, cwd, and env values

Fixes #26166

## Tests
- `npm run test --workspace @google/gemini-cli-core -- mcp-client.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx prettier --check packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts`
- `npx eslint packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts`