### PR TITLE
perf: skip redundant GEMINI.md loading in partialConfig

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1174,6 +1174,20 @@ describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {
       ['.git'], // boundaryMarkers
     );
   });
+
+  it('should NOT call loadServerHierarchicalMemory when skipMemoryLoad is true', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      experimental: { jitContext: false },
+    });
+
+    const argv = await parseArguments(settings);
+    await loadCliConfig(settings, 'session-id', argv, {
+      skipMemoryLoad: true,
+    });
+
+    expect(ServerConfig.loadServerHierarchicalMemory).not.toHaveBeenCalled();
+  });
 });
 
 describe('mergeMcpServers', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -560,6 +560,7 @@ export interface LoadCliConfigOptions {
   };
   worktreeSettings?: WorktreeSettings;
   skipExtensions?: boolean;
+  skipMemoryLoad?: boolean;
 }
 
 export async function loadCliConfig(
@@ -568,7 +569,12 @@ export async function loadCliConfig(
   argv: CliArgs,
   options: LoadCliConfigOptions = {},
 ): Promise<Config> {
-  const { cwd = process.cwd(), projectHooks, skipExtensions = false } = options;
+  const {
+    cwd = process.cwd(),
+    projectHooks,
+    skipExtensions = false,
+    skipMemoryLoad = false,
+  } = options;
   const debugMode = isDebugMode(argv);
 
   const worktreeSettings =
@@ -681,7 +687,7 @@ export async function loadCliConfig(
   const finalExtensionLoader =
     extensionManager ?? new SimpleExtensionLoader([]);
 
-  if (!experimentalJitContext) {
+  if (!experimentalJitContext && !skipMemoryLoad) {
     // Call the (now wrapper) loadHierarchicalGeminiMemory which calls the server's version
     const result = await loadServerHierarchicalMemory(
       cwd,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -412,6 +412,7 @@ export async function main() {
   const partialConfig = await loadCliConfig(settings.merged, sessionId, argv, {
     projectHooks: settings.workspace.settings.hooks,
     skipExtensions: true,
+    skipMemoryLoad: true,
   });
 
   adminControlsListner.setConfig(partialConfig);


### PR DESCRIPTION
## Summary

This PR implements the `skipMemoryLoad` option in `loadCliConfig()` to avoid redundant loading of `GEMINI.md` files during the initial authentication bootstrapping phase. This significantly reduces startup latency in projects with large numbers of memory files or when JIT context is disabled.

## Details

- Added `skipMemoryLoad` to `LoadCliConfigOptions`.
- Updated `loadCliConfig` to honor the flag by skipping `loadServerHierarchicalMemory`.
- Updated `gemini.tsx` to pass `skipMemoryLoad: true` to the first `loadCliConfig` call.
- Verified that memory loading still occurs correctly in the final configuration phase used by the agent.

## Related Issues

Closes #17637

## How to Validate

1. Create a project with a deep hierarchy of `GEMINI.md` files.
2. Run with `DEBUG=1` and `experimental.jitContext: false`.
3. Observe that `MemoryDiscovery` logs appear only once (for the final load) instead of multiple times.
4. Verify that the agent still follows instructions from `GEMINI.md` files.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run