### PR TITLE
feat(core): allow reusing existing worktrees with --worktree flag

### DIFF
--- a/docs/cli/git-worktrees.md
+++ b/docs/cli/git-worktrees.md
@@ -80,8 +80,23 @@ manually remove the worktree if you no longer need it.
 
 ## Resuming work in a Git worktree
 
-To resume a session in a worktree, navigate to the worktree directory and start
-Gemini CLI with the `--resume` flag and the session ID:
+To resume a session in an existing worktree, you can simply run Gemini with the
+same `--worktree` (`-w`) name:
+
+```bash
+gemini --worktree feature-search
+```
+
+Alternatively, you can navigate to the worktree directory and start Gemini
+directly:
+
+```bash
+cd .gemini/worktrees/feature-search
+gemini
+```
+
+To resume a specific previous chat session within that worktree, use the
+`--resume` flag and the session ID:
 
 ```bash
 cd .gemini/worktrees/feature-search

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -109,7 +109,7 @@ describe('worktree utilities', () => {
     });
 
     it('should throw an error if git worktree add fails', async () => {
-      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.promises.stat).mockRejectedValue({ code: 'ENOENT' } as any);
       vi.mocked(execa).mockRejectedValue(new Error('git failed'));
 
       await expect(createWorktree(projectRoot, worktreeName)).rejects.toThrow(

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -86,7 +86,7 @@ describe('worktree utilities', () => {
 
   describe('createWorktree', () => {
     it('should execute git worktree add with correct branch and path if it does not exist', async () => {
-      vi.mocked(fs.promises.stat).mockRejectedValue({ code: 'ENOENT' } as any);
+      vi.mocked(fs.stat).mockRejectedValue({ code: 'ENOENT' });
       vi.mocked(execa).mockResolvedValue({ stdout: '' } as never);
 
       const resultPath = await createWorktree(projectRoot, worktreeName);
@@ -100,7 +100,9 @@ describe('worktree utilities', () => {
     });
 
     it('should return existing path and not call git if it already exists', async () => {
-      vi.mocked(fs.promises.stat).mockResolvedValue({ isDirectory: () => true } as any);
+      vi.mocked(fs.stat).mockResolvedValue({
+        isDirectory: () => true,
+      } as never);
 
       const resultPath = await createWorktree(projectRoot, worktreeName);
 
@@ -109,7 +111,7 @@ describe('worktree utilities', () => {
     });
 
     it('should throw an error if git worktree add fails', async () => {
-      vi.mocked(fs.promises.stat).mockRejectedValue({ code: 'ENOENT' } as any);
+      vi.mocked(fs.stat).mockRejectedValue({ code: 'ENOENT' });
       vi.mocked(execa).mockRejectedValue(new Error('git failed'));
 
       await expect(createWorktree(projectRoot, worktreeName)).rejects.toThrow(

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -85,7 +85,8 @@ describe('worktree utilities', () => {
   });
 
   describe('createWorktree', () => {
-    it('should execute git worktree add with correct branch and path', async () => {
+    it('should execute git worktree add with correct branch and path if it does not exist', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
       vi.mocked(execa).mockResolvedValue({ stdout: '' } as never);
 
       const resultPath = await createWorktree(projectRoot, worktreeName);
@@ -98,7 +99,17 @@ describe('worktree utilities', () => {
       );
     });
 
+    it('should return existing path and not call git if it already exists', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+
+      const resultPath = await createWorktree(projectRoot, worktreeName);
+
+      expect(resultPath).toBe(expectedPath);
+      expect(execa).not.toHaveBeenCalled();
+    });
+
     it('should throw an error if git worktree add fails', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
       vi.mocked(execa).mockRejectedValue(new Error('git failed'));
 
       await expect(createWorktree(projectRoot, worktreeName)).rejects.toThrow(

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -100,7 +100,7 @@ describe('worktree utilities', () => {
     });
 
     it('should return existing path and not call git if it already exists', async () => {
-      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.promises.stat).mockResolvedValue({ isDirectory: () => true } as any);
 
       const resultPath = await createWorktree(projectRoot, worktreeName);
 

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -86,7 +86,7 @@ describe('worktree utilities', () => {
 
   describe('createWorktree', () => {
     it('should execute git worktree add with correct branch and path if it does not exist', async () => {
-      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.promises.stat).mockRejectedValue({ code: 'ENOENT' } as any);
       vi.mocked(execa).mockResolvedValue({ stdout: '' } as never);
 
       const resultPath = await createWorktree(projectRoot, worktreeName);

--- a/packages/core/src/services/worktreeService.ts
+++ b/packages/core/src/services/worktreeService.ts
@@ -120,6 +120,15 @@ export async function createWorktree(
   name: string,
 ): Promise<string> {
   const worktreePath = getWorktreePath(projectRoot, name);
+
+  try {
+    await fs.access(worktreePath);
+    // Worktree path already exists, reuse it
+    return worktreePath;
+  } catch {
+    // Does not exist, proceed to create
+  }
+
   const branchName = `worktree-${name}`;
 
   await execa('git', ['worktree', 'add', worktreePath, '-b', branchName], {

--- a/packages/core/src/services/worktreeService.ts
+++ b/packages/core/src/services/worktreeService.ts
@@ -128,12 +128,19 @@ export async function createWorktree(
   }
 
   try {
-    const stats = await fs.promises.stat(worktreePath);
-    if (stats.isDirectory() && await isGeminiWorktree(worktreePath)) {
+    const stats = await fs.stat(worktreePath);
+    if (stats.isDirectory() && isGeminiWorktree(worktreePath, projectRoot)) {
       return worktreePath;
     }
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      'code' in err &&
+      err.code !== 'ENOENT'
+    ) {
+      throw err;
+    }
   }
 
   const branchName = `worktree-${name}`;

--- a/packages/core/src/services/worktreeService.ts
+++ b/packages/core/src/services/worktreeService.ts
@@ -121,12 +121,19 @@ export async function createWorktree(
 ): Promise<string> {
   const worktreePath = getWorktreePath(projectRoot, name);
 
+  const worktreesBaseDir = path.join(projectRoot, '.gemini', 'worktrees');
+  const relative = path.relative(worktreesBaseDir, worktreePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Invalid worktree name');
+  }
+
   try {
-    await fs.access(worktreePath);
-    // Worktree path already exists, reuse it
-    return worktreePath;
-  } catch {
-    // Does not exist, proceed to create
+    const stats = await fs.promises.stat(worktreePath);
+    if (stats.isDirectory() && await isGeminiWorktree(worktreePath)) {
+      return worktreePath;
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
   }
 
   const branchName = `worktree-${name}`;


### PR DESCRIPTION
## Summary

Allow the `--worktree` (`-w`) flag to reuse an existing worktree directory instead of failing with an error. This makes it easier to resume work in a previously created worktree without manually navigating to it.

## Details

- Modified `createWorktree` in `packages/core/src/services/worktreeService.ts` to check if the target directory exists using `fs.access`.
- If the directory exists, it is returned immediately, skipping the `git worktree add` call.
- Updated documentation in `docs/cli/git-worktrees.md` to reflect this new capability.
- Added unit tests to verify the reuse logic.

## Related Issues

Fixes #25029

## How to Validate

1. Create a worktree: `gemini --worktree my-feature` (ensure `experimental.worktrees: true` is set in your settings).
2. Exit Gemini.
3. Try to resume using the same command: `gemini --worktree my-feature`
4. It should now successfully start Gemini in the existing worktree instead of reporting that it already exists.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
