### PR TITLE
fix(github): do not sync 'help wanted' label to PRs

### DIFF
--- a/.github/scripts/pr-triage.sh
+++ b/.github/scripts/pr-triage.sh
@@ -40,7 +40,8 @@ get_issue_labels() {
     fi
 
     local labels
-    labels=$(echo "${gh_output}" | grep -x -E '(area|priority)/.*|help wanted|🔒 maintainer only' | tr '\n' ',' | sed 's/,$//' || echo "")
+    # Note: 'help wanted' is intentionally omitted here so it does not propagate from issues to PRs.
+    labels=$(echo "${gh_output}" | grep -x -E '(area|priority)/.*|🔒 maintainer only' | tr '\n' ',' | sed 's/,$//' || echo "")
     
     # Save to flat cache
     ISSUE_LABELS_CACHE_FLAT="${ISSUE_LABELS_CACHE_FLAT}${ISSUE_NUM}:${labels}|"


### PR DESCRIPTION
## Summary

Removes `help wanted` from the allowed labels being synced from issues to pull requests.

## Details

The `.github/scripts/pr-triage.sh` script previously matched `help wanted` in its label allowlist, which caused the bot to propagate the label from an issue onto a linked PR. This update removes `help wanted` from the regex and adds an explanatory comment so it will no longer be synced.

## Related Issues

Fixes #26297

## How to Validate

- Review `.github/scripts/pr-triage.sh` and confirm `help wanted` is removed from the `grep` regex in `get_issue_labels()`.
- The script passes `bash -n` validation.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
