### PR TITLE
feat(cli): exit shell mode with backspace on empty input

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -901,9 +901,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (
         keyMatchers[Command.DELETE_CHAR_LEFT](key) &&
         buffer.text === '' &&
-        shellModeActive
+        shellModeActive &&
+        !reverseSearchActive &&
+        !commandSearchActive
       ) {
         setShellModeActive(false);
+        resetTurnBaseline();
         return true;
       }
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -898,6 +898,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (
+        keyMatchers[Command.DELETE_CHAR_LEFT](key) &&
+        buffer.text === '' &&
+        shellModeActive
+      ) {
+        setShellModeActive(false);
+        return true;
+      }
+
+      if (
         key.sequence === '!' &&
         buffer.text === '' &&
         !(completion.showSuggestions && isShellSuggestionsVisible)

--- a/packages/cli/src/ui/components/ShellModeIndicator.test.tsx
+++ b/packages/cli/src/ui/components/ShellModeIndicator.test.tsx
@@ -12,7 +12,7 @@ describe('ShellModeIndicator', () => {
   it('renders correctly', async () => {
     const { lastFrame, unmount } = await render(<ShellModeIndicator />);
     expect(lastFrame()).toContain('shell mode enabled');
-    expect(lastFrame()).toContain('esc to disable');
+    expect(lastFrame()).toContain('esc or backspace to disable');
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/ShellModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ShellModeIndicator.tsx
@@ -12,7 +12,7 @@ export const ShellModeIndicator: React.FC = () => (
   <Box>
     <Text color={theme.ui.symbol}>
       shell mode enabled
-      <Text color={theme.text.secondary}> (esc to disable)</Text>
+      <Text color={theme.text.secondary}> (esc or backspace to disable)</Text>
     </Text>
   </Box>
 );


### PR DESCRIPTION
## Summary

- Adds backspace-to-exit behavior for shell mode: pressing backspace on an empty input buffer while in shell mode deactivates it, matching the intuitive expectation of "erasing" the `!` that entered shell mode.
- Updates the shell mode indicator text from `(esc to disable)` to `(esc or backspace to disable)`.

Fixes #26299

## Test plan

- [ ] Type `!` in empty prompt → enters shell mode
- [ ] Press backspace on empty buffer → exits shell mode
- [ ] Type `!` again → re-enters shell mode
- [ ] In shell mode, type text, then backspace → deletes character (does NOT exit shell mode)
- [ ] Escape still exits shell mode as before
- [ ] Shell mode indicator shows updated text