### PR TITLE
fix(cli): ensure branch indicator updates in sub-directories and worktrees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,7 +449,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1535,6 +1536,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
       "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2212,6 +2214,7 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2392,6 +2395,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2441,6 +2445,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2815,6 +2820,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2848,6 +2854,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2902,6 +2909,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4139,6 +4147,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4412,6 +4421,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5187,6 +5197,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7304,7 +7315,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7889,6 +7901,7 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8499,6 +8512,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9765,6 +9779,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10024,6 +10039,7 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.9.tgz",
       "integrity": "sha512-RL9sSiLQZECnjbmBwjIHOp8yVGdWF7C/uifg7ISv/e+F3nLNsfl7FdUFQs8iZARFMJAYxMFpxW6OW+HSt9drwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "ansi-styles": "^6.2.3",
@@ -13799,6 +13815,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13809,6 +13826,7 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -15961,6 +15979,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16183,7 +16202,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16191,6 +16211,7 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16356,6 +16377,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16423,6 +16445,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -16842,6 +16865,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17412,6 +17436,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17424,6 +17449,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18062,6 +18088,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18498,6 +18525,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -18616,6 +18644,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,8 +449,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1536,7 +1535,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
       "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2214,7 +2212,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2395,7 +2392,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2445,7 +2441,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2820,7 +2815,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
       "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2854,7 +2848,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
       "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0"
@@ -2909,7 +2902,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
       "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/resources": "2.5.0",
@@ -4147,7 +4139,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4421,7 +4412,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5197,7 +5187,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7315,8 +7304,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7901,7 +7889,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8512,7 +8499,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9779,7 +9765,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10039,7 +10024,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.9.tgz",
       "integrity": "sha512-RL9sSiLQZECnjbmBwjIHOp8yVGdWF7C/uifg7ISv/e+F3nLNsfl7FdUFQs8iZARFMJAYxMFpxW6OW+HSt9drwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "ansi-styles": "^6.2.3",
@@ -13815,7 +13799,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13826,7 +13809,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -15979,7 +15961,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16202,8 +16183,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16211,7 +16191,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16377,7 +16356,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16445,7 +16423,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -16865,7 +16842,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17436,7 +17412,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17449,7 +17424,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18088,7 +18062,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18525,7 +18498,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -18644,7 +18616,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -40,7 +40,8 @@ vi.mock('node:fs/promises', async () => {
 });
 
 const CWD = '/test/project';
