### PR TITLE
fix(cli): prevent informational logs from polluting json output

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -819,22 +819,22 @@ export function initializeOutputListenersAndFlush(config?: Config) {
         writeToStdout(payload.chunk, payload.encoding);
       }
     });
+  }
 
-    if (coreEvents.listenerCount(CoreEvent.ConsoleLog) === 0) {
-      coreEvents.on(CoreEvent.ConsoleLog, (payload: ConsoleLogPayload) => {
-        if (payload.type === 'error' || payload.type === 'warn') {
-          writeToStderr(payload.content + '\n');
-        } else {
-          writeToStderr(payload.content + '\n');
-        }
-      });
-    }
+  if (coreEvents.listenerCount(CoreEvent.ConsoleLog) === 0) {
+    coreEvents.on(CoreEvent.ConsoleLog, (payload: ConsoleLogPayload) => {
+      if (payload.type === 'error' || payload.type === 'warn') {
+        writeToStderr(payload.content + '\n');
+      } else {
+        writeToStderr(payload.content + '\n');
+      }
+    });
+  }
 
-    if (coreEvents.listenerCount(CoreEvent.UserFeedback) === 0) {
-      coreEvents.on(CoreEvent.UserFeedback, (payload: UserFeedbackPayload) => {
-        writeToStderr(payload.message + '\n');
-      });
-    }
+  if (coreEvents.listenerCount(CoreEvent.UserFeedback) === 0) {
+    coreEvents.on(CoreEvent.UserFeedback, (payload: UserFeedbackPayload) => {
+      writeToStderr(payload.message + '\n');
+    });
   }
 
   const outputFormat = config?.getOutputFormat();

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -262,6 +262,7 @@ export async function startInteractiveUI(
 }
 
 export async function main() {
+  let config: Config | undefined;
   const cliStartupHandle = startupProfiler.start('cli_startup');
 
   // Listen for admin controls from parent process (IPC) in non-sandbox mode. In
@@ -272,22 +273,11 @@ export async function main() {
   registerCleanup(adminControlsListner.cleanup);
 
   const cleanupStdio = patchStdio();
-  if (isHeadlessMode()) {
-    // In headless mode, ensure all console output during early initialization
-    // goes to stderr so it doesn't pollute stdout (e.g. JSON output).
-    // ConsolePatcher will perform a more comprehensive patch later.
-    /* eslint-disable no-console */
-    console.log = console.error;
-    console.info = console.error;
-    /* eslint-enable no-console */
-  }
   registerSyncCleanup(() => {
     // This is needed to ensure we don't lose any buffered output.
     initializeOutputListenersAndFlush(config);
     cleanupStdio();
   });
-
-  let config: Config | undefined;
 
   setupUnhandledRejectionHandler();
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -838,7 +838,7 @@ export function initializeOutputListenersAndFlush(config?: Config) {
   }
 
   const outputFormat = config?.getOutputFormat();
-  const forceToStderr = outputFormat === 'json';
+  const forceToStderr = outputFormat === 'json' || config === undefined;
 
   coreEvents.drainBacklogs(
     <K extends keyof CoreEvents>(event: K, args: CoreEvents[K]) => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -13,6 +13,7 @@ import {
   type OutputPayload,
   type ConsoleLogPayload,
   type UserFeedbackPayload,
+  type CoreEvents,
   createSessionId,
   logUserPrompt,
   AuthType,
@@ -271,11 +272,22 @@ export async function main() {
   registerCleanup(adminControlsListner.cleanup);
 
   const cleanupStdio = patchStdio();
+  if (isHeadlessMode()) {
+    // In headless mode, ensure all console output during early initialization
+    // goes to stderr so it doesn't pollute stdout (e.g. JSON output).
+    // ConsolePatcher will perform a more comprehensive patch later.
+    /* eslint-disable no-console */
+    console.log = console.error;
+    console.info = console.error;
+    /* eslint-enable no-console */
+  }
   registerSyncCleanup(() => {
     // This is needed to ensure we don't lose any buffered output.
-    initializeOutputListenersAndFlush();
+    initializeOutputListenersAndFlush(config);
     cleanupStdio();
   });
+
+  let config: Config | undefined;
 
   setupUnhandledRejectionHandler();
 
@@ -534,7 +546,7 @@ export async function main() {
   // may have side effects.
   {
     const loadConfigHandle = startupProfiler.start('load_cli_config');
-    const config = await loadCliConfig(settings.merged, sessionId, argv, {
+    config = await loadCliConfig(settings.merged, sessionId, argv, {
       projectHooks: settings.workspace.settings.hooks,
       worktreeSettings: worktreeInfo,
     });
@@ -780,7 +792,7 @@ export async function main() {
       debugLogger.log('Session ID: %s', sessionId);
     }
 
-    initializeOutputListenersAndFlush();
+    initializeOutputListenersAndFlush(config);
 
     await runNonInteractive({
       config,
@@ -795,7 +807,7 @@ export async function main() {
   }
 }
 
-export function initializeOutputListenersAndFlush() {
+export function initializeOutputListenersAndFlush(config?: Config) {
   // If there are no listeners for output, make sure we flush so output is not
   // lost.
   if (coreEvents.listenerCount(CoreEvent.Output) === 0) {
@@ -824,7 +836,26 @@ export function initializeOutputListenersAndFlush() {
       });
     }
   }
-  coreEvents.drainBacklogs();
+
+  const outputFormat = config?.getOutputFormat();
+  const forceToStderr = outputFormat === 'json';
+
+  coreEvents.drainBacklogs(
+    <K extends keyof CoreEvents>(event: K, args: CoreEvents[K]) => {
+      if (forceToStderr && event === (CoreEvent.Output as string)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const payload = args[0] as OutputPayload;
+        if (!payload.isStderr) {
+          return {
+            event,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            args: [{ ...payload, isStderr: true }] as unknown as CoreEvents[K],
+          };
+        }
+      }
+      return { event, args };
+    },
+  );
 }
 
 function setupAdminControlsListener() {

--- a/packages/cli/src/output-redirection.test.ts
+++ b/packages/cli/src/output-redirection.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { initializeOutputListenersAndFlush } from './gemini.js';
-import { coreEvents, type Config } from '@google/gemini-cli-core';
+import { coreEvents, CoreEvent, type Config } from '@google/gemini-cli-core';
 
 // Mock core dependencies
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -79,5 +79,22 @@ describe('Output Redirection', () => {
     // Verify it was forced to stderr
     expect(writeToStderr).toHaveBeenCalledWith('early init message', undefined);
     expect(writeToStdout).not.toHaveBeenCalled();
+  });
+
+  it('should attach ConsoleLog and UserFeedback listeners even if Output already has one', () => {
+    // Manually attach an Output listener
+    coreEvents.on(CoreEvent.Output, vi.fn());
+
+    // Initialize - should still attach ConsoleLog and UserFeedback defaults
+    initializeOutputListenersAndFlush(undefined);
+
+    // Simulate events
+    coreEvents.emitConsoleLog('info', 'stray log');
+    coreEvents.emitFeedback('info', 'stray feedback');
+
+    // Draining happens inside initializeOutputListenersAndFlush for existing backlog,
+    // but here we check the newly attached listeners for immediate emission.
+    expect(writeToStderr).toHaveBeenCalledWith('stray log\n');
+    expect(writeToStderr).toHaveBeenCalledWith('stray feedback\n');
   });
 });

--- a/packages/cli/src/output-redirection.test.ts
+++ b/packages/cli/src/output-redirection.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initializeOutputListenersAndFlush } from './gemini.js';
+import { coreEvents, type Config } from '@google/gemini-cli-core';
+
+// Mock core dependencies
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    writeToStdout: vi.fn(),
+    writeToStderr: vi.fn(),
+  };
+});
+
+import { writeToStdout, writeToStderr } from '@google/gemini-cli-core';
+
+describe('Output Redirection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear listeners to simulate a clean state for each test
+    coreEvents.removeAllListeners();
+  });
+
+  afterEach(() => {
+    coreEvents.removeAllListeners();
+  });
+
+  it('should redirect buffered stdout to stderr when output format is json', () => {
+    const mockConfig = {
+      getOutputFormat: () => 'json',
+    } as unknown as Config;
+
+    // Simulate buffered output
+    coreEvents.emitOutput(false, 'informational message');
+    coreEvents.emitOutput(true, 'error message');
+
+    // Initialize listeners and flush
+    initializeOutputListenersAndFlush(mockConfig);
+
+    // Verify informational message was forced to stderr
+    expect(writeToStderr).toHaveBeenCalledWith(
+      'informational message',
+      undefined,
+    );
+    expect(writeToStderr).toHaveBeenCalledWith('error message', undefined);
+    expect(writeToStdout).not.toHaveBeenCalled();
+  });
+
+  it('should NOT redirect buffered stdout to stderr when output format is NOT json', () => {
+    const mockConfig = {
+      getOutputFormat: () => 'text',
+    } as unknown as Config;
+
+    // Simulate buffered output
+    coreEvents.emitOutput(false, 'regular message');
+
+    // Initialize listeners and flush
+    initializeOutputListenersAndFlush(mockConfig);
+
+    // Verify regular message went to stdout
+    expect(writeToStdout).toHaveBeenCalledWith('regular message', undefined);
+    expect(writeToStderr).not.toHaveBeenCalled();
+  });
+
+  it('should force stdout to stderr when config is undefined (early failure)', () => {
+    // Simulate buffered output during early init
+    coreEvents.emitOutput(false, 'early init message');
+
+    // Initialize with undefined config
+    initializeOutputListenersAndFlush(undefined);
+
+    // Verify it was forced to stderr
+    expect(writeToStderr).toHaveBeenCalledWith('early init message', undefined);
+    expect(writeToStdout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/utils/events.test.ts
+++ b/packages/core/src/utils/events.test.ts
@@ -9,6 +9,7 @@ import {
   CoreEventEmitter,
   CoreEvent,
   coreEvents,
+  type CoreEvents,
   type UserFeedbackPayload,
   type McpProgressPayload,
 } from './events.js';
@@ -265,6 +266,61 @@ describe('CoreEventEmitter', () => {
       expect(listener).toHaveBeenCalledTimes(MAX_BACKLOG_SIZE);
       // Verify strictly that the FIRST call was Output 10 (0-9 dropped)
       expect(listener.mock.calls[0][0]).toMatchObject({ chunk: 'Output 10' });
+    });
+  });
+
+  describe('drainBacklogs Transformation', () => {
+    it('should transform events during drain', () => {
+      const listener = vi.fn();
+      events.emitOutput(false, 'stdout chunk');
+      events.emitFeedback('info', 'info message');
+
+      events.on(CoreEvent.Output, listener);
+      events.on(CoreEvent.UserFeedback, listener);
+
+      events.drainBacklogs(
+        <K extends keyof CoreEvents>(event: K, args: CoreEvents[K]) => {
+          if (event === (CoreEvent.Output as string)) {
+            const payload = args[0] as { isStderr: boolean; chunk: string };
+            return {
+              event,
+              args: [
+                { ...payload, isStderr: true },
+              ] as unknown as CoreEvents[K],
+            };
+          }
+          return { event, args };
+        },
+      );
+
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ isStderr: true, chunk: 'stdout chunk' }),
+      );
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'info message' }),
+      );
+    });
+
+    it('should drop events when transform returns undefined', () => {
+      const listener = vi.fn();
+      events.emitOutput(false, 'drop me');
+      events.emitFeedback('info', 'keep me');
+
+      events.on(CoreEvent.Output, listener);
+      events.on(CoreEvent.UserFeedback, listener);
+
+      events.drainBacklogs((event, args) => {
+        if (event === CoreEvent.Output) {
+          return undefined;
+        }
+        return { event, args };
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'keep me' }),
+      );
     });
   });
 

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -422,8 +422,15 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   /**
    * Flushes buffered messages. Call this immediately after primary UI listener
    * subscribes.
+   *
+   * @param transform - Optional function to transform events before they are emitted.
    */
