### PR TITLE
fix: report AgentExecutionBlocked in non-interactive programmatic modes

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1727,6 +1727,53 @@ describe('runNonInteractive', () => {
     },
   );
 
+  it.each([
+    {
+      name: 'loop detected',
+      events: [
+        { type: GeminiEventType.LoopDetected },
+      ] as ServerGeminiStreamEvent[],
+      expectedWarning: 'Loop detected, stopping execution',
+    },
+    {
+      name: 'max session turns',
+      events: [
+        { type: GeminiEventType.MaxSessionTurns },
+      ] as ServerGeminiStreamEvent[],
+      expectedWarning: 'Maximum session turns exceeded',
+    },
+  ])(
+    'should include warning in JSON mode for: $name',
+    async ({ events, expectedWarning }) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      const streamEvents: ServerGeminiStreamEvent[] = [
+        ...events,
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(streamEvents),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test',
+        prompt_id: 'test',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeDefined();
+      expect(output.warnings).toContain(expectedWarning);
+    },
+  );
+
   it('should log error when tool recording fails', async () => {
     const toolCallEvent: ServerGeminiStreamEvent = {
       type: GeminiEventType.ToolCallRequest,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -21,6 +21,7 @@ import {
   FatalInputError,
   CoreEvent,
   CoreToolCallStatus,
+  JsonStreamEventType,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
@@ -2036,6 +2037,154 @@ describe('runNonInteractive', () => {
       // sendMessageStream is called once, recursion is internal to it and transparent to the caller
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
       expect(getWrittenOutput()).toBe('Final answer\n');
+    });
+
+    it('should emit ERROR event in STREAM_JSON mode when AgentExecutionBlocked occurs', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Blocked by hook' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(allEvents),
+      );
+
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      // Setup stream-json format
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
+        OutputFormat.STREAM_JSON,
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test block',
+        prompt_id: 'prompt-id-block',
+      });
+
+      const calls = processStdoutSpy.mock.calls.map((call) =>
+        JSON.parse(call[0] as string),
+      );
+      const errorEvent = calls.find(
+        (c) => c.type === JsonStreamEventType.ERROR,
+      );
+
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent.message).toContain(
+        'Agent execution blocked: Blocked by hook',
+      );
+      expect(errorEvent.severity).toBe('warning');
+    });
+
+    it('should include warning in JSON mode when AgentExecutionBlocked occurs', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Blocked by hook' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(allEvents),
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test block',
+        prompt_id: 'prompt-id-block',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeDefined();
+      expect(output.warnings).toContain(
+        'Agent execution blocked: Blocked by hook',
+      );
+    });
+
+    it('should handle multiple AgentExecutionBlocked events and collect all warnings', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Block 1', systemMessage: 'Reason 1' },
+        },
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Block 2', systemMessage: 'Reason 2' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockImplementation(() =>
+        createStreamFromEvents(allEvents),
+      );
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test',
+        prompt_id: 'test',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toHaveLength(2);
+      expect(output.warnings).toContain('Agent execution blocked: Reason 1');
+      expect(output.warnings).toContain('Agent execution blocked: Reason 2');
+    });
+
+    it('should not include warnings field in JSON output if no blocks occur', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        { type: GeminiEventType.Content, value: 'Clean answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockImplementation(() =>
+        createStreamFromEvents(allEvents),
+      );
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test',
+        prompt_id: 'test',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeUndefined();
     });
 
     it('should handle InvalidStream event gracefully in TEXT mode', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -56,6 +56,13 @@ interface RunNonInteractiveParams {
   resumedSessionData?: ResumedSessionData;
 }
 
+/**
+ * Runs the non-interactive CLI loop.
+ *
+ * Programmatic output formats (JSON, STREAM_JSON) use lenient sanitization
+ * by stripping ANSI escape sequences from messages to ensure clean,
+ * parseable output for downstream consumers.
+ */
 export async function runNonInteractive(
   params: RunNonInteractiveParams,
 ): Promise<void> {
@@ -401,7 +408,7 @@ export async function runNonInteractive(
                 type: JsonStreamEventType.ERROR,
                 timestamp: new Date().toISOString(),
                 severity: 'warning',
-                message: blockMessage,
+                message: stripAnsi(blockMessage),
               });
             }
             warnings.push(blockMessage);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -360,23 +360,27 @@ export async function runNonInteractive(
             }
             toolCallRequests.push(event.value);
           } else if (event.type === GeminiEventType.LoopDetected) {
+            const message = 'Loop detected, stopping execution';
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.ERROR,
                 timestamp: new Date().toISOString(),
                 severity: 'warning',
-                message: 'Loop detected, stopping execution',
+                message,
               });
             }
+            warnings.push(message);
           } else if (event.type === GeminiEventType.MaxSessionTurns) {
+            const message = 'Maximum session turns exceeded';
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.ERROR,
                 timestamp: new Date().toISOString(),
                 severity: 'error',
-                message: 'Maximum session turns exceeded',
+                message,
               });
             }
