### PR TITLE
fix(shell): stop foreground commands after excessive output

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -29,6 +29,12 @@ The tool returns a JSON object containing:
 - `Exit Code`: The process return code.
 - `Background PIDs`: PIDs of any started background processes.
 
+Foreground commands that produce more than 10 MiB of output are stopped
+automatically to avoid unbounded context growth. Run long-lived streams such as
+`docker compose logs -f`, `tail -f`, and development servers with
+`is_background: true`, then inspect bounded snapshots with
+`read_background_output`.
+
 ## Configuration
 
 You can configure the behavior of the `run_shell_command` tool by modifying your

--- a/packages/core/src/services/executionLifecycleService.ts
+++ b/packages/core/src/services/executionLifecycleService.ts
@@ -24,6 +24,7 @@ export interface ExecutionResult {
   signal: number | null;
   error: Error | null;
   aborted: boolean;
+  outputLimitExceeded?: boolean;
   pid: number | undefined;
   executionMethod: ExecutionMethod;
   backgrounded?: boolean;

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -387,6 +387,28 @@ describe('ShellExecutionService', () => {
       );
     });
 
+    it('should stop a foreground PTY when output exceeds the configured limit', async () => {
+      const { result } = await simulateExecution(
+        'streaming-command',
+        async (pty) => {
+          pty.onData.mock.calls[0][0]('01234567890');
+          await new Promise(process.nextTick);
+          pty.onExit.mock.calls[0][0]({ exitCode: null, signal: 15 });
+        },
+        { ...shellExecutionConfig, maxOutputBytes: 10 },
+      );
+
+      expect(result.outputLimitExceeded).toBe(true);
+      expect(result.output).toContain(
+        'Command output exceeded the 10 bytes limit',
+      );
+      expect(result.output).toContain('read_background_output');
+      expect(mockProcessKill).toHaveBeenCalledWith(
+        -mockPtyProcess.pid,
+        'SIGTERM',
+      );
+    });
+
     it('should not wrap long lines in the final output', async () => {
       // Set a small width to force wrapping
       const narrowConfig = { ...shellExecutionConfig, terminalWidth: 10 };
@@ -1279,6 +1301,7 @@ describe('ShellExecutionService child_process fallback', () => {
       cp: typeof mockChildProcess,
       ac: AbortController,
     ) => void | Promise<void>,
+    config = shellExecutionConfig,
   ) => {
     const abortController = new AbortController();
     const handle = await ShellExecutionService.execute(
@@ -1287,7 +1310,7 @@ describe('ShellExecutionService child_process fallback', () => {
       onOutputEventMock,
       abortController.signal,
       true,
-      shellExecutionConfig,
+      config,
     );
 
     await new Promise((resolve) => process.nextTick(resolve));
@@ -1408,6 +1431,29 @@ describe('ShellExecutionService child_process fallback', () => {
       ).toBe(true);
       expect(outputWithoutMessage.endsWith('c'.repeat(20))).toBe(true);
     }, 120000);
+
+    it('should stop a foreground child process when output exceeds the configured limit', async () => {
+      const { result } = await simulateExecution(
+        'streaming-output',
+        async (cp) => {
+          cp.stdout?.emit('data', Buffer.from('01234567890'));
+          await new Promise(process.nextTick);
+          cp.emit('exit', null, 'SIGTERM');
+        },
+        { ...shellExecutionConfig, maxOutputBytes: 10 },
+      );
+
+      expect(result.outputLimitExceeded).toBe(true);
+      expect(result.aborted).toBe(false);
+      expect(result.output).toContain(
+        'Command output exceeded the 10 bytes limit',
+      );
+      expect(result.output).toContain('read_background_output');
+      expect(mockProcessKill).toHaveBeenCalledWith(
+        -mockChildProcess.pid!,
+        'SIGTERM',
+      );
+    });
   });
 
   describe('Failed Execution', () => {
@@ -1879,9 +1925,8 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GEMINI_CLI_TEST_VAR', 'test-value'); // A test var that should be kept
 
     vi.resetModules();
-    const { ShellExecutionService } = await import(
-      './shellExecutionService.js'
-    );
+    const { ShellExecutionService } =
+      await import('./shellExecutionService.js');
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -1939,9 +1984,8 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GEMINI_CLI_TEST_VAR', 'test-value'); // A test var that should be kept
 
     vi.resetModules();
-    const { ShellExecutionService } = await import(
-      './shellExecutionService.js'
-    );
+    const { ShellExecutionService } =
+      await import('./shellExecutionService.js');
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -1996,9 +2040,8 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GITHUB_SHA', '');
     vi.stubEnv('SURFACE', '');
     vi.resetModules();
-    const { ShellExecutionService } = await import(
-      './shellExecutionService.js'
-    );
+    const { ShellExecutionService } =
+      await import('./shellExecutionService.js');
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -2104,9 +2147,8 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GIT_CONFIG_KEY_1', 'pull.rebase');
     vi.stubEnv('GIT_CONFIG_VALUE_1', 'true');
 
-    const { ShellExecutionService } = await import(
-      './shellExecutionService.js'
-    );
+    const { ShellExecutionService } =
+      await import('./shellExecutionService.js');
 
     mockGetPty.mockResolvedValue(null); // Force child_process fallback
     await ShellExecutionService.execute(
@@ -2156,9 +2198,8 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GCM_INTERACTIVE', undefined);
     vi.stubEnv('GIT_CONFIG_COUNT', undefined);
 
-    const { ShellExecutionService } = await import(
-      './shellExecutionService.js'
-    );
+    const { ShellExecutionService } =
+      await import('./shellExecutionService.js');
 
     mockGetPty.mockResolvedValue(null); // Force child_process fallback
     await ShellExecutionService.execute(

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -409,6 +409,27 @@ describe('ShellExecutionService', () => {
       );
     });
 
+    it('should disable the PTY output limit after moving to background', async () => {
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'streaming-command',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        { ...shellExecutionConfig, maxOutputBytes: 10 },
+      );
+
+      await new Promise((resolve) => process.nextTick(resolve));
+      ShellExecutionService.background(12345, 'default', 'streaming-command');
+      mockPtyProcess.onData.mock.calls[0][0]('01234567890');
+
+      const result = await handle.result;
+      expect(result.backgrounded).toBe(true);
+      expect(result.outputLimitExceeded).toBeFalsy();
+      expect(mockProcessKill).not.toHaveBeenCalled();
+    });
+
     it('should not wrap long lines in the final output', async () => {
       // Set a small width to force wrapping
       const narrowConfig = { ...shellExecutionConfig, terminalWidth: 10 };
@@ -1454,6 +1475,21 @@ describe('ShellExecutionService child_process fallback', () => {
         'SIGTERM',
       );
     });
+
+    it('should disable the child process output limit after moving to background', async () => {
+      const { result } = await simulateExecution(
+        'streaming-output',
+        (cp) => {
+          ShellExecutionService.background(12345, 'default', 'streaming-output');
+          cp.stdout?.emit('data', Buffer.from('01234567890'));
+        },
+        { ...shellExecutionConfig, maxOutputBytes: 10 },
+      );
+
+      expect(result.backgrounded).toBe(true);
+      expect(result.outputLimitExceeded).toBeFalsy();
+      expect(mockProcessKill).not.toHaveBeenCalled();
+    });
   });
 
   describe('Failed Execution', () => {
@@ -1925,8 +1961,9 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GEMINI_CLI_TEST_VAR', 'test-value'); // A test var that should be kept
 
     vi.resetModules();
-    const { ShellExecutionService } =
-      await import('./shellExecutionService.js');
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -1984,8 +2021,9 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GEMINI_CLI_TEST_VAR', 'test-value'); // A test var that should be kept
 
     vi.resetModules();
-    const { ShellExecutionService } =
-      await import('./shellExecutionService.js');
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -2040,8 +2078,9 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GITHUB_SHA', '');
     vi.stubEnv('SURFACE', '');
     vi.resetModules();
-    const { ShellExecutionService } =
-      await import('./shellExecutionService.js');
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
 
     // Test pty path
     await ShellExecutionService.execute(
@@ -2147,8 +2186,9 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GIT_CONFIG_KEY_1', 'pull.rebase');
     vi.stubEnv('GIT_CONFIG_VALUE_1', 'true');
 
-    const { ShellExecutionService } =
-      await import('./shellExecutionService.js');
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
 
     mockGetPty.mockResolvedValue(null); // Force child_process fallback
     await ShellExecutionService.execute(
@@ -2198,8 +2238,9 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GCM_INTERACTIVE', undefined);
     vi.stubEnv('GIT_CONFIG_COUNT', undefined);
 
-    const { ShellExecutionService } =
-      await import('./shellExecutionService.js');
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
 
     mockGetPty.mockResolvedValue(null); // Force child_process fallback
     await ShellExecutionService.execute(

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -47,6 +47,7 @@ import {
 const { Terminal } = pkg;
 
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
+export const DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024; // 10MB
 
 /**
  * An environment variable that is set for shell executions. This can be used
@@ -101,6 +102,7 @@ export interface ShellExecutionConfig {
   disableDynamicLineTrimming?: boolean;
   scrollback?: number;
   maxSerializedLines?: number;
+  maxOutputBytes?: number;
   sandboxConfig?: SandboxConfig;
   backgroundCompletionBehavior?: 'inject' | 'notify' | 'silent';
   originalCommand?: string;
@@ -384,6 +386,14 @@ export class ShellExecutionService {
     return { newBuffer: truncatedBuffer + chunk, truncated: true };
   }
 
+  private static getOutputLimitExceededMessage(maxOutputBytes: number): string {
+    const limit =
+      maxOutputBytes >= 1024 * 1024
+        ? `${(maxOutputBytes / (1024 * 1024)).toFixed(1)}MB`
+        : `${maxOutputBytes} bytes`;
+    return `[GEMINI_CLI_WARNING: Command output exceeded the ${limit} limit for foreground shell commands and was stopped. Long-running or streaming commands should be run in the background, then inspected with read_background_output.]`;
+  }
+
   private static async prepareExecution(
     commandToExecute: string,
     cwd: string,
@@ -618,8 +628,36 @@ export class ShellExecutionService {
       let isStreamingRawContent = true;
       const MAX_SNIFF_SIZE = 4096;
       let sniffedBytes = 0;
+      let streamedBytes = 0;
+      let outputLimitExceeded = false;
+
+      const maxOutputBytes = shellExecutionConfig.maxOutputBytes;
+      const maybeStopForOutputLimit = (bytesReceived: number) => {
+        if (!maxOutputBytes || outputLimitExceeded || exited) {
+          return;
+        }
+        streamedBytes += bytesReceived;
+        if (streamedBytes <= maxOutputBytes) {
+          return;
+        }
+
+        outputLimitExceeded = true;
+        if (child.pid) {
+          killProcessGroup({
+            pid: child.pid,
+            escalate: true,
+            isExited: () => exited,
+          }).catch((err) => {
+            debugLogger.warn(
+              'Failed to stop shell command after output limit:',
+              err,
+            );
+          });
+        }
+      };
 
       const handleOutput = (data: Buffer, stream: 'stdout' | 'stderr') => {
+        maybeStopForOutputLimit(data.length);
         if (!stdoutDecoder || !stderrDecoder) {
           const encoding = getCachedEncodingForBuffer(data);
           try {
@@ -703,6 +741,11 @@ export class ShellExecutionService {
         cmdCleanup?.();
 
         let combinedOutput = state.output;
+        if (outputLimitExceeded && maxOutputBytes) {
+          combinedOutput += `\n${ShellExecutionService.getOutputLimitExceededMessage(
+            maxOutputBytes,
+          )}`;
+        }
         if (state.truncated) {
           const truncationMessage = `\n[GEMINI_CLI_WARNING: Output truncated. The buffer is limited to ${
             MAX_CHILD_PROCESS_BUFFER_SIZE / (1024 * 1024)
@@ -724,6 +767,7 @@ export class ShellExecutionService {
           signal: exitSignal,
           error,
           aborted: abortSignal.aborted,
+          outputLimitExceeded,
           pid: child.pid,
           executionMethod: 'child_process',
         };
@@ -1000,9 +1044,33 @@ export class ShellExecutionService {
       let isStreamingRawContent = true;
       const MAX_SNIFF_SIZE = 4096;
       let sniffedBytes = 0;
+      let streamedBytes = 0;
+      let outputLimitExceeded = false;
       let isWriting = false;
       let hasStartedOutput = false;
       let renderTimeout: NodeJS.Timeout | null = null;
+      const maxOutputBytes = shellExecutionConfig.maxOutputBytes;
+
+      const maybeStopForOutputLimit = (bytesReceived: number) => {
+        if (!maxOutputBytes || outputLimitExceeded || exited) {
+          return;
+        }
+        streamedBytes += bytesReceived;
+        if (streamedBytes <= maxOutputBytes) {
+          return;
+        }
+
+        outputLimitExceeded = true;
+        killProcessGroup({
+          pid: ptyPid,
+          escalate: true,
+          isExited: () => exited,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          pty: ptyProcess,
+        }).catch((err) => {
+          debugLogger.warn('Failed to stop PTY after output limit:', err);
+        });
+      };
 
       const renderFn = () => {
         renderTimeout = null;
@@ -1112,6 +1180,7 @@ export class ShellExecutionService {
       });
 
       const handleOutput = (data: Buffer) => {
+        maybeStopForOutputLimit(data.length);
         processingChain = processingChain.then(
           () =>
             new Promise<void>((resolveChunk) => {
@@ -1222,6 +1291,11 @@ export class ShellExecutionService {
               endLine,
             );
             const finalOutput = getFullBufferText(headlessTerminal);
+            const output = outputLimitExceeded
+              ? `${finalOutput}\n${ShellExecutionService.getOutputLimitExceededMessage(
+                  maxOutputBytes!,
+                )}`
+              : finalOutput;
 
             // Dispose the headless terminal to free scrollback buffers.
             // This must happen after getFullBufferText() extracts the output.
@@ -1238,12 +1312,13 @@ export class ShellExecutionService {
 
             ExecutionLifecycleService.completeWithResult(ptyPid, {
               rawOutput: Buffer.from(''),
-              output: finalOutput,
+              output,
               ansiOutput: ansiOutputSnapshot,
               exitCode,
               signal: signal ?? null,
               error,
               aborted: abortSignal.aborted,
+              outputLimitExceeded,
               pid: ptyPid,
               executionMethod: ptyInfo?.name ?? 'node-pty',
             });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -47,7 +47,7 @@ import {
 const { Terminal } = pkg;
 
 const MAX_CHILD_PROCESS_BUFFER_SIZE = 16 * 1024 * 1024; // 16MB
-export const DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024; // 10MB
+export const DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 /**
  * An environment variable that is set for shell executions. This can be used
@@ -120,6 +120,7 @@ interface ActivePty {
   ptyProcess: DestroyablePty;
   headlessTerminal: pkg.Terminal;
   maxSerializedLines?: number;
+  outputLimitDisabled?: boolean;
   command: string;
   sessionId?: string;
 }
@@ -129,6 +130,7 @@ interface ActiveChildProcess {
   state: {
     output: string;
     truncated: boolean;
+    outputLimitDisabled?: boolean;
     sniffChunks: Buffer[];
     binaryBytesReceived: number;
   };
@@ -389,7 +391,7 @@ export class ShellExecutionService {
   private static getOutputLimitExceededMessage(maxOutputBytes: number): string {
     const limit =
       maxOutputBytes >= 1024 * 1024
-        ? `${(maxOutputBytes / (1024 * 1024)).toFixed(1)}MB`
+        ? `${(maxOutputBytes / (1024 * 1024)).toFixed(1)}MiB`
         : `${maxOutputBytes} bytes`;
     return `[GEMINI_CLI_WARNING: Command output exceeded the ${limit} limit for foreground shell commands and was stopped. Long-running or streaming commands should be run in the background, then inspected with read_background_output.]`;
   }
@@ -556,7 +558,7 @@ export class ShellExecutionService {
         env: finalEnv,
       });
 
-      const state = {
+      const state: ActiveChildProcess['state'] = {
         output: '',
         truncated: false,
         sniffChunks: [] as Buffer[],
@@ -633,7 +635,13 @@ export class ShellExecutionService {
 
       const maxOutputBytes = shellExecutionConfig.maxOutputBytes;
       const maybeStopForOutputLimit = (bytesReceived: number) => {
-        if (!maxOutputBytes || outputLimitExceeded || exited) {
+        if (
+          maxOutputBytes === undefined ||
+          outputLimitExceeded ||
+          exited ||
+          state.outputLimitDisabled ||
+          child.pid === undefined
+        ) {
           return;
         }
         streamedBytes += bytesReceived;
@@ -642,18 +650,16 @@ export class ShellExecutionService {
         }
 
         outputLimitExceeded = true;
-        if (child.pid) {
-          killProcessGroup({
-            pid: child.pid,
-            escalate: true,
-            isExited: () => exited,
-          }).catch((err) => {
-            debugLogger.warn(
-              'Failed to stop shell command after output limit:',
-              err,
-            );
-          });
-        }
+        killProcessGroup({
+          pid: child.pid,
+          escalate: true,
+          isExited: () => exited,
+        }).catch((err) => {
+          debugLogger.warn(
+            'Failed to stop shell command after output limit:',
+            err,
+          );
+        });
       };
 
       const handleOutput = (data: Buffer, stream: 'stdout' | 'stderr') => {
@@ -741,7 +747,7 @@ export class ShellExecutionService {
         cmdCleanup?.();
 
         let combinedOutput = state.output;
-        if (outputLimitExceeded && maxOutputBytes) {
+        if (outputLimitExceeded && maxOutputBytes !== undefined) {
           combinedOutput += `\n${ShellExecutionService.getOutputLimitExceededMessage(
             maxOutputBytes,
           )}`;
@@ -1052,7 +1058,12 @@ export class ShellExecutionService {
       const maxOutputBytes = shellExecutionConfig.maxOutputBytes;
 
       const maybeStopForOutputLimit = (bytesReceived: number) => {
-        if (!maxOutputBytes || outputLimitExceeded || exited) {
+        if (
+          maxOutputBytes === undefined ||
+          outputLimitExceeded ||
+          exited ||
+          ShellExecutionService.activePtys.get(ptyPid)?.outputLimitDisabled
+        ) {
           return;
         }
         streamedBytes += bytesReceived;
@@ -1291,11 +1302,12 @@ export class ShellExecutionService {
               endLine,
             );
             const finalOutput = getFullBufferText(headlessTerminal);
-            const output = outputLimitExceeded
-              ? `${finalOutput}\n${ShellExecutionService.getOutputLimitExceededMessage(
-                  maxOutputBytes!,
-                )}`
-              : finalOutput;
+            let output = finalOutput;
+            if (outputLimitExceeded && maxOutputBytes !== undefined) {
+              output += `\n${ShellExecutionService.getOutputLimitExceededMessage(
+                maxOutputBytes,
+              )}`;
+            }
 
             // Dispose the headless terminal to free scrollback buffers.
             // This must happen after getFullBufferText() extracts the output.
@@ -1456,6 +1468,13 @@ export class ShellExecutionService {
 
     if (!resolvedSessionId) {
       throw new Error('Session ID is required for background operations');
+    }
+
+    if (activePty) {
+      activePty.outputLimitDisabled = true;
+    }
+    if (activeChild) {
+      activeChild.state.outputLimitDisabled = true;
     }
 
     const MAX_BACKGROUND_PROCESS_HISTORY_SIZE = 100;

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -22,6 +22,7 @@ const mockShellExecutionService = vi.hoisted(() => vi.fn());
 const mockShellBackground = vi.hoisted(() => vi.fn());
 
 vi.mock('../services/shellExecutionService.js', () => ({
+  DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES: 10 * 1024 * 1024,
   ShellExecutionService: {
     execute: mockShellExecutionService,
     background: mockShellBackground,
@@ -1002,6 +1003,23 @@ EOF`;
       const result = await promise;
       // Should only contain Output field
       expect(result.llmContent).toBe('Output: hello');
+    });
+
+    it('should explain when a foreground command is stopped for too much output', async () => {
+      const invocation = shellTool.build({ command: 'docker compose logs -f' });
+      const promise = invocation.execute({ abortSignal: mockAbortSignal });
+      resolveShellExecution({
+        output: 'log line',
+        outputLimitExceeded: true,
+        exitCode: null,
+        signal: 15,
+      });
+
+      const result = await promise;
+      expect(result.llmContent).toContain('produced too much output');
+      expect(result.llmContent).toContain('is_background=true');
+      expect(result.llmContent).toContain('read_background_output');
+      expect(result.returnDisplay).toContain('Output before stopping');
     });
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -29,6 +29,7 @@ import {
 import { getErrorMessage } from '../utils/errors.js';
 import { summarizeToolOutput } from '../utils/summarizer.js';
 import {
+  DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES,
   ShellExecutionService,
   type ShellOutputEvent,
 } from '../services/shellExecutionService.js';
@@ -600,6 +601,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
             backgroundCompletionBehavior:
               this.context.config.getShellBackgroundCompletionBehavior(),
             originalCommand: strippedCommand,
+            maxOutputBytes: this.params.is_background
+              ? undefined
+              : (shellExecutionConfig?.maxOutputBytes ??
+                DEFAULT_FOREGROUND_OUTPUT_LIMIT_BYTES),
           },
         );
 
@@ -683,7 +688,17 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
       let llmContent = '';
       let timeoutMessage = '';
-      if (result.aborted) {
+      if (result.outputLimitExceeded) {
+        timeoutMessage =
+          'Command was automatically stopped because it produced too much output. ' +
+          'For long-running or streaming commands, run the command with is_background=true and inspect it with read_background_output.';
+        llmContent = timeoutMessage;
+        if (result.output.trim()) {
+          llmContent += ` Below is the output before it was stopped:\n${result.output}`;
+        } else {
+          llmContent += ' There was no output before it was stopped.';
+        }
+      } else if (result.aborted) {
         if (timeoutController.signal.aborted) {
           timeoutMessage = `Command was automatically cancelled because it exceeded the timeout of ${(
             timeoutMs / 60000
@@ -745,6 +760,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
       } else {
         if (this.params.is_background || result.backgrounded) {
           returnDisplay = `Command moved to background (PID: ${result.pid}). Output hidden. Press Ctrl+B to view.`;
+        } else if (result.outputLimitExceeded) {
+          if (result.output.trim()) {
+            returnDisplay = `${timeoutMessage}\n\nOutput before stopping:\n${result.output}`;
+          } else {
+            returnDisplay = timeoutMessage;
+          }
         } else if (result.aborted) {
           const cancelMsg = timeoutMessage || 'Command cancelled by user.';
           if (result.output.trim()) {


### PR DESCRIPTION
## Summary
- Add a foreground shell output guard to stop commands after 10 MiB of output.
- Surface an `outputLimitExceeded` result so the shell tool can explain that long-running streams should use background mode.
- Cover both child_process and PTY execution paths with regression tests.

## Context
This helps prevent commands like `docker compose logs -f`, `tail -f`, and dev servers from producing unbounded foreground output and growing the model context indefinitely.

Related:
- #14367
- #25615

## Test plan
- `npx vitest run packages/core/src/services/shellExecutionService.test.ts packages/core/src/tools/shell.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx eslint "packages/core/src/services/executionLifecycleService.ts" "packages/core/src/services/shellExecutionService.ts" "packages/core/src/services/shellExecutionService.test.ts" "packages/core/src/tools/shell.ts" "packages/core/src/tools/shell.test.ts" --max-warnings 0`
- `git diff --check`

Made with [Cursor](https://cursor.com)