### PR TITLE
fix(core): externalize https-proxy-agent to fix proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "ink": "npm:@jrichman/ink@6.6.9",
         "latest-version": "^9.0.0",
         "node-fetch-native": "^1.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "packages/*"
       ],
       "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "ink": "npm:@jrichman/ink@6.6.9",
         "latest-version": "^9.0.0",
         "node-fetch-native": "^1.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18401,6 +18401,7 @@
         "glob": "^12.0.0",
         "google-auth-library": "^9.11.0",
         "html-to-text": "^9.0.5",
+        "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "ignore": "^7.0.0",
         "ipaddr.js": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -143,8 +143,6 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "http-proxy-agent": "^7.0.2",
-    "https-proxy-agent": "^7.0.6",
     "ink": "npm:@jrichman/ink@6.6.9",
     "latest-version": "^9.0.0",
     "node-fetch-native": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,8 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "ink": "npm:@jrichman/ink@6.6.9",
     "latest-version": "^9.0.0",
     "node-fetch-native": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
     "glob": "^12.0.0",
     "node-domexception": "npm:empty@^0.10.1",
     "prebuild-install": "npm:nop@1.0.0",
-    "cross-spawn": "^7.0.6",
-    "http-proxy-agent": "^7.0.2"
+    "cross-spawn": "^7.0.6"
   },
   "bin": {
     "gemini": "bundle/gemini.js"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "glob": "^12.0.0",
     "node-domexception": "npm:empty@^0.10.1",
     "prebuild-install": "npm:nop@1.0.0",
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "http-proxy-agent": "^7.0.2"
   },
   "bin": {
     "gemini": "bundle/gemini.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "glob": "^12.0.0",
     "google-auth-library": "^9.11.0",
     "html-to-text": "^9.0.5",
+    "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
     "ignore": "^7.0.0",
     "ipaddr.js": "^1.9.1",

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -13,6 +13,8 @@ import {
 } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { GoogleGenAI } from '@google/genai';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { Config } from '../config/config.js';
 import { LoggingContentGenerator } from './loggingContentGenerator.js';
 import { loadApiKey } from './apiKeyCredentialStorage.js';
@@ -422,6 +424,100 @@ describe('createContentGenerator', () => {
         }),
       }),
     );
+  });
+
+  it('should inject HttpsProxyAgent into googleAuthOptions when proxy URL uses https://', async () => {
+    const mockConfigWithProxy = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue('https://proxy.example.com:8080'),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator);
+
+    await createContentGenerator(
+      {
+        apiKey: 'test-api-key',
+        vertexai: true,
+        authType: AuthType.USE_VERTEX_AI,
+        proxy: 'https://proxy.example.com:8080',
+      },
+      mockConfigWithProxy,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleAuthOptions: {
+          clientOptions: {
+            transporterOptions: {
+              agent: expect.any(HttpsProxyAgent),
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should inject HttpProxyAgent into googleAuthOptions when proxy URL uses http://', async () => {
+    const mockConfigWithProxy = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue('http://proxy.example.com:8080'),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator);
+
+    await createContentGenerator(
+      {
+        apiKey: 'test-api-key',
+        vertexai: true,
+        authType: AuthType.USE_VERTEX_AI,
+        proxy: 'http://proxy.example.com:8080',
+      },
+      mockConfigWithProxy,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleAuthOptions: {
+          clientOptions: {
+            transporterOptions: {
+              agent: expect.any(HttpProxyAgent),
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should not include googleAuthOptions when no proxy is configured', async () => {
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator);
+
+    await createContentGenerator(
+      {
+        apiKey: 'test-api-key',
+        vertexai: true,
+        authType: AuthType.USE_VERTEX_AI,
+      },
+      mockConfig,
+    );
+
+    const callArg = vi.mocked(GoogleGenAI).mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg).not.toHaveProperty('googleAuthOptions');
   });
 
   it('should pass api key as Authorization Header when GEMINI_API_KEY_AUTH_MECHANISM is set to bearer', async () => {

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -462,7 +462,7 @@ describe('createContentGenerator', () => {
     );
   });
 
-  it('should inject HttpProxyAgent into googleAuthOptions when proxy URL uses http://', async () => {
+  it('should still use HttpsProxyAgent for HTTPS destinations even when proxy URL uses http://', async () => {
     const mockConfigWithProxy = {
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       getProxy: vi.fn().mockReturnValue('http://proxy.example.com:8080'),
@@ -490,7 +490,81 @@ describe('createContentGenerator', () => {
         googleAuthOptions: {
           clientOptions: {
             transporterOptions: {
+              agent: expect.any(HttpsProxyAgent),
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should inject HttpProxyAgent when destination baseUrl uses http://', async () => {
+    const mockConfigWithProxy = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue('http://proxy.example.com:8080'),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator);
+
+    vi.stubEnv('GOOGLE_VERTEX_BASE_URL', 'http://localhost:9999');
+
+    await createContentGenerator(
+      {
+        apiKey: 'test-api-key',
+        vertexai: true,
+        authType: AuthType.USE_VERTEX_AI,
+        proxy: 'http://proxy.example.com:8080',
+      },
+      mockConfigWithProxy,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleAuthOptions: {
+          clientOptions: {
+            transporterOptions: {
               agent: expect.any(HttpProxyAgent),
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('should trim whitespace from proxy URL before instantiating agent', async () => {
+    const mockConfigWithProxy = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue('  https://proxy.example.com:8080  '),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator);
+
+    await createContentGenerator(
+      {
+        apiKey: 'test-api-key',
+        vertexai: true,
+        authType: AuthType.USE_VERTEX_AI,
+        proxy: '  https://proxy.example.com:8080  ',
+      },
+      mockConfigWithProxy,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleAuthOptions: {
+          clientOptions: {
+            transporterOptions: {
+              agent: expect.any(HttpsProxyAgent),
             },
           },
         },

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -338,9 +338,9 @@ export async function createContentGenerator(
         httpOptions.baseUrl = baseUrl;
       }
 
-      const proxyUrl = config.proxy;
+      const proxyUrl = config.proxy?.trim();
       const proxyAgent = proxyUrl
-        ? proxyUrl.startsWith('http://')
+        ? baseUrl?.startsWith('http://')
           ? new HttpProxyAgent(proxyUrl)
           : new HttpsProxyAgent(proxyUrl)
         : undefined;

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -13,6 +13,8 @@ import {
   type EmbedContentResponse,
   type EmbedContentParameters,
 } from '@google/genai';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as os from 'node:os';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
 import { isCloudShell } from '../ide/detect-ide.js';
@@ -336,11 +338,25 @@ export async function createContentGenerator(
         httpOptions.baseUrl = baseUrl;
       }
 
+      const proxyUrl = config.proxy;
+      const proxyAgent = proxyUrl
+        ? proxyUrl.startsWith('http://')
+          ? new HttpProxyAgent(proxyUrl)
+          : new HttpsProxyAgent(proxyUrl)
+        : undefined;
+
       const googleGenAI = new GoogleGenAI({
         apiKey: config.apiKey === '' ? undefined : config.apiKey,
         vertexai: config.vertexai ?? config.authType === AuthType.USE_VERTEX_AI,
         httpOptions,
         ...(apiVersionEnv && { apiVersion: apiVersionEnv }),
+        ...(proxyAgent && {
+          googleAuthOptions: {
+            clientOptions: {
+              transporterOptions: { agent: proxyAgent },
+            },
+          },
+        }),
       });
       return new LoggingContentGenerator(googleGenAI.models, gcConfig);
     }


### PR DESCRIPTION
# fix(core): inject proxy agent statically to fix Vertex AI proxy support

## Summary

Fix `TypeError: HttpsProxyAgent is not a constructor` that occurs when calling Vertex AI / Gemini API through an HTTP/HTTPS proxy (`HTTPS_PROXY` / `HTTP_PROXY`). The bug is a P1 blocker for proxy users — particularly enterprise Vertex AI users.

This PR is a follow-up to the original review feedback by @scidomino: instead of externalizing the proxy package from the esbuild bundle, we statically import `HttpsProxyAgent` / `HttpProxyAgent` and inject the pre-instantiated agent into `GoogleGenAI`'s underlying transporter.

## Root cause

esbuild's `splitting: true` + `format: 'esm'` causes CJS packages resolved via dynamic `import()` to lose named exports. `gaxios@7.x` (used by `google-auth-library` → `@google/genai`) dynamically imports `https-proxy-agent`:

```js
this.#proxyAgent ||= (await import('https-proxy-agent')).HttpsProxyAgent;
```

esbuild generates an ESM chunk with only a `default` export, so `.HttpsProxyAgent` resolves to `undefined`, and `new this.#proxyAgent(...)` throws.

## Fix

Statically import both proxy agents in `packages/core/src/core/contentGenerator.ts` and pre-instantiate the agent before constructing `GoogleGenAI`. The agent is injected via `googleAuthOptions.clientOptions.transporterOptions.agent`, which causes gaxios to skip its dynamic import path entirely (gaxios checks `opts.agent` and uses it if present, falling through to dynamic import only when absent).

```typescript
import { HttpProxyAgent } from 'http-proxy-agent';
import { HttpsProxyAgent } from 'https-proxy-agent';

// inside createContentGenerator (GoogleGenAI branch):
const proxyUrl = config.proxy?.trim();
const proxyAgent = proxyUrl
  ? baseUrl?.startsWith('http://')
    ? new HttpProxyAgent(proxyUrl)
    : new HttpsProxyAgent(proxyUrl)
  : undefined;

const googleGenAI = new GoogleGenAI({
  apiKey,
  vertexai,
  httpOptions,
  ...(proxyAgent && {
    googleAuthOptions: {
      clientOptions: {
        transporterOptions: { agent: proxyAgent },
      },
    },
  }),
});
```

Agent selection is based on the **destination URL** (`baseUrl`), not the proxy URL — `HttpsProxyAgent` is required for HTTPS destinations (which both Gemini API and Vertex AI use by default), regardless of the proxy's own scheme.

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/core/contentGenerator.ts` | Static imports + agent construction + injection via `googleAuthOptions` |
| `packages/core/src/core/contentGenerator.test.ts` | 5 new test cases covering https/http proxy URL, http baseUrl, whitespace trimming, and no-proxy case |
| `packages/core/package.json` | Add `http-proxy-agent: ^7.0.2` (was already a transitive dep; making it explicit) |
| `package.json` | Add `http-proxy-agent` and `https-proxy-agent` to root `dependencies` for consistency |
| `package-lock.json` | Regenerated |

**No esbuild or bundle script changes** are needed with this approach — by avoiding the dynamic import path entirely, we don't need to externalize anything from the bundle.

## Related issues

- Fixes #24471
- Related to #25169

## How to validate

1. Build:
   ```bash
   npm run bundle
   ```
2. Verify under proxy (should succeed without `TypeError`):
   ```bash
   HTTPS_PROXY=http://<your-proxy>:<port> npm start -- --prompt "hello"
   ```
3. Verify without proxy (regression check):
   ```bash
   npm start -- --prompt "hello"
   ```
4. Run unit tests for the proxy injection:
   ```bash
   cd packages/core && npx vitest run src/core/contentGenerator.test.ts
   ```
   Expected: all 39 tests pass (5 new + 34 existing).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (N/A — internal implementation only)
- [x] Added/updated tests (5 new unit tests in `contentGenerator.test.ts`)
- [x] Noted breaking changes (none)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

This PR unblocks all users who are currently unable to access Vertex AI due to proxy issues.
