### PR TITLE
fix(cli): insert voice transcription at cursor position instead of ap…

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -348,7 +348,7 @@ describe('InputPrompt', () => {
       visualToLogicalMap: [[0, 0]],
       visualToTransformedMap: [0],
       transformationsByLine: [],
-      getOffset: vi.fn().mockReturnValue(0),
+      getOffset: vi.fn().mockImplementation(() => mockBuffer.cursor[1]),
       pastedContent: {},
     } as unknown as TextBuffer;
 
@@ -5114,17 +5114,15 @@ describe('InputPrompt', () => {
         );
       });
       await waitFor(() => {
-        expect(mockBuffer.setText).toHaveBeenCalledWith('initial hello', 'end');
+        expect(mockBuffer.setText).toHaveBeenCalledWith('initial hello', 13);
       });
 
-      // Emit turnComplete (Gemini Live starts over after this)
+      // turnComplete advances the baseline; next turn appends after it
       await act(async () => {
         (fakeTranscriptionProvider as unknown as EventEmitter).emit(
           'turnComplete',
         );
       });
-
-      // Emit second part (Gemini Live sends new turn text starting from empty)
       await act(async () => {
         (fakeTranscriptionProvider as unknown as EventEmitter).emit(
           'transcription',
@@ -5132,10 +5130,9 @@ describe('InputPrompt', () => {
         );
       });
       await waitFor(() => {
-        // Should have appended 'world' to the baseline 'initial hello'
         expect(mockBuffer.setText).toHaveBeenCalledWith(
           'initial hello world',
-          'end',
+          19,
         );
       });
 
@@ -5172,10 +5169,45 @@ describe('InputPrompt', () => {
       await waitFor(() => {
         expect(mockBuffer.setText).toHaveBeenCalledWith(
           'First turn. Second turn.',
-          'end',
+          24,
         );
       });
 
+      unmount();
+    });
+
+    it('should insert transcription at cursor position when buffer has text before and after (toggle)', async () => {
+      await act(async () => {
+        mockBuffer.setText('hello world');
+        mockBuffer.cursor = [0, 5]; // cursor after 'hello'
+      });
+      const { stdin, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} focus={true} buffer={mockBuffer} />,
+        {
+          uiState: { isVoiceModeEnabled: true } as UIState,
+          settings: createMockSettings({
+            experimental: { voice: { activationMode: 'toggle' } },
+          }),
+        },
+      );
+
+      await act(async () => {
+        stdin.write(' ');
+      });
+      await act(async () => {
+        (fakeTranscriptionProvider as unknown as EventEmitter).emit(
+          'transcription',
+          'there',
+        );
+      });
+
+      // 'hello'(5) + ' '(1) + 'there'(5) = cursor at 11; ' world' preserved after
+      await waitFor(() => {
+        expect(mockBuffer.setText).toHaveBeenCalledWith(
+          'hello there world',
+          11,
+        );
+      });
       unmount();
     });
 

--- a/packages/cli/src/ui/hooks/useVoiceMode.ts
+++ b/packages/cli/src/ui/hooks/useVoiceMode.ts
@@ -200,13 +200,17 @@ export function useVoiceMode({
           const textBefore = baseline.slice(0, insertOffset);
           const textAfter = baseline.slice(insertOffset);
 
-          const needsSpace =
-            textBefore.length > 0 &&
-            !textBefore.endsWith(' ') &&
-            !textBefore.endsWith('\n');
-          const prefix = needsSpace ? textBefore + ' ' : textBefore;
+          const prefix =
+            textBefore.length > 0 && !/\s$/.test(textBefore)
+              ? textBefore + ' '
+              : textBefore;
 
-          const newTotalText = prefix + text + textAfter;
+          const suffix =
+            text.length > 0 && textAfter.length > 0 && !/^\s/.test(textAfter)
+              ? ' '
+              : '';
+
+          const newTotalText = prefix + text + suffix + textAfter;
           bufferRef.current.setText(newTotalText, prefix.length + text.length);
         }
         liveTranscriptionRef.current = text;

--- a/packages/cli/src/ui/hooks/useVoiceMode.ts
+++ b/packages/cli/src/ui/hooks/useVoiceMode.ts
@@ -51,6 +51,7 @@ export function useVoiceMode({
   const recorderRef = useRef<AudioRecorder | null>(null);
   const transcriptionServiceRef = useRef<TranscriptionProvider | null>(null);
   const turnBaselineRef = useRef<string | null>(null);
+  const turnBaselineCursorOffsetRef = useRef<number>(0);
 
   const pttStateRef = useRef<'idle' | 'possible-hold' | 'recording'>('idle');
   const pttTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -112,6 +113,7 @@ export function useVoiceMode({
 
     recordingInProgressRef.current = true;
     turnBaselineRef.current = bufferRef.current.text;
+    turnBaselineCursorOffsetRef.current = bufferRef.current.getOffset();
 
     setIsConnecting(true);
     setIsRecording(true);
@@ -193,29 +195,19 @@ export function useVoiceMode({
         }
 
         if (text) {
-          const currentBufferText = bufferRef.current.text;
-          const previousTranscription = liveTranscriptionRef.current;
+          const baseline = turnBaselineRef.current ?? '';
+          const insertOffset = turnBaselineCursorOffsetRef.current;
+          const textBefore = baseline.slice(0, insertOffset);
+          const textAfter = baseline.slice(insertOffset);
 
-          let newTotalText = currentBufferText;
+          const needsSpace =
+            textBefore.length > 0 &&
+            !textBefore.endsWith(' ') &&
+            !textBefore.endsWith('\n');
+          const prefix = needsSpace ? textBefore + ' ' : textBefore;
 
-          if (
-            previousTranscription &&
-            currentBufferText.endsWith(previousTranscription)
-          ) {
-            newTotalText = currentBufferText.slice(
-              0,
-              -previousTranscription.length,
-            );
-          } else if (
-            currentBufferText &&
-            !currentBufferText.endsWith(' ') &&
-            !currentBufferText.endsWith('\n')
-          ) {
-            newTotalText += ' ';
-          }
-
-          newTotalText += text;
-          bufferRef.current.setText(newTotalText, 'end');
+          const newTotalText = prefix + text + textAfter;
+          bufferRef.current.setText(newTotalText, prefix.length + text.length);
         }
         liveTranscriptionRef.current = text;
       });
@@ -226,6 +218,9 @@ export function useVoiceMode({
           stopRequestedRef.current
         )
           return;
+        // Advance the baseline so subsequent turns append after this turn's text
+        turnBaselineRef.current = bufferRef.current.text;
+        turnBaselineCursorOffsetRef.current = bufferRef.current.getOffset();
         liveTranscriptionRef.current = '';
       });
 


### PR DESCRIPTION
## Summary

Voice transcription text was always appended to the end of the input buffer, ignoring the cursor position.

## Details

Capture the cursor offset (via `getOffset()`) when recording starts alongside the existing text baseline snapshot.
On each transcription event, splice the text at that fixed offset instead of appending.
On `turnComplete`, advance the baseline so subsequent speech turns chain correctly after the previous one.

## Related Issues

Fixes #25494 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
