### PR TITLE
fix(ci): robust version checking in release verification

### DIFF
--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -63,7 +63,7 @@ runs:
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |-
-        gemini_version=$(gemini --version)
+        gemini_version=$(gemini --version 2>/dev/null)
         if [ "$gemini_version" != "${INPUTS_EXPECTED_VERSION}" ]; then
           echo "❌ NPM Version mismatch: Got $gemini_version from ${INPUTS_NPM_PACKAGE}, expected ${INPUTS_EXPECTED_VERSION}"
           exit 1
@@ -80,7 +80,7 @@ runs:
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |-
-        gemini_version=$(npx --prefer-online "${INPUTS_NPM_PACKAGE}" --version)
+        gemini_version=$(npx --prefer-online "${INPUTS_NPM_PACKAGE}" --version 2>/dev/null)
         if [ "$gemini_version" != "${INPUTS_EXPECTED_VERSION}" ]; then
           echo "❌ NPX Run Version mismatch: Got $gemini_version from ${INPUTS_NPM_PACKAGE}, expected ${INPUTS_EXPECTED_VERSION}"
           exit 1


### PR DESCRIPTION
## Summary

Discard error output when fetching version.

## Details

Harmless warnings [broke the nightly build](https://github.com/google-gemini/gemini-cli/actions/runs/25196755690/job/73879010176) because it was expecting the version to be the only output.