### PR TITLE
Document security review notes

### DIFF
--- a/.github/security-notes/security-review-2026-05-02-8934717b.md
+++ b/.github/security-notes/security-review-2026-05-02-8934717b.md
@@ -1,0 +1,173 @@
+# Security review notes
+
+These notes summarize security-relevant findings that are worth maintainer review. They do not claim that every item is remediated.
+
+## Review context
+
+- Project: `gemini-cli`
+- Source: `github.com/google-gemini/gemini-cli#main`
+- Risk score: **100/100**
+- Findings included: **99**
+- Baseline: **no saved baseline**
+
+## Risk breakdown
+
+- Runtime / agent risk: **Critical** (100/100)
+- CI / supply-chain posture: **Low** (17/100)
+- Dependency risk: **Moderate** (21/100)
+- Secrets risk: **Critical** (100/100)
+
+## Findings requiring review
+
+### 1. High-entropy secret-like value committed
+
+- Severity: `critical`
+- Category: `secret_exposure`
+- Rule: `secret.generic-high-entropy-assignment`
+- Locations: `.github/actions/npm-auth-token/action.yml:43`, `.github/actions/npm-auth-token/action.yml:51`, `.github/workflows/chained_e2e.yml:41`, `.github/workflows/chained_e2e.yml:124`, `.github/workflows/ci.yml:47`, `.github/workflows/docs-audit.yml:49`, `.github/workflows/eval.yml:30`, `.github/workflows/release-notes.yml:57`, and 6 more
+- Confidence: 86%
+- Recommendation: Rotate the value if it was real, remove it from source control, and load it from a server-only secret store or environment variable.
+- Evidence: `AUTH_TOKEN="...redacted"`
+- Evidence: `INPUTS_WOMBAT_TOKEN_A2A_SERVER: '...redacted inputs.wombat-token-a2a-server }}'`
+- Evidence: `secret: '...redacted secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'`
+
+### 2. High-risk secret name with assigned value
+
+- Severity: `critical`
+- Category: `secret_exposure`
+- Rule: `secret.high-risk-name.assigned-value`
+- Locations: `.github/workflows/gemini-automated-issue-dedup.yml:97`, `.github/workflows/gemini-scheduled-issue-dedup.yml:77`, `packages/core/src/sandbox/macos/MacOsSandboxManager.test.ts:109`, `packages/core/src/services/sandboxManager.test.ts:262`, `packages/core/src/tools/mcp-client.test.ts:2144`
+- Confidence: 82%
+- Recommendation: Move the value to a server-only environment variable, rotate it if it was real, and commit only placeholders.
+- Evidence: `"GITHUB_TOKEN": "${GITHUB_TOKEN}",`
+- Evidence: `GITHUB_TOKEN: '...redacted',`
+- Evidence: `SECRET_KEY: '...redacted',`
+
+### 3. Workflow uses pull_request_target
+
+- Severity: `high`
+- Category: `repo_security_posture`
+- Rule: `github-actions.pull-request-target`
+- Locations: `.github/workflows/eval-pr.yml:4`, `.github/workflows/pr-rate-limiter.yaml:8`
+- Confidence: 86%
+- Recommendation: Use pull_request where possible, or strictly avoid checking out and executing untrusted fork code under privileged tokens.
+- Evidence: `pull_request_target:`
+
+### 4. Dynamic tool selection from user input
+
+- Severity: `high`
+- Category: `mcp_risk`
+- Rule: `rule.mcp_risk.dynamic.tool.selection.from.user.input`
+- Locations: `packages/test-utils/src/test-mcp-server-template.mjs:48`
+- Confidence: 82%
+- Recommendation: Use an explicit allowlist of tools and validate tool names server-side before dispatch.
+- Evidence: `const toolName = request.params.name;`
+
+### 5. Dynamic tool selection from user input
+
+- Severity: `high`
+- Category: `unsafe_tool_calling`
+- Rule: `rule.unsafe_tool_calling.dynamic.tool.selection.from.user.input`
+- Locations: `packages/core/src/scheduler/tool-executor.ts:63`
+- Confidence: 82%
+- Recommendation: Use an explicit allowlist of tools and validate tool names server-side before dispatch.
+- Evidence: `const toolName = request.name;`
+
+### 6. child_process usage detected
+
+- Severity: `high`
+- Category: `dangerous_code`
+- Rule: `rule.dangerous_code.child.process.usage.detected`
+- Locations: `.gemini/skills/ci/scripts/ci.mjs:9`, `.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js:11`, `.github/scripts/backfill-need-triage.cjs:9`, `.github/scripts/backfill-pr-notification.cjs:17`, `evals/test-helper.ts:11`, `integration-tests/acp-env-auth.test.ts:9`, `integration-tests/browser-agent.test.ts:22`, `integration-tests/browser-policy.test.ts:11`, and 40 more
+- Confidence: 80%
+- Recommendation: Avoid dynamic code execution and sanitize all HTML/user input. If shell or file access is required, use strict allowlists and fixed paths.
+- Evidence: `import { execSync } from 'node:child_process';`
+- Evidence: `import { exec } from 'node:child_process';`
+- Evidence: `const { execFileSync } = require('child_process');`
+
+### 7. Shell process call detected
+
+- Severity: `high`
+- Category: `dangerous_code`
+- Rule: `rule.dangerous_code.shell.process.call.detected`
+- Locations: `.github/scripts/sync-maintainer-labels.cjs:57`, `integration-tests/acp-env-auth.test.ts:58`, `packages/cli/src/acp/acpSession.ts:1290`, `packages/cli/src/acp/commands/about.ts:32`, `packages/cli/src/commands/gemma/logs.ts:105`, `packages/cli/src/commands/gemma/start.ts:47`, `packages/cli/src/services/McpPromptLoader.ts:245`, `packages/cli/src/ui/commands/aboutCommand.test.ts:134`, and 13 more
+- Confidence: 80%
+- Recommendation: Avoid dynamic code execution and sanitize all HTML/user input. If shell or file access is required, use strict allowlists and fixed paths.
+- Evidence: `while ((match = urlRegex.exec(text)) !== null) {`
+- Evidence: `child = spawn('node', [bundlePath, '--acp'], {`
+- Evidence: `const match = fileContentRegex.exec(part);`
+
+### 8. File write appears to use request input
+
+- Severity: `high`
+- Category: `dangerous_code`
+- Rule: `rule.dangerous_code.file.write.appears.to.use.request.input`
+- Locations: `integration-tests/mcp-resources.test.ts:36`, `integration-tests/test-mcp-support.test.ts:41`
+- Confidence: 80%
+- Recommendation: Avoid dynamic code execution and sanitize all HTML/user input. If shell or file access is required, use strict allowlists and fixed paths.
+- Evidence: `fs.writeFileSync(join(userGeminiDir, 'projects.json'), '{"projects":{}}');`
+
+### 9. Dynamic eval call detected
+
+- Severity: `high`
+- Category: `dangerous_code`
+- Rule: `rule.dangerous_code.dynamic.eval.call.detected`
+- Locations: `packages/core/src/agents/browser/browserAgentFactory.test.ts:49`
+- Confidence: 80%
+- Recommendation: Avoid dynamic code execution and sanitize all HTML/user input. If shell or file access is required, use strict allowlists and fixed paths.
+- Evidence: `// Add static methods — use mockImplementation for lazy eval (hoisting-safe)`
+
+### 10. Known vulnerable dependency: @modelcontextprotocol/sdk
+
+- Severity: `medium`
+- Category: `dependency_vulnerability`
+- Rule: `dependency.osv.known-vulnerability`
+- Locations: `packages/cli/src/commands/extensions/examples/mcp-server/package.json:8`
+- Confidence: 92%
+- Recommendation: Upgrade @modelcontextprotocol/sdk to a non-vulnerable version and confirm whether it is a direct dependency.
+- Evidence: `npm:@modelcontextprotocol/sdk@1.23.0 -> GHSA-345p-7cg4-v4c7`
+- Evidence: `npm:@modelcontextprotocol/sdk@1.23.0 -> GHSA-8r9q-7v3j-jr4g`
+- Evidence: `npm:@modelcontextprotocol/sdk@1.23.0 -> GHSA-w48q-cv73-mx4w`
+
+### 11. Known vulnerable dependency: ws
+
+- Severity: `medium`
+- Category: `dependency_vulnerability`
+- Rule: `dependency.osv.known-vulnerability`
+- Locations: `packages/devtools/package.json:30`
+- Confidence: 92%
+- Recommendation: Upgrade ws to a non-vulnerable version and confirm whether it is a direct dependency.
+- Evidence: `npm:ws@8.16.0 -> GHSA-3h5v-q93c-6h6q`
+
+## Pull request context
+
+**Branch:** `security/review-8934717b`
+**Base:** `main`
+
+### Low-risk changes applied
+
+- No code files were changed in this PR.
+
+### Files changed
+
+- `.github/security-notes/security-review-2026-05-02-8934717b.md`
+
+### Findings requiring human review
+
+- High-entropy secret-like value committed (`.github/actions/npm-auth-token/action.yml:43`, `.github/actions/npm-auth-token/action.yml:51`, `.github/workflows/chained_e2e.yml:41`, `.github/workflows/chained_e2e.yml:124`, and 10 more) remains review-required.
+- High-risk secret name with assigned value (`.github/workflows/gemini-automated-issue-dedup.yml:97`, `.github/workflows/gemini-scheduled-issue-dedup.yml:77`, `packages/core/src/sandbox/macos/MacOsSandboxManager.test.ts:109`, `packages/core/src/services/sandboxManager.test.ts:262`, and 1 more) remains review-required.
+- Workflow uses pull_request_target (`.github/workflows/eval-pr.yml:4`, `.github/workflows/pr-rate-limiter.yaml:8`) remains review-required.
+- Dynamic tool selection from user input (`packages/test-utils/src/test-mcp-server-template.mjs:48`) remains review-required.
+- Dynamic tool selection from user input (`packages/core/src/scheduler/tool-executor.ts:63`) remains review-required.
+- child_process usage detected (`.gemini/skills/ci/scripts/ci.mjs:9`, `.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js:11`, `.github/scripts/backfill-need-triage.cjs:9`, `.github/scripts/backfill-pr-notification.cjs:17`, and 44 more) remains review-required.
+- Shell process call detected (`.github/scripts/sync-maintainer-labels.cjs:57`, `integration-tests/acp-env-auth.test.ts:58`, `packages/cli/src/acp/acpSession.ts:1290`, `packages/cli/src/acp/commands/about.ts:32`, and 17 more) remains review-required.
+- File write appears to use request input (`integration-tests/mcp-resources.test.ts:36`, `integration-tests/test-mcp-support.test.ts:41`) remains review-required.
+- Dynamic eval call detected (`packages/core/src/agents/browser/browserAgentFactory.test.ts:49`) remains review-required.
+- Known vulnerable dependency: @modelcontextprotocol/sdk (`packages/cli/src/commands/extensions/examples/mcp-server/package.json:8`) remains review-required.
+- Known vulnerable dependency: ws (`packages/devtools/package.json:30`) remains review-required.
+
+## Review policy
+
+- This pull request does not include speculative code patches.
+- Architecture-sensitive findings, including auth, rate limits, agent tools, MCP, CI permissions, and supply-chain posture, remain maintainer-reviewed.
+- Local-only report links are intentionally omitted because public maintainers cannot open them.