-  drainBacklogs(): void {
+  drainBacklogs(
+    transform?: <K extends keyof CoreEvents>(
+      event: K,
+      args: CoreEvents[K],
+    ) => { event: K; args: CoreEvents[K] } | undefined,
+  ): void {
     const backlog = this._eventBacklog;
     const head = this._backlogHead;
     this._eventBacklog = [];
@@ -431,10 +438,21 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
     for (let i = head; i < backlog.length; i++) {
       const item = backlog[i];
       if (item === undefined) continue;
+
+      let eventToEmit = item.event;
+      let argsToEmit = item.args;
+
+      if (transform) {
+        const transformed = transform(item.event, item.args);
+        if (!transformed) continue;
+        eventToEmit = transformed.event;
+        argsToEmit = transformed.args;
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       (this.emit as (event: keyof CoreEvents, ...args: unknown[]) => boolean)(
-        item.event,
-        ...item.args,
+        eventToEmit,
+        ...argsToEmit,
       );
     }
   }


### PR DESCRIPTION
## Summary

This PR prevents informational logs (e.g. MCP discovery messages, debug logs) from polluting the `stdout` stream when the CLI is running in non-interactive mode with JSON output.

## Details

The issue occurred because `patchStdio()` starts buffering output very early, but the full `ConsolePatcher` (which redirects `console.log` to `stderr`) is initialized later. Any logs during this window were captured as `stdout` and then flushed to the real `stdout` during the pre-session drain.

Key changes:
- **Early Redirection:** Immediately after starting the capture buffer, `console.log` and `console.info` are shallow-patched to point to `console.error` if in headless mode.
- **Smart Draining:** `coreEvents.drainBacklogs` now supports an optional transformer. `initializeOutputListenersAndFlush` uses this to force any buffered `stdout` items to `stderr` if JSON output is active.
- **Robustness:** Refactored `gemini.tsx` to manage the `config` variable more reliably during the initialization and cleanup phases.

## Related Issues

Fixes #19198

## How to Validate

1. Add a `console.log('STRAY')` at the beginning of `main()` in `gemini.tsx`.
2. Run `npm run bundle`.
3. Run `node bundle/gemini.js --prompt 'hi' --output-format json > out.json`.
4. Observe that `out.json` is valid JSON and does not contain 'STRAY', while 'STRAY' appears in `stderr`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
