### PR TITLE
fix(web-fetch): enforce rate limiting in fallback fetch execution and add tests

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -669,6 +669,36 @@ describe('WebFetchTool', () => {
         }
       },
     );
+
+    it('should respect rate limit in fallback execution', async () => {
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+
+      // Force fallback (primary fails)
+      mockGenerateContent.mockResolvedValueOnce({
+        candidates: [],
+      });
+
+      // Mock fetch success
+      mockFetch('https://ratelimit-test.com/', {
+        text: () => Promise.resolve('ok'),
+      });
+
+      const tool = new WebFetchTool(mockConfig, bus);
+
+      // Hit rate limit (10 times)
+      for (let i = 0; i < 10; i++) {
+        await tool
+          .build({ prompt: 'fetch https://ratelimit-test.com' })
+          .execute({ abortSignal: new AbortController().signal });
+      }
+
+      // 11th call → should trigger rate limit inside fallback
+      const result = await tool
+        .build({ prompt: 'fetch https://ratelimit-test.com' })
+        .execute({ abortSignal: new AbortController().signal });
+
+      expect(result.llmContent).toContain('Error');
+    });
   });
 
   describe('shouldConfirmExecute', () => {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -285,6 +285,10 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
+    const rate = checkRateLimit(urlStr);
+    if (!rate.allowed) {
+      throw new Error(`Rate limit exceeded for ${urlStr}`);
+    }
     if (this.isBlockedHost(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(


### PR DESCRIPTION
## Summary

Fixes a gap where rate limiting was enforced in the primary web fetch path but not consistently respected in the fallback execution path. This could allow excessive requests to the same host when fallback logic is triggered.

This change ensures rate limiting is applied uniformly across both primary and fallback fetch flows.

---

## Details

- Enforced host-based rate limiting inside fallback execution (`executeFallbackForUrl`)
- Ensured skipped/blocked URLs are handled consistently with primary flow
- Added test coverage for:
  - Rate limit enforcement during fallback execution
  - Error behavior when limit is exceeded in fallback path

This keeps behavior aligned between primary and fallback fetch mechanisms and prevents unintended request bursts.

---

## Related Issues

Fixes #26382

---

## How to Validate

1. Run tests:
   ```bash
   npm test
   ```
2. Verify new test:

- should respect rate limit in fallback execution

3. Manual validation:

- Trigger multiple requests (>10) to same host
- Confirm:

      -  Requests are blocked after limit
      -  Proper error is returned