### PR TITLE
fix(cli): use resolved sandbox state for auto-update check

### DIFF
--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -179,7 +179,12 @@ export async function startInteractiveUI(
 
   checkForUpdates(settings)
     .then((info) => {
-      handleAutoUpdate(info, settings, config.getProjectRoot());
+      handleAutoUpdate(
+        info,
+        settings,
+        config.getProjectRoot(),
+        config.getSandboxEnabled(),
+      );
     })
     .catch((err) => {
       // Silently ignore update check errors.

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -96,7 +96,7 @@ describe('handleAutoUpdate', () => {
   });
 
   it('should do nothing if update info is null', () => {
-    handleAutoUpdate(null, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(null, mockSettings, '/root', false, mockSpawn);
     expect(mockGetInstallationInfo).not.toHaveBeenCalled();
     expect(updateEventEmitter.emit).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('handleAutoUpdate', () => {
 
     expect(isUpdateInProgress()).toBe(false);
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(isUpdateInProgress()).toBe(true);
 
@@ -129,7 +129,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(isUpdateInProgress()).toBe(true);
 
@@ -178,7 +178,7 @@ describe('handleAutoUpdate', () => {
 
   it('should do nothing if update prompts are disabled', () => {
     mockSettings.merged.general.enableAutoUpdateNotification = false;
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
     expect(mockGetInstallationInfo).not.toHaveBeenCalled();
     expect(updateEventEmitter.emit).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
@@ -219,7 +219,7 @@ describe('handleAutoUpdate', () => {
         packageManager,
       });
 
-      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
       expect(updateEventEmitter.emit).not.toHaveBeenCalled();
       expect(mockSpawn).not.toHaveBeenCalled();
@@ -234,7 +234,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
@@ -253,7 +253,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
@@ -276,7 +276,7 @@ describe('handleAutoUpdate', () => {
       mockChildProcess.emit('close', 0);
     }, 0);
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(mockSpawn).toHaveBeenCalledOnce();
   });
@@ -296,7 +296,7 @@ describe('handleAutoUpdate', () => {
         resolve();
       }, 0);
 
-      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
     });
 
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
@@ -320,7 +320,7 @@ describe('handleAutoUpdate', () => {
         resolve();
       }, 0);
 
-      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
     });
 
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
@@ -345,7 +345,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(mockSpawn).toHaveBeenCalledWith(
       'npm i -g @google/gemini-cli@nightly',
@@ -372,7 +372,7 @@ describe('handleAutoUpdate', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
 
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -392,13 +392,22 @@ describe('handleAutoUpdate', () => {
         resolve();
       }, 0);
 
-      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
+      handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
     });
 
     expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-success', {
       message:
         'Update successful! The new version will be used on your next run.',
     });
+  });
+
+  it('should suppress update if isSandboxEnabled is true', () => {
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', true, mockSpawn);
+
+    expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-info', {
+      message: `${mockUpdateInfo.message}\nAutomatic update is not available in sandbox mode.`,
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -68,13 +68,14 @@ export function handleAutoUpdate(
   info: UpdateObject | null,
   settings: LoadedSettings,
   projectRoot: string,
+  isSandboxEnabled: boolean,
   spawnFn: typeof spawn = spawnWrapper,
 ) {
   if (!info) {
     return;
   }
 
-  if (settings.merged.tools.sandbox || process.env['GEMINI_SANDBOX']) {
+  if (isSandboxEnabled) {
     updateEventEmitter.emit('update-info', {
       message: `${info.message}\nAutomatic update is not available in sandbox mode.`,
     });


### PR DESCRIPTION
## Summary

Fixes an issue where Gemini CLI fails to self-update if the sandbox is configured in `settings.json`, even when the CLI is run with the sandbox disabled via CLI flags (e.g., `-s false`).

## Details

The `handleAutoUpdate` function was directly checking the raw `settings.merged.tools.sandbox` and the `GEMINI_SANDBOX` environment variable. This bypassed the CLI's configuration resolution logic, which is responsible for overriding settings with command-line flags.

This PR:
- Updates `handleAutoUpdate` to accept an `isSandboxEnabled` boolean parameter.
- Updates `interactiveCli.tsx` to pass the resolved sandbox state from `config.getSandboxEnabled()`.
- Updates unit tests to reflect the new signature and adds a regression test case.

## Related Issues

Fixes #24000

## How to Validate

1. Run unit tests: `npm test -w @google/gemini-cli -- packages/cli/src/utils/handleAutoUpdate.test.ts`
2. Verify type safety: `npm run typecheck`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
