### PR TITLE
feat(devtools)#25439: add console log filtering

### DIFF
--- a/packages/devtools/client/src/App.tsx
+++ b/packages/devtools/client/src/App.tsx
@@ -4,8 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { useDevToolsData, type ConsoleLog, type NetworkLog } from './hooks';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useDeferredValue,
+} from 'react';
+import { useDevToolsData, type ConsoleLog, type NetworkLog } from './hooks.js';
+import {
+  CONSOLE_LOG_TYPES,
+  countConsoleLogsByType,
+  filterConsoleLogs,
+  getConsoleLogTypeLabel,
+  isConsoleLogType,
+  type ConsoleLogTypeFilter,
+} from './consoleUtils.js';
 
 type ThemeMode = 'light' | 'dark' | null; // null means follow system
 
@@ -121,9 +135,17 @@ export default function App() {
             const timestamp = parsed.timestamp;
 
             if (type === 'console') {
+              const importedType = isConsoleLogType(payload.type)
+                ? payload.type
+                : 'log';
               consoleLogs.push({
-                ...payload,
-                type,
+                content:
+                  typeof payload.content === 'string' ? payload.content : '',
+                sessionId:
+                  typeof parsed.sessionId === 'string'
+                    ? parsed.sessionId
+                    : undefined,
+                type: importedType,
                 timestamp,
                 id: payload.id || Math.random().toString(36).substring(2, 11),
               });
@@ -134,7 +156,6 @@ export default function App() {
               if (!networkMap.has(id)) {
                 networkMap.set(id, {
                   ...payload,
-                  type,
                   timestamp,
                   id,
                 } as NetworkLog);
@@ -144,8 +165,7 @@ export default function App() {
                 networkMap.set(id, {
                   ...existing,
                   ...payload,
-                  // Ensure we don't overwrite the original timestamp or type
-                  type: existing.type,
+                  // Ensure we don't overwrite the original timestamp.
                   timestamp: existing.timestamp,
                 } as NetworkLog);
               }
@@ -607,6 +627,8 @@ function TabButton({
 
 // --- Console Components ---
 
+const CONSOLE_AUTO_FOLLOW_THRESHOLD_PX = 48;
+
 function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const content = log.content || '';
@@ -620,9 +642,37 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
 
   const isError = log.type === 'error';
   const isWarn = log.type === 'warn';
+  const isInfo = log.type === 'info';
+  const isDebug = log.type === 'debug';
   const bg = isError ? t.errorBg : isWarn ? t.warnBg : 'transparent';
   const color = isError ? t.errorText : isWarn ? t.warnText : t.text;
-  const icon = isError ? '❌' : isWarn ? '⚠️' : ' ';
+  const icon = isError
+    ? '❌'
+    : isWarn
+      ? '⚠️'
+      : isInfo
+        ? 'ℹ️'
+        : isDebug
+          ? '🐞'
+          : '•';
+  const iconColor = isError
+    ? t.errorText
+    : isWarn
+      ? t.warnText
+      : isInfo
+        ? t.accent
+        : t.textSecondary;
+  const badgeColor = isError
+    ? t.errorText
+    : isWarn
+      ? t.warnText
+      : isInfo
+        ? t.accent
+        : isDebug
+          ? t.textSecondary
+          : t.text;
+  const badgeBg = isError ? t.errorBg : isWarn ? t.warnBg : t.bgSecondary;
+  const typeLabel = getConsoleLogTypeLabel(log.type);
 
   let displayContent = content;
   if (needsCollapse && !isExpanded) {
@@ -647,6 +697,10 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
         alignItems: 'flex-start',
 
         gap: '8px',
+
+        contentVisibility: 'auto',
+
+        containIntrinsicSize: '72px',
       }}
     >
       <div
@@ -660,7 +714,10 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
           fontSize: '10px',
 
           marginTop: '2px',
+
+          color: iconColor,
         }}
+        title={typeLabel}
       >
         {icon}
       </div>
@@ -674,6 +731,46 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
           flexDirection: 'column',
         }}
       >
+        <div
+          style={{
+            display: 'flex',
+
+            alignItems: 'center',
+
+            gap: '8px',
+
+            marginBottom: '4px',
+          }}
+        >
+          <span
+            style={{
+              display: 'inline-flex',
+
+              alignItems: 'center',
+
+              borderRadius: '999px',
+
+              border: `1px solid ${t.border}`,
+
+              background: badgeBg,
+
+              color: badgeColor,
+
+              fontSize: '9px',
+
+              fontWeight: 700,
+
+              letterSpacing: '0.03em',
+
+              padding: '1px 6px',
+
+              textTransform: 'uppercase',
+            }}
+          >
+            {typeLabel}
+          </span>
+        </div>
+
         <div
           style={{
             whiteSpace: 'pre-wrap',
@@ -703,7 +800,8 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
         }}
       >
         {needsCollapse && (
-          <div
+          <button
+            type="button"
             onClick={() => setIsExpanded(!isExpanded)}
             style={{
               fontSize: '12px',
@@ -735,16 +833,17 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
               transition: 'all 0.1s',
             }}
             onMouseOver={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background = t.bgHover;
+              (e.currentTarget as HTMLButtonElement).style.background =
+                t.bgHover;
             }}
             onMouseOut={(e) => {
-              (e.currentTarget as HTMLDivElement).style.background =
+              (e.currentTarget as HTMLButtonElement).style.background =
                 t.bgSecondary;
             }}
             title={isExpanded ? 'Collapse' : 'Expand'}
           >
             {isExpanded ? '−' : '+'}
-          </div>
+          </button>
         )}
 
         <div
