### PR TITLE
fix(acp): recognise structured ENOENT codes and broader not-found phrasings

### DIFF
--- a/packages/cli/src/acp/acpFileSystemService.test.ts
+++ b/packages/cli/src/acp/acpFileSystemService.test.ts
@@ -196,6 +196,31 @@ describe('AcpFileSystemService', () => {
         message: 'opaque server message',
       });
     });
+
+    it('should preserve the message when a structured ENOENT error is a plain (non-Error) object', async () => {
+      service = new AcpFileSystemService(
+        mockConnection,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        mockFallback,
+        '/path/to',
+      );
+      // JSON-RPC clients often surface error responses as plain objects
+      // (not Error instances). The `message` field must still be preserved
+      // — without explicit handling, `String({})` collapses to
+      // '[object Object]' and the real diagnostic is lost.
+      mockConnection.readTextFile.mockRejectedValue({
+        code: 'ENOENT',
+        message: 'plain object error message',
+      });
+
+      await expect(
+        service.readTextFile('/path/to/missing'),
+      ).rejects.toMatchObject({
+        code: 'ENOENT',
+        message: 'plain object error message',
+      });
+    });
   });
 
   describe('writeTextFile', () => {

--- a/packages/cli/src/acp/acpFileSystemService.test.ts
+++ b/packages/cli/src/acp/acpFileSystemService.test.ts
@@ -145,6 +145,57 @@ describe('AcpFileSystemService', () => {
         message: 'Resource not found for document',
       });
     });