-const GIT_LOGS_HEAD_PATH = path.join(CWD, '.git', 'logs', 'HEAD');
+const GIT_DIR = path.join(CWD, '.git');
+const GIT_HEAD_PATH = path.join(GIT_DIR, 'HEAD');
 
 describe('useGitBranchName', () => {
   let deferredSpawn: Array<{
@@ -52,7 +53,7 @@ describe('useGitBranchName', () => {
   beforeEach(() => {
     vol.reset(); // Reset in-memory filesystem
     vol.fromJSON({
-      [GIT_LOGS_HEAD_PATH]: 'ref: refs/heads/main',
+      [GIT_HEAD_PATH]: 'ref: refs/heads/main',
     });
 
     deferredSpawn = [];
@@ -86,16 +87,39 @@ describe('useGitBranchName', () => {
     };
   };
 
+  /**
+   * Helper to resolve pending spawns for a hook render.
+   * Since setupWatcher and fetchBranchName run in separate floating promises,
+   * we might have multiple spawns to resolve.
+   */
+  const resolveInitialSpawns = async (
+    branch: string = 'main',
+    gitDir: string = GIT_DIR,
+  ) => {
+    await act(async () => {
+      // We might have multiple spawns (abbrev-ref and absolute-git-dir)
+      // Resolve them one by one.
+      while (deferredSpawn.length > 0) {
+        const spawn = deferredSpawn.shift()!;
+        if (spawn.args.includes('--abbrev-ref')) {
+          spawn.resolve({ stdout: `${branch}\n`, stderr: '' });
+        } else if (spawn.args.includes('--absolute-git-dir')) {
+          spawn.resolve({ stdout: `${gitDir}\n`, stderr: '' });
+        } else if (spawn.args.includes('--short')) {
+          spawn.resolve({ stdout: `${branch}\n`, stderr: '' });
+        }
+        // Small wait to allow the next promise tick
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    });
+  };
+
   it('should return branch name', async () => {
     const { result } = await renderGitBranchNameHook(CWD);
 
     expect(result.current).toBeUndefined();
 
-    await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'main\n', stderr: '' });
-    });
+    await resolveInitialSpawns('main');
 
     expect(result.current).toBe('main');
   });
@@ -104,9 +128,17 @@ describe('useGitBranchName', () => {
     const { result } = await renderGitBranchNameHook(CWD);
 
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.reject(new Error('Git error'));
+      const abbrevSpawn = deferredSpawn.find((s) =>
+        s.args.includes('--abbrev-ref'),
+      );
+      if (abbrevSpawn) {
+        abbrevSpawn.reject(new Error('Git error'));
+      }
+      // Resolve other spawns if any
+      for (const s of deferredSpawn) {
+        if (s !== abbrevSpawn)
+          s.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
+      }
     });
 
     expect(result.current).toBeUndefined();
@@ -115,17 +147,28 @@ describe('useGitBranchName', () => {
   it('should return short commit hash if branch is HEAD (detached state)', async () => {
     const { result } = await renderGitBranchNameHook(CWD);
 
+    // Initial spawns: --abbrev-ref (will return HEAD) and --absolute-git-dir
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'HEAD\n', stderr: '' });
+      const abbrevSpawn = deferredSpawn.find((s) =>
+        s.args.includes('--abbrev-ref'),
+      )!;
+      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '' });
+
+      const gitDirSpawn = deferredSpawn.find((s) =>
+        s.args.includes('--absolute-git-dir'),
+      )!;
+      gitDirSpawn.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
     });
 
     // It should now call spawnAsync again for the short hash
+    await waitFor(() => {
+      if (!deferredSpawn.find((s) => s.args.includes('--short'))) {
+        throw new Error('Short spawn not found');
+      }
+    });
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--short');
-      spawn.resolve({ stdout: 'a1b2c3d\n', stderr: '' });
+      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'))!;
+      shortSpawn.resolve({ stdout: 'a1b2c3d\n', stderr: '' });
     });
 
     expect(result.current).toBe('a1b2c3d');
@@ -135,15 +178,25 @@ describe('useGitBranchName', () => {
     const { result } = await renderGitBranchNameHook(CWD);
 
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'HEAD\n', stderr: '' });
+      const abbrevSpawn = deferredSpawn.find((s) =>
+        s.args.includes('--abbrev-ref'),
+      )!;
+      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '' });
+
+      const gitDirSpawn = deferredSpawn.find((s) =>
+        s.args.includes('--absolute-git-dir'),
+      )!;
+      gitDirSpawn.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
     });
 
+    await waitFor(() => {
+      if (!deferredSpawn.find((s) => s.args.includes('--short'))) {
+        throw new Error('Short spawn not found');
+      }
+    });
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--short');
-      spawn.reject(new Error('Git error'));
+      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'))!;
+      shortSpawn.reject(new Error('Git error'));
     });
 
     expect(result.current).toBeUndefined();