@@ -775,12 +874,115 @@ function ConsoleLogEntry({ log, t }: { log: ConsoleLog; t: ThemeColors }) {
   );
 }
 
+function ConsoleFilterChip({
+  label,
+  count,
+  active,
+  onClick,
+  t,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+  t: ThemeColors;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 10px',
+        borderRadius: '999px',
+        border: `1px solid ${active ? t.accent : t.border}`,
+        background: active ? t.accent : t.bg,
+        color: active ? '#fff' : t.text,
+        cursor: 'pointer',
+        fontSize: '11px',
+        fontWeight: 600,
+      }}
+    >
+      <span>{label}</span>
+      <span
+        style={{
+          borderRadius: '999px',
+          background: active ? 'rgba(255, 255, 255, 0.2)' : t.bgSecondary,
+          color: active ? '#fff' : t.textSecondary,
+          padding: '0 6px',
+          fontSize: '10px',
+          lineHeight: 1.6,
+        }}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
 function ConsoleView({ logs, t }: { logs: ConsoleLog[]; t: ThemeColors }) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const [typeFilter, setTypeFilter] = useState<ConsoleLogTypeFilter>('all');
+  const [isFollowingLatest, setIsFollowingLatest] = useState(true);
+
+  const consoleLogCounts = useMemo(() => countConsoleLogsByType(logs), [logs]);
+
+  const filteredLogs = useMemo(
+    () =>
+      filterConsoleLogs(logs, {
+        query: deferredSearchQuery,
+        type: typeFilter,
+      }),
+    [logs, deferredSearchQuery, typeFilter],
+  );
+
+  const hasActiveFilters =
+    searchQuery.trim().length > 0 || typeFilter !== 'all';
+  const shouldShowJumpToLatest = !isFollowingLatest && filteredLogs.length > 0;
+  const latestFilteredLogId = filteredLogs[filteredLogs.length - 1]?.id;
+  const visibleLogCountLabel =
+    filteredLogs.length === logs.length
+      ? `${logs.length} logs`
+      : `Showing ${filteredLogs.length} of ${logs.length} logs`;
+
+  const scrollToBottom = () => {
+    const list = listRef.current;
+    if (!list) {
+      return;
+    }
+
+    list.scrollTo({
+      top: list.scrollHeight,
+      behavior: 'auto',
+    });
+  };
+
+  const updateFollowState = () => {
+    const list = listRef.current;
+    if (!list) {
+      return;
+    }
+
+    const distanceFromBottom =
+      list.scrollHeight - list.scrollTop - list.clientHeight;
+    const isNearBottom = distanceFromBottom <= CONSOLE_AUTO_FOLLOW_THRESHOLD_PX;
+
+    setIsFollowingLatest((previousValue) =>
+      previousValue === isNearBottom ? previousValue : isNearBottom,
+    );
+  };
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [logs.length]);
+    if (!isFollowingLatest) {
+      return;
+    }
+
+    scrollToBottom();
+  }, [latestFilteredLogId, isFollowingLatest]);
 
   if (logs.length === 0) {
     return (
@@ -806,8 +1008,9 @@ function ConsoleView({ logs, t }: { logs: ConsoleLog[]; t: ThemeColors }) {
     <div
       style={{
         flex: 1,
-
-        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
 
         fontFamily:
           'SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace',
@@ -817,11 +1020,163 @@ function ConsoleView({ logs, t }: { logs: ConsoleLog[]; t: ThemeColors }) {
         fontSize: '12px',
       }}
     >
-      {logs.map((log) => (
-        <ConsoleLogEntry key={log.id} log={log} t={t} />
-      ))}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+          padding: '8px',
+          background: t.bgSecondary,
+          borderBottom: `1px solid ${t.border}`,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            gap: '8px',
+            alignItems: 'center',
+          }}
+        >
+          <input
+            type="text"
+            placeholder="Search log content or severity..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            style={{
+              flex: 1,
+              boxSizing: 'border-box',
+              padding: '6px 10px',
+              background: t.bg,
+              color: t.text,
+              border: `1px solid ${t.border}`,
+              borderRadius: '6px',
+              fontSize: '12px',
+            }}
+          />
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearchQuery('');
+                setTypeFilter('all');
+              }}
+              style={{
+                padding: '6px 10px',
+                borderRadius: '6px',
+                border: `1px solid ${t.border}`,
+                background: t.bg,
+                color: t.text,
+                cursor: 'pointer',
+                fontSize: '11px',
+                fontWeight: 600,
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
 
-      <div ref={bottomRef} />
+        <div
+          style={{
+            display: 'flex',
+            gap: '6px',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+          }}
+        >
+          <ConsoleFilterChip
+            label="All"
+            count={logs.length}
+            active={typeFilter === 'all'}
+            onClick={() => setTypeFilter('all')}
+            t={t}
+          />
+          {CONSOLE_LOG_TYPES.map((logType) => (
+            <ConsoleFilterChip
+              key={logType}
+              label={getConsoleLogTypeLabel(logType)}
+              count={consoleLogCounts[logType]}
+              active={typeFilter === logType}
+              onClick={() =>
+                setTypeFilter((previousValue) =>
+                  previousValue === logType ? 'all' : logType,
+                )
+              }
+              t={t}
+            />
+          ))}
+          <span
+            style={{
+              marginLeft: 'auto',
+              color: t.textSecondary,
+              fontSize: '11px',
+            }}
+          >
+            {visibleLogCountLabel}
+          </span>
+          <span
+            style={{
+              color: isFollowingLatest ? t.textSecondary : t.accent,
+              fontSize: '11px',
+              fontWeight: 600,
+            }}
+          >
+            {isFollowingLatest ? 'Following live output' : 'Auto-follow paused'}
+          </span>
+        </div>
+      </div>
+
+      <div
+        ref={listRef}
+        onScroll={updateFollowState}
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+        }}
+      >
+        {filteredLogs.length > 0 ? (
+          filteredLogs.map((log) => (
+            <ConsoleLogEntry key={log.id} log={log} t={t} />
+          ))
+        ) : (
+          <div
+            style={{
+              padding: '20px',
+              color: t.textSecondary,
+              fontSize: '11px',
+              textAlign: 'center',
+            }}
+          >
+            No logs match the current filters
+          </div>
+        )}
+      </div>
+
+      {shouldShowJumpToLatest && (
+        <button
+          type="button"
+          onClick={() => {
+            setIsFollowingLatest(true);
+            scrollToBottom();
+          }}
+          style={{
+            position: 'absolute',
+            right: '16px',
+            bottom: '16px',
+            padding: '8px 12px',
+            borderRadius: '999px',
+            border: `1px solid ${t.accent}`,
+            background: t.accent,
+            color: '#fff',
+            cursor: 'pointer',
+            fontSize: '11px',
+            fontWeight: 700,
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.2)',
+          }}
+        >
+          Jump to latest
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/devtools/client/src/consoleUtils.test.ts
+++ b/packages/devtools/client/src/consoleUtils.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { InspectorConsoleLog } from '../../src/types.js';
+import {
+  countConsoleLogsByType,
+  filterConsoleLogs,
+  getConsoleLogTypeLabel,
+  isConsoleLogType,
+} from './consoleUtils.js';
+
+function createLog(
+  overrides: Partial<InspectorConsoleLog>,
+): InspectorConsoleLog {
+  return {
+    id: overrides.id ?? 'log-id',
+    timestamp: overrides.timestamp ?? 1,
+    type: overrides.type ?? 'log',
+    content: overrides.content ?? 'message',
+    sessionId: overrides.sessionId,
+  };
+}
+
+describe('consoleUtils', () => {
+  describe('isConsoleLogType', () => {
+    it('accepts known console log types', () => {
+      expect(isConsoleLogType('error')).toBe(true);
+      expect(isConsoleLogType('warn')).toBe(true);
+      expect(isConsoleLogType('info')).toBe(true);
+      expect(isConsoleLogType('debug')).toBe(true);
+      expect(isConsoleLogType('log')).toBe(true);
+    });
+
+    it('rejects unknown values', () => {
+      expect(isConsoleLogType('console')).toBe(false);
+      expect(isConsoleLogType('trace')).toBe(false);
+      expect(isConsoleLogType(null)).toBe(false);
+    });
+  });
+
+  describe('getConsoleLogTypeLabel', () => {
+    it('returns a human readable label', () => {
+      expect(getConsoleLogTypeLabel('warn')).toBe('Warning');
+    });
+  });
+
+  describe('countConsoleLogsByType', () => {
+    it('returns counts for each log type', () => {
+      const logs: InspectorConsoleLog[] = [
+        createLog({ type: 'error', id: '1' }),
+        createLog({ type: 'error', id: '2' }),
+        createLog({ type: 'warn', id: '3' }),
+        createLog({ type: 'debug', id: '4' }),
+      ];
+
+      expect(countConsoleLogsByType(logs)).toEqual({
+        error: 2,
+        warn: 1,
+        info: 0,
+        debug: 1,
+        log: 0,
+      });
+    });
+  });
+
+  describe('filterConsoleLogs', () => {
+    const logs: InspectorConsoleLog[] = [
+      createLog({
+        id: '1',
+        type: 'error',
+        content: 'Request failed with status 500',
+      }),
+      createLog({
+        id: '2',
+        type: 'warn',
+        content: 'Retrying request after backoff',
+      }),
+      createLog({
+        id: '3',
+        type: 'debug',
+        content: 'Auth token refresh complete',
+      }),
+      createLog({
+        id: '4',
+        type: 'log',
+        content: 'Server started successfully',
+      }),
+    ];
+
+    it('filters by selected log type', () => {
+      expect(filterConsoleLogs(logs, { query: '', type: 'warn' })).toEqual([
+        logs[1],
+      ]);
+    });
+
+    it('matches search text case-insensitively', () => {
+      expect(
+        filterConsoleLogs(logs, { query: 'STATUS 500', type: 'all' }),
+      ).toEqual([logs[0]]);
+    });
+
+    it('matches severity aliases from classification terms', () => {
+      expect(
+        filterConsoleLogs(logs, { query: 'warning retrying', type: 'all' }),
+      ).toEqual([logs[1]]);
+    });
+
+    it('combines text search with the selected type filter', () => {
+      expect(
+        filterConsoleLogs(logs, { query: 'request', type: 'error' }),
+      ).toEqual([logs[0]]);
+      expect(
+        filterConsoleLogs(logs, { query: 'request', type: 'debug' }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/devtools/client/src/consoleUtils.ts
+++ b/packages/devtools/client/src/consoleUtils.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InspectorConsoleLog } from '../../src/types.js';
+
+export const CONSOLE_LOG_TYPES = [
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'log',
+] as const;
+
+export type ConsoleLogType = (typeof CONSOLE_LOG_TYPES)[number];
+export type ConsoleLogTypeFilter = ConsoleLogType | 'all';
+
+const CONSOLE_LOG_TYPE_LABELS: Record<ConsoleLogType, string> = {
+  error: 'Error',
+  warn: 'Warning',
+  info: 'Info',
+  debug: 'Debug',
+  log: 'Log',
+};
+
+const CONSOLE_LOG_TYPE_SEARCH_TERMS: Record<ConsoleLogType, string[]> = {
+  error: ['error', 'errors', 'failure', 'failed'],
+  warn: ['warn', 'warning', 'warnings'],
+  info: ['info', 'information'],
+  debug: ['debug', 'trace'],
+  log: ['log', 'logs', 'output'],
+};
+
+function createEmptyConsoleLogCounts(): Record<ConsoleLogType, number> {
+  return {
+    error: 0,
+    warn: 0,
+    info: 0,
+    debug: 0,
+    log: 0,
+  };
+}
+
+function getConsoleLogSearchText(log: InspectorConsoleLog): string {
+  return [
+    log.content,
+    log.type,
+    getConsoleLogTypeLabel(log.type),
+    ...CONSOLE_LOG_TYPE_SEARCH_TERMS[log.type],
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
+export function isConsoleLogType(value: unknown): value is ConsoleLogType {
+  return (
+    typeof value === 'string' &&
+    (CONSOLE_LOG_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function getConsoleLogTypeLabel(type: ConsoleLogType): string {
+  return CONSOLE_LOG_TYPE_LABELS[type];
+}
+
+export function countConsoleLogsByType(
+  logs: InspectorConsoleLog[],
+): Record<ConsoleLogType, number> {
+  return logs.reduce((counts, log) => {
+    counts[log.type] += 1;
+    return counts;
+  }, createEmptyConsoleLogCounts());
+}
+
+export function filterConsoleLogs(
+  logs: InspectorConsoleLog[],
+  options: {
+    query: string;
+    type: ConsoleLogTypeFilter;
+  },
+): InspectorConsoleLog[] {
+  const trimmedQuery = options.query.trim().toLowerCase();
+  const queryTokens = trimmedQuery.length > 0 ? trimmedQuery.split(/\s+/) : [];
+
+  return logs.filter((log) => {
+    if (options.type !== 'all' && log.type !== options.type) {
+      return false;
+    }
+
+    if (queryTokens.length === 0) {
+      return true;
+    }
+
+    const searchText = getConsoleLogSearchText(log);
+    return queryTokens.every((token) => searchText.includes(token));
+  });
+}

--- a/packages/devtools/client/src/main.tsx
+++ b/packages/devtools/client/src/main.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import App from './App.js';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -13,7 +13,10 @@
   },
   "scripts": {
     "build": "npm run build:client && tsc -p tsconfig.build.json",
-    "build:client": "node esbuild.client.js"
+    "build:client": "node esbuild.client.js",
+    "test": "vitest run client/src/consoleUtils.test.ts",
+    "test:ci": "vitest run client/src/consoleUtils.test.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- add severity chips and text search to the devtools console tab
- show per-severity counts and clearer badges for console entries
- stop forcing smooth auto-scroll on every new log and add a jump-to-latest action when follow mode is paused
- normalize imported console logs so filtering works for imported sessions too
- add devtools tests/typecheck coverage for the new console filter helpers

## Why
Issue #25439 asks for a better way to troubleshoot large log streams. The existing console view rendered every entry with no classification filter and always smooth-scrolled on new logs, which made long sessions noisy and harder to inspect.

## Validation
- `npm run test --workspace @google/gemini-cli-devtools`
- `npm run typecheck --workspace @google/gemini-cli-devtools`
- `npm run build --workspace @google/gemini-cli-devtools`
- `npx eslint packages/devtools/client/src/App.tsx packages/devtools/client/src/consoleUtils.ts packages/devtools/client/src/consoleUtils.test.ts packages/devtools/client/src/main.tsx --max-warnings 0`
- `npm run lint:all`

Fixes #25439
