### PR TITLE
fix(core): implement system ripgrep fallback when bundled binary is missing

### DIFF
--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -38,6 +38,7 @@ import {
 import { RIP_GREP_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { type GrepMatch, formatGrepResults } from './grep-utils.js';
+import { isBinaryAvailable } from '../utils/binaryCheck.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -59,6 +60,11 @@ export async function getRipgrepPath(): Promise<string | null> {
     if (await fileExists(candidate)) {
       return candidate;
     }
+  }
+
+  // 3. Fallback to system PATH
+  if (isBinaryAvailable('rg')) {
+    return 'rg';
   }
 
   return null;


### PR DESCRIPTION
### Description
This PR implements a fallback mechanism to detect and use a system-installed `ripgrep` binary when the bundled vendor binaries are not available.

### Context
Previous updates (PR #25841) successfully removed architecture-specific `ripgrep` binaries from NPM tarballs to significantly reduce package size. However, while this optimization was beneficial for package weight, it unintentionally left NPM users without a high-performance search path because the CLI lacked the logic to check the host system's `PATH` for an existing `rg` installation.

As a result, users with `ripgrep` already installed on their machines were still seeing \"Ripgrep is not available\" warnings and experiencing severe search performance degradation due to the mandatory fallback to the JavaScript-based `GrepTool`.

### Changes
- Updated `getRipgrepPath` in `packages/core/src/tools/ripGrep.ts` to check the system `PATH` using the `isBinaryAvailable` utility if bundled binaries are missing.

### Testing
- **Local Verification:** Verified the fix by running a locally bundled version of the CLI without internal `vendor` binaries. 
- **Debug Logging:** Confirmed via `--debug` logs that the CLI successfully identifies and executes the system `rg` binary.
- **Regression Testing:** Verified that the \"Ripgrep is not available. Falling back to GrepTool\" warning is no longer triggered when a system `rg` is present.
- **Validation:** Ran the full `npm run preflight` suite; all linting and unit tests passed successfully.

Fixes #26193