@@ -151,32 +204,38 @@ describe('useGitBranchName', () => {
 
   it('should update branch name when .git/HEAD changes', async () => {
     vi.spyOn(fsPromises, 'access').mockResolvedValue(undefined);
-    const watchSpy = vi.spyOn(fs, 'watch');
+    let watchCallback:
+      | ((eventType: string, filename: string | null) => void)
+      | undefined;
+    const watchSpy = vi.spyOn(fs, 'watch').mockImplementation(((
+      _path: string,
+      callback: (eventType: string, filename: string | null) => void,
+    ) => {
+      watchCallback = callback;
+      return { close: vi.fn() };
+    }) as unknown as typeof fs.watch);
 
     const { result } = await renderGitBranchNameHook(CWD);
 
-    await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'main\n', stderr: '' });
-    });
+    await resolveInitialSpawns('main');
 
     expect(result.current).toBe('main');
 
     // Wait for watcher to be set up
     await waitFor(() => {
-      expect(watchSpy).toHaveBeenCalled();
+      expect(watchSpy).toHaveBeenCalledWith(GIT_DIR, expect.any(Function));
     });
 
-    // Simulate file change event
+    // Simulate file change event for HEAD
     await act(async () => {
-      fs.writeFileSync(GIT_LOGS_HEAD_PATH, 'ref: refs/heads/develop'); // Trigger watcher
+      if (watchCallback) {
+        watchCallback('change', 'HEAD');
+      }
     });
 
     // Resolving the new branch name fetch
     await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
+      const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
       spawn.resolve({ stdout: 'develop\n', stderr: '' });
     });
 
