### PR TITLE
fix(acp): resolve agent mode disconnect and improve mode awareness

### DIFF
--- a/packages/cli/src/acp/acpRpcDispatcher.ts
+++ b/packages/cli/src/acp/acpRpcDispatcher.ts
@@ -33,6 +33,10 @@ export class GeminiAgent {
     this.sessionManager = new AcpSessionManager(settings, argv, connection);
   }
 
+  dispose(): void {
+    this.sessionManager.dispose();
+  }
+
   async initialize(
     args: acp.InitializeRequest,
   ): Promise<acp.InitializeResponse> {

--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -564,4 +564,26 @@ describe('Session', () => {
 
     expect(result.stopReason).toBe('max_turn_requests');
   });
+
+  it('should send sessionUpdate when approval mode changes', async () => {
+    const { coreEvents, CoreEvent, ApprovalMode } = await import(
+      '@google/gemini-cli-core'
+    );
+
+    coreEvents.emit(CoreEvent.ApprovalModeChanged, {
+      sessionId: 'session-1',
+      mode: ApprovalMode.PLAN,
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: {
+          type: 'text',
+          text: `[MODE_UPDATE] ${ApprovalMode.PLAN}`,
+        },
+      },
+    });
+  });
 });

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -8,6 +8,9 @@ import {
   type ApprovalMode,
   type ConversationRecord,
   CoreToolCallStatus,
+  coreEvents,
+  CoreEvent,
+  type ApprovalModeChangedPayload,
   logToolCall,
   convertToFunctionResponse,
   ToolConfirmationOutcome,
@@ -69,7 +72,31 @@ export class Session {
     private readonly context: AgentLoopContext,
     private readonly connection: acp.AgentSideConnection,
     private readonly settings: LoadedSettings,
-  ) {}
+  ) {
+    coreEvents.on(
+      CoreEvent.ApprovalModeChanged,
+      this.handleApprovalModeChanged,
+    );
+  }
+
+  private handleApprovalModeChanged = (payload: ApprovalModeChangedPayload) => {
+    if (payload.sessionId === this.id) {
+      void this.sendUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: {
+          type: 'text',
+          text: `[MODE_UPDATE] ${payload.mode}`,
+        },
+      });
+    }
+  };
+
+  dispose(): void {
+    coreEvents.off(
+      CoreEvent.ApprovalModeChanged,
+      this.handleApprovalModeChanged,
+    );
+  }
 
   async cancelPendingPrompt(): Promise<void> {
     if (!this.pendingPrompt) {

--- a/packages/cli/src/acp/acpSessionManager.ts
+++ b/packages/cli/src/acp/acpSessionManager.ts
@@ -48,6 +48,13 @@ export class AcpSessionManager {
     return this.sessions.get(sessionId);
   }
 
+  dispose(): void {
+    for (const session of this.sessions.values()) {
+      session.dispose();
+    }
+    this.sessions.clear();
+  }
+
   async newSession(
     { cwd, mcpServers }: acp.NewSessionRequest,
     authDetails: AuthDetails,
@@ -183,6 +190,12 @@ export class AcpSessionManager {
       this.connection,
       this.settings,
     );
+
+    const existingSession = this.sessions.get(sessionId);
+    if (existingSession) {
+      existingSession.dispose();
+    }
+
     this.sessions.set(sessionId, session);
 
     // Stream history back to client

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -202,6 +202,7 @@ const mockCoreEvents = vi.hoisted(() => ({
   emitConsoleLog: vi.fn(),
   emitQuotaChanged: vi.fn(),
   on: vi.fn(),
+  emit: vi.fn(),
 }));
 
 const mockSetGlobalProxy = vi.hoisted(() => vi.fn());

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2680,26 +2680,28 @@ export class Config implements McpContext, AgentLoopContext {
         this,
         new ApprovalModeSwitchEvent(currentMode, mode),
       );
-    }
 
-    this.policyEngine.setApprovalMode(mode);
-    this.refreshSandboxManager();
+      this.policyEngine.setApprovalMode(mode);
+      this.refreshSandboxManager();
+      coreEvents.emit(CoreEvent.ApprovalModeChanged, {
+        sessionId: this.getSessionId(),
+        mode,
+      });
 
-    const isPlanModeTransition =
-      currentMode !== mode &&
-      (currentMode === ApprovalMode.PLAN || mode === ApprovalMode.PLAN);
-    const isYoloModeTransition =
-      currentMode !== mode &&
-      (currentMode === ApprovalMode.YOLO || mode === ApprovalMode.YOLO);
+      const isPlanModeTransition =
+        currentMode === ApprovalMode.PLAN || mode === ApprovalMode.PLAN;
+      const isYoloModeTransition =
+        currentMode === ApprovalMode.YOLO || mode === ApprovalMode.YOLO;
 
-    if (isPlanModeTransition || isYoloModeTransition) {
-      if (this._geminiClient?.isInitialized()) {
-        this._geminiClient.clearCurrentSequenceModel();
-        this._geminiClient.setTools().catch((err) => {
-          debugLogger.error('Failed to update tools', err);
-        });
+      if (isPlanModeTransition || isYoloModeTransition) {
+        if (this._geminiClient?.isInitialized()) {
+          this._geminiClient.clearCurrentSequenceModel();
+          this._geminiClient.setTools().catch((err) => {
+            debugLogger.error('Failed to update tools', err);
+          });
+        }
+        this.updateSystemInstructionIfInitialized();
       }
-      this.updateSystemInstructionIfInitialized();
     }
   }
 

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Core System Prompt (prompts.ts) > ApprovalMode in System Prompt > Approved Plan in Plan Mode > should NOT include approved plan section if no plan is set in config 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Plan** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -181,7 +181,7 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 `;
 
 exports[`Core System Prompt (prompts.ts) > ApprovalMode in System Prompt > Approved Plan in Plan Mode > should include approved plan path when set in config 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Plan** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -482,7 +482,7 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 `;
 
 exports[`Core System Prompt (prompts.ts) > ApprovalMode in System Prompt > should include PLAN mode instructions 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Plan** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -662,7 +662,7 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 `;
 
 exports[`Core System Prompt (prompts.ts) > should append userMemory with separator when provided 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -843,7 +843,7 @@ Be extra polite.
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator (enabled=false) 1`] = `
-"You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -976,7 +976,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should handle CodebaseInvestigator (enabled=true) 1`] = `
-"You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -1591,7 +1591,7 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include available_skills with updated verbiage for preview models 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -1768,7 +1768,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include correct sandbox instructions for SANDBOX=sandbox-exec 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -1936,7 +1936,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include correct sandbox instructions for SANDBOX=true 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -2104,7 +2104,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include correct sandbox instructions for SANDBOX=undefined 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -2268,7 +2268,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include mandate to distinguish between Directives and Inquiries 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -2432,7 +2432,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include modern approved plan instructions with completion in DEFAULT mode when approvedPlanPath is set 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -2590,7 +2590,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include planning phase suggestion when enter_plan_mode tool is enabled 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -2722,7 +2722,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include sub-agents in XML for preview models when invoke_agent tool is enabled 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -3014,7 +3014,7 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 `;
 
 exports[`Core System Prompt (prompts.ts) > should include the TASK MANAGEMENT PROTOCOL when task tracker is enabled 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -3436,7 +3436,7 @@ project context
 `;
 
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is empty string 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -3600,7 +3600,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should return the base prompt when userMemory is whitespace only 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -3878,7 +3878,7 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 `;
 
 exports[`Core System Prompt (prompts.ts) > should use chatty system prompt for preview flash model 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 
@@ -4042,7 +4042,7 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 `;
 
 exports[`Core System Prompt (prompts.ts) > should use chatty system prompt for preview model 1`] = `
-"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+"You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. You are currently operating in **Default** mode. Your primary goal is to help users safely and effectively.
 
 # Core Mandates
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -2055,6 +2055,29 @@ ${JSON.stringify(
       );
     });
 
+    it('should update system instruction when ApprovalModeChanged event is emitted', async () => {
+      const { ApprovalMode } = await import('../policy/types.js');
+
+      vi.mocked(mockConfig.getSessionId).mockReturnValue('session-1');
+      vi.mocked(mockConfig.getSystemInstructionMemory).mockReturnValue(
+        'Current Memory',
+      );
+
+      const { getCoreSystemPrompt } = await import('./prompts.js');
+      const mockGetCoreSystemPrompt = vi.mocked(getCoreSystemPrompt);
+      mockGetCoreSystemPrompt.mockClear();
+
+      coreEvents.emit(CoreEvent.ApprovalModeChanged, {
+        sessionId: 'session-1',
+        mode: ApprovalMode.YOLO,
+      });
+
+      expect(mockGetCoreSystemPrompt).toHaveBeenCalledWith(
+        mockConfig,
+        'Current Memory',
+      );
+    });
+
     it('should propagate InvalidStream events without injecting "Please continue." or recursing', async () => {
       // Arrange: a single turn that yields an InvalidStream event.
       const mockStream = (async function* () {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -67,7 +67,11 @@ import {
 } from '../availability/policyHelpers.js';
 import { getDisplayString, resolveModel } from '../config/models.js';
 import { partToString } from '../utils/partUtils.js';
-import { coreEvents, CoreEvent } from '../utils/events.js';
+import {
+  coreEvents,
+  CoreEvent,
+  type ApprovalModeChangedPayload,
+} from '../utils/events.js';
 import { initializeContextManager } from '../context/initializer.js';
 
 const MAX_TURNS = 100;
@@ -116,6 +120,10 @@ export class GeminiClient {
 
     coreEvents.on(CoreEvent.ModelChanged, this.handleModelChanged);
     coreEvents.on(CoreEvent.MemoryChanged, this.handleMemoryChanged);
+    coreEvents.on(
+      CoreEvent.ApprovalModeChanged,
+      this.handleApprovalModeChanged,
+    );
   }
 
   private get config(): Config {
@@ -128,6 +136,12 @@ export class GeminiClient {
 
   private handleMemoryChanged = () => {
     this.updateSystemInstruction();
+  };
+
+  private handleApprovalModeChanged = (payload: ApprovalModeChangedPayload) => {
+    if (payload.sessionId === this.config.getSessionId()) {
+      this.updateSystemInstruction();
+    }
   };
 
   clearCurrentSequenceModel(): void {
@@ -314,6 +328,10 @@ export class GeminiClient {
   dispose() {
     coreEvents.off(CoreEvent.ModelChanged, this.handleModelChanged);
     coreEvents.off(CoreEvent.MemoryChanged, this.handleMemoryChanged);
+    coreEvents.off(
+      CoreEvent.ApprovalModeChanged,
+      this.handleApprovalModeChanged,
+    );
   }
 
   async resumeChat(

--- a/packages/core/src/prompts/promptProvider.ts
+++ b/packages/core/src/prompts/promptProvider.ts
@@ -142,6 +142,7 @@ export class PromptProvider {
       const options: snippets.SystemPromptOptions = {
         preamble: this.withSection('preamble', () => ({
           interactive: interactiveMode,
+          approvalMode,
         })),
         coreMandates: this.withSection('coreMandates', () => ({
           interactive: interactiveMode,

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -37,6 +37,7 @@ import {
 } from '../tools/tool-names.js';
 import type { HierarchicalMemory } from '../config/memory.js';
 import { DEFAULT_CONTEXT_FILENAME } from '../tools/memoryTool.js';
+import type { ApprovalMode } from '../policy/types.js';
 
 // --- Options Structs ---
 
@@ -57,6 +58,7 @@ export interface SystemPromptOptions {
 
 export interface PreambleOptions {
   interactive: boolean;
+  approvalMode: ApprovalMode;
 }
 
 export interface CoreMandatesOptions {
@@ -188,9 +190,17 @@ ${renderUserMemory(userMemory, contextFilenames)}
 
 export function renderPreamble(options?: PreambleOptions): string {
   if (!options) return '';
-  return options.interactive
-    ? 'You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.'
-    : 'You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.';
+
+  let modeStr = 'Default';
+  if (options.approvalMode === 'plan') modeStr = 'Plan';
+  if (options.approvalMode === 'yolo') modeStr = 'YOLO';
+  if (options.approvalMode === 'autoEdit') modeStr = 'Auto-Edit';
+
+  const base = options.interactive
+    ? 'You are Gemini CLI, an interactive CLI agent specializing in software engineering tasks.'
+    : 'You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks.';
+
+  return `${base} You are currently operating in **${modeStr}** mode. Your primary goal is to help users safely and effectively.`;
 }
 
 export function renderCoreMandates(options?: CoreMandatesOptions): string {

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -14,6 +14,7 @@ import type {
   KeychainAvailabilityEvent,
 } from '../telemetry/types.js';
 import { debugLogger } from './debugLogger.js';
+import type { ApprovalMode } from '../policy/types.js';
 
 /**
  * Defines the severity level for user-facing feedback.
@@ -50,6 +51,20 @@ export interface ModelChangedPayload {
    * The new model that was set.
    */
   model: string;
+}
+
+/**
+ * Payload for the 'approval-mode-changed' event.
+ */
+export interface ApprovalModeChangedPayload {
+  /**
+   * The session ID associated with the mode change.
+   */
+  sessionId: string;
+  /**
+   * The new approval mode.
+   */
+  mode: ApprovalMode;
 }
 
 /**
@@ -181,6 +196,7 @@ export interface QuotaChangedPayload {
 export enum CoreEvent {
   UserFeedback = 'user-feedback',
   ModelChanged = 'model-changed',
+  ApprovalModeChanged = 'approval-mode-changed',
   ConsoleLog = 'console-log',
   Output = 'output',
   MemoryChanged = 'memory-changed',
@@ -215,6 +231,7 @@ export interface EditorSelectedPayload {
 export interface CoreEvents extends ExtensionEvents {
   [CoreEvent.UserFeedback]: [UserFeedbackPayload];
   [CoreEvent.ModelChanged]: [ModelChangedPayload];
+  [CoreEvent.ApprovalModeChanged]: [ApprovalModeChangedPayload];
   [CoreEvent.ConsoleLog]: [ConsoleLogPayload];
   [CoreEvent.Output]: [OutputPayload];
   [CoreEvent.MemoryChanged]: [MemoryChangedPayload];
@@ -325,6 +342,14 @@ export class CoreEventEmitter extends EventEmitter<CoreEvents> {
   emitModelChanged(model: string): void {
     const payload: ModelChangedPayload = { model };
     this.emit(CoreEvent.ModelChanged, payload);
+  }
+
+  /**
+   * Notifies subscribers that the approval mode has changed.
+   */
+  emitApprovalModeChanged(sessionId: string, mode: ApprovalMode): void {
+    const payload: ApprovalModeChangedPayload = { sessionId, mode };
+    this.emit(CoreEvent.ApprovalModeChanged, payload);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the disconnect between ACP Client ( such as JetBrains/Zed ) and the agent regarding the agent mode (`Plan`, `Default`, `YOLO`, `Auto-Edit`). Addresses both the scenario where the agent ignores a mode change from the client, and the scenario where the UI is not updated after an internal mode change. Also improves prompt to make agent aware of current mode.

## Details

To resolve the issue :
-  Added `ApprovalModeChanged` event to `CoreEvent`.
-  Emitted it in `Config.setApprovalMode()`.
-  Listened to it in GeminiClient to update system instructions.
-  Listened to it in Session to send `sessionUpdate()` to client.
-  Included current mode in the preamble of the system prompt in `snippets.ts` and `promptProvider.ts`.
-  Updated snapshots and tests.

## Related Issues

Fixes google-gemini/maintainers-gemini-cli#1647

## How to Validate

<img width="1434" height="2014" alt="image" src="https://github.com/user-attachments/assets/f07668c3-041e-45d1-8c21-8316368e4321" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [✅] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [✅] Validated on required platforms/methods:
  - [✅] MacOS
    - [✅] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
