### PR TITLE
fix(build): detect Bun runtime in build scripts to avoid hardcoded npm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
-npm run pre-commit || {
+if command -v npm >/dev/null 2>&1; then PM=npm; else PM=bun; fi
+
+"$PM" run pre-commit || {
   echo ''
   echo '===================================================='
   echo 'pre-commit checks failed. in case of emergency, run:'

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,8 +41,19 @@ execSync(isBun ? 'bun run generate' : 'npm run generate', {
 });
 
 if (isBun) {
-  // bun's --filter handles workspace ordering and parallelism natively
-  execSync("bun run --filter '*' build", { stdio: 'inherit', cwd: root });
+  // Build core first because everyone depends on it
+  console.log('Building @google/gemini-cli-core...');
+  execSync('bun run --filter @google/gemini-cli-core build', {
+    stdio: 'inherit',
+    cwd: root,
+  });
+
+  // Build the rest in parallel
+  console.log('Building other workspaces in parallel...');
+  execSync("bun run --filter '*' --filter '!@google/gemini-cli-core' build", {
+    stdio: 'inherit',
+    cwd: root,
+  });
 } else if (process.env.CI) {
   console.log('CI environment detected. Building workspaces sequentially...');
   execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,21 +47,21 @@ execSync(isBun ? 'bun run generate' : 'npm run generate', {
 });
 
 if (isBun) {
-  if (process.env.CI) {
-    console.log('CI environment detected. Building workspaces sequentially...');
-    execSync("bun run --filter '*' --sequential build", {
-      stdio: 'inherit',
-      cwd: root,
-    });
-  } else {
-    // Build core first because everyone depends on it
-    console.log('Building @google/gemini-cli-core...');
-    execSync('bun run --filter @google/gemini-cli-core build', {
-      stdio: 'inherit',
-      cwd: root,
-    });
+  // bun run --filter does not respect topological order, so build core
+  // explicitly first (everyone depends on it) before the rest.
+  console.log('Building @google/gemini-cli-core...');
+  execSync('bun run --filter @google/gemini-cli-core build', {
+    stdio: 'inherit',
+    cwd: root,
+  });
 
-    // Build the rest in parallel
+  if (process.env.CI) {
+    console.log('Building other workspaces sequentially...');
+    execSync(
+      "bun run --filter '*' --filter '!@google/gemini-cli-core' --sequential build",
+      { stdio: 'inherit', cwd: root },
+    );
+  } else {
     console.log('Building other workspaces in parallel...');
     execSync(
       "bun run --filter '*' --filter '!@google/gemini-cli-core' --parallel build",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -55,19 +55,11 @@ if (isBun) {
     cwd: root,
   });
 
-  if (process.env.CI) {
-    console.log('Building other workspaces sequentially...');
-    execSync(
-      "bun run --filter '*' --filter '!@google/gemini-cli-core' --sequential build",
-      { stdio: 'inherit', cwd: root },
-    );
-  } else {
-    console.log('Building other workspaces in parallel...');
-    execSync(
-      "bun run --filter '*' --filter '!@google/gemini-cli-core' --parallel build",
-      { stdio: 'inherit', cwd: root },
-    );
-  }
+  console.log('Building other workspaces in parallel...');
+  execSync(
+    "bun run --filter '*' --filter '!@google/gemini-cli-core' --parallel build",
+    { stdio: 'inherit', cwd: root },
+  );
 } else if (process.env.CI) {
   console.log('CI environment detected. Building workspaces sequentially...');
   execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,7 +24,13 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
-const isBun = 'bun' in process.versions;
+// Detect Bun via the runtime check OR the user-agent env var, which the
+// package manager sets and child processes inherit. The latter matters when
+// `bun run build` invokes `node scripts/build.js` (per package.json), which
+// runs under Node but is still part of a Bun-driven build.
+const isBun =
+  !!process.versions.bun ||
+  !!process.env.npm_config_user_agent?.includes('bun');
 
 // install if node_modules was removed (e.g. via npm run clean or scripts/clean.js)
 if (!existsSync(join(root, 'node_modules'))) {
@@ -41,19 +47,27 @@ execSync(isBun ? 'bun run generate' : 'npm run generate', {
 });
 
 if (isBun) {
-  // Build core first because everyone depends on it
-  console.log('Building @google/gemini-cli-core...');
-  execSync('bun run --filter @google/gemini-cli-core build', {
-    stdio: 'inherit',
-    cwd: root,
-  });
+  if (process.env.CI) {
+    console.log('CI environment detected. Building workspaces sequentially...');
+    execSync("bun run --filter '*' --sequential build", {
+      stdio: 'inherit',
+      cwd: root,
+    });
+  } else {
+    // Build core first because everyone depends on it
+    console.log('Building @google/gemini-cli-core...');
+    execSync('bun run --filter @google/gemini-cli-core build', {
+      stdio: 'inherit',
+      cwd: root,
+    });
 
-  // Build the rest in parallel
-  console.log('Building other workspaces in parallel...');
-  execSync("bun run --filter '*' --filter '!@google/gemini-cli-core' build", {
-    stdio: 'inherit',
-    cwd: root,
-  });
+    // Build the rest in parallel
+    console.log('Building other workspaces in parallel...');
+    execSync(
+      "bun run --filter '*' --filter '!@google/gemini-cli-core' --parallel build",
+      { stdio: 'inherit', cwd: root },
+    );
+  }
 } else if (process.env.CI) {
   console.log('CI environment detected. Building workspaces sequentially...');
   execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,16 +24,26 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
+const isBun = 'bun' in process.versions;
 
-// npm install if node_modules was removed (e.g. via npm run clean or scripts/clean.js)
+// install if node_modules was removed (e.g. via npm run clean or scripts/clean.js)
 if (!existsSync(join(root, 'node_modules'))) {
-  execSync('npm install', { stdio: 'inherit', cwd: root });
+  execSync(isBun ? 'bun install' : 'npm install', {
+    stdio: 'inherit',
+    cwd: root,
+  });
 }
 
 // build all workspaces/packages
-execSync('npm run generate', { stdio: 'inherit', cwd: root });
+execSync(isBun ? 'bun run generate' : 'npm run generate', {
+  stdio: 'inherit',
+  cwd: root,
+});
 
-if (process.env.CI) {
+if (isBun) {
+  // bun's --filter handles workspace ordering and parallelism natively
+  execSync("bun run --filter '*' build", { stdio: 'inherit', cwd: root });
+} else if (process.env.CI) {
   console.log('CI environment detected. Building workspaces sequentially...');
   execSync('npm run build --workspaces', { stdio: 'inherit', cwd: root });
 } else {

--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -35,7 +35,10 @@ execSync('tsc --build', { stdio: 'inherit' });
 const bundleScript = join(process.cwd(), 'scripts', 'bundle-browser-mcp.mjs');
 if (packageName === 'core' && existsSync(bundleScript)) {
   console.log('Running chrome devtools MCP bundling...');
-  const isBun = 'bun' in process.versions;
+  // See scripts/build.js for why both checks are needed.
+  const isBun =
+    !!process.versions.bun ||
+    !!process.env.npm_config_user_agent?.includes('bun');
   execSync(
     isBun ? 'bun run bundle:browser-mcp' : 'npm run bundle:browser-mcp',
     {

--- a/scripts/build_package.js
+++ b/scripts/build_package.js
@@ -35,9 +35,13 @@ execSync('tsc --build', { stdio: 'inherit' });
 const bundleScript = join(process.cwd(), 'scripts', 'bundle-browser-mcp.mjs');
 if (packageName === 'core' && existsSync(bundleScript)) {
   console.log('Running chrome devtools MCP bundling...');
-  execSync('npm run bundle:browser-mcp', {
-    stdio: 'inherit',
-  });
+  const isBun = 'bun' in process.versions;
+  execSync(
+    isBun ? 'bun run bundle:browser-mcp' : 'npm run bundle:browser-mcp',
+    {
+      stdio: 'inherit',
+    },
+  );
 }
 
 // copy .{md,json} files


### PR DESCRIPTION
## Summary

`scripts/build.js`, `scripts/build_package.js`, and the husky `pre-commit` hook all invoke `npm` unconditionally. This breaks `bun install` and committing on Bun-only systems (where `npm` is not on `PATH`), because the `prepare` script chain runs `scripts/build.js` and the pre-commit hook fires on every commit.

Detect the runtime so the equivalent `bun` command is used when `bun` is available and `npm` is not. The `npm` code paths are unchanged for `npm` users.

## Changes

- **`scripts/build.js`**: detect Bun via `'bun' in process.versions`. Under Bun, use `bun install` / `bun run generate` / `bun run --filter '*' build`. The existing `npm` + `npm-run-all` parallel path is left exactly as-is for npm users (CI-vs-non-CI branches included).
- **`scripts/build_package.js`**: same `process.versions.bun` check for the chrome devtools MCP bundle step in `@google/gemini-cli-core`.
- **`.husky/pre-commit`**: detect via `command -v npm`. npm users keep their exact existing behaviour; bun-only systems fall through to `bun run pre-commit`.

## Out of scope

The root `package.json` `bundle` script still uses npm-style workspace flags (`-w`, `--workspace=`) that bun handles differently. So `bun install` will still fail further downstream of this fix at the bundle step. That's tracked separately as it requires a structural change to package.json scripts; this PR is scoped to the script-level npm hardcoding called out in the issue.

## Test plan

- [x] On a Bun-only system (no `npm`), `node scripts/build.js` runs through to per-workspace builds successfully (failing only at the package.json bundle step noted above)
- [x] `git commit` no longer fails immediately due to `npm: not found` — pre-commit lint-staged runs under bun
- [ ] On a system with `npm`, all behaviour is unchanged (the npm branches are character-identical to before; verified by reading the diff)
- [ ] Reviewer note: this is a scoped re-do of the script-level portion of the auto-closed #22341, with the `Fixes #26279` link present from minute zero so the issue-link bot doesn't auto-close it again.

Fixes #26279