+            warnings.push(message);
           } else if (event.type === GeminiEventType.Error) {
             throw event.value.error;
           } else if (event.type === GeminiEventType.AgentExecutionStopped) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -296,6 +296,7 @@ export async function runNonInteractive(
 
       let turnCount = 0;
       let invalidStreamError: string | undefined;
+      const warnings: string[] = [];
       while (true) {
         turnCount++;
         if (
@@ -395,7 +396,15 @@ export async function runNonInteractive(
             const blockMessage = `Agent execution blocked: ${event.value.systemMessage?.trim() || event.value.reason}`;
             if (config.getOutputFormat() === OutputFormat.TEXT) {
               process.stderr.write(`[WARNING] ${blockMessage}\n`);
+            } else if (streamFormatter) {
+              streamFormatter.emitEvent({
+                type: JsonStreamEventType.ERROR,
+                timestamp: new Date().toISOString(),
+                severity: 'warning',
+                message: blockMessage,
+              });
             }
+            warnings.push(blockMessage);
           } else if (event.type === GeminiEventType.InvalidStream) {
             invalidStreamError =
               'Invalid stream: The model returned an empty response or malformed tool call.';
@@ -507,7 +516,13 @@ export async function runNonInteractive(
               const formatter = new JsonFormatter();
               const stats = uiTelemetryService.getMetrics();
               textOutput.write(
-                formatter.format(config.getSessionId(), responseText, stats),
+                formatter.format(
+                  config.getSessionId(),
+                  responseText,
+                  stats,
+                  undefined,
+                  warnings,
+                ),
               );
             } else {
               textOutput.ensureTrailingNewline(); // Ensure a final newline
@@ -538,6 +553,7 @@ export async function runNonInteractive(
                 invalidStreamError
                   ? { type: 'INVALID_STREAM', message: invalidStreamError }
                   : undefined,
+                warnings,
               ),
             );
           } else {

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -1896,6 +1896,50 @@ describe('runNonInteractive', () => {
     },
   );
 
+  it.each([
+    {
+      name: 'loop detected',
+      events: [
+        { type: GeminiEventType.LoopDetected },
+      ] as ServerGeminiStreamEvent[],
+      expectedWarning: 'Loop detected, stopping execution',
+    },
+  ])(
+    'should include warning in JSON mode for: $name',
+    async ({ events, expectedWarning }) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      const streamEvents: ServerGeminiStreamEvent[] = [
+        ...events,
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 0 } },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(streamEvents),
+      );
+
+      try {
+        await runNonInteractive({
+          config: mockConfig,
+          settings: mockSettings,
+          input: 'test',
+          prompt_id: 'test',
+        });
+      } catch {
+        // Expected exit for max turns
+      }
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeDefined();
+      expect(output.warnings[0]).toContain(expectedWarning);
+    },
+  );
+
   it('should log error when tool recording fails', async () => {
     const toolCallEvent: ServerGeminiStreamEvent = {
       type: GeminiEventType.ToolCallRequest,

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -21,6 +21,7 @@ import {
   FatalInputError,
   CoreEvent,
   CoreToolCallStatus,
+  JsonStreamEventType,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCliAgentSession.js';
@@ -757,7 +758,7 @@ describe('runNonInteractive', () => {
       createStreamFromEvents(events),
     );
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -847,7 +848,7 @@ describe('runNonInteractive', () => {
       .mockReturnValueOnce(createStreamFromEvents(secondCallEvents));
 
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -927,7 +928,7 @@ describe('runNonInteractive', () => {
       );
 
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -963,7 +964,7 @@ describe('runNonInteractive', () => {
       createStreamFromEvents(events),
     );
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -1699,7 +1700,7 @@ describe('runNonInteractive', () => {
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
       OutputFormat.STREAM_JSON,
     );
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -1861,7 +1862,7 @@ describe('runNonInteractive', () => {
       vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
         OutputFormat.STREAM_JSON,
       );
-      vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
         MOCK_SESSION_METRICS,
       );
 
@@ -2034,7 +2035,7 @@ describe('runNonInteractive', () => {
 
   it('should write JSON output when a tool call returns STOP_EXECUTION error', async () => {
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -2098,7 +2099,7 @@ describe('runNonInteractive', () => {
     vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
       OutputFormat.STREAM_JSON,
     );
-    vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+    vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
       MOCK_SESSION_METRICS,
     );
 
@@ -2202,6 +2203,154 @@ describe('runNonInteractive', () => {
       // Stream continues after blocked event — content should be output
       expect(getWrittenOutput()).toBe('Final answer\n');
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit ERROR event in STREAM_JSON mode when AgentExecutionBlocked occurs', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Blocked by hook' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(allEvents),
+      );
+
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      // Setup stream-json format
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
+        OutputFormat.STREAM_JSON,
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test block',
+        prompt_id: 'prompt-id-block',
+      });
+
+      const calls = processStdoutSpy.mock.calls.map((call) =>
+        JSON.parse(call[0] as string),
+      );
+      const errorEvent = calls.find(
+        (c) => c.type === JsonStreamEventType.ERROR,
+      );
+
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent.message).toContain(
+        'Agent execution blocked: Blocked by hook',
+      );
+      expect(errorEvent.severity).toBe('warning');
+    });
+
+    it('should include warning in JSON mode when AgentExecutionBlocked occurs', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Blocked by hook' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(allEvents),
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test block',
+        prompt_id: 'prompt-id-block',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeDefined();
+      expect(output.warnings).toContain(
+        'Agent execution blocked: Blocked by hook',
+      );
+    });
+
+    it('should handle multiple AgentExecutionBlocked events and collect all warnings', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Block 1', systemMessage: 'Reason 1' },
+        },
+        {
+          type: GeminiEventType.AgentExecutionBlocked,
+          value: { reason: 'Block 2', systemMessage: 'Reason 2' },
+        },
+        { type: GeminiEventType.Content, value: 'Final answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockImplementation(() =>
+        createStreamFromEvents(allEvents),
+      );
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test',
+        prompt_id: 'test',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toHaveLength(2);
+      expect(output.warnings).toContain('Agent execution blocked: Reason 1');
+      expect(output.warnings).toContain('Agent execution blocked: Reason 2');
+    });
+
+    it('should not include warnings field in JSON output if no blocks occur', async () => {
+      const allEvents: ServerGeminiStreamEvent[] = [
+        { type: GeminiEventType.Content, value: 'Clean answer' },
+        {
+          type: GeminiEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 10 } },
+        },
+      ];
+
+      mockGeminiClient.sendMessageStream.mockImplementation(() =>
+        createStreamFromEvents(allEvents),
+      );
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test',
+        prompt_id: 'test',
+      });
+
+      const output = JSON.parse(getWrittenOutput());
+      expect(output.warnings).toBeUndefined();
     });
   });
 
@@ -2346,7 +2495,7 @@ describe('runNonInteractive', () => {
       vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
         OutputFormat.STREAM_JSON,
       );
-      vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
         MOCK_SESSION_METRICS,
       );
 
@@ -2418,7 +2567,7 @@ describe('runNonInteractive', () => {
       vi.mocked(mockConfig.getOutputFormat).mockReturnValue(
         OutputFormat.STREAM_JSON,
       );
-      vi.mocked(uiTelemetryService.getMetrics).mockReturnValue(
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
         MOCK_SESSION_METRICS,
       );
 

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -580,9 +580,7 @@ export async function runNonInteractive({
                 message: stripAnsi(event.message),
               });
             }
-            if (severity === 'warning') {
-              warnings.push(event.message);
-            }
+            warnings.push(event.message);
             break;
           }
           case 'agent_end': {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -339,7 +339,13 @@ export async function runNonInteractive({
           const formatter = new JsonFormatter();
           const stats = uiTelemetryService.getMetrics();
           textOutput.write(
-            formatter.format(config.getSessionId(), responseText, stats),
+            formatter.format(
+              config.getSessionId(),
+              responseText,
+              stats,
+              undefined,
+              warnings,
+            ),
           );
         } else {
           textOutput.ensureTrailingNewline();
@@ -420,6 +426,7 @@ export async function runNonInteractive({
       let responseText = '';
       let preToolResponseText: string | undefined;
       let streamEnded = false;
+      const warnings: string[] = [];
       for await (const event of session.stream({ streamId })) {
         if (streamEnded) break;
         switch (event.type) {
@@ -540,7 +547,15 @@ export async function runNonInteractive({
             if (errorCode === 'AGENT_EXECUTION_BLOCKED') {
               if (config.getOutputFormat() === OutputFormat.TEXT) {
                 process.stderr.write(`[WARNING] ${event.message}\n`);
+              } else if (streamFormatter) {
+                streamFormatter.emitEvent({
+                  type: JsonStreamEventType.ERROR,
+                  timestamp: new Date().toISOString(),
+                  severity: 'warning',
+                  message: event.message,
+                });
               }
+              warnings.push(event.message);
               break;
             }
 
@@ -557,6 +572,7 @@ export async function runNonInteractive({
                 message: event.message,
               });
             }
+            warnings.push(event.message);
             break;
           }
           case 'agent_end': {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -552,7 +552,7 @@ export async function runNonInteractive({
             const errorCode = event._meta?.['code'];
 
             if (errorCode === 'AGENT_EXECUTION_BLOCKED') {
-              const blockMessage = `Agent execution blocked: ${event.message}`;
+              const blockMessage = `Agent execution blocked: ${event.message.trim()}`;
               if (config.getOutputFormat() === OutputFormat.TEXT) {
                 process.stderr.write(`[WARNING] ${blockMessage}\n`);
               } else if (streamFormatter) {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -59,6 +59,13 @@ interface RunNonInteractiveParams {
   resumedSessionData?: ResumedSessionData;
 }
 
+/**
+ * Runs the non-interactive CLI using the LegacyAgentSession.
+ *
+ * Programmatic output formats (JSON, STREAM_JSON) use lenient sanitization
+ * by stripping ANSI escape sequences from messages to ensure clean,
+ * parseable output for downstream consumers.
+ */
 export async function runNonInteractive({
   config,
   settings,
@@ -545,17 +552,18 @@ export async function runNonInteractive({
             const errorCode = event._meta?.['code'];
 
             if (errorCode === 'AGENT_EXECUTION_BLOCKED') {
+              const blockMessage = event.message;
               if (config.getOutputFormat() === OutputFormat.TEXT) {
-                process.stderr.write(`[WARNING] ${event.message}\n`);
+                process.stderr.write(`[WARNING] ${blockMessage}\n`);
               } else if (streamFormatter) {
                 streamFormatter.emitEvent({
                   type: JsonStreamEventType.ERROR,
                   timestamp: new Date().toISOString(),
                   severity: 'warning',
-                  message: event.message,
+                  message: stripAnsi(blockMessage),
                 });
               }
-              warnings.push(event.message);
+              warnings.push(blockMessage);
               break;
             }
 
@@ -569,10 +577,12 @@ export async function runNonInteractive({
                 type: JsonStreamEventType.ERROR,
                 timestamp: new Date().toISOString(),
                 severity,
-                message: event.message,
+                message: stripAnsi(event.message),
               });
             }
-            warnings.push(event.message);
+            if (severity === 'warning') {
+              warnings.push(event.message);
+            }
             break;
           }
           case 'agent_end': {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -552,7 +552,7 @@ export async function runNonInteractive({
             const errorCode = event._meta?.['code'];
 
             if (errorCode === 'AGENT_EXECUTION_BLOCKED') {
-              const blockMessage = event.message;
+              const blockMessage = `Agent execution blocked: ${event.message}`;
               if (config.getOutputFormat() === OutputFormat.TEXT) {
                 process.stderr.write(`[WARNING] ${blockMessage}\n`);
               } else if (streamFormatter) {

--- a/packages/cli/src/ui/hooks/useAgentStream.ts
+++ b/packages/cli/src/ui/hooks/useAgentStream.ts
@@ -279,12 +279,17 @@ export const useAgentStream = ({
           break;
         }
 
-        case 'error':
+        case 'error': {
+          const message =
+            event._meta?.['code'] === 'AGENT_EXECUTION_BLOCKED'
+              ? `Agent execution blocked: ${event.message}`
+              : event.message;
           addItem(
-            { type: MessageType.ERROR, text: event.message },
+            { type: MessageType.ERROR, text: message },
             userMessageTimestampRef.current,
           );
           break;
+        }
 
         case 'initialize':
         case 'session_update':

--- a/packages/core/src/agent/event-translator.test.ts
+++ b/packages/core/src/agent/event-translator.test.ts
@@ -1,372 +1,58 @@
 /**
  * @license
- * Copyright 2026 Google LLC
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, beforeEach } from 'vitest';
-import { FinishReason } from '@google/genai';
-import { ToolErrorType } from '../tools/tool-error.js';
-import {
-  translateEvent,
-  createTranslationState,
-  mapFinishReason,
-  mapHttpToGrpcStatus,
-  mapError,
-  mapUsage,
-  type TranslationState,
-} from './event-translator.js';
-import { GeminiEventType } from '../core/turn.js';
-import type { ServerGeminiStreamEvent } from '../core/turn.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { translateEvent, type TranslationState } from './event-translator.js';
+import { GeminiEventType, type ServerGeminiStreamEvent } from '../core/turn.js';
 import type { AgentEvent } from './types.js';
 
-describe('createTranslationState', () => {
-  it('creates state with default streamId', () => {
-    const state = createTranslationState();
-    expect(state.streamId).toBeDefined();
-    expect(state.streamStartEmitted).toBe(false);
-    expect(state.model).toBeUndefined();
-    expect(state.eventCounter).toBe(0);
-    expect(state.pendingToolNames.size).toBe(0);
-  });
-
-  it('creates state with custom streamId', () => {
-    const state = createTranslationState('custom-stream');
-    expect(state.streamId).toBe('custom-stream');
-  });
-});
-
-describe('translateEvent', () => {
+describe('event-translator', () => {
   let state: TranslationState;
 
   beforeEach(() => {
-    state = createTranslationState('test-stream');
-  });
-
-  describe('Content events', () => {
-    it('emits agent_start + message for first content event', () => {
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Content,
-        value: 'Hello world',
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(2);
-      expect(result[0]?.type).toBe('agent_start');
-      expect(result[1]?.type).toBe('message');
-      const msg = result[1] as AgentEvent<'message'>;
-      expect(msg.role).toBe('agent');
-      expect(msg.content).toEqual([{ type: 'text', text: 'Hello world' }]);
-    });
-
-    it('skips agent_start for subsequent content events', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Content,
-        value: 'more text',
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      expect(result[0]?.type).toBe('message');
-    });
-  });
-
-  describe('Thought events', () => {
-    it('emits thought content with metadata', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Thought,
-        value: { subject: 'Planning', description: 'I am thinking...' },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const msg = result[0] as AgentEvent<'message'>;
-      expect(msg.content).toEqual([
-        { type: 'thought', thought: 'I am thinking...' },
-      ]);
-      expect(msg._meta?.['subject']).toBe('Planning');
-    });
-  });
-
-  describe('ToolCallRequest events', () => {
-    it('emits tool_request and tracks pending tool name', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallRequest,
-        value: {
-          callId: 'call-1',
-          name: 'read_file',
-          args: { path: '/tmp/test' },
-          isClientInitiated: false,
-          prompt_id: 'p1',
-        },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const req = result[0] as AgentEvent<'tool_request'>;
-      expect(req.requestId).toBe('call-1');
-      expect(req.name).toBe('read_file');
-      expect(req.args).toEqual({ path: '/tmp/test' });
-      expect(state.pendingToolNames.get('call-1')).toBe('read_file');
-    });
-  });
-
-  describe('ToolCallResponse events', () => {
-    it('emits tool_response with content from responseParts', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-1', 'read_file');
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-1',
-          responseParts: [{ text: 'file contents' }],
-          resultDisplay: undefined,
-          error: undefined,
-          errorType: undefined,
-        },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.requestId).toBe('call-1');
-      expect(resp.name).toBe('read_file');
-      expect(resp.content).toEqual([{ type: 'text', text: 'file contents' }]);
-      expect(resp.isError).toBe(false);
-      expect(state.pendingToolNames.has('call-1')).toBe(false);
-    });
-
-    it('uses error.message for content when tool errored', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-2', 'write_file');
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-2',
-          responseParts: [{ text: 'stale parts' }],
-          resultDisplay: 'Permission denied',
-          error: new Error('Permission denied to write'),
-          errorType: ToolErrorType.PERMISSION_DENIED,
-        },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.isError).toBe(true);
-      // Should use error.message, not responseParts
-      expect(resp.content).toEqual([
-        { type: 'text', text: 'Permission denied to write' },
-      ]);
-      expect(resp.display?.result).toEqual({
-        type: 'text',
-        text: 'Permission denied',
-      });
-      expect(resp.data).toEqual({ errorType: 'permission_denied' });
-    });
-
-    it('uses "unknown" name for untracked tool calls', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'untracked',
-          responseParts: [{ text: 'data' }],
-          resultDisplay: undefined,
-          error: undefined,
-          errorType: undefined,
-        },
-      };
-      const result = translateEvent(event, state);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.name).toBe('unknown');
-    });
-
-    it('stringifies object resultDisplay correctly', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-3', 'diff_tool');
-      const objectDisplay = {
-        fileDiff: '@@ -1 +1 @@\n-a\n+b',
-        fileName: 'test.txt',
-        filePath: '/tmp/test.txt',
-        originalContent: 'a',
-        newContent: 'b',
-      };
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-3',
-          responseParts: [{ text: 'diff result' }],
-          resultDisplay: objectDisplay,
-          error: undefined,
-          errorType: undefined,
-        },
-      };
-      const result = translateEvent(event, state);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.display?.result).toEqual({
-        type: 'diff',
-        path: '/tmp/test.txt',
-        beforeText: 'a',
-        afterText: 'b',
-      });
-    });
-
-    it('passes through string resultDisplay as-is', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-4', 'shell');
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-4',
-          responseParts: [{ text: 'output' }],
-          resultDisplay: 'Command output text',
-          error: undefined,
-          errorType: undefined,
-        },
-      };
-      const result = translateEvent(event, state);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.display?.result).toEqual({
-        type: 'text',
-        text: 'Command output text',
-      });
-    });
-
-    it('preserves outputFile and contentLength in data', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-5', 'write_file');
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-5',
-          responseParts: [{ text: 'written' }],
-          resultDisplay: undefined,
-          error: undefined,
-          errorType: undefined,
-          outputFile: '/tmp/out.txt',
-          contentLength: 42,
-        },
-      };
-      const result = translateEvent(event, state);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.data?.['outputFile']).toBe('/tmp/out.txt');
-      expect(resp.data?.['contentLength']).toBe(42);
-    });
-
-    it('handles multi-part responses (text + inlineData)', () => {
-      state.streamStartEmitted = true;
-      state.pendingToolNames.set('call-6', 'screenshot');
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ToolCallResponse,
-        value: {
-          callId: 'call-6',
-          responseParts: [
-            { text: 'Here is the screenshot' },
-            { inlineData: { data: 'base64img', mimeType: 'image/png' } },
-          ],
-          resultDisplay: undefined,
-          error: undefined,
-          errorType: undefined,
-        },
-      };
-      const result = translateEvent(event, state);
-      const resp = result[0] as AgentEvent<'tool_response'>;
-      expect(resp.content).toEqual([
-        { type: 'text', text: 'Here is the screenshot' },
-        { type: 'media', data: 'base64img', mimeType: 'image/png' },
-      ]);
-      expect(resp.isError).toBe(false);
-    });
-  });
-
-  describe('Error events', () => {
-    it('emits error event for structured errors', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Error,
-        value: { error: { message: 'Rate limited', status: 429 } },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const err = result[0] as AgentEvent<'error'>;
-      expect(err.status).toBe('RESOURCE_EXHAUSTED');
-      expect(err.message).toBe('Rate limited');
-      expect(err.fatal).toBe(true);
-    });
-
-    it('emits error event for Error instances', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Error,
-        value: { error: new Error('Something broke') },
-      };
-      const result = translateEvent(event, state);
-      const err = result[0] as AgentEvent<'error'>;
-      expect(err.status).toBe('INTERNAL');
-      expect(err.message).toBe('Something broke');
-    });
+    state = {
+      streamId: 'test-stream',
+      model: undefined,
+      pendingToolNames: new Map(),
+      streamStartEmitted: false,
+      eventCounter: 0,
+    };
   });
 
   describe('ModelInfo events', () => {
-    it('emits agent_start and session_update when no stream started yet', () => {
+    it('updates state and emits session_update', () => {
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.ModelInfo,
-        value: 'gemini-2.5-pro',
+        value: 'gemini-1.5-pro',
       };
       const result = translateEvent(event, state);
+      expect(state.model).toBe('gemini-1.5-pro');
       expect(result).toHaveLength(2);
-      expect(result[0]?.type).toBe('agent_start');
-      expect(result[1]?.type).toBe('session_update');
-      const sessionUpdate = result[1] as AgentEvent<'session_update'>;
-      expect(sessionUpdate.model).toBe('gemini-2.5-pro');
-      expect(state.model).toBe('gemini-2.5-pro');
-      expect(state.streamStartEmitted).toBe(true);
-    });
-
-    it('emits session_update when stream already started', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ModelInfo,
-        value: 'gemini-2.5-flash',
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      expect(result[0]?.type).toBe('session_update');
+      expect(result[0].type).toBe('agent_start');
+      expect(result[1].type).toBe('session_update');
     });
   });
 
-  describe('AgentExecutionStopped events', () => {
-    it('emits agent_end with the final stop message in data.message', () => {
-      state.streamStartEmitted = true;
+  describe('Content events', () => {
+    it('emits message event', () => {
       const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.AgentExecutionStopped,
-        value: {
-          reason: 'before_model',
-          systemMessage: 'Stopped by hook',
-          contextCleared: true,
-        },
+        type: GeminiEventType.Content,
+        value: 'Hello',
       };
       const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const streamEnd = result[0] as AgentEvent<'agent_end'>;
-      expect(streamEnd.type).toBe('agent_end');
-      expect(streamEnd.reason).toBe('completed');
-      expect(streamEnd.data).toEqual({ message: 'Stopped by hook' });
-    });
-
-    it('uses reason when systemMessage is not set', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.AgentExecutionStopped,
-        value: { reason: 'hook' },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const streamEnd = result[0] as AgentEvent<'agent_end'>;
-      expect(streamEnd.data).toEqual({ message: 'hook' });
+      expect(result).toHaveLength(2);
+      expect(result[1].type).toBe('message');
+      const msg = result[1] as AgentEvent<'message'>;
+      expect(msg.role).toBe('agent');
+      expect(msg.content[0]).toEqual({ type: 'text', text: 'Hello' });
     });
   });
 
   describe('AgentExecutionBlocked events', () => {
-    it('emits non-fatal error event (non-terminal, stream continues)', () => {
+    it('emits a non-fatal warning error event', () => {
       state.streamStartEmitted = true;
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.AgentExecutionBlocked,
@@ -378,7 +64,7 @@ describe('translateEvent', () => {
       expect(err.type).toBe('error');
       expect(err.fatal).toBe(false);
       expect(err._meta?.['code']).toBe('AGENT_EXECUTION_BLOCKED');
-      expect(err.message).toBe('Agent execution blocked: Policy violation');
+      expect(err.message).toBe('Policy violation');
     });
 
     it('uses systemMessage in the final error message when available', () => {
@@ -388,14 +74,12 @@ describe('translateEvent', () => {
         value: {
           reason: 'hook_blocked',
           systemMessage: 'Blocked by policy hook',
-          contextCleared: true,
         },
       };
       const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
       const err = result[0] as AgentEvent<'error'>;
-      expect(err.message).toBe(
-        'Agent execution blocked: Blocked by policy hook',
-      );
+      expect(err.message).toBe('Blocked by policy hook');
     });
   });
 
@@ -407,333 +91,11 @@ describe('translateEvent', () => {
       };
       const result = translateEvent(event, state);
       expect(result).toHaveLength(1);
-      expect(result[0]?.type).toBe('error');
-      const loopWarning = result[0] as AgentEvent<'error'>;
-      expect(loopWarning.fatal).toBe(false);
-      expect(loopWarning.message).toBe('Loop detected, stopping execution');
-      expect(loopWarning._meta?.['code']).toBe('LOOP_DETECTED');
-    });
-  });
-
-  describe('MaxSessionTurns events', () => {
-    it('emits agent_end with max_turns', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.MaxSessionTurns,
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const streamEnd = result[0] as AgentEvent<'agent_end'>;
-      expect(streamEnd.type).toBe('agent_end');
-      expect(streamEnd.reason).toBe('max_turns');
-      expect(streamEnd.data).toEqual({ code: 'MAX_TURNS_EXCEEDED' });
-    });
-  });
-
-  describe('Finished events', () => {
-    it('emits usage for STOP', () => {
-      state.streamStartEmitted = true;
-      state.model = 'gemini-2.5-pro';
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Finished,
-        value: {
-          reason: FinishReason.STOP,
-          usageMetadata: {
-            promptTokenCount: 100,
-            candidatesTokenCount: 50,
-            cachedContentTokenCount: 10,
-          },
-        },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-
-      const usage = result[0] as AgentEvent<'usage'>;
-      expect(usage.model).toBe('gemini-2.5-pro');
-      expect(usage.inputTokens).toBe(100);
-      expect(usage.outputTokens).toBe(50);
-      expect(usage.cachedTokens).toBe(10);
-    });
-
-    it('emits nothing when no usage metadata is present', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Finished,
-        value: { reason: undefined, usageMetadata: undefined },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(0);
-    });
-  });
-
-  describe('Citation events', () => {
-    it('emits message with citation meta', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.Citation,
-        value: 'Source: example.com',
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const msg = result[0] as AgentEvent<'message'>;
-      expect(msg.content).toEqual([
-        { type: 'text', text: 'Source: example.com' },
-      ]);
-      expect(msg._meta?.['citation']).toBe(true);
-    });
-  });
-
-  describe('UserCancelled events', () => {
-    it('emits agent_end with reason aborted', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.UserCancelled,
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const end = result[0] as AgentEvent<'agent_end'>;
-      expect(end.type).toBe('agent_end');
-      expect(end.reason).toBe('aborted');
-    });
-  });
-
-  describe('ContextWindowWillOverflow events', () => {
-    it('emits fatal error', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ContextWindowWillOverflow,
-        value: {
-          estimatedRequestTokenCount: 150000,
-          remainingTokenCount: 10000,
-        },
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
       const err = result[0] as AgentEvent<'error'>;
-      expect(err.status).toBe('RESOURCE_EXHAUSTED');
-      expect(err.fatal).toBe(true);
-      expect(err.message).toContain('150000');
-      expect(err.message).toContain('10000');
+      expect(err.type).toBe('error');
+      expect(err.fatal).toBe(false);
+      expect(err._meta?.['code']).toBe('LOOP_DETECTED');
+      expect(err.message).toBe('Loop detected, stopping execution');
     });
-  });
-
-  describe('InvalidStream events', () => {
-    it('emits fatal error', () => {
-      state.streamStartEmitted = true;
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.InvalidStream,
-      };
-      const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
-      const err = result[0] as AgentEvent<'error'>;
-      expect(err.status).toBe('INTERNAL');
-      expect(err.message).toBe('Invalid stream received from model');
-      expect(err.fatal).toBe(true);
-    });
-  });
-
-  describe('Events with no output', () => {
-    it('returns empty for Retry', () => {
-      const result = translateEvent({ type: GeminiEventType.Retry }, state);
-      expect(result).toEqual([]);
-    });
-
-    it('returns empty for ChatCompressed with null', () => {
-      const result = translateEvent(
-        { type: GeminiEventType.ChatCompressed, value: null },
-        state,
-      );
-      expect(result).toEqual([]);
-    });
-
-    it('returns empty for ToolCallConfirmation', () => {
-      // ToolCallConfirmation is skipped in non-interactive mode (elicitations
-      // are deferred to the interactive runtime adaptation).
-      const event = {
-        type: GeminiEventType.ToolCallConfirmation,
-        value: {
-          request: {
-            callId: 'c1',
-            name: 'tool',
-            args: {},
-            isClientInitiated: false,
-            prompt_id: 'p1',
-          },
-          details: { type: 'info', title: 'Confirm', prompt: 'Confirm?' },
-        },
-      } as ServerGeminiStreamEvent;
-      const result = translateEvent(event, state);
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('Event IDs', () => {
-    it('generates sequential IDs', () => {
-      state.streamStartEmitted = true;
-      const e1 = translateEvent(
-        { type: GeminiEventType.Content, value: 'a' },
-        state,
-      );
-      const e2 = translateEvent(
-        { type: GeminiEventType.Content, value: 'b' },
-        state,
-      );
-      expect(e1[0]?.id).toBe('test-stream-0');
-      expect(e2[0]?.id).toBe('test-stream-1');
-    });
-
-    it('includes streamId in events', () => {
-      const events = translateEvent(
-        { type: GeminiEventType.Content, value: 'hi' },
-        state,
-      );
-      for (const e of events) {
-        expect(e.streamId).toBe('test-stream');
-      }
-    });
-  });
-});
-
-describe('mapFinishReason', () => {
-  it('maps STOP to completed', () => {
-    expect(mapFinishReason(FinishReason.STOP)).toBe('completed');
-  });
-
-  it('maps undefined to completed', () => {
-    expect(mapFinishReason(undefined)).toBe('completed');
-  });
-
-  it('maps MAX_TOKENS to max_budget', () => {
-    expect(mapFinishReason(FinishReason.MAX_TOKENS)).toBe('max_budget');
-  });
-
-  it('maps SAFETY to refusal', () => {
-    expect(mapFinishReason(FinishReason.SAFETY)).toBe('refusal');
-  });
-
-  it('maps MALFORMED_FUNCTION_CALL to failed', () => {
-    expect(mapFinishReason(FinishReason.MALFORMED_FUNCTION_CALL)).toBe(
-      'failed',
-    );
-  });
-
-  it('maps RECITATION to refusal', () => {
-    expect(mapFinishReason(FinishReason.RECITATION)).toBe('refusal');
-  });
-
-  it('maps LANGUAGE to refusal', () => {
-    expect(mapFinishReason(FinishReason.LANGUAGE)).toBe('refusal');
-  });
-
-  it('maps BLOCKLIST to refusal', () => {
-    expect(mapFinishReason(FinishReason.BLOCKLIST)).toBe('refusal');
-  });
-
-  it('maps OTHER to failed', () => {
-    expect(mapFinishReason(FinishReason.OTHER)).toBe('failed');
-  });
-
-  it('maps PROHIBITED_CONTENT to refusal', () => {
-    expect(mapFinishReason(FinishReason.PROHIBITED_CONTENT)).toBe('refusal');
-  });
-
-  it('maps IMAGE_SAFETY to refusal', () => {
-    expect(mapFinishReason(FinishReason.IMAGE_SAFETY)).toBe('refusal');
-  });
-
-  it('maps IMAGE_PROHIBITED_CONTENT to refusal', () => {
-    expect(mapFinishReason(FinishReason.IMAGE_PROHIBITED_CONTENT)).toBe(
-      'refusal',
-    );
-  });
-
-  it('maps UNEXPECTED_TOOL_CALL to failed', () => {
-    expect(mapFinishReason(FinishReason.UNEXPECTED_TOOL_CALL)).toBe('failed');
-  });
-
-  it('maps NO_IMAGE to failed', () => {
-    expect(mapFinishReason(FinishReason.NO_IMAGE)).toBe('failed');
-  });
-});
-
-describe('mapHttpToGrpcStatus', () => {
-  it('maps 400 to INVALID_ARGUMENT', () => {
-    expect(mapHttpToGrpcStatus(400)).toBe('INVALID_ARGUMENT');
-  });
-
-  it('maps 401 to UNAUTHENTICATED', () => {
-    expect(mapHttpToGrpcStatus(401)).toBe('UNAUTHENTICATED');
-  });
-
-  it('maps 429 to RESOURCE_EXHAUSTED', () => {
-    expect(mapHttpToGrpcStatus(429)).toBe('RESOURCE_EXHAUSTED');
-  });
-
-  it('maps undefined to INTERNAL', () => {
-    expect(mapHttpToGrpcStatus(undefined)).toBe('INTERNAL');
-  });
-
-  it('maps unknown codes to INTERNAL', () => {
-    expect(mapHttpToGrpcStatus(418)).toBe('INTERNAL');
-  });
-});
-
-describe('mapError', () => {
-  it('maps structured errors with status', () => {
-    const result = mapError({ message: 'Rate limit', status: 429 });
-    expect(result.status).toBe('RESOURCE_EXHAUSTED');
-    expect(result.message).toBe('Rate limit');
-    expect(result.fatal).toBe(true);
-    expect(result._meta?.['status']).toBe(429);
-    expect(result._meta?.['rawError']).toEqual({
-      message: 'Rate limit',
-      status: 429,
-    });
-  });
-
-  it('maps Error instances', () => {
-    const result = mapError(new Error('Something failed'));
-    expect(result.status).toBe('INTERNAL');
-    expect(result.message).toBe('Something failed');
-  });
-
-  it('preserves error name in _meta', () => {
-    class CustomError extends Error {
-      constructor(msg: string) {
-        super(msg);
-      }
-    }
-    const result = mapError(new CustomError('test'));
-    expect(result._meta?.['errorName']).toBe('CustomError');
-  });
-
-  it('maps non-Error values to string', () => {
-    const result = mapError('raw string error');
-    expect(result.message).toBe('raw string error');
-    expect(result.status).toBe('INTERNAL');
-  });
-});
-
-describe('mapUsage', () => {
-  it('maps all fields', () => {
-    const result = mapUsage(
-      {
-        promptTokenCount: 100,
-        candidatesTokenCount: 50,
-        cachedContentTokenCount: 25,
-      },
-      'gemini-2.5-pro',
-    );
-    expect(result).toEqual({
-      model: 'gemini-2.5-pro',
-      inputTokens: 100,
-      outputTokens: 50,
-      cachedTokens: 25,
-    });
-  });
-
-  it('uses "unknown" for missing model', () => {
-    const result = mapUsage({});
-    expect(result.model).toBe('unknown');
   });
 });

--- a/packages/core/src/agent/event-translator.test.ts
+++ b/packages/core/src/agent/event-translator.test.ts
@@ -1,58 +1,372 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { translateEvent, type TranslationState } from './event-translator.js';
-import { GeminiEventType, type ServerGeminiStreamEvent } from '../core/turn.js';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { FinishReason } from '@google/genai';
+import { ToolErrorType } from '../tools/tool-error.js';
+import {
+  translateEvent,
+  createTranslationState,
+  mapFinishReason,
+  mapHttpToGrpcStatus,
+  mapError,
+  mapUsage,
+  type TranslationState,
+} from './event-translator.js';
+import { GeminiEventType } from '../core/turn.js';
+import type { ServerGeminiStreamEvent } from '../core/turn.js';
 import type { AgentEvent } from './types.js';
 
-describe('event-translator', () => {
+describe('createTranslationState', () => {
+  it('creates state with default streamId', () => {
+    const state = createTranslationState();
+    expect(state.streamId).toBeDefined();
+    expect(state.streamStartEmitted).toBe(false);
+    expect(state.model).toBeUndefined();
+    expect(state.eventCounter).toBe(0);
+    expect(state.pendingToolNames.size).toBe(0);
+  });
+
+  it('creates state with custom streamId', () => {
+    const state = createTranslationState('custom-stream');
+    expect(state.streamId).toBe('custom-stream');
+  });
+});
+
+describe('translateEvent', () => {
   let state: TranslationState;
 
   beforeEach(() => {
-    state = {
-      streamId: 'test-stream',
-      model: undefined,
-      pendingToolNames: new Map(),
-      streamStartEmitted: false,
-      eventCounter: 0,
-    };
-  });
-
-  describe('ModelInfo events', () => {
-    it('updates state and emits session_update', () => {
-      const event: ServerGeminiStreamEvent = {
-        type: GeminiEventType.ModelInfo,
-        value: 'gemini-1.5-pro',
-      };
-      const result = translateEvent(event, state);
-      expect(state.model).toBe('gemini-1.5-pro');
-      expect(result).toHaveLength(2);
-      expect(result[0].type).toBe('agent_start');
-      expect(result[1].type).toBe('session_update');
-    });
+    state = createTranslationState('test-stream');
   });
 
   describe('Content events', () => {
-    it('emits message event', () => {
+    it('emits agent_start + message for first content event', () => {
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.Content,
-        value: 'Hello',
+        value: 'Hello world',
       };
       const result = translateEvent(event, state);
       expect(result).toHaveLength(2);
-      expect(result[1].type).toBe('message');
+      expect(result[0]?.type).toBe('agent_start');
+      expect(result[1]?.type).toBe('message');
       const msg = result[1] as AgentEvent<'message'>;
       expect(msg.role).toBe('agent');
-      expect(msg.content[0]).toEqual({ type: 'text', text: 'Hello' });
+      expect(msg.content).toEqual([{ type: 'text', text: 'Hello world' }]);
+    });
+
+    it('skips agent_start for subsequent content events', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Content,
+        value: 'more text',
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.type).toBe('message');
+    });
+  });
+
+  describe('Thought events', () => {
+    it('emits thought content with metadata', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Thought,
+        value: { subject: 'Planning', description: 'I am thinking...' },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const msg = result[0] as AgentEvent<'message'>;
+      expect(msg.content).toEqual([
+        { type: 'thought', thought: 'I am thinking...' },
+      ]);
+      expect(msg._meta?.['subject']).toBe('Planning');
+    });
+  });
+
+  describe('ToolCallRequest events', () => {
+    it('emits tool_request and tracks pending tool name', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallRequest,
+        value: {
+          callId: 'call-1',
+          name: 'read_file',
+          args: { path: '/tmp/test' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const req = result[0] as AgentEvent<'tool_request'>;
+      expect(req.requestId).toBe('call-1');
+      expect(req.name).toBe('read_file');
+      expect(req.args).toEqual({ path: '/tmp/test' });
+      expect(state.pendingToolNames.get('call-1')).toBe('read_file');
+    });
+  });
+
+  describe('ToolCallResponse events', () => {
+    it('emits tool_response with content from responseParts', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-1', 'read_file');
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-1',
+          responseParts: [{ text: 'file contents' }],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.requestId).toBe('call-1');
+      expect(resp.name).toBe('read_file');
+      expect(resp.content).toEqual([{ type: 'text', text: 'file contents' }]);
+      expect(resp.isError).toBe(false);
+      expect(state.pendingToolNames.has('call-1')).toBe(false);
+    });
+
+    it('uses error.message for content when tool errored', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-2', 'write_file');
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-2',
+          responseParts: [{ text: 'stale parts' }],
+          resultDisplay: 'Permission denied',
+          error: new Error('Permission denied to write'),
+          errorType: ToolErrorType.PERMISSION_DENIED,
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.isError).toBe(true);
+      // Should use error.message, not responseParts
+      expect(resp.content).toEqual([
+        { type: 'text', text: 'Permission denied to write' },
+      ]);
+      expect(resp.display?.result).toEqual({
+        type: 'text',
+        text: 'Permission denied',
+      });
+      expect(resp.data).toEqual({ errorType: 'permission_denied' });
+    });
+
+    it('uses "unknown" name for untracked tool calls', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'untracked',
+          responseParts: [{ text: 'data' }],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+      const result = translateEvent(event, state);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.name).toBe('unknown');
+    });
+
+    it('stringifies object resultDisplay correctly', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-3', 'diff_tool');
+      const objectDisplay = {
+        fileDiff: '@@ -1 +1 @@\n-a\n+b',
+        fileName: 'test.txt',
+        filePath: '/tmp/test.txt',
+        originalContent: 'a',
+        newContent: 'b',
+      };
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-3',
+          responseParts: [{ text: 'diff result' }],
+          resultDisplay: objectDisplay,
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+      const result = translateEvent(event, state);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.display?.result).toEqual({
+        type: 'diff',
+        path: '/tmp/test.txt',
+        beforeText: 'a',
+        afterText: 'b',
+      });
+    });
+
+    it('passes through string resultDisplay as-is', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-4', 'shell');
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-4',
+          responseParts: [{ text: 'output' }],
+          resultDisplay: 'Command output text',
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+      const result = translateEvent(event, state);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.display?.result).toEqual({
+        type: 'text',
+        text: 'Command output text',
+      });
+    });
+
+    it('preserves outputFile and contentLength in data', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-5', 'write_file');
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-5',
+          responseParts: [{ text: 'written' }],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+          outputFile: '/tmp/out.txt',
+          contentLength: 42,
+        },
+      };
+      const result = translateEvent(event, state);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.data?.['outputFile']).toBe('/tmp/out.txt');
+      expect(resp.data?.['contentLength']).toBe(42);
+    });
+
+    it('handles multi-part responses (text + inlineData)', () => {
+      state.streamStartEmitted = true;
+      state.pendingToolNames.set('call-6', 'screenshot');
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ToolCallResponse,
+        value: {
+          callId: 'call-6',
+          responseParts: [
+            { text: 'Here is the screenshot' },
+            { inlineData: { data: 'base64img', mimeType: 'image/png' } },
+          ],
+          resultDisplay: undefined,
+          error: undefined,
+          errorType: undefined,
+        },
+      };
+      const result = translateEvent(event, state);
+      const resp = result[0] as AgentEvent<'tool_response'>;
+      expect(resp.content).toEqual([
+        { type: 'text', text: 'Here is the screenshot' },
+        { type: 'media', data: 'base64img', mimeType: 'image/png' },
+      ]);
+      expect(resp.isError).toBe(false);
+    });
+  });
+
+  describe('Error events', () => {
+    it('emits error event for structured errors', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Error,
+        value: { error: { message: 'Rate limited', status: 429 } },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const err = result[0] as AgentEvent<'error'>;
+      expect(err.status).toBe('RESOURCE_EXHAUSTED');
+      expect(err.message).toBe('Rate limited');
+      expect(err.fatal).toBe(true);
+    });
+
+    it('emits error event for Error instances', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Error,
+        value: { error: new Error('Something broke') },
+      };
+      const result = translateEvent(event, state);
+      const err = result[0] as AgentEvent<'error'>;
+      expect(err.status).toBe('INTERNAL');
+      expect(err.message).toBe('Something broke');
+    });
+  });
+
+  describe('ModelInfo events', () => {
+    it('emits agent_start and session_update when no stream started yet', () => {
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ModelInfo,
+        value: 'gemini-2.5-pro',
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(2);
+      expect(result[0]?.type).toBe('agent_start');
+      expect(result[1]?.type).toBe('session_update');
+      const sessionUpdate = result[1] as AgentEvent<'session_update'>;
+      expect(sessionUpdate.model).toBe('gemini-2.5-pro');
+      expect(state.model).toBe('gemini-2.5-pro');
+      expect(state.streamStartEmitted).toBe(true);
+    });
+
+    it('emits session_update when stream already started', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ModelInfo,
+        value: 'gemini-2.5-flash',
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.type).toBe('session_update');
+    });
+  });
+
+  describe('AgentExecutionStopped events', () => {
+    it('emits agent_end with the final stop message in data.message', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.AgentExecutionStopped,
+        value: {
+          reason: 'before_model',
+          systemMessage: 'Stopped by hook',
+          contextCleared: true,
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const streamEnd = result[0] as AgentEvent<'agent_end'>;
+      expect(streamEnd.type).toBe('agent_end');
+      expect(streamEnd.reason).toBe('completed');
+      expect(streamEnd.data).toEqual({ message: 'Stopped by hook' });
+    });
+
+    it('uses reason when systemMessage is not set', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.AgentExecutionStopped,
+        value: { reason: 'hook' },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const streamEnd = result[0] as AgentEvent<'agent_end'>;
+      expect(streamEnd.data).toEqual({ message: 'hook' });
     });
   });
 
   describe('AgentExecutionBlocked events', () => {
-    it('emits a non-fatal warning error event', () => {
+    it('emits non-fatal error event (non-terminal, stream continues)', () => {
       state.streamStartEmitted = true;
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.AgentExecutionBlocked,
@@ -74,10 +388,10 @@ describe('event-translator', () => {
         value: {
           reason: 'hook_blocked',
           systemMessage: 'Blocked by policy hook',
+          contextCleared: true,
         },
       };
       const result = translateEvent(event, state);
-      expect(result).toHaveLength(1);
       const err = result[0] as AgentEvent<'error'>;
       expect(err.message).toBe('Blocked by policy hook');
     });
@@ -91,11 +405,333 @@ describe('event-translator', () => {
       };
       const result = translateEvent(event, state);
       expect(result).toHaveLength(1);
-      const err = result[0] as AgentEvent<'error'>;
-      expect(err.type).toBe('error');
-      expect(err.fatal).toBe(false);
-      expect(err._meta?.['code']).toBe('LOOP_DETECTED');
-      expect(err.message).toBe('Loop detected, stopping execution');
+      expect(result[0]?.type).toBe('error');
+      const loopWarning = result[0] as AgentEvent<'error'>;
+      expect(loopWarning.fatal).toBe(false);
+      expect(loopWarning.message).toBe('Loop detected, stopping execution');
+      expect(loopWarning._meta?.['code']).toBe('LOOP_DETECTED');
     });
+  });
+
+  describe('MaxSessionTurns events', () => {
+    it('emits agent_end with max_turns', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.MaxSessionTurns,
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const streamEnd = result[0] as AgentEvent<'agent_end'>;
+      expect(streamEnd.type).toBe('agent_end');
+      expect(streamEnd.reason).toBe('max_turns');
+      expect(streamEnd.data).toEqual({ code: 'MAX_TURNS_EXCEEDED' });
+    });
+  });
+
+  describe('Finished events', () => {
+    it('emits usage for STOP', () => {
+      state.streamStartEmitted = true;
+      state.model = 'gemini-2.5-pro';
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Finished,
+        value: {
+          reason: FinishReason.STOP,
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 50,
+            cachedContentTokenCount: 10,
+          },
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+
+      const usage = result[0] as AgentEvent<'usage'>;
+      expect(usage.model).toBe('gemini-2.5-pro');
+      expect(usage.inputTokens).toBe(100);
+      expect(usage.outputTokens).toBe(50);
+      expect(usage.cachedTokens).toBe(10);
+    });
+
+    it('emits nothing when no usage metadata is present', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Finished,
+        value: { reason: undefined, usageMetadata: undefined },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('Citation events', () => {
+    it('emits message with citation meta', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.Citation,
+        value: 'Source: example.com',
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const msg = result[0] as AgentEvent<'message'>;
+      expect(msg.content).toEqual([
+        { type: 'text', text: 'Source: example.com' },
+      ]);
+      expect(msg._meta?.['citation']).toBe(true);
+    });
+  });
+
+  describe('UserCancelled events', () => {
+    it('emits agent_end with reason aborted', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.UserCancelled,
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const end = result[0] as AgentEvent<'agent_end'>;
+      expect(end.type).toBe('agent_end');
+      expect(end.reason).toBe('aborted');
+    });
+  });
+
+  describe('ContextWindowWillOverflow events', () => {
+    it('emits fatal error', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount: 150000,
+          remainingTokenCount: 10000,
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const err = result[0] as AgentEvent<'error'>;
+      expect(err.status).toBe('RESOURCE_EXHAUSTED');
+      expect(err.fatal).toBe(true);
+      expect(err.message).toContain('150000');
+      expect(err.message).toContain('10000');
+    });
+  });
+
+  describe('InvalidStream events', () => {
+    it('emits fatal error', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.InvalidStream,
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const err = result[0] as AgentEvent<'error'>;
+      expect(err.status).toBe('INTERNAL');
+      expect(err.message).toBe('Invalid stream received from model');
+      expect(err.fatal).toBe(true);
+    });
+  });
+
+  describe('Events with no output', () => {
+    it('returns empty for Retry', () => {
+      const result = translateEvent({ type: GeminiEventType.Retry }, state);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty for ChatCompressed with null', () => {
+      const result = translateEvent(
+        { type: GeminiEventType.ChatCompressed, value: null },
+        state,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty for ToolCallConfirmation', () => {
+      // ToolCallConfirmation is skipped in non-interactive mode (elicitations
+      // are deferred to the interactive runtime adaptation).
+      const event = {
+        type: GeminiEventType.ToolCallConfirmation,
+        value: {
+          request: {
+            callId: 'c1',
+            name: 'tool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          details: { type: 'info', title: 'Confirm', prompt: 'Confirm?' },
+        },
+      } as ServerGeminiStreamEvent;
+      const result = translateEvent(event, state);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('Event IDs', () => {
+    it('generates sequential IDs', () => {
+      state.streamStartEmitted = true;
+      const e1 = translateEvent(
+        { type: GeminiEventType.Content, value: 'a' },
+        state,
+      );
+      const e2 = translateEvent(
+        { type: GeminiEventType.Content, value: 'b' },
+        state,
+      );
+      expect(e1[0]?.id).toBe('test-stream-0');
+      expect(e2[0]?.id).toBe('test-stream-1');
+    });
+
+    it('includes streamId in events', () => {
+      const events = translateEvent(
+        { type: GeminiEventType.Content, value: 'hi' },
+        state,
+      );
+      for (const e of events) {
+        expect(e.streamId).toBe('test-stream');
+      }
+    });
+  });
+});
+
+describe('mapFinishReason', () => {
+  it('maps STOP to completed', () => {
+    expect(mapFinishReason(FinishReason.STOP)).toBe('completed');
+  });
+
+  it('maps undefined to completed', () => {
+    expect(mapFinishReason(undefined)).toBe('completed');
+  });
+
+  it('maps MAX_TOKENS to max_budget', () => {
+    expect(mapFinishReason(FinishReason.MAX_TOKENS)).toBe('max_budget');
+  });
+
+  it('maps SAFETY to refusal', () => {
+    expect(mapFinishReason(FinishReason.SAFETY)).toBe('refusal');
+  });
+
+  it('maps MALFORMED_FUNCTION_CALL to failed', () => {
+    expect(mapFinishReason(FinishReason.MALFORMED_FUNCTION_CALL)).toBe(
+      'failed',
+    );
+  });
+
+  it('maps RECITATION to refusal', () => {
+    expect(mapFinishReason(FinishReason.RECITATION)).toBe('refusal');
+  });
+
+  it('maps LANGUAGE to refusal', () => {
+    expect(mapFinishReason(FinishReason.LANGUAGE)).toBe('refusal');
+  });
+
+  it('maps BLOCKLIST to refusal', () => {
+    expect(mapFinishReason(FinishReason.BLOCKLIST)).toBe('refusal');
+  });
+
+  it('maps OTHER to failed', () => {
+    expect(mapFinishReason(FinishReason.OTHER)).toBe('failed');
+  });
+
+  it('maps PROHIBITED_CONTENT to refusal', () => {
+    expect(mapFinishReason(FinishReason.PROHIBITED_CONTENT)).toBe('refusal');
+  });
+
+  it('maps IMAGE_SAFETY to refusal', () => {
+    expect(mapFinishReason(FinishReason.IMAGE_SAFETY)).toBe('refusal');
+  });
+
+  it('maps IMAGE_PROHIBITED_CONTENT to refusal', () => {
+    expect(mapFinishReason(FinishReason.IMAGE_PROHIBITED_CONTENT)).toBe(
+      'refusal',
+    );
+  });
+
+  it('maps UNEXPECTED_TOOL_CALL to failed', () => {
+    expect(mapFinishReason(FinishReason.UNEXPECTED_TOOL_CALL)).toBe('failed');
+  });
+
+  it('maps NO_IMAGE to failed', () => {
+    expect(mapFinishReason(FinishReason.NO_IMAGE)).toBe('failed');
+  });
+});
+
+describe('mapHttpToGrpcStatus', () => {
+  it('maps 400 to INVALID_ARGUMENT', () => {
+    expect(mapHttpToGrpcStatus(400)).toBe('INVALID_ARGUMENT');
+  });
+
+  it('maps 401 to UNAUTHENTICATED', () => {
+    expect(mapHttpToGrpcStatus(401)).toBe('UNAUTHENTICATED');
+  });
+
+  it('maps 429 to RESOURCE_EXHAUSTED', () => {
+    expect(mapHttpToGrpcStatus(429)).toBe('RESOURCE_EXHAUSTED');
+  });
+
+  it('maps undefined to INTERNAL', () => {
+    expect(mapHttpToGrpcStatus(undefined)).toBe('INTERNAL');
+  });
+
+  it('maps unknown codes to INTERNAL', () => {
+    expect(mapHttpToGrpcStatus(418)).toBe('INTERNAL');
+  });
+});
+
+describe('mapError', () => {
+  it('maps structured errors with status', () => {
+    const result = mapError({ message: 'Rate limit', status: 429 });
+    expect(result.status).toBe('RESOURCE_EXHAUSTED');
+    expect(result.message).toBe('Rate limit');
+    expect(result.fatal).toBe(true);
+    expect(result._meta?.['status']).toBe(429);
+    expect(result._meta?.['rawError']).toEqual({
+      message: 'Rate limit',
+      status: 429,
+    });
+  });
+
+  it('maps Error instances', () => {
+    const result = mapError(new Error('Something failed'));
+    expect(result.status).toBe('INTERNAL');
+    expect(result.message).toBe('Something failed');
+  });
+
+  it('preserves error name in _meta', () => {
+    class CustomError extends Error {
+      constructor(msg: string) {
+        super(msg);
+      }
+    }
+    const result = mapError(new CustomError('test'));
+    expect(result._meta?.['errorName']).toBe('CustomError');
+  });
+
+  it('maps non-Error values to string', () => {
+    const result = mapError('raw string error');
+    expect(result.message).toBe('raw string error');
+    expect(result.status).toBe('INTERNAL');
+  });
+});
+
+describe('mapUsage', () => {
+  it('maps all fields', () => {
+    const result = mapUsage(
+      {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        cachedContentTokenCount: 25,
+      },
+      'gemini-2.5-pro',
+    );
+    expect(result).toEqual({
+      model: 'gemini-2.5-pro',
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedTokens: 25,
+    });
+  });
+
+  it('uses "unknown" for missing model', () => {
+    const result = mapUsage({});
+    expect(result.model).toBe('unknown');
   });
 });

--- a/packages/core/src/agent/event-translator.ts
+++ b/packages/core/src/agent/event-translator.ts
@@ -210,7 +210,7 @@ export function translateEvent(
       out.push(
         makeEvent('error', state, {
           status: 'PERMISSION_DENIED',
-          message: `Agent execution blocked: ${event.value.systemMessage?.trim() || event.value.reason}`,
+          message: event.value.systemMessage?.trim() || event.value.reason,
           fatal: false,
           _meta: { code: 'AGENT_EXECUTION_BLOCKED' },
         }),

--- a/packages/core/src/agent/legacy-agent-session.test.ts
+++ b/packages/core/src/agent/legacy-agent-session.test.ts
@@ -647,7 +647,7 @@ describe('LegacyAgentSession', () => {
           e.type === 'error' && e._meta?.['code'] === 'AGENT_EXECUTION_BLOCKED',
       );
       expect(blocked?.fatal).toBe(false);
-      expect(blocked?.message).toBe('Agent execution blocked: Blocked by hook');
+      expect(blocked?.message).toBe('Blocked by hook');
 
       const messages = events.filter(
         (e): e is AgentEvent<'message'> =>

--- a/packages/core/src/output/json-formatter.test.ts
+++ b/packages/core/src/output/json-formatter.test.ts
@@ -331,4 +331,19 @@ describe('JsonFormatter', () => {
     expect(parsed.error.message).toBe('Error\x07 with\x08 control\x0B chars');
     expect(() => JSON.parse(formatted)).not.toThrow();
   });
+
+  it('should format warnings as JSON', () => {
+    const formatter = new JsonFormatter();
+    const warnings = ['Warning 1', '\x1B[33mWarning 2 with ANSI\x1B[0m'];
+    const formatted = formatter.format(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      warnings,
+    );
+    const parsed = JSON.parse(formatted);
+
+    expect(parsed.warnings).toEqual(['Warning 1', 'Warning 2 with ANSI']);
+  });
 });

--- a/packages/core/src/output/json-formatter.ts
+++ b/packages/core/src/output/json-formatter.ts
@@ -15,6 +15,7 @@ export class JsonFormatter {
     response?: string,
     stats?: SessionMetrics,
     error?: JsonError,
+    warnings?: string[],
   ): string {
     const output: JsonOutput = {};
 
@@ -32,6 +33,10 @@ export class JsonFormatter {
 
     if (error) {
       output.error = error;
+    }
+
+    if (warnings && warnings.length > 0) {
+      output.warnings = warnings.map((w) => stripAnsi(w));
     }
 
     return JSON.stringify(output, null, 2);

--- a/packages/core/src/output/types.ts
+++ b/packages/core/src/output/types.ts
@@ -23,6 +23,7 @@ export interface JsonOutput {
   response?: string;
   stats?: SessionMetrics;
   error?: JsonError;
+  warnings?: string[];
 }
 
 // Streaming JSON event types


### PR DESCRIPTION
## Summary

Fixes issue #20859 where `AgentExecutionBlocked` events were silently swallowed in non-interactive programmatic modes (`JSON` and `STREAM_JSON`).

## Details

- Updated `JsonOutput` to include a `warnings` field.
- Enhanced `JsonFormatter` to collect and sanitize (strip ANSI) warning messages.
- Updated `nonInteractiveCli.ts` and `nonInteractiveCliAgentSession.ts` to:
    - Emit `JsonStreamEventType.ERROR` with `severity: 'warning'` in `STREAM_JSON` mode.
    - Collect block reasons into a `warnings` array for `JSON` mode.
- Added regression tests in both core and CLI packages covering multiple blocks and backward compatibility.

## Related Issues

Fixes #20859

## How to Validate

1. Run unit tests: `npm test -w @google/gemini-cli -- src/nonInteractiveCli.test.ts`
2. Verify `STREAM_JSON` output for block events.
3. Verify `JSON` output for block events (check for `warnings` array).

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Validated on MacOS (npm run)