+
+    it.each([
+      {
+        name: 'snake_case "not_found"',
+        message: 'fs/read_text_file not_found: missing path',
+      },
+      {
+        name: 'phrase "file not found"',
+        message: 'agent: file not found at /tmp/x',
+      },
+    ])(
+      'should throw normalized ENOENT for $name message variants',
+      async ({ message }) => {
+        service = new AcpFileSystemService(
+          mockConnection,
+          'session-1',
+          { readTextFile: true, writeTextFile: true },
+          mockFallback,
+          '/path/to',
+        );
+        mockConnection.readTextFile.mockRejectedValue(new Error(message));
+
+        await expect(
+          service.readTextFile('/path/to/missing'),
+        ).rejects.toMatchObject({
+          code: 'ENOENT',
+          message,
+        });
+      },
+    );
+
+    it('should throw normalized ENOENT when the ACP error carries a structured `code: "ENOENT"` field', async () => {
+      service = new AcpFileSystemService(
+        mockConnection,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        mockFallback,
+        '/path/to',
+      );
+      const structured = Object.assign(new Error('opaque server message'), {
+        code: 'ENOENT',
+      });
+      mockConnection.readTextFile.mockRejectedValue(structured);
+
+      await expect(
+        service.readTextFile('/path/to/missing'),
+      ).rejects.toMatchObject({
+        code: 'ENOENT',
+        message: 'opaque server message',
+      });
+    });
   });
 
   describe('writeTextFile', () => {

--- a/packages/cli/src/acp/acpFileSystemService.ts
+++ b/packages/cli/src/acp/acpFileSystemService.ts
@@ -35,11 +35,27 @@ export class AcpFileSystemService implements FileSystemService {
 
   private normalizeFileSystemError(err: unknown): never {
     const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // Structured signal first: a JSON-RPC error object's `code` field is the
+    // authoritative not-found indicator when the ACP server emits it. Falls
+    // back to substring matching below for servers that haven't migrated to
+    // structured error codes yet.
+    if (err && typeof err === 'object' && 'code' in err) {
+      const code = (err as { code?: unknown }).code;
+      if (code === 'ENOENT') {
+        const newErr = new Error(errorMessage) as NodeJS.ErrnoException;
+        newErr.code = 'ENOENT';
+        throw newErr;
+      }
+    }
+
     if (
       errorMessage.includes('Resource not found') ||
       errorMessage.includes('ENOENT') ||
       errorMessage.includes('does not exist') ||
-      errorMessage.includes('No such file')
+      errorMessage.includes('No such file') ||
+      errorMessage.includes('not_found') ||
+      errorMessage.includes('file not found')
     ) {
       const newErr = new Error(errorMessage) as NodeJS.ErrnoException;
       newErr.code = 'ENOENT';

--- a/packages/cli/src/acp/acpFileSystemService.ts
+++ b/packages/cli/src/acp/acpFileSystemService.ts
@@ -34,7 +34,18 @@ export class AcpFileSystemService implements FileSystemService {
   }
 
   private normalizeFileSystemError(err: unknown): never {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    // Resolve a useful message for both Error instances and plain objects
+    // that carry a `message` field (a common shape for JSON-RPC error
+    // responses). Avoids `String({}) === '[object Object]'` swallowing
+    // the real message for non-Error rejections.
+    const errMessage = (() => {
+      if (err instanceof Error) return err.message;
+      if (err && typeof err === 'object' && 'message' in err) {
+        const m = (err as { message?: unknown }).message;
+        if (typeof m === 'string') return m;
+      }
+      return String(err);
+    })();
 
     // Structured signal first: a JSON-RPC error object's `code` field is the
     // authoritative not-found indicator when the ACP server emits it. Falls
@@ -43,21 +54,21 @@ export class AcpFileSystemService implements FileSystemService {
     if (err && typeof err === 'object' && 'code' in err) {
       const code = (err as { code?: unknown }).code;
       if (code === 'ENOENT') {
-        const newErr = new Error(errorMessage) as NodeJS.ErrnoException;
+        const newErr = new Error(errMessage) as NodeJS.ErrnoException;
         newErr.code = 'ENOENT';
         throw newErr;
       }
     }
 
     if (
-      errorMessage.includes('Resource not found') ||
-      errorMessage.includes('ENOENT') ||
-      errorMessage.includes('does not exist') ||
-      errorMessage.includes('No such file') ||
-      errorMessage.includes('not_found') ||
-      errorMessage.includes('file not found')
+      errMessage.includes('Resource not found') ||
+      errMessage.includes('ENOENT') ||
+      errMessage.includes('does not exist') ||
+      errMessage.includes('No such file') ||
+      errMessage.includes('not_found') ||
+      errMessage.includes('file not found')
     ) {
-      const newErr = new Error(errorMessage) as NodeJS.ErrnoException;
+      const newErr = new Error(errMessage) as NodeJS.ErrnoException;
       newErr.code = 'ENOENT';
       throw newErr;
     }


### PR DESCRIPTION
## Problem

`AcpFileSystemService.normalizeFileSystemError` classifies a read failure as
file-not-found by string-matching the message against four exact substrings:

```ts
errorMessage.includes('Resource not found') ||
errorMessage.includes('ENOENT') ||
errorMessage.includes('does not exist') ||
errorMessage.includes('No such file')
```

JSON-RPC error responses also carry a structured `code` field, but it was
ignored. Common phrasings that don't match any of those four substrings —
notably `not_found` (snake_case) and `file not found` (no capitalisation, no
"No such") — fall through to the generic `throw err` branch.

The downstream effect is severe. The `write-file` tool calls `readTextFile`
first to check existence, and a non-ENOENT-shaped error short-circuits the
call site with `error: { code: FILE_WRITE_FAILURE }` rather than
`fileExists: false` (see
[`packages/core/src/tools/write-file.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/tools/write-file.ts#L102-L141)).
The agent's reasoning loop then commonly hallucinates "the tool succeeded"
and reports success in the final `stop_reason: end_turn` response — a
silent failure pattern that's hard to detect from outside the CLI.

## Fix

This PR makes `normalizeFileSystemError`:

1. **Prefer the structured signal**: when the rejection carries `code: 'ENOENT'`,
   recognise it as ENOENT regardless of message wording. Cheapest signal,
   matches what well-behaved JSON-RPC servers should emit.
2. **Relax the legacy substring matcher**: also accept `not_found` and
   `file not found` phrasings. These are common in JSON-RPC servers in the
   wild and appear in the agent-client-protocol ecosystem in particular.

The existing four substrings are preserved for backward compatibility.

## Tests added

In `packages/cli/src/acp/acpFileSystemService.test.ts`:

- `it.each` over the two new message variants (`not_found` snake_case and
  `file not found` lowercase).
- A separate test for the structured-code path: server throws `Object.assign(new Error('opaque server message'), { code: 'ENOENT' })` and the matcher recognises it.

`npm run test:ci -- src/acp/acpFileSystemService` → **13 passed (3 new + 10 existing)**.

## How this surfaced

Discovered while running gemini-cli in ACP mode against a third-party stdio
JSON-RPC server. The server raised
`fs/read_text_file not_found: file not found: <path>` for a non-existent
file. None of the four current substrings matched, so every gemini-cli
write to that worktree silently produced no file changes. After this patch
a single-file write smoke against the same server goes from ~9 minutes
with three server restarts (recovered by chance) to ~36 seconds clean.

## Compatibility

- Behaviour for the four pre-existing substrings is unchanged.
- The two new substrings (`not_found`, `file not found`) and the structured
  `code === 'ENOENT'` path are strictly additive — they only convert
  errors that previously fell through to `throw err` into ENOENT-coded
  errors, never the reverse. No risk of regression for existing servers
  that already produce one of the four recognised messages.


Fixes #26448.
