### PR TITLE
fix(cli): prompt for editor selection on CTRL-G fallback

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer-external.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external.test.ts
@@ -60,7 +60,7 @@ describe('useTextBuffer external editor', () => {
     vi.clearAllMocks();
   });
 
-  it('should emit RequestEditorSelection when openFileInEditor throws EditorNotConfiguredError', async () => {
+  it('should emit feedback when openFileInEditor throws EditorNotConfiguredError', async () => {
     vi.mocked(openFileInEditor).mockRejectedValue(
       new EditorNotConfiguredError(),
     );
@@ -76,7 +76,11 @@ describe('useTextBuffer external editor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(coreEvents.emit).toHaveBeenCalledWith(
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'warning',
+      'No external editor configured. Please set your preferred editor in settings.',
+    );
+    expect(coreEvents.emit).not.toHaveBeenCalledWith(
       CoreEvent.RequestEditorSelection,
     );
   });

--- a/packages/cli/src/ui/components/shared/text-buffer-external.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { renderHook } from '../../../test-utils/render.js';
+import { useTextBuffer } from './text-buffer.js';
+import {
+  openFileInEditor,
+  EditorNotConfiguredError,
+} from '../../utils/editorUtils.js';
+import { coreEvents, CoreEvent } from '@google/gemini-cli-core';
+import fs from 'node:fs';
+
+vi.mock('node:fs', () => ({
+  default: {
+    mkdtempSync: vi.fn().mockReturnValue('/tmp/gemini-edit-123'),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockReturnValue('updated text'),
+    unlinkSync: vi.fn(),
+    rmdirSync: vi.fn(),
+  },
+}));
+
+vi.mock('node:os', () => ({
+  default: {
+    tmpdir: vi.fn().mockReturnValue('/tmp'),
+  },
+}));
+
+vi.mock('../../utils/editorUtils.js', () => ({
+  openFileInEditor: vi.fn(),
+  EditorNotConfiguredError: class extends Error {
+    constructor() {
+      super('No external editor configured');
+      this.name = 'EditorNotConfiguredError';
+    }
+  },
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...original,
+    coreEvents: {
+      emit: vi.fn(),
+      emitFeedback: vi.fn(),
+    },
+  };
+});
+
+describe('useTextBuffer external editor', () => {
+  const viewport = { width: 80, height: 24 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should emit RequestEditorSelection when openFileInEditor throws EditorNotConfiguredError', async () => {
+    vi.mocked(openFileInEditor).mockRejectedValue(
+      new EditorNotConfiguredError(),
+    );
+
+    const { result } = await renderHook(() =>
+      useTextBuffer({
+        initialText: 'some text',
+        viewport,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(coreEvents.emit).toHaveBeenCalledWith(
+      CoreEvent.RequestEditorSelection,
+    );
+  });
+
+  it('should update text when openFileInEditor succeeds', async () => {
+    vi.mocked(openFileInEditor).mockResolvedValue(undefined);
+    vi.mocked(fs.readFileSync).mockReturnValue('updated text from editor');
+
+    const { result } = await renderHook(() =>
+      useTextBuffer({
+        initialText: 'initial text',
+        viewport,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('updated text from editor');
+  });
+
+  it('should log feedback error for other errors', async () => {
+    const unexpectedError = new Error('Some unexpected error');
+    vi.mocked(openFileInEditor).mockRejectedValue(unexpectedError);
+
+    const { result } = await renderHook(() =>
+      useTextBuffer({
+        initialText: 'some text',
+        viewport,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      '[useTextBuffer] external editor error',
+      unexpectedError,
+    );
+    expect(coreEvents.emit).not.toHaveBeenCalledWith(
+      CoreEvent.RequestEditorSelection,
+    );
+  });
+});

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -12,6 +12,7 @@ import { useState, useCallback, useEffect, useMemo, useReducer } from 'react';
 import { LRUCache } from 'mnemonist';
 import {
   coreEvents,
+  CoreEvent,
   debugLogger,
   unescapePath,
   type EditorType,
@@ -29,7 +30,10 @@ import { Command } from '../../key/keyMatchers.js';
 import type { VimAction } from './vim-buffer-actions.js';
 import { handleVimAction } from './vim-buffer-actions.js';
 import { LRU_BUFFER_PERF_CACHE_LIMIT } from '../../constants.js';
-import { openFileInEditor } from '../../utils/editorUtils.js';
+import {
+  openFileInEditor,
+  EditorNotConfiguredError,
+} from '../../utils/editorUtils.js';
 import { useKeyMatchers } from '../../hooks/useKeyMatchers.js';
 
 export const LARGE_PASTE_LINE_THRESHOLD = 5;
@@ -3342,6 +3346,10 @@ export function useTextBuffer({
 
       dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
     } catch (err) {
+      if (err instanceof EditorNotConfiguredError) {
+        coreEvents.emit(CoreEvent.RequestEditorSelection);
+        return;
+      }
       coreEvents.emitFeedback(
         'error',
         '[useTextBuffer] external editor error',

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -12,7 +12,6 @@ import { useState, useCallback, useEffect, useMemo, useReducer } from 'react';
 import { LRUCache } from 'mnemonist';
 import {
   coreEvents,
-  CoreEvent,
   debugLogger,
   unescapePath,
   type EditorType,
@@ -3347,7 +3346,10 @@ export function useTextBuffer({
       dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
     } catch (err) {
       if (err instanceof EditorNotConfiguredError) {
-        coreEvents.emit(CoreEvent.RequestEditorSelection);
+        coreEvents.emitFeedback(
+          'warning',
+          'No external editor configured. Please set your preferred editor in settings.',
+        );
         return;
       }
       coreEvents.emitFeedback(

--- a/packages/cli/src/ui/utils/editorUtils.test.ts
+++ b/packages/cli/src/ui/utils/editorUtils.test.ts
@@ -12,7 +12,11 @@ import {
   type SpawnSyncReturns,
   type ChildProcess,
 } from 'node:child_process';
-import { CoreEvent, coreEvents } from '@google/gemini-cli-core';
+import {
+  CoreEvent,
+  coreEvents,
+  getEditorCommand,
+} from '@google/gemini-cli-core';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
@@ -54,7 +58,7 @@ describe('editorUtils', () => {
     } as SpawnSyncReturns<Buffer>);
     await openFileInEditor('test.txt', null, undefined, 'vim');
     expect(spawnSync).toHaveBeenCalledWith(
-      'vim',
+      getEditorCommand('vim'),
       expect.arrayContaining(['test.txt']),
       expect.anything(),
     );
@@ -73,7 +77,7 @@ describe('editorUtils', () => {
     vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
     await openFileInEditor('test.txt', null, undefined, 'vscode');
     expect(spawn).toHaveBeenCalledWith(
-      'code',
+      getEditorCommand('vscode'),
       expect.arrayContaining(['--wait', 'test.txt']),
       expect.anything(),
     );

--- a/packages/cli/src/ui/utils/editorUtils.test.ts
+++ b/packages/cli/src/ui/utils/editorUtils.test.ts
@@ -46,7 +46,7 @@ describe('editorUtils', () => {
     vi.unstubAllEnvs();
   });
 
-  it('should throw EditorNotConfiguredError if no editor is configured and no env vars set', async () => {
+  it('should throw EditorNotConfiguredError if no editor is configured', async () => {
     await expect(openFileInEditor('test.txt', null, undefined)).rejects.toThrow(
       EditorNotConfiguredError,
     );
@@ -86,40 +86,13 @@ describe('editorUtils', () => {
     );
   });
 
-  it('should use VISUAL env var if set', async () => {
-    vi.stubEnv('VISUAL', 'nano');
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-    } as SpawnSyncReturns<Buffer>);
-    await openFileInEditor('test.txt', null, undefined);
-    expect(spawnSync).toHaveBeenCalledWith(
-      'nano',
-      expect.arrayContaining(['test.txt']),
-      expect.anything(),
-    );
-  });
-
-  it('should use EDITOR env var if set', async () => {
-    vi.stubEnv('EDITOR', 'nano');
-    vi.mocked(spawnSync).mockReturnValue({
-      status: 0,
-    } as SpawnSyncReturns<Buffer>);
-    await openFileInEditor('test.txt', null, undefined);
-    expect(spawnSync).toHaveBeenCalledWith(
-      'nano',
-      expect.arrayContaining(['test.txt']),
-      expect.anything(),
-    );
-  });
-
   it('should handle editor exit with non-zero status', async () => {
-    vi.stubEnv('EDITOR', 'vim');
     vi.mocked(spawnSync).mockReturnValue({
       status: 1,
     } as SpawnSyncReturns<Buffer>);
-    await expect(openFileInEditor('test.txt', null, undefined)).rejects.toThrow(
-      'External editor exited with status 1',
-    );
+    await expect(
+      openFileInEditor('test.txt', null, undefined, 'vim'),
+    ).rejects.toThrow('External editor exited with status 1');
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'error',
       expect.any(String),

--- a/packages/cli/src/ui/utils/editorUtils.test.ts
+++ b/packages/cli/src/ui/utils/editorUtils.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { openFileInEditor, EditorNotConfiguredError } from './editorUtils.js';
+import {
+  spawnSync,
+  spawn,
+  type SpawnSyncReturns,
+  type ChildProcess,
+} from 'node:child_process';
+import { CoreEvent, coreEvents } from '@google/gemini-cli-core';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...original,
+    coreEvents: {
+      emit: vi.fn(),
+      emitFeedback: vi.fn(),
+    },
+  };
+});
+
+describe('editorUtils', () => {
+  beforeEach(() => {
+    vi.stubEnv('VISUAL', '');
+    vi.stubEnv('EDITOR', '');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should throw EditorNotConfiguredError if no editor is configured and no env vars set', async () => {
+    await expect(openFileInEditor('test.txt', null, undefined)).rejects.toThrow(
+      EditorNotConfiguredError,
+    );
+  });
+
+  it('should use preferredEditorType if provided (terminal editor)', async () => {
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+    } as SpawnSyncReturns<Buffer>);
+    await openFileInEditor('test.txt', null, undefined, 'vim');
+    expect(spawnSync).toHaveBeenCalledWith(
+      'vim',
+      expect.arrayContaining(['test.txt']),
+      expect.anything(),
+    );
+    expect(coreEvents.emit).toHaveBeenCalledWith(
+      CoreEvent.ExternalEditorClosed,
+    );
+  });
+
+  it('should use preferredEditorType if provided (GUI editor)', async () => {
+    const mockChild = {
+      on: vi.fn((event: string, cb: (code: number) => void) => {
+        if (event === 'close') cb(0);
+        return mockChild;
+      }),
+    };
+    vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
+    await openFileInEditor('test.txt', null, undefined, 'vscode');
+    expect(spawn).toHaveBeenCalledWith(
+      'code',
+      expect.arrayContaining(['--wait', 'test.txt']),
+      expect.anything(),
+    );
+    expect(coreEvents.emit).toHaveBeenCalledWith(
+      CoreEvent.ExternalEditorClosed,
+    );
+  });
+
+  it('should use VISUAL env var if set', async () => {
+    vi.stubEnv('VISUAL', 'nano');
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+    } as SpawnSyncReturns<Buffer>);
+    await openFileInEditor('test.txt', null, undefined);
+    expect(spawnSync).toHaveBeenCalledWith(
+      'nano',
+      expect.arrayContaining(['test.txt']),
+      expect.anything(),
+    );
+  });
+
+  it('should use EDITOR env var if set', async () => {
+    vi.stubEnv('EDITOR', 'nano');
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+    } as SpawnSyncReturns<Buffer>);
+    await openFileInEditor('test.txt', null, undefined);
+    expect(spawnSync).toHaveBeenCalledWith(
+      'nano',
+      expect.arrayContaining(['test.txt']),
+      expect.anything(),
+    );
+  });
+
+  it('should handle editor exit with non-zero status', async () => {
+    vi.stubEnv('EDITOR', 'vim');
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 1,
+    } as SpawnSyncReturns<Buffer>);
+    await expect(openFileInEditor('test.txt', null, undefined)).rejects.toThrow(
+      'External editor exited with status 1',
+    );
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'error',
+      expect.any(String),
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -48,7 +48,7 @@ export async function openFileInEditor(
   }
 
   if (!command) {
-    command = process.env['VISUAL'] ?? process.env['EDITOR'];
+    command = process.env['VISUAL'] || process.env['EDITOR'];
     if (command) {
       const lowerCommand = command.toLowerCase();
       const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((gui) =>

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -48,23 +48,6 @@ export async function openFileInEditor(
   }
 
   if (!command) {
-    command = process.env['VISUAL']?.trim() || process.env['EDITOR']?.trim();
-    if (command) {
-      const lowerCommand = command.toLowerCase();
-      const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((gui) =>
-        lowerCommand.includes(gui),
-      );
-      if (
-        isGui &&
-        !lowerCommand.includes('--wait') &&
-        !lowerCommand.includes('-w')
-      ) {
-        args.unshift(lowerCommand.includes('subl') ? '-w' : '--wait');
-      }
-    }
-  }
-
-  if (!command) {
     throw new EditorNotConfiguredError();
   }
 

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -48,7 +48,7 @@ export async function openFileInEditor(
   }
 
   if (!command) {
-    command = process.env['VISUAL'] || process.env['EDITOR'];
+    command = process.env['VISUAL']?.trim() || process.env['EDITOR']?.trim();
     if (command) {
       const lowerCommand = command.toLowerCase();
       const isGui = ['code', 'cursor', 'subl', 'zed', 'atom'].some((gui) =>

--- a/packages/cli/src/ui/utils/editorUtils.ts
+++ b/packages/cli/src/ui/utils/editorUtils.ts
@@ -15,6 +15,13 @@ import {
   isTerminalEditor,
 } from '@google/gemini-cli-core';
 
+export class EditorNotConfiguredError extends Error {
+  constructor() {
+    super('No external editor configured');
+    this.name = 'EditorNotConfiguredError';
+  }
+}
+
 /**
  * Opens a file in an external editor and waits for it to close.
  * Handles raw mode switching to ensure the editor can interact with the terminal.
@@ -58,7 +65,7 @@ export async function openFileInEditor(
   }
 
   if (!command) {
-    command = process.platform === 'win32' ? 'notepad' : 'vi';
+    throw new EditorNotConfiguredError();
   }
 
   const [executable = '', ...initialArgs] = command.split(' ');


### PR DESCRIPTION
## Summary

This PR fixes an issue where pressing \`CTRL-G\` (open external editor) would silently fall back to \`vi\` (or \`notepad\` on Windows) if no preferred editor was configured. This often left users in an unfamiliar and confusing state.

Now, if no editor is configured via \`general.preferredEditor\`, \`VISUAL\`, or \`EDITOR\`, the CLI will prompt the user to select their preferred editor.

## Details

- Introduced \`EditorNotConfiguredError\` in \`editorUtils.ts\`.
- Updated \`openFileInEditor\` to throw this error when no command is resolved.
- Updated \`useTextBuffer\` hook to catch this error and emit \`CoreEvent.RequestEditorSelection\`, triggering the editor selection UI.

## Related Issues

Fixes #18029

## How to Validate

1. Ensure \`general.preferredEditor\` is NOT set in your configuration.
2. Ensure \`VISUAL\` and \`EDITOR\` environment variables are NOT set.
3. Start the Gemini CLI.
4. Press \`CTRL-G\` at the prompt.
5. **Expected result**: The editor selection dialog should appear.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
