### PR TITLE
fix(cli): allow early stdout when config is undefined

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -830,7 +830,7 @@ export function initializeOutputListenersAndFlush(config?: Config) {
   }
 
   const outputFormat = config?.getOutputFormat();
-  const forceToStderr = outputFormat === 'json' || config === undefined;
+  const forceToStderr = outputFormat === 'json';
 
   coreEvents.drainBacklogs(
     <K extends keyof CoreEvents>(event: K, args: CoreEvents[K]) => {

--- a/packages/cli/src/output-redirection.test.ts
+++ b/packages/cli/src/output-redirection.test.ts
@@ -69,16 +69,16 @@ describe('Output Redirection', () => {
     expect(writeToStderr).not.toHaveBeenCalled();
   });
 
-  it('should force stdout to stderr when config is undefined (early failure)', () => {
+  it('should NOT force stdout to stderr when config is undefined (early init/version)', () => {
     // Simulate buffered output during early init
     coreEvents.emitOutput(false, 'early init message');
 
     // Initialize with undefined config
     initializeOutputListenersAndFlush(undefined);
 
-    // Verify it was forced to stderr
-    expect(writeToStderr).toHaveBeenCalledWith('early init message', undefined);
-    expect(writeToStdout).not.toHaveBeenCalled();
+    // Verify it went to stdout (default behavior)
+    expect(writeToStdout).toHaveBeenCalledWith('early init message', undefined);
+    expect(writeToStderr).not.toHaveBeenCalled();
   });
 
   it('should attach ConsoleLog and UserFeedback listeners even if Output already has one', () => {


### PR DESCRIPTION
## Summary
This PR fixes a regression where early CLI output (like `--version` and `--help`) was being incorrectly redirected to `stderr` because the `config` object was not yet initialized. 

The `config === undefined` check was originally added to protect JSON output during early crashes, but it was too aggressive and intercepted legitimate early-exit output. 

## Changes
- Removed `config === undefined` from the `forceToStderr` condition in `initializeOutputListenersAndFlush`.
- Updated unit tests to verify that `undefined` config defaults to `stdout`.

Fixes #26359