### PR TITLE
fix(cli): continue task after skill slash activation

### DIFF
--- a/packages/cli/src/services/SkillCommandLoader.test.ts
+++ b/packages/cli/src/services/SkillCommandLoader.test.ts
@@ -88,7 +88,8 @@ describe('SkillCommandLoader', () => {
       type: 'tool',
       toolName: ACTIVATE_SKILL_TOOL_NAME,
       toolArgs: { name: 'test-skill' },
-      postSubmitPrompt: 'Use the skill test-skill',
+      postSubmitPrompt:
+        "The test-skill skill is now activated. If there is an active task in the conversation, continue it using this skill's instructions. If no task was provided, ask what task to apply it to.",
     });
   });
 

--- a/packages/cli/src/services/SkillCommandLoader.ts
+++ b/packages/cli/src/services/SkillCommandLoader.ts
@@ -8,6 +8,10 @@ import { type Config, ACTIVATE_SKILL_TOOL_NAME } from '@google/gemini-cli-core';
 import { CommandKind, type SlashCommand } from '../ui/commands/types.js';
 import { type ICommandLoader } from './types.js';
 
+function getDefaultPostSubmitPrompt(skillName: string): string {
+  return `The ${skillName} skill is now activated. If there is an active task in the conversation, continue it using this skill's instructions. If no task was provided, ask what task to apply it to.`;
+}
+
 /**
  * Loads Agent Skills as slash commands.
  */
@@ -42,15 +46,18 @@ export class SkillCommandLoader implements ICommandLoader {
         kind: CommandKind.SKILL,
         autoExecute: true,
         extensionName: skill.extensionName,
-        action: async (_context, args) => ({
-          type: 'tool',
-          toolName: ACTIVATE_SKILL_TOOL_NAME,
-          toolArgs: { name: skill.name },
-          postSubmitPrompt:
-            args.trim().length > 0
-              ? args.trim()
-              : `Use the skill ${skill.name}`,
-        }),
+        action: async (_context, args) => {
+          const trimmedArgs = args.trim();
+          return {
+            type: 'tool',
+            toolName: ACTIVATE_SKILL_TOOL_NAME,
+            toolArgs: { name: skill.name },
+            postSubmitPrompt:
+              trimmedArgs.length > 0
+                ? trimmedArgs
+                : getDefaultPostSubmitPrompt(skill.name),
+          };
+        },
       };
     });
   }


### PR DESCRIPTION
Made-with: Cursor

## Summary

Skill slash commands now continue an active task after activating the skill, instead of only sending a weak default prompt like `Use the skill <name>`.

This reduces the extra follow-up prompt users often need after manually invoking a skill with `/<skill-name>`.

## Details

When a skill slash command is invoked without arguments, the CLI now sends a more explicit follow-up prompt telling the model to continue an active task in the conversation using the activated skill. If no task was provided, the model is instructed to ask what task to apply the skill to.

Explicit arguments are unchanged: `/<skill-name> some task` still uses `some task` as the follow-up prompt.

## Related Issues

Related to #21165
Related to #21760
Related to #25318

## How to Validate

Run:

- `npm run test --workspace @google/gemini-cli -- SkillCommandLoader.test.ts`
- `npx prettier --check packages/cli/src/services/SkillCommandLoader.ts packages/cli/src/services/SkillCommandLoader.test.ts`
- `npx eslint packages/cli/src/services/SkillCommandLoader.ts packages/cli/src/services/SkillCommandLoader.test.ts`

Expected results:

- `SkillCommandLoader.test.ts` passes.
- Prettier reports all matched files use Prettier style.
- ESLint exits successfully.

Manual edge cases:

- `/<skill-name>` activates the skill and asks the model to continue an active task if one exists.
- `/<skill-name> review this change` still uses `review this change` unchanged as the follow-up prompt.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker