### PR TITLE
fix(cli): improve mcp list UX in untrusted folders

### DIFF
--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -204,6 +204,7 @@ describe('mcp list command', () => {
           'test-server': { command: '/test/server' },
         },
       },
+      isTrusted: true,
     });
 
     mockClient.connect.mockRejectedValue(new Error('Connection failed'));
@@ -371,7 +372,7 @@ describe('mcp list command', () => {
     );
   });
 
-  it('should show stdio servers as disconnected in untrusted folders', async () => {
+  it('should show stdio servers as disabled in untrusted folders', async () => {
     const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
     mockedLoadSettings.mockReturnValue({
       merged: {
@@ -383,15 +384,15 @@ describe('mcp list command', () => {
       isTrusted: false,
     });
 
-    // createTransport will throw in core if not trusted
-    mockedCreateTransport.mockRejectedValue(new Error('Folder not trusted'));
-
     await listMcpServers();
 
     expect(debugLogger.log).toHaveBeenCalledWith(
       expect.stringContaining(
-        'test-server: /test/server  (stdio) - Disconnected',
+        'Warning: MCP servers are configured but disabled because this folder is untrusted.',
       ),
+    );
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('test-server: /test/server  (stdio) - Disabled'),
     );
   });
 
@@ -442,6 +443,47 @@ describe('mcp list command', () => {
     expect(debugLogger.log).toHaveBeenCalledWith(
       expect.stringContaining(
         'disabled-server: /test/server  (stdio) - Disabled',
+      ),
+    );
+    expect(mockedCreateTransport).not.toHaveBeenCalled();
+  });
+
+  it('should display warning and disabled status in untrusted folders', async () => {
+    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
+    const mcpServers = {
+      'project-server': { command: '/path/to/project/server' },
+      'user-server': { url: 'https://example.com/user' },
+    };
+
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        ...defaultMergedSettings,
+        mcpServers: {
+          'user-server': mcpServers['user-server'],
+        },
+      },
+      isTrusted: false,
+      getMergedSettingsAsIfTrusted: () => ({
+        ...defaultMergedSettings,
+        mcpServers,
+      }),
+    });
+
+    await listMcpServers();
+
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Warning: MCP servers are configured but disabled because this folder is untrusted.',
+      ),
+    );
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'project-server: /path/to/project/server  (stdio) - Disabled',
+      ),
+    );
+    expect(debugLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'user-server: https://example.com/user (http) - Disabled',
       ),
     );
     expect(mockedCreateTransport).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -14,16 +14,17 @@ import {
   type Mock,
 } from 'vitest';
 import { listMcpServers } from './list.js';
+import { loadSettings } from '../../config/settings.js';
 import {
-  loadSettings,
-  mergeSettings,
-  type LoadedSettings,
-} from '../../config/settings.js';
-import { createTransport, debugLogger } from '@google/gemini-cli-core';
+  createTransport,
+  debugLogger,
+  type AdminControlsSettings,
+} from '@google/gemini-cli-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { ExtensionStorage } from '../../config/extensions/storage.js';
 import { ExtensionManager } from '../../config/extension-manager.js';
 import { McpServerEnablementManager } from '../../config/mcp/index.js';
+import { createMockSettings } from '../../test-utils/settings.js';
 
 vi.mock('../../config/settings.js', async (importOriginal) => {
   const actual =
@@ -133,10 +134,7 @@ describe('mcp list command', () => {
   });
 
   it('should display message when no servers configured', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: { ...defaultMergedSettings, mcpServers: {} },
-    });
+    mockedLoadSettings.mockReturnValue(createMockSettings({ mcpServers: {} }));
 
     await listMcpServers();
 
@@ -144,10 +142,8 @@ describe('mcp list command', () => {
   });
 
   it('should display different server types with connected status', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'stdio-server': { command: '/path/to/server', args: ['arg1'] },
           'sse-server': { url: 'https://example.com/sse', type: 'sse' },
@@ -158,9 +154,9 @@ describe('mcp list command', () => {
             type: 'http',
           },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockClient.connect.mockResolvedValue(undefined);
     mockClient.ping.mockResolvedValue(undefined);
@@ -196,16 +192,14 @@ describe('mcp list command', () => {
   });
 
   it('should display disconnected status when connection fails', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'test-server': { command: '/test/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockClient.connect.mockRejectedValue(new Error('Connection failed'));
 
@@ -219,16 +213,14 @@ describe('mcp list command', () => {
   });
 
   it('should display connected status even if ping fails', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'test-server': { command: '/test/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockClient.connect.mockResolvedValue(undefined);
     mockClient.ping.mockRejectedValue(new Error('Ping failed'));
@@ -241,16 +233,14 @@ describe('mcp list command', () => {
   });
 
   it('should use configured timeout for connection', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'test-server': { command: '/test/server', timeout: 12345 },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockClient.connect.mockResolvedValue(undefined);
 
@@ -266,16 +256,14 @@ describe('mcp list command', () => {
   });
 
   it('should use default timeout for connection when not configured', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'test-server': { command: '/test/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockClient.connect.mockResolvedValue(undefined);
 
@@ -291,16 +279,14 @@ describe('mcp list command', () => {
   });
 
   it('should merge extension servers with config servers', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'config-server': { command: '/config/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     mockExtensionManager.loadExtensions.mockReturnValue([
       {
@@ -327,36 +313,40 @@ describe('mcp list command', () => {
   });
 
   it('should filter servers based on admin allowlist passed in settings', async () => {
-    const settingsWithAllowlist = mergeSettings({}, {}, {}, {}, true);
-    settingsWithAllowlist.admin = {
-      secureModeEnabled: false,
-      extensions: { enabled: true },
-      skills: { enabled: true },
-      mcp: {
-        enabled: true,
-        config: {
-          'allowed-server': { url: 'http://allowed' },
+    const adminControls = {
+      strictModeDisabled: true,
+      mcpSetting: {
+        mcpEnabled: true,
+        mcpConfig: {
+          mcpServers: {
+            'allowed-server': { url: 'http://allowed' },
+          },
         },
-        requiredConfig: {},
       },
     };
 
-    settingsWithAllowlist.mcpServers = {
+    const mcpServers = {
       'allowed-server': { command: 'cmd1' },
       'forbidden-server': { command: 'cmd2' },
     };
 
-    mockedLoadSettings.mockReturnValue({
-      merged: settingsWithAllowlist,
+    const mockSettings = createMockSettings({
+      mcpServers,
+      isTrusted: true,
     });
+    // setRemoteAdminSettings is the correct way to set admin settings in tests
+    (
+      mockSettings as unknown as {
+        setRemoteAdminSettings: (controls: AdminControlsSettings) => void;
+      }
+    ).setRemoteAdminSettings(adminControls as unknown as AdminControlsSettings);
+
+    mockedLoadSettings.mockReturnValue(mockSettings);
 
     mockClient.connect.mockResolvedValue(undefined);
     mockClient.ping.mockResolvedValue(undefined);
 
-    await listMcpServers({
-      merged: settingsWithAllowlist,
-      isTrusted: true,
-    } as unknown as LoadedSettings);
+    await listMcpServers(mockSettings);
 
     expect(debugLogger.log).toHaveBeenCalledWith(
       expect.stringContaining('allowed-server'),
@@ -373,16 +363,14 @@ describe('mcp list command', () => {
   });
 
   it('should show stdio servers as disabled in untrusted folders', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'test-server': { command: '/test/server' },
         },
-      },
-      isTrusted: false,
-    });
+        isTrusted: false,
+      }),
+    );
 
     await listMcpServers();
 
@@ -397,19 +385,17 @@ describe('mcp list command', () => {
   });
 
   it('should display blocked status for servers in excluded list', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcp: {
           excluded: ['blocked-server'],
         },
         mcpServers: {
           'blocked-server': { command: '/test/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     await listMcpServers();
 
@@ -422,16 +408,14 @@ describe('mcp list command', () => {
   });
 
   it('should display disabled status for servers disabled via enablement manager', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
         mcpServers: {
           'disabled-server': { command: '/test/server' },
         },
-      },
-      isTrusted: true,
-    });
+        isTrusted: true,
+      }),
+    );
 
     vi.spyOn(
       McpServerEnablementManager.prototype,
@@ -449,25 +433,28 @@ describe('mcp list command', () => {
   });
 
   it('should display warning and disabled status in untrusted folders', async () => {
-    const defaultMergedSettings = mergeSettings({}, {}, {}, {}, true);
-    const mcpServers = {
-      'project-server': { command: '/path/to/project/server' },
+    const userMcpServers = {
       'user-server': { url: 'https://example.com/user' },
     };
+    const workspaceMcpServers = {
+      'project-server': { command: '/path/to/project/server' },
+    };
 
-    mockedLoadSettings.mockReturnValue({
-      merged: {
-        ...defaultMergedSettings,
-        mcpServers: {
-          'user-server': mcpServers['user-server'],
+    mockedLoadSettings.mockReturnValue(
+      createMockSettings({
+        user: {
+          settings: { mcpServers: userMcpServers },
+          originalSettings: { mcpServers: userMcpServers },
+          path: '/mock/user/settings.json',
         },
-      },
-      isTrusted: false,
-      getMergedSettingsAsIfTrusted: () => ({
-        ...defaultMergedSettings,
-        mcpServers,
+        workspace: {
+          settings: { mcpServers: workspaceMcpServers },
+          originalSettings: { mcpServers: workspaceMcpServers },
+          path: '/mock/workspace/settings.json',
+        },
+        isTrusted: false,
       }),
-    });
+    );
 
     await listMcpServers();
 

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -179,6 +179,10 @@ async function getServerStatus(
     return MCPServerStatus.DISABLED;
   }
 
+  if (!isTrusted) {
+    return MCPServerStatus.DISABLED;
+  }
+
   // Test all server types by attempting actual connection
   return testMCPConnection(serverName, server, isTrusted, activeSettings);
 }
@@ -189,8 +193,15 @@ export async function listMcpServers(
   const loadedSettings = loadedSettingsArg ?? loadSettings();
   const activeSettings = loadedSettings.merged;
 
+  // If the folder is untrusted, we want to show all configured servers (including
+  // project-scoped ones) as disabled.
+  const allSettings =
+    !loadedSettings.isTrusted && loadedSettings.getMergedSettingsAsIfTrusted
+      ? loadedSettings.getMergedSettingsAsIfTrusted()
+      : activeSettings;
+
   const { mcpServers, blockedServerNames } =
-    await getMcpServersFromConfig(activeSettings);
+    await getMcpServersFromConfig(allSettings);
   const serverNames = Object.keys(mcpServers);
 
   if (blockedServerNames.length > 0) {
@@ -208,6 +219,15 @@ export async function listMcpServers(
     return;
   }
 
+  if (!loadedSettings.isTrusted) {
+    debugLogger.log(
+      chalk.yellow(
+        'Warning: MCP servers are configured but disabled because this folder is untrusted.\n' +
+          'User-level servers are also suppressed in untrusted folders to prevent accidental side-effects.\n',
+      ),
+    );
+  }
+
   debugLogger.log('Configured MCP servers:\n');
 
   for (const serverName of serverNames) {
@@ -217,7 +237,7 @@ export async function listMcpServers(
       serverName,
       server,
       loadedSettings.isTrusted,
-      activeSettings,
+      allSettings,
     );
 
     let statusIndicator = '';

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -195,10 +195,9 @@ export async function listMcpServers(
 
   // If the folder is untrusted, we want to show all configured servers (including
   // project-scoped ones) as disabled.
-  const allSettings =
-    !loadedSettings.isTrusted && loadedSettings.getMergedSettingsAsIfTrusted
-      ? loadedSettings.getMergedSettingsAsIfTrusted()
-      : activeSettings;
+  const allSettings = !loadedSettings.isTrusted
+    ? loadedSettings.getMergedSettingsAsIfTrusted()
+    : activeSettings;
 
   const { mcpServers, blockedServerNames } =
     await getMcpServersFromConfig(allSettings);

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -237,7 +237,7 @@ export async function listMcpServers(
       serverName,
       server,
       loadedSettings.isTrusted,
-      allSettings,
+      activeSettings,
     );
 
     let statusIndicator = '';

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -348,6 +348,15 @@ export class LoadedSettings {
     return this._merged;
   }
 
+  /**
+   * Returns a merged settings object as if the folder were trusted.
+   * This is useful for commands like 'mcp list' that want to show
+   * what's configured even if it's currently disabled for security reasons.
+   */
+  getMergedSettingsAsIfTrusted(): MergedSettings {
+    return this.computeMergedSettings(true);
+  }
+
   setTrusted(isTrusted: boolean): void {
     if (this.isTrusted === isTrusted) {
       return;
@@ -368,13 +377,16 @@ export class LoadedSettings {
     };
   }
 
-  private computeMergedSettings(): MergedSettings {
+  private computeMergedSettings(forceTrusted = false): MergedSettings {
+    const isTrusted = forceTrusted || this.isTrusted;
+    const workspace = forceTrusted ? this._workspaceFile : this.workspace;
+
     const merged = mergeSettings(
       this.system.settings,
       this.systemDefaults.settings,
       this.user.settings,
-      this.workspace.settings,
-      this.isTrusted,
+      workspace.settings,
+      isTrusted,
     );
 
     // Remote admin settings always take precedence and file-based admin settings


### PR DESCRIPTION
## Summary

This PR improves the UX of the `gemini mcp list` command when run in untrusted folders. It ensures that all configured MCP servers (including project-scoped ones) are visible and explicitly marked as `Disabled`, accompanied by a clear warning message explaining why they are not active.

## Details

- **LoadedSettings Enhancement**: Added `getMergedSettingsAsIfTrusted()` to `packages/cli/src/config/settings.ts`. This allows the CLI to peek into project-scoped settings even when folder trust is not yet established, purely for informational commands like `list`.
- **mcp list Logic**: Updated `packages/cli/src/commands/mcp/list.ts` to use the "as-if-trusted" settings to identify configured servers. It now prints a warning when in an untrusted folder and forces the status of all servers to `Disabled` without attempting connection.
- **Improved Consistency**: Previously, project-scoped servers were completely hidden, and user-scoped servers were shown as "Connected" (if they could connect) even though they were suppressed in the interactive shell. This change makes the `list` command's output consistent with the actual execution environment's restrictions.

## Related Issues

Fixes #24258

## How to Validate

1. Create a new directory and don't trust it.
2. Add an MCP server to the project settings: `gemini mcp add -t http -s project test-remote https://example.com/mcp`
3. Run `gemini mcp list`.
   - **Expected**: A warning message appears, and `test-remote` is listed as `○ test-remote: https://example.com/mcp (http) - Disabled`.
4. Trust the folder: `gemini trust` (or follow the prompt in the shell).
5. Run `gemini mcp list` again.
   - **Expected**: No warning, and `test-remote` shows its actual connection status (e.g., `✓ Connected`).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
