### PR TITLE
fix(cli): prevent ghost text wrapping infinite loop

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
 import {
   InputPrompt,
+  splitWordForWidth,
   tryTogglePasteExpansion,
   type InputPromptProps,
 } from './InputPrompt.js';
@@ -480,6 +481,28 @@ describe('InputPrompt', () => {
       expect(mockShellHistory.getPreviousCommand).toHaveBeenCalled(),
     );
     unmount();
+  });
+
+  describe('splitWordForWidth', () => {
+    it('continues consuming text when max width is zero', () => {
+      const lines = splitWordForWidth('@getskill.sh:3', 0);
+
+      expect(lines.join('')).toBe('@getskill.sh:3');
+      expect(lines).toEqual('@getskill.sh:3'.split(''));
+    });
+
+    it('continues consuming wide characters that exceed max width', () => {
+      const lines = splitWordForWidth('表x', 1);
+
+      expect(lines.join('')).toBe('表x');
+      expect(lines).toEqual(['表', 'x']);
+    });
+
+    it('does not split words when max width is infinite', () => {
+      expect(splitWordForWidth('@getskill.sh:3', Infinity)).toEqual([
+        '@getskill.sh:3',
+      ]);
+    });
   });
 
   it('should call shellHistory.getNextCommand on down arrow in shell mode', async () => {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -160,6 +160,37 @@ export function isLargePaste(text: string): boolean {
   );
 }
 
+export function splitWordForWidth(word: string, maxWidth: number): string[] {
+  const width = maxWidth > 0 ? maxWidth : 1;
+  const lines: string[] = [];
+  let currentPart = '';
+  let currentPartWidth = 0;
+
+  for (const char of toCodePoints(word)) {
+    const charWidth = stringWidth(char);
+    if (currentPartWidth + charWidth > width && currentPartWidth > 0) {
+      lines.push(currentPart);
+      currentPart = '';
+      currentPartWidth = 0;
+    }
+
+    currentPart += char;
+    currentPartWidth += charWidth;
+
+    if (currentPartWidth > width) {
+      lines.push(currentPart);
+      currentPart = '';
+      currentPartWidth = 0;
+    }
+  }
+
+  if (currentPart) {
+    lines.push(currentPart);
+  }
+
+  return lines;
+}
+
 const DOUBLE_TAB_CLEAN_UI_TOGGLE_WINDOW_MS = 350;
 /**
  * Attempt to toggle expansion of a paste placeholder in the buffer.
@@ -1485,26 +1516,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               additionalLines.push(currentLine);
             }
 
-            let wordToProcess = word;
-            while (stringWidth(wordToProcess) > inputWidth) {
-              let part = '';
-              const wordCP = toCodePoints(wordToProcess);
-              let partWidth = 0;
-              let splitIndex = 0;
-              for (let i = 0; i < wordCP.length; i++) {
-                const char = wordCP[i];
-                const charWidth = stringWidth(char);
-                if (partWidth + charWidth > inputWidth) {
-                  break;
-                }
-                part += char;
-                partWidth += charWidth;
-                splitIndex = i + 1;
-              }
-              additionalLines.push(part);
-              wordToProcess = cpSlice(wordToProcess, splitIndex);
-            }
-            currentLine = wordToProcess;
+            const splitWord = splitWordForWidth(word, inputWidth);
+            additionalLines.push(...splitWord.slice(0, -1));
+            currentLine = splitWord.at(-1) ?? '';
           } else {
             currentLine = prospectiveLine;
           }


### PR DESCRIPTION
## Summary

Prevent the interactive CLI from hanging while wrapping long prompt-completion ghost text, including inputs like `@getskill.sh:3`.

## Details

`InputPrompt` split long unbroken ghost-text words by terminal width, but if the available width was zero or narrower than the next character, the loop could keep slicing from index `0` forever.

This moves that wrapping into `splitWordForWidth`, which clamps the working width to at least `1` and always consumes one code point when a character is wider than the available width. The existing ghost-text rendering path now uses that helper.

## Related Issues

Fixes #19985

## How to Validate

Run these from the repository root with Node 20:

```bash
npm run test --workspace @google/gemini-cli -- src/ui/components/InputPrompt.test.tsx -t splitWordForWidth
npx prettier --check packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx
npx eslint packages/cli/src/ui/components/InputPrompt.tsx packages/cli/src/ui/components/InputPrompt.test.tsx
npm run typecheck --workspace @google/gemini-cli
```

I also ran the full local preflight path. It reached `test:ci`; the only failures were `src/gemini.test.tsx` trust checks in a headless workspace. Re-running that file with `GEMINI_CLI_TRUST_WORKSPACE=true` passed, and `test:scripts` plus `test:sea-launch` passed.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
