### PR TITLE
fix(cli): use os.homedir() for home directory warning check

### DIFF
--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -29,10 +29,9 @@ vi.mock('os', async (importOriginal) => {
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import('@google/gemini-cli-core')>();
+    await importOriginal<typeof import('@google-gemini-cli-core')>();
   return {
     ...actual,
-    homedir: () => os.homedir(),
     getCompatibilityWarnings: vi.fn().mockReturnValue([]),
     isHeadlessMode: vi.fn().mockReturnValue(false),
     WarningPriority: {
@@ -108,6 +107,60 @@ describe('getUserStartupWarnings', () => {
       const warnings = await getUserStartupWarnings({}, homeDir);
       expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
     });
+
+    it('should not return a warning when running in a subdirectory of home', async () => {
+      const subDir = path.join(homeDir, 'projects', 'my-app');
+      await fs.mkdir(subDir, { recursive: true });
+      const warnings = await getUserStartupWarnings({}, subDir);
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+
+    it('should not return a warning when home directory is a symlink and running in a subdirectory', async () => {
+      const realHome = path.join(testRootDir, 'real-home');
+      await fs.mkdir(realHome, { recursive: true });
+      const symlinkedHome = path.join(testRootDir, 'symlinked-home');
+      await fs.symlink(realHome, symlinkedHome);
+      vi.mocked(os.homedir).mockReturnValue(symlinkedHome);
+
+      const subDir = path.join(symlinkedHome, 'projects');
+      await fs.mkdir(subDir, { recursive: true });
+      const warnings = await getUserStartupWarnings({}, subDir);
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+
+    it('should return a warning when home directory is a symlink and running in it', async () => {
+      const realHome = path.join(testRootDir, 'real-home2');
+      await fs.mkdir(realHome, { recursive: true });
+      const symlinkedHome = path.join(testRootDir, 'symlinked-home2');
+      await fs.symlink(realHome, symlinkedHome);
+      vi.mocked(os.homedir).mockReturnValue(symlinkedHome);
+
+      const warnings = await getUserStartupWarnings({}, symlinkedHome);
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          id: 'home-directory',
+          message: expect.stringContaining(
+            'Warning you are running Gemini CLI in your home directory',
+          ),
+          priority: WarningPriority.Low,
+        }),
+      );
+    });
+
+    it('should not return a warning when GEMINI_CLI_HOME differs from os.homedir', async () => {
+      const projectDir = path.join(testRootDir, 'project');
+      await fs.mkdir(projectDir, { recursive: true });
+      vi.stubEnv('GEMINI_CLI_HOME', projectDir);
+
+      const warnings = await getUserStartupWarnings({}, projectDir);
+      expect(warnings.find((w) => w.id === 'home-directory')).toBeUndefined();
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRootDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   describe('root directory check', () => {

--- a/packages/cli/src/utils/userStartupWarnings.ts
+++ b/packages/cli/src/utils/userStartupWarnings.ts
@@ -5,10 +5,10 @@
  */
 
 import fs from 'node:fs/promises';
+import { homedir as osHomedir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import {
-  homedir,
   getCompatibilityWarnings,
   WarningPriority,
   type StartupWarning,
@@ -39,7 +39,7 @@ const homeDirectoryCheck: WarningCheck = {
     try {
       const [workspaceRealPath, homeRealPath] = await Promise.all([
         fs.realpath(workspaceRoot),
-        fs.realpath(homedir()),
+        fs.realpath(osHomedir()),
       ]);
 
       if (workspaceRealPath === homeRealPath) {


### PR DESCRIPTION
## Summary

The "running in home directory" warning was triggering incorrectly in subdirectories of home. The root cause: the warning check used the core `homedir()` helper, which respects the `GEMINI_CLI_HOME` environment variable. This is wrong because `GEMINI_CLI_HOME` is for configuring the config directory — it should not affect whether the user is literally in their OS home directory.

## Changes

**`packages/cli/src/utils/userStartupWarnings.ts`**
- Replace `homedir()` (from `@google/gemini-cli-core`) with `os.homedir()` (from `node:os`)
- The warning now always compares against the real OS home directory, regardless of `GEMINI_CLI_HOME`

**`packages/cli/src/utils/userStartupWarnings.test.ts`**
- Remove the `homedir: () => os.homedir()` mock passthrough (no longer needed)
- Add 4 new test cases:
  - Subdirectory of home — no warning
  - Symlinked home + subdirectory — no warning
  - Symlinked home (exact match) — warning shown
  - `GEMINI_CLI_HOME` differs from `os.homedir()` — no warning

Fixes #22309

## How to Validate

1. `npx vitest run packages/cli/src/utils/userStartupWarnings.test.ts` — all tests pass
2. Manual: run `gemini` from `~` — warning appears; from `~/some-project` — no warning

## Related

- #25890 — enhance shell command validation and add core tools allowlist (shares `userStartupWarnings.ts` but different concern)