### PR DESCRIPTION
## Summary

This PR records focused security review notes for `github.com/google-gemini/gemini-cli#main` without applying speculative code changes.

## What changed

- Added maintainer-facing review notes.

## Findings for maintainer review

- High-entropy secret-like value committed (`.github/actions/npm-auth-token/action.yml:43`, `.github/actions/npm-auth-token/action.yml:51`, `.github/workflows/chained_e2e.yml:41`, `.github/workflows/chained_e2e.yml:124`, and 10 more) remains review-required.
- High-risk secret name with assigned value (`.github/workflows/gemini-automated-issue-dedup.yml:97`, `.github/workflows/gemini-scheduled-issue-dedup.yml:77`, `packages/core/src/sandbox/macos/MacOsSandboxManager.test.ts:109`, `packages/core/src/services/sandboxManager.test.ts:262`, and 1 more) remains review-required.
- Workflow uses pull_request_target (`.github/workflows/eval-pr.yml:4`, `.github/workflows/pr-rate-limiter.yaml:8`) remains review-required.
- Dynamic tool selection from user input (`packages/test-utils/src/test-mcp-server-template.mjs:48`) remains review-required.
- Dynamic tool selection from user input (`packages/core/src/scheduler/tool-executor.ts:63`) remains review-required.
- child_process usage detected (`.gemini/skills/ci/scripts/ci.mjs:9`, `.gemini/skills/pr-address-comments/scripts/fetch-pr-info.js:11`, `.github/scripts/backfill-need-triage.cjs:9`, `.github/scripts/backfill-pr-notification.cjs:17`, and 44 more) remains review-required.
- Shell process call detected (`.github/scripts/sync-maintainer-labels.cjs:57`, `integration-tests/acp-env-auth.test.ts:58`, `packages/cli/src/acp/acpSession.ts:1290`, `packages/cli/src/acp/commands/about.ts:32`, and 17 more) remains review-required.
- File write appears to use request input (`integration-tests/mcp-resources.test.ts:36`, `integration-tests/test-mcp-support.test.ts:41`) remains review-required.
- Dynamic eval call detected (`packages/core/src/agents/browser/browserAgentFactory.test.ts:49`) remains review-required.
- Known vulnerable dependency: @modelcontextprotocol/sdk (`packages/cli/src/commands/extensions/examples/mcp-server/package.json:8`) remains review-required.
- Known vulnerable dependency: ws (`packages/devtools/package.json:30`) remains review-required.

## Notes

- The detailed review notes are included under `.github/security-notes/`.
- This PR avoids speculative or placeholder fixes that could change production behavior.
- Review all security-sensitive changes before merging.
- Head fork: `MauroProto/gemini-cli`.