### PR TITLE
Guard stdin cleanup after SSH/TTY disconnect

### DIFF
--- a/packages/cli/src/utils/cleanup.test.ts
+++ b/packages/cli/src/utils/cleanup.test.ts
@@ -126,6 +126,66 @@ describe('cleanup', () => {
     expect(successFn).toHaveBeenCalledTimes(1);
   });
 
+  it('should skip draining stdin when tty input has already been torn down', async () => {
+    const originalResume = process.stdin.resume;
+    const originalIsTTY = process.stdin.isTTY;
+    const originalDestroyed = process.stdin.destroyed;
+    const resumeSpy = vi.fn();
+
+    process.stdin.resume = resumeSpy;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, 'destroyed', {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      await runExitCleanup();
+    } finally {
+      process.stdin.resume = originalResume;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+      Object.defineProperty(process.stdin, 'destroyed', {
+        value: originalDestroyed,
+        configurable: true,
+      });
+    }
+
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should ignore errors raised while draining stdin during shutdown', async () => {
+    const cleanupFn = vi.fn();
+    const originalResume = process.stdin.resume;
+    const originalIsTTY = process.stdin.isTTY;
+
+    registerCleanup(cleanupFn);
+    process.stdin.resume = vi.fn().mockImplementation(() => {
+      throw new Error('stdin closed');
+    });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      await expect(runExitCleanup()).resolves.not.toThrow();
+    } finally {
+      process.stdin.resume = originalResume;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
   describe('sync cleanup', () => {
     it('should run registered sync functions', async () => {
       const syncFn = vi.fn();

--- a/packages/cli/src/utils/cleanup.ts
+++ b/packages/cli/src/utils/cleanup.ts
@@ -114,15 +114,30 @@ export async function runExitCleanup() {
 }
 
 async function drainStdin() {
-  if (!process.stdin?.isTTY) return;
-  // Resume stdin and attach a no-op listener to drain the buffer.
-  // We use removeAllListeners to ensure we don't trigger other handlers.
-  process.stdin
-    .resume()
-    .removeAllListeners('data')
-    .on('data', () => {});
-  // Give it a moment to flush the OS buffer.
-  await new Promise((resolve) => setTimeout(resolve, 50));
+  const stdin = process.stdin;
+  if (
+    !stdin?.isTTY ||
+    stdin.destroyed ||
+    stdin.readableEnded ||
+    stdin.closed ||
+    stdin.readable === false
+  ) {
+    return;
+  }
+
+  try {
+    // Resume stdin and attach a no-op listener to drain the buffer.
+    // We use removeAllListeners to ensure we don't trigger other handlers.
+    stdin
+      .resume()
+      .removeAllListeners('data')
+      .on('data', () => {});
+    // Give it a moment to flush the OS buffer.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } catch {
+    // Ignore stdio teardown errors. This path can run after an SSH/TTY
+    // disconnect, where touching stdin may itself fail during exit cleanup.
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- skip stdin draining when the TTY stream has already been torn down
- swallow stdin drain errors during shutdown so SSH disconnect cleanup can still complete
- add cleanup tests covering torn-down stdin and drain failures

## Why
When `gemini --yolo` is run in an interactive SSH session and the client disconnects, the CLI can enter shutdown with a dead TTY/stdin. The current exit cleanup path still tries to `resume()` and rewire `process.stdin`, which is a plausible trigger for the server-side SIGSEGV/SIGABRT coredumps reported in #26360.

This keeps the existing stdin-draining behavior for healthy interactive sessions, but avoids touching stdin once it has already been torn down.

## Testing
- `npx vitest run packages/cli/src/utils/cleanup.test.ts`

Closes #26360