### PR TITLE
feat: add minimal V8 heap snapshot utility for memory diagnostics

### DIFF
--- a/packages/core/src/telemetry/heap-snapshot.test.ts
+++ b/packages/core/src/telemetry/heap-snapshot.test.ts
@@ -8,33 +8,42 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import v8 from 'node:v8';
 import fs from 'node:fs';
 import { captureHeapSnapshot } from './heap-snapshot.js';
+import { debugLogger } from '../utils/debugLogger.js';
 
 vi.mock('node:v8');
 vi.mock('node:fs');
+vi.mock('../utils/debugLogger.js', () => ({
+  debugLogger: {
+    error: vi.fn(),
+  },
+}));
 
 describe('heap-snapshot', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('should capture a heap snapshot to the correct directory', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+  it('should capture a heap snapshot to a secure directory', () => {
+    vi.mocked(fs.mkdtempSync).mockReturnValue('/tmp/gemini-heap-abc123');
 
     const filePath = captureHeapSnapshot();
 
-    expect(filePath).toContain('gemini-snapshots');
+    expect(filePath).toContain('gemini-heap-abc123');
     expect(filePath).toContain('.heapsnapshot');
     expect(v8.writeHeapSnapshot).toHaveBeenCalledWith(filePath);
   });
 
-  it('should create the snapshots directory if it does not exist', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+  it('should return null and log an error if capture fails', () => {
+    vi.mocked(fs.mkdtempSync).mockImplementation(() => {
+      throw new Error('Disk full');
+    });
 
-    captureHeapSnapshot();
+    const result = captureHeapSnapshot();
 
-    expect(fs.mkdirSync).toHaveBeenCalledWith(
-      expect.stringContaining('gemini-snapshots'),
-      { recursive: true },
+    expect(result).toBeNull();
+    expect(debugLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to capture heap snapshot'),
+      expect.any(Error),
     );
   });
 });

--- a/packages/core/src/telemetry/heap-snapshot.test.ts
+++ b/packages/core/src/telemetry/heap-snapshot.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import v8 from 'node:v8';
+import fs from 'node:fs';
+import { captureHeapSnapshot } from './heap-snapshot.js';
+
+vi.mock('node:v8');
+vi.mock('node:fs');
+
+describe('heap-snapshot', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should capture a heap snapshot to the correct directory', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const filePath = captureHeapSnapshot();
+
+    expect(filePath).toContain('gemini-snapshots');
+    expect(filePath).toContain('.heapsnapshot');
+    expect(v8.writeHeapSnapshot).toHaveBeenCalledWith(filePath);
+  });
+
+  it('should create the snapshots directory if it does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    captureHeapSnapshot();
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('gemini-snapshots'),
+      { recursive: true },
+    );
+  });
+});

--- a/packages/core/src/telemetry/heap-snapshot.ts
+++ b/packages/core/src/telemetry/heap-snapshot.ts
@@ -7,28 +7,32 @@
 import v8 from 'node:v8';
 import path from 'node:path';
 import fs from 'node:fs';
-import { tmpdir } from '../utils/paths.js';
+import os from 'node:os';
+import { debugLogger } from '../utils/debugLogger.js';
 
 /**
- * Minimal utility to capture a V8 heap snapshot.
- * Snapshots are saved to the system temporary directory.
+ * Utility to capture a V8 heap snapshot.
+ * Snapshots are saved to a secure, uniquely named temporary directory.
  *
- * @returns The absolute path to the generated .heapsnapshot file.
+ * @returns The absolute path to the generated .heapsnapshot file, or null if it failed.
  */
