### PR TITLE
fix(telemetry): stop buffering events when telemetry is disabled

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1390,10 +1390,16 @@ export class Config implements McpContext, AgentLoopContext {
       setGeminiMdFilename(params.contextFileName);
     }
 
-    if (this.telemetrySettings.enabled) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      initializeTelemetry(this);
-    }
+    // Always call initializeTelemetry, even when telemetry is disabled.
+    // The function short-circuits to markTelemetryDisabled() in that case,
+    // which sets the disabled flag and clears any events that were already
+    // pushed to the buffer at module-load time. Skipping the call would leave
+    // the buffer growing unbounded for the lifetime of the process — every
+    // log* helper pushes a closure capturing its event, and ApiRequestEvent /
+    // ApiResponseEvent / ApiErrorEvent each retain the full conversation
+    // contents.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    initializeTelemetry(this);
 
     const proxy = this.getProxy();
     if (proxy) {

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -359,6 +359,78 @@ describe('Telemetry SDK', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       expect(callback).toHaveBeenCalled();
     });
+
+    it('should drop pre-init events and stop buffering when telemetry is disabled', async () => {
+      // Regression test: when telemetry is disabled, every `logApi*` helper
+      // pushed a closure capturing the full event (with conversation contents)
+      // onto telemetryBuffer, which was never drained because init bailed
+      // before flipping `telemetryInitialized` to true. Confirmed live to
+      // retain GBs over a long-running session with frequent API errors.
+      //
+      // The fix has two halves: events buffered before init runs must be
+      // discarded once init sees telemetry is off, and events submitted after
+      // init must short-circuit instead of pushing onto the buffer.
+      const beforeInitCallback = vi.fn();
+      bufferTelemetryEvent(beforeInitCallback);
+
+      vi.spyOn(mockConfig, 'getTelemetryEnabled').mockReturnValue(false);
+      await initializeTelemetry(mockConfig);
+
+      const afterInitCallback = vi.fn();
+      bufferTelemetryEvent(afterInitCallback);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(beforeInitCallback).not.toHaveBeenCalled();
+      expect(afterInitCallback).not.toHaveBeenCalled();
+    });
+
+    it('should drop events when telemetry is disabled by config conflict', async () => {
+      // The other permanent-disable path: useCollector + useCliAuth both true.
+      vi.spyOn(mockConfig, 'getTelemetryUseCollector').mockReturnValue(true);
+      vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
+      await initializeTelemetry(mockConfig);
+
+      const callback = vi.fn();
+      bufferTelemetryEvent(callback);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should re-enable buffering after a disabled init when telemetry is later enabled', async () => {
+      // Re-init scenario: first call disabled (sets telemetryDisabled=true),
+      // second call enabled. The second init must clear the flag so that
+      // events submitted after it are not silently dropped.
+      vi.spyOn(mockConfig, 'getTelemetryEnabled').mockReturnValue(false);
+      await initializeTelemetry(mockConfig);
+
+      vi.mocked(mockConfig.getTelemetryEnabled).mockReturnValue(true);
+      await initializeTelemetry(mockConfig);
+
+      const callback = vi.fn();
+      bufferTelemetryEvent(callback);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  it('should clean up the auth listener when shutdown is called from the deferred-init state', async () => {
+    // Reproduces a latent listener leak: when telemetry is enabled but uses
+    // CLI auth and no credentials are available yet, init registers an
+    // `authListener` and returns without setting `telemetryInitialized`. If
+    // shutdown is called before the post-auth re-init, the listener must
+    // still be detached.
+    vi.spyOn(mockConfig, 'getTelemetryUseCliAuth').mockReturnValue(true);
+    vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
+      TelemetryTarget.GCP,
+    );
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
+
+    const baseline = authEvents.listenerCount('post_auth');
+    await initializeTelemetry(mockConfig);
+    expect(authEvents.listenerCount('post_auth')).toBe(baseline + 1);
+
+    await shutdownTelemetry(mockConfig);
+    expect(authEvents.listenerCount('post_auth')).toBe(baseline);
   });
 
   it('should disable telemetry and log error if useCollector and useCliAuth are both true', async () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -98,6 +98,14 @@ let spanProcessor: BatchSpanProcessor | undefined;
 let logRecordProcessor: BatchLogRecordProcessor | undefined;
 let metricReader: PeriodicExportingMetricReader | undefined;
 let telemetryInitialized = false;
+// Set when telemetry is permanently off for this process (i.e. disabled in
+// config, or disabled because of an unresolvable misconfiguration). Used to
+// short-circuit `bufferTelemetryEvent` so that closures capturing huge events
+// (full conversation contents on every API request/response/error) are not
+// retained forever in `telemetryBuffer`. The deferred-init case (waiting for
+// OAuth credentials) intentionally leaves this false so events still buffer
+// and get flushed once init completes.
+let telemetryDisabled = false;
 let callbackRegistered = false;
 let authListener: ((newCredentials: JWTInput) => Promise<void>) | undefined =
   undefined;
@@ -115,12 +123,23 @@ export function isTelemetrySdkInitialized(): boolean {
 }
 
 export function bufferTelemetryEvent(fn: () => void | Promise<void>): void {
+  if (telemetryDisabled) {
+    return;
+  }
   if (telemetryInitialized) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fn();
   } else {
     telemetryBuffer.push(fn);
   }
+}
+
+function markTelemetryDisabled(): void {
+  telemetryDisabled = true;
+  // Drop anything that was buffered before we knew telemetry was off — those
+  // closures retain their captured event objects (which can include the full
+  // conversation contents on API events) and would otherwise live forever.
+  telemetryBuffer.length = 0;
 }
 
 async function flushTelemetryBuffer(): Promise<void> {
@@ -167,8 +186,17 @@ export async function initializeTelemetry(
   credentials?: JWTInput,
 ): Promise<void> {
   if (!config.getTelemetryEnabled()) {
+    markTelemetryDisabled();
     return;
   }
+
+  // Reset the disabled flag in case a previous init had set it (e.g. config
+  // reload, or a test that re-enables telemetry without an intervening
+  // shutdown). Every code path past this point either flips
+  // `telemetryInitialized` true on success, calls `markTelemetryDisabled()`
+  // again on a permanent-off branch, or leaves the flag false to let the
+  // deferred-init path keep buffering until post-auth re-init.
+  telemetryDisabled = false;
 
   if (telemetryInitialized) {
     if (
@@ -188,6 +216,7 @@ export async function initializeTelemetry(
         'CLI authentication is only supported with in-process exporters. ' +
         'Disabling telemetry.',
     );
+    markTelemetryDisabled();
     return;
   }
 
@@ -417,47 +446,52 @@ export async function shutdownTelemetry(
   config: Config,
   fromProcessExit = true,
 ): Promise<void> {
-  if (!telemetryInitialized || !sdk) {
-    return;
-  }
-  try {
-    ClearcutLogger.getInstance()?.shutdown();
-    await sdk.shutdown();
-    if (config.getDebugMode() && fromProcessExit) {
-      debugLogger.log('OpenTelemetry SDK shut down successfully.');
+  // Tear down the OTel SDK only if it was actually started.
+  if (telemetryInitialized && sdk) {
+    try {
+      ClearcutLogger.getInstance()?.shutdown();
+      await sdk.shutdown();
+      if (config.getDebugMode() && fromProcessExit) {
+        debugLogger.log('OpenTelemetry SDK shut down successfully.');
+      }
+    } catch (error) {
+      debugLogger.error('Error shutting down SDK:', error);
     }
-  } catch (error) {
-    debugLogger.error('Error shutting down SDK:', error);
-  } finally {
-    telemetryInitialized = false;
-    sdk = undefined;
-    // Fully reset the global APIs to allow for re-initialization.
-    // This is primarily for testing environments where the SDK is started
-    // and stopped multiple times in the same process.
+    // Reset the global OTel APIs so a subsequent init can re-register them.
     trace.disable();
     context.disable();
     metrics.disable();
     propagation.disable();
     diag.disable();
-    if (authListener) {
-      authEvents.off('post_auth', authListener);
-      authListener = undefined;
-    }
-    if (keychainAvailabilityListener) {
-      coreEvents.off(
-        CoreEvent.TelemetryKeychainAvailability,
-        keychainAvailabilityListener,
-      );
-      keychainAvailabilityListener = undefined;
-    }
-    if (tokenStorageTypeListener) {
-      coreEvents.off(
-        CoreEvent.TelemetryTokenStorageType,
-        tokenStorageTypeListener,
-      );
-      tokenStorageTypeListener = undefined;
-    }
-    callbackRegistered = false;
-    activeTelemetryEmail = undefined;
   }
+
+  // Always reset module-level state and detach listeners, even when the SDK
+  // never finished initializing. This covers two cases that would otherwise
+  // leak: tests (and any caller) that init/shutdown multiple times, and the
+  // deferred-init path (CLI auth waiting for credentials) where
+  // `authListener` is registered before `telemetryInitialized` is flipped.
+  telemetryInitialized = false;
+  sdk = undefined;
+  telemetryDisabled = false;
+  telemetryBuffer.length = 0;
+  if (authListener) {
+    authEvents.off('post_auth', authListener);
+    authListener = undefined;
+  }
+  if (keychainAvailabilityListener) {
+    coreEvents.off(
+      CoreEvent.TelemetryKeychainAvailability,
+      keychainAvailabilityListener,
+    );
+    keychainAvailabilityListener = undefined;
+  }
+  if (tokenStorageTypeListener) {
+    coreEvents.off(
+      CoreEvent.TelemetryTokenStorageType,
+      tokenStorageTypeListener,
+    );
+    tokenStorageTypeListener = undefined;
+  }
+  callbackRegistered = false;
+  activeTelemetryEmail = undefined;
 }


### PR DESCRIPTION
## Summary

`telemetryBuffer` (in `packages/core/src/telemetry/sdk.ts`) grows unbounded when telemetry is disabled. Every `log*` call pushes a closure capturing its event; on API/MCP errors that's `ApiResponseEvent`/`ApiErrorEvent` carrying the full pre-stringified conversation. Live debug session: 183 closures pinning ~2.5 GB live heap (56 copies of a 48 MB request body).

## Details

1. `bufferTelemetryEvent` short-circuits on a new `telemetryDisabled` flag, which also clears anything buffered at module-load time.
2. `Config`'s constructor always calls `initializeTelemetry` (was `if (this.telemetrySettings.enabled)`) so the flag actually gets set on the disabled path.

Distinct from merged #23281 — that fixed closure retention in `runInDevTraceSpan` from abandoned async generators. #23281 is in this branch's base; the buffer leak still reproduces.

## Related Issues

Fixes #21255

## How to Validate

```
npm test -w @google/gemini-cli-core -- src/telemetry/sdk.test.ts
```

Two new regression tests cover both permanent-disable paths (telemetry off; `useCollector` + `useCliAuth` conflict).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
  - [ ] Linux
