### PR TITLE
fix(ci): checkout PR branch instead of main in bot workflow

### DIFF
--- a/.github/workflows/gemini-cli-bot-brain.yml
+++ b/.github/workflows/gemini-cli-bot-brain.yml
@@ -283,7 +283,7 @@ jobs:
               exit 1
             fi
 
-            git checkout -b "$BRANCH_NAME"
+            git checkout -B "$BRANCH_NAME"
             git apply "${{ runner.temp }}/brain-data/bot-changes.patch"
             git add .
 

--- a/.github/workflows/gemini-cli-bot-brain.yml
+++ b/.github/workflows/gemini-cli-bot-brain.yml
@@ -53,9 +53,25 @@ jobs:
     env:
       GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
+      - name: 'Determine Checkout Ref'
+        id: determine_ref
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}'
+        run: |
+          REF="${{ github.ref }}"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            PR_HEAD=$(gh pr view "$ISSUE_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq .headRefName 2>/dev/null || echo "")
+            if [ -n "$PR_HEAD" ]; then
+              REF="$PR_HEAD"
+            fi
+          fi
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          ref: '${{ steps.determine_ref.outputs.ref }}'
           fetch-depth: 0
           persist-credentials: false
 
@@ -218,10 +234,25 @@ jobs:
           permission-pull-requests: 'write'
           permission-issues: 'write'
 
+      - name: 'Determine Checkout Ref'
+        id: determine_ref
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}'
+        run: |
+          REF="main"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            PR_HEAD=$(gh pr view "$ISSUE_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq .headRefName 2>/dev/null || echo "")
+            if [ -n "$PR_HEAD" ]; then
+              REF="$PR_HEAD"
+            fi
+          fi
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
-          ref: 'main'
+          ref: '${{ steps.determine_ref.outputs.ref }}'
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/gemini-cli-bot-brain.yml
+++ b/.github/workflows/gemini-cli-bot-brain.yml
@@ -54,7 +54,7 @@ jobs:
       GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Determine Checkout Ref'
-        id: determine_ref
+        id: 'determine_ref'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}'
@@ -66,7 +66,7 @@ jobs:
               REF="$PR_HEAD"
             fi
           fi
-          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
@@ -235,7 +235,7 @@ jobs:
           permission-issues: 'write'
 
       - name: 'Determine Checkout Ref'
-        id: determine_ref
+        id: 'determine_ref'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ISSUE_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}'
@@ -247,7 +247,7 @@ jobs:
               REF="$PR_HEAD"
             fi
           fi
-          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5


### PR DESCRIPTION
## Summary

This PR updates the `gemini-cli-bot-brain.yml` workflow to checkout the correct feature branch when triggered by an issue comment on a PR. Previously, it defaulted to checking out `main`, which caused patch application failures.

## Details

- Added a `Determine Checkout Ref` step that uses `gh pr view` to extract the `headRefName` for the triggered issue.
- Updated the `actions/checkout` step in both the `reasoning` and `publish` jobs to use the dynamically determined reference.

## Related Issues

<!-- Related to issue ... -->

## How to Validate

1. Trigger the bot on an open PR with a comment.
2. Observe the GitHub Actions run logs.
3. Verify that the `Checkout` step uses the PR's branch reference instead of `main`.
4. Verify that the bot successfully applies patches and pushes updates to the correct branch.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