-export function captureHeapSnapshot(): string {
-  const timestamp = Date.now();
-  const filename = `gemini-heap-${timestamp}.heapsnapshot`;
-  const snapshotsDir = path.join(tmpdir(), 'gemini-snapshots');
+export function captureHeapSnapshot(): string | null {
+  try {
+    const timestamp = Date.now();
+    const filename = `gemini-heap-${timestamp}.heapsnapshot`;
 
-  // Ensure directory exists
-  if (!fs.existsSync(snapshotsDir)) {
-    fs.mkdirSync(snapshotsDir, { recursive: true });
+    // Use mkdtempSync for a secure, uniquely named directory (mitigates symlink attacks)
+    const snapshotsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-heap-'));
+    const filePath = path.join(snapshotsDir, filename);
+
+    // Note: v8.writeHeapSnapshot is a synchronous, blocking operation.
+    // This is intentional during diagnostics to capture a consistent heap state.
+    v8.writeHeapSnapshot(filePath);
+
+    return filePath;
+  } catch (error) {
+    // Telemetry/diagnostic failures should not crash the application
+    debugLogger.error('Failed to capture heap snapshot:', error);
+    return null;
   }
-
-  const filePath = path.join(snapshotsDir, filename);
-
-  // v8.writeHeapSnapshot returns the filename it wrote to
-  v8.writeHeapSnapshot(filePath);
-
-  return filePath;
 }

--- a/packages/core/src/telemetry/heap-snapshot.ts
+++ b/packages/core/src/telemetry/heap-snapshot.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import v8 from 'node:v8';
+import path from 'node:path';
+import fs from 'node:fs';
+import { tmpdir } from '../utils/paths.js';
+
+/**
+ * Minimal utility to capture a V8 heap snapshot.
+ * Snapshots are saved to the system temporary directory.
+ *
+ * @returns The absolute path to the generated .heapsnapshot file.
+ */
+export function captureHeapSnapshot(): string {
+  const timestamp = Date.now();
+  const filename = `gemini-heap-${timestamp}.heapsnapshot`;
+  const snapshotsDir = path.join(tmpdir(), 'gemini-snapshots');
+
+  // Ensure directory exists
+  if (!fs.existsSync(snapshotsDir)) {
+    fs.mkdirSync(snapshotsDir, { recursive: true });
+  }
+
+  const filePath = path.join(snapshotsDir, filename);
+
+  // v8.writeHeapSnapshot returns the filename it wrote to
+  v8.writeHeapSnapshot(filePath);
+
+  return filePath;
+}

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -92,6 +92,7 @@ export {
   startGlobalMemoryMonitoring,
   stopGlobalMemoryMonitoring,
 } from './memory-monitor.js';
+export { captureHeapSnapshot } from './heap-snapshot.js';
 export type { MemorySnapshot, ProcessMetrics } from './memory-monitor.js';
 export {
   EventLoopMonitor,

--- a/packages/core/src/telemetry/memory-monitor.ts
+++ b/packages/core/src/telemetry/memory-monitor.ts
@@ -389,9 +389,9 @@ export class MemoryMonitor {
 
   /**
    * Capture a V8 heap snapshot for memory diagnostics.
-   * @returns The absolute path to the generated .heapsnapshot file.
+   * @returns The absolute path to the generated .heapsnapshot file, or null if it failed.
    */
-  captureHeapSnapshot(): string {
+  captureHeapSnapshot(): string | null {
     return captureHeapSnapshot();
   }
 

--- a/packages/core/src/telemetry/memory-monitor.ts
+++ b/packages/core/src/telemetry/memory-monitor.ts
@@ -17,6 +17,7 @@ import {
   isPerformanceMonitoringActive,
 } from './metrics.js';
 import { RateLimiter } from './rate-limiter.js';
+import { captureHeapSnapshot } from './heap-snapshot.js';
 
 export interface MemorySnapshot {
   timestamp: number;
@@ -384,6 +385,14 @@ export class MemoryMonitor {
    */
   resetHighWaterMarks(): void {
     this.highWaterMarkTracker.resetAllHighWaterMarks();
+  }
+
+  /**
+   * Capture a V8 heap snapshot for memory diagnostics.
+   * @returns The absolute path to the generated .heapsnapshot file.
+   */
+  captureHeapSnapshot(): string {
+    return captureHeapSnapshot();
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR introduces a minimal utility to capture V8 heap snapshots in the Gemini CLI. This is a foundational feature for diagnosing memory leaks and OOM crashes, providing the necessary diagnostic data for deep analysis using Chrome DevTools.

## Details

- Implemented `captureHeapSnapshot()` in `packages/core/src/telemetry/heap-snapshot.ts`.
- Snapshots are saved to a dedicated `gemini-snapshots` directory in the system's temporary folder.
- Integrated the utility into the `MemoryMonitor` class.
- Added unit tests and verified the implementation with manual end-to-end testing.
- The design prioritizes simplicity and low maintenance while providing a critical debugging 'hook'.

## Related Issues

Closes #23422

## How to Validate

1. **Unit Tests**:
   ```bash
   npm test -w @google/gemini-cli-core -- src/telemetry/heap-snapshot.test.ts
   ```
2. **Manual Verification**:
   - Run the CLI or a script that calls `captureHeapSnapshot()`.
   - Check the system temporary directory (e.g., `/tmp/gemini-snapshots/` or equivalent).
   - Verify that a `.heapsnapshot` file exists and has a non-zero size.
   - (Optional) Load the file in Chrome DevTools -> Memory tab to confirm it's valid.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