@@ -184,8 +243,21 @@ describe('useGitBranchName', () => {
   });
 
   it('should handle watcher setup error silently', async () => {
-    // Remove .git/logs/HEAD to cause an error in fs.watch setup
-    vol.unlinkSync(GIT_LOGS_HEAD_PATH);
+    // Cause an error in fs.watch setup (e.g. absolute-git-dir fails)
+    vi.mocked(mockSpawnAsync).mockImplementationOnce(
+      (_command: string, args: string[]) => {
+        if (args.includes('--absolute-git-dir')) {
+          return Promise.reject(new Error('Git error'));
+        }
+        return new Promise((resolve) => {
+          deferredSpawn.push({
+            resolve,
+            reject: () => {},
+            args,
+          });
+        });
+      },
+    );
 
     const { result } = await renderGitBranchNameHook(CWD);
 
@@ -197,18 +269,15 @@ describe('useGitBranchName', () => {
 
     expect(result.current).toBe('main');
 
-    // This write would trigger the watcher if it was set up
-    // We need to create the file again for writeFileSync to not throw
-    vol.fromJSON({
-      [GIT_LOGS_HEAD_PATH]: 'ref: refs/heads/develop',
-    });
-
+    // Trigger a mock write that would normally be watched
     await act(async () => {
-      fs.writeFileSync(GIT_LOGS_HEAD_PATH, 'ref: refs/heads/develop');
+      fs.writeFileSync(GIT_HEAD_PATH, 'ref: refs/heads/develop');
     });
 
     // spawnAsync should NOT have been called again for updating
-    expect(deferredSpawn.length).toBe(0);
+    expect(
+      deferredSpawn.filter((s) => s.args.includes('--abbrev-ref')).length,
+    ).toBe(0);
     expect(result.current).toBe('main');
   });
 
@@ -221,18 +290,11 @@ describe('useGitBranchName', () => {
 
     const { unmount } = await renderGitBranchNameHook(CWD);
 
-    await act(async () => {
-      const spawn = deferredSpawn.shift()!;
-      expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'main\n', stderr: '' });
-    });
+    await resolveInitialSpawns('main');
 
     // Wait for watcher to be set up BEFORE unmounting
     await waitFor(() => {
-      expect(watchMock).toHaveBeenCalledWith(
-        GIT_LOGS_HEAD_PATH,
-        expect.any(Function),
-      );
+      expect(watchMock).toHaveBeenCalledWith(GIT_DIR, expect.any(Function));
     });
 
     unmount();

--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -235,11 +235,30 @@ describe('useGitBranchName', () => {
 
     // Resolving the new branch name fetch
     await act(async () => {
+      // Find the specific abbrev-ref spawn for this update
       const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
+      // Remove it from the array so subsequent lookups don't find the same one
+      deferredSpawn.splice(deferredSpawn.indexOf(spawn), 1);
       spawn.resolve({ stdout: 'develop\n', stderr: '' });
     });
 
     expect(result.current).toBe('develop');
+
+    // Simulate file change event with null filename (platform compatibility)
+    await act(async () => {
+      if (watchCallback) {
+        watchCallback('change', null);
+      }
+    });
+
+    // Resolving the new branch name fetch
+    await act(async () => {
+      const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
+      deferredSpawn.splice(deferredSpawn.indexOf(spawn), 1);
+      spawn.resolve({ stdout: 'feature-x\n', stderr: '' });
+    });
+
+    expect(result.current).toBe('feature-x');
   });
 
   it('should handle watcher setup error silently', async () => {

--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -12,7 +12,10 @@ import { useGitBranchName } from './useGitBranchName.js';
 import { fs, vol } from 'memfs';
 import * as fsPromises from 'node:fs/promises';
 import path from 'node:path'; // For mocking fs
-import { spawnAsync as mockSpawnAsync } from '@google/gemini-cli-core';
+import {
+  spawnAsync as mockSpawnAsync,
+  getAbsoluteGitDir as mockGetAbsoluteGitDir,
+} from '@google/gemini-cli-core';
 
 // Mock @google/gemini-cli-core
 vi.mock('@google/gemini-cli-core', async () => {
@@ -22,6 +25,7 @@ vi.mock('@google/gemini-cli-core', async () => {
   return {
     ...original,
     spawnAsync: vi.fn(),
+    getAbsoluteGitDir: vi.fn(),
   };
 });
 
@@ -45,12 +49,13 @@ const GIT_HEAD_PATH = path.join(GIT_DIR, 'HEAD');
 
 describe('useGitBranchName', () => {
   let deferredSpawn: Array<{
-    resolve: (val: { stdout: string; stderr: string }) => void;
+    resolve: (val: { stdout: string; stderr: string; code: number }) => void;
     reject: (err: Error) => void;
     args: string[];
   }> = [];
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vol.reset(); // Reset in-memory filesystem
     vol.fromJSON({
       [GIT_HEAD_PATH]: 'ref: refs/heads/main',
@@ -63,9 +68,11 @@ describe('useGitBranchName', () => {
           deferredSpawn.push({ resolve, reject, args });
         }),
     );
+    vi.mocked(mockGetAbsoluteGitDir).mockResolvedValue(GIT_DIR);
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -89,27 +96,23 @@ describe('useGitBranchName', () => {
 
   /**
    * Helper to resolve pending spawns for a hook render.
-   * Since setupWatcher and fetchBranchName run in separate floating promises,
-   * we might have multiple spawns to resolve.
    */
-  const resolveInitialSpawns = async (
-    branch: string = 'main',
-    gitDir: string = GIT_DIR,
-  ) => {
+  const resolveInitialSpawns = async (branch: string = 'main') => {
     await act(async () => {
-      // We might have multiple spawns (abbrev-ref and absolute-git-dir)
-      // Resolve them one by one.
-      while (deferredSpawn.length > 0) {
-        const spawn = deferredSpawn.shift()!;
-        if (spawn.args.includes('--abbrev-ref')) {
-          spawn.resolve({ stdout: `${branch}\n`, stderr: '' });
-        } else if (spawn.args.includes('--absolute-git-dir')) {
-          spawn.resolve({ stdout: `${gitDir}\n`, stderr: '' });
-        } else if (spawn.args.includes('--short')) {
-          spawn.resolve({ stdout: `${branch}\n`, stderr: '' });
+      let resolvedAny = true;
+      while (resolvedAny || deferredSpawn.length > 0) {
+        resolvedAny = false;
+        while (deferredSpawn.length > 0) {
+          const spawn = deferredSpawn.shift()!;
+          if (spawn.args.includes('--abbrev-ref')) {
+            spawn.resolve({ stdout: `${branch}\n`, stderr: '', code: 0 });
+            resolvedAny = true;
+          } else if (spawn.args.includes('--short')) {
+            spawn.resolve({ stdout: `${branch}\n`, stderr: '', code: 0 });
+            resolvedAny = true;
+          }
         }
-        // Small wait to allow the next promise tick
-        await new Promise((r) => setTimeout(r, 0));
+        await vi.advanceTimersByTimeAsync(1);
       }
     });
   };
@@ -134,11 +137,7 @@ describe('useGitBranchName', () => {
       if (abbrevSpawn) {
         abbrevSpawn.reject(new Error('Git error'));
       }
-      // Resolve other spawns if any
-      for (const s of deferredSpawn) {
-        if (s !== abbrevSpawn)
-          s.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
-      }
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBeUndefined();
@@ -147,28 +146,23 @@ describe('useGitBranchName', () => {
   it('should return short commit hash if branch is HEAD (detached state)', async () => {
     const { result } = await renderGitBranchNameHook(CWD);
 
-    // Initial spawns: --abbrev-ref (will return HEAD) and --absolute-git-dir
     await act(async () => {
       const abbrevSpawn = deferredSpawn.find((s) =>
         s.args.includes('--abbrev-ref'),
       )!;
-      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '' });
-
-      const gitDirSpawn = deferredSpawn.find((s) =>
-        s.args.includes('--absolute-git-dir'),
-      )!;
-      gitDirSpawn.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
+      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     // It should now call spawnAsync again for the short hash
-    await waitFor(() => {
-      if (!deferredSpawn.find((s) => s.args.includes('--short'))) {
+    await act(async () => {
+      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'));
+      if (shortSpawn) {
+        shortSpawn.resolve({ stdout: 'a1b2c3d\n', stderr: '', code: 0 });
+      } else {
         throw new Error('Short spawn not found');
       }
-    });
-    await act(async () => {
-      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'))!;
-      shortSpawn.resolve({ stdout: 'a1b2c3d\n', stderr: '' });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBe('a1b2c3d');
@@ -181,22 +175,18 @@ describe('useGitBranchName', () => {
       const abbrevSpawn = deferredSpawn.find((s) =>
         s.args.includes('--abbrev-ref'),
       )!;
-      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '' });
-
-      const gitDirSpawn = deferredSpawn.find((s) =>
-        s.args.includes('--absolute-git-dir'),
-      )!;
-      gitDirSpawn.resolve({ stdout: `${GIT_DIR}\n`, stderr: '' });
+      abbrevSpawn.resolve({ stdout: 'HEAD\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
-    await waitFor(() => {
-      if (!deferredSpawn.find((s) => s.args.includes('--short'))) {
+    await act(async () => {
+      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'));
+      if (shortSpawn) {
+        shortSpawn.reject(new Error('Git error'));
+      } else {
         throw new Error('Short spawn not found');
       }
-    });
-    await act(async () => {
-      const shortSpawn = deferredSpawn.find((s) => s.args.includes('--short'))!;
-      shortSpawn.reject(new Error('Git error'));
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBeUndefined();
@@ -231,6 +221,7 @@ describe('useGitBranchName', () => {
       if (watchCallback) {
         watchCallback('change', 'HEAD');
       }
+      await vi.advanceTimersByTimeAsync(150); // triggers debounce
     });
 
     // Resolving the new branch name fetch
@@ -239,7 +230,8 @@ describe('useGitBranchName', () => {
       const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
       // Remove it from the array so subsequent lookups don't find the same one
       deferredSpawn.splice(deferredSpawn.indexOf(spawn), 1);
-      spawn.resolve({ stdout: 'develop\n', stderr: '' });
+      spawn.resolve({ stdout: 'develop\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBe('develop');
@@ -249,33 +241,24 @@ describe('useGitBranchName', () => {
       if (watchCallback) {
         watchCallback('change', null);
       }
+      await vi.advanceTimersByTimeAsync(150);
     });
 
     // Resolving the new branch name fetch
     await act(async () => {
       const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
       deferredSpawn.splice(deferredSpawn.indexOf(spawn), 1);
-      spawn.resolve({ stdout: 'feature-x\n', stderr: '' });
+      spawn.resolve({ stdout: 'feature-x\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBe('feature-x');
   });
 
   it('should handle watcher setup error silently', async () => {
-    // Cause an error in fs.watch setup (e.g. absolute-git-dir fails)
-    vi.mocked(mockSpawnAsync).mockImplementationOnce(
-      (_command: string, args: string[]) => {
-        if (args.includes('--absolute-git-dir')) {
-          return Promise.reject(new Error('Git error'));
-        }
-        return new Promise((resolve) => {
-          deferredSpawn.push({
-            resolve,
-            reject: () => {},
-            args,
-          });
-        });
-      },
+    // Cause an error in absolute git dir setup
+    vi.mocked(mockGetAbsoluteGitDir).mockRejectedValueOnce(
+      new Error('Git error'),
     );
 
     const { result } = await renderGitBranchNameHook(CWD);
@@ -283,7 +266,8 @@ describe('useGitBranchName', () => {
     await act(async () => {
       const spawn = deferredSpawn.shift()!;
       expect(spawn.args).toContain('--abbrev-ref');
-      spawn.resolve({ stdout: 'main\n', stderr: '' });
+      spawn.resolve({ stdout: 'main\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     expect(result.current).toBe('main');
@@ -291,6 +275,7 @@ describe('useGitBranchName', () => {
     // Trigger a mock write that would normally be watched
     await act(async () => {
       fs.writeFileSync(GIT_HEAD_PATH, 'ref: refs/heads/develop');
+      await vi.advanceTimersByTimeAsync(1);
     });
 
     // spawnAsync should NOT have been called again for updating

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -56,16 +56,23 @@ export function useGitBranchName(cwd: string): string | undefined {
         await fsPromises.access(gitDir, fs.constants.F_OK);
         if (cancelled) return;
 
-        watcher = fs.watch(
+        const w = fs.watch(
           gitDir,
           (eventType: string, filename: string | null) => {
-            // Changes to HEAD indicate branch checkout or detached commit
-            if (filename === 'HEAD') {
+            // Changes to HEAD indicate branch checkout or detached commit.
+            // On some platforms filename may be null, so we refresh in that case too.
+            if (!filename || filename === 'HEAD') {
               // eslint-disable-next-line @typescript-eslint/no-floating-promises
               fetchBranchName();
             }
           },
         );
+
+        if (cancelled) {
+          w.close();
+        } else {
+          watcher = w;
+        }
       } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),
         // similar to how exec errors are handled.

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useCallback } from 'react';
-import { spawnAsync } from '@google/gemini-cli-core';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { spawnAsync, getAbsoluteGitDir } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 
 export function useGitBranchName(cwd: string): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const fetchBranchName = useCallback(async () => {
     try {
@@ -36,20 +37,14 @@ export function useGitBranchName(cwd: string): string | undefined {
   }, [cwd, setBranchName]);
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    fetchBranchName(); // Initial fetch
+    void fetchBranchName(); // Initial fetch
 
     let watcher: fs.FSWatcher | undefined;
     let cancelled = false;
 
     const setupWatcher = async () => {
       try {
-        const { stdout } = await spawnAsync(
-          'git',
-          ['rev-parse', '--absolute-git-dir'],
-          { cwd },
-        );
-        const gitDir = stdout.toString().trim();
+        const gitDir = await getAbsoluteGitDir(cwd);
         if (!gitDir) return;
 
         // Ensure we can access the git dir
@@ -62,8 +57,12 @@ export function useGitBranchName(cwd: string): string | undefined {
             // Changes to HEAD indicate branch checkout or detached commit.
             // On some platforms filename may be null, so we refresh in that case too.
             if (!filename || filename === 'HEAD') {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              fetchBranchName();
+              if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+              }
+              timeoutRef.current = setTimeout(() => {
+                void fetchBranchName();
+              }, 100);
             }
           },
         );
@@ -80,11 +79,13 @@ export function useGitBranchName(cwd: string): string | undefined {
       }
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setupWatcher();
+    void setupWatcher();
 
     return () => {
       cancelled = true;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
       watcher?.close();
     };
   }, [cwd, fetchBranchName]);

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -8,7 +8,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { spawnAsync } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
-import path from 'node:path';
 
 export function useGitBranchName(cwd: string): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
@@ -40,23 +39,33 @@ export function useGitBranchName(cwd: string): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchBranchName(); // Initial fetch
 
-    const gitLogsHeadPath = path.join(cwd, '.git', 'logs', 'HEAD');
     let watcher: fs.FSWatcher | undefined;
     let cancelled = false;
 
     const setupWatcher = async () => {
       try {
-        // Check if .git/logs/HEAD exists, as it might not in a new repo or orphaned head
-        await fsPromises.access(gitLogsHeadPath, fs.constants.F_OK);
+        const { stdout } = await spawnAsync(
+          'git',
+          ['rev-parse', '--absolute-git-dir'],
+          { cwd },
+        );
+        const gitDir = stdout.toString().trim();
+        if (!gitDir) return;
+
+        // Ensure we can access the git dir
+        await fsPromises.access(gitDir, fs.constants.F_OK);
         if (cancelled) return;
-        watcher = fs.watch(gitLogsHeadPath, (eventType: string) => {
-          // Changes to .git/logs/HEAD (appends) indicate HEAD has likely changed
-          if (eventType === 'change' || eventType === 'rename') {
-            // Handle rename just in case
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            fetchBranchName();
-          }
-        });
+
+        watcher = fs.watch(
+          gitDir,
+          (eventType: string, filename: string | null) => {
+            // Changes to HEAD indicate branch checkout or detached commit
+            if (filename === 'HEAD') {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              fetchBranchName();
+            }
+          },
+        );
       } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),
         // similar to how exec errors are handled.

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -6,6 +6,18 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { spawnAsync } from './shell-utils.js';
+
+/**
+ * Gets the absolute path to the git directory (.git) for the given working directory.
+ * This handles standard git repositories, subdirectories, and worktrees.
+ */
+export async function getAbsoluteGitDir(cwd: string): Promise<string> {
+  const result = await spawnAsync('git', ['rev-parse', '--absolute-git-dir'], {
+    cwd,
+  });
+  return result.stdout.trim();
+}
 
 /**
  * Checks if a directory is within a git repository


### PR DESCRIPTION
## Summary

This PR fixes issue #19271, where the branch indicator in the CLI footer fails to update when switching git branches via shell commands (e.g., \`!git checkout <branch>\`).

## Details

The \`useGitBranchName\` hook previously assumed that \`.git/logs/HEAD\` existed relative to the current working directory. This broke in sub-directories or when using git worktrees.

I've updated the hook to:
1.  Dynamically resolve the absolute git directory using \`git rev-parse --absolute-git-dir\`.
2.  Watch the resolved git directory for changes to the \`HEAD\` file, which reliably triggers on branch checkouts and commits (including detached HEAD).

## Related Issues

Fixes #19271

## How to Validate

1.  Run the CLI from a sub-directory: \`npm run start -w @google/gemini-cli\`.
2.  Check the current branch in the footer.
3.  Switch branches using a shell command: \`!git checkout <another-branch>\`.
4.  **Result:** The branch indicator in the footer should update immediately.
5.  Repeat the same in a git worktree setup.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
