### PR TITLE
revert: fix(ci): robust version checking in release verification (#26337)

### DIFF
--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -63,7 +63,7 @@ runs:
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |-
-        gemini_version=$(gemini --version 2>/dev/null)
+        gemini_version=$(gemini --version)
         if [ "$gemini_version" != "${INPUTS_EXPECTED_VERSION}" ]; then
           echo "❌ NPM Version mismatch: Got $gemini_version from ${INPUTS_NPM_PACKAGE}, expected ${INPUTS_EXPECTED_VERSION}"
           exit 1
@@ -80,7 +80,7 @@ runs:
       shell: 'bash'
       working-directory: '${{ inputs.working-directory }}'
       run: |-
-        gemini_version=$(npx --prefer-online "${INPUTS_NPM_PACKAGE}" --version 2>/dev/null)
+        gemini_version=$(npx --prefer-online "${INPUTS_NPM_PACKAGE}" --version)
         if [ "$gemini_version" != "${INPUTS_EXPECTED_VERSION}" ]; then
           echo "❌ NPX Run Version mismatch: Got $gemini_version from ${INPUTS_NPM_PACKAGE}, expected ${INPUTS_EXPECTED_VERSION}"
           exit 1


### PR DESCRIPTION
## Summary

Revert "fix(ci): robust version checking in release verification (#26337)"

## Details

This PR did nothing as `$()` already reads only from std out.

## Related Issues

For #26359

