### PR TITLE
ci(release): build and attach unsigned macOS binaries to releases

### DIFF
--- a/.github/actions/download-mac-binaries/action.yml
+++ b/.github/actions/download-mac-binaries/action.yml
@@ -1,0 +1,23 @@
+name: 'Download Mac Binaries'
+description: 'Downloads the unsigned macOS binaries (x64 and arm64)'
+inputs:
+  path:
+    description: 'The base path to download the binaries to'
+    required: true
+    default: 'dist'
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Download macOS arm64 binary'
+      uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: 'gemini-darwin-arm64-unsigned'
+        path: '${{ inputs.path }}/darwin-arm64'
+
+    - name: 'Download macOS x64 binary'
+      uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
+      continue-on-error: true
+      with:
+        name: 'gemini-darwin-x64-unsigned'
+        path: '${{ inputs.path }}/darwin-x64'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -312,14 +312,12 @@ runs:
 
         # Check for and prepare macOS binaries if they exist
         if [[ -f "dist/darwin-arm64/gemini" ]]; then
-          cp dist/darwin-arm64/gemini gemini-darwin-arm64-unsigned
-          zip gemini-darwin-arm64-unsigned.zip gemini-darwin-arm64-unsigned
+          zip -j gemini-darwin-arm64-unsigned.zip dist/darwin-arm64/gemini
           RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned.zip")
         fi
 
         if [[ -f "dist/darwin-x64/gemini" ]]; then
-          cp dist/darwin-x64/gemini gemini-darwin-x64-unsigned
-          zip gemini-darwin-x64-unsigned.zip gemini-darwin-x64-unsigned
+          zip -j gemini-darwin-x64-unsigned.zip dist/darwin-x64/gemini
           RELEASE_ASSETS+=("gemini-darwin-x64-unsigned.zip")
         fi
 

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -313,12 +313,14 @@ runs:
         # Check for and prepare macOS binaries if they exist
         if [[ -f "dist/darwin-arm64/gemini" ]]; then
           cp dist/darwin-arm64/gemini gemini-darwin-arm64-unsigned
-          RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned")
+          zip gemini-darwin-arm64-unsigned.zip gemini-darwin-arm64-unsigned
+          RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned.zip")
         fi
 
         if [[ -f "dist/darwin-x64/gemini" ]]; then
           cp dist/darwin-x64/gemini gemini-darwin-x64-unsigned
-          RELEASE_ASSETS+=("gemini-darwin-x64-unsigned")
+          zip gemini-darwin-x64-unsigned.zip gemini-darwin-x64-unsigned
+          RELEASE_ASSETS+=("gemini-darwin-x64-unsigned.zip")
         fi
 
         gh release create "${INPUTS_RELEASE_TAG}" \

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -308,8 +308,21 @@ runs:
         fi
         rm -rf test-bundle
 
+        RELEASE_ASSETS=("gemini-cli-bundle.zip")
+
+        # Check for and prepare macOS binaries if they exist
+        if [[ -f "dist/darwin-arm64/gemini" ]]; then
+          cp dist/darwin-arm64/gemini gemini-darwin-arm64-unsigned
+          RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned")
+        fi
+
+        if [[ -f "dist/darwin-x64/gemini" ]]; then
+          cp dist/darwin-x64/gemini gemini-darwin-x64-unsigned
+          RELEASE_ASSETS+=("gemini-darwin-x64-unsigned")
+        fi
+
         gh release create "${INPUTS_RELEASE_TAG}" \
-          gemini-cli-bundle.zip \
+          "${RELEASE_ASSETS[@]}" \
           --target "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}" \
           --title "Release ${INPUTS_RELEASE_TAG}" \
           --notes-start-tag "${INPUTS_PREVIOUS_TAG}" \

--- a/.github/workflows/build-unsigned-mac-binaries.yml
+++ b/.github/workflows/build-unsigned-mac-binaries.yml
@@ -2,6 +2,12 @@ name: 'Build Unsigned Mac Binaries'
 
 on:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch, tag, or SHA to build from.'
+        required: true
+        type: string
 
 permissions:
   contents: 'read'
@@ -22,6 +28,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
+        with:
+          ref: '${{ inputs.ref || github.ref }}'
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
@@ -52,5 +60,5 @@ jobs:
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
-          path: 'dist/darwin-${{ matrix.arch }}/'
+          path: 'dist/darwin-${{ matrix.arch }}/gemini'
           retention-days: 14

--- a/.github/workflows/build-unsigned-mac-binaries.yml
+++ b/.github/workflows/build-unsigned-mac-binaries.yml
@@ -53,4 +53,4 @@ jobs:
         with:
           name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
           path: 'dist/darwin-${{ matrix.arch }}/'
-          retention-days: 5
+          retention-days: 14

--- a/.github/workflows/build-unsigned-mac-binaries.yml
+++ b/.github/workflows/build-unsigned-mac-binaries.yml
@@ -7,7 +7,7 @@ on:
       ref:
         description: 'The branch, tag, or SHA to build from.'
         required: true
-        type: string
+        type: 'string'
 
 permissions:
   contents: 'read'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -47,40 +47,10 @@ on:
 
 jobs:
   build-mac:
-    name: 'Build Unsigned (${{ matrix.arch }})'
     if: "github.repository == 'google-gemini/gemini-cli'"
-    runs-on: 'macos-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x64', 'arm64']
-    steps:
-      - name: 'Checkout Ref'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
-        with:
-          ref: '${{ github.event.inputs.ref }}'
-
-      - name: 'Set up Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
-        with:
-          node-version-file: '.nvmrc'
-          architecture: '${{ matrix.arch }}'
-          cache: 'npm'
-
-      - name: 'Install dependencies'
-        run: 'npm ci'
-
-      - name: 'Build Binary'
-        env:
-          SKIP_SIGNING: 'true'
-        run: 'npm run build:binary'
-
-      - name: 'Upload Artifact'
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
-        with:
-          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
-          path: 'dist/darwin-${{ matrix.arch }}/gemini'
-          retention-days: 1
+    uses: './.github/workflows/build-unsigned-mac-binaries.yml'
+    with:
+      ref: '${{ github.event.inputs.ref }}'
 
   release:
     if: "github.repository == 'google-gemini/gemini-cli'"
@@ -120,19 +90,10 @@ jobs:
         working-directory: './release'
         run: 'npm ci'
 
-      - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
+      - name: 'Download macOS Binaries'
+        uses: './.github/actions/download-mac-binaries'
         with:
-          name: 'gemini-darwin-arm64-unsigned'
-          path: 'release/dist/darwin-arm64'
-
-      - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: 'gemini-darwin-x64-unsigned'
-          path: 'release/dist/darwin-x64'
+          path: 'release/dist'
 
       - name: 'Prepare Release Info'
         id: 'release_info'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -46,8 +46,45 @@ on:
         default: 'prod'
 
 jobs:
+  build-mac:
+    name: 'Build Unsigned (${{ matrix.arch }})'
+    if: "github.repository == 'google-gemini/gemini-cli'"
+    runs-on: 'macos-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x64', 'arm64']
+    steps:
+      - name: 'Checkout Ref'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          ref: '${{ github.event.inputs.ref }}'
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+        with:
+          node-version-file: '.nvmrc'
+          architecture: '${{ matrix.arch }}'
+          cache: 'npm'
+
+      - name: 'Install dependencies'
+        run: 'npm ci'
+
+      - name: 'Build Binary'
+        env:
+          SKIP_SIGNING: 'true'
+        run: 'npm run build:binary'
+
+      - name: 'Upload Artifact'
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
+        with:
+          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
+          path: 'dist/darwin-${{ matrix.arch }}/gemini'
+          retention-days: 1
+
   release:
     if: "github.repository == 'google-gemini/gemini-cli'"
+    needs: ['build-mac']
     runs-on: 'ubuntu-latest'
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
@@ -82,6 +119,20 @@ jobs:
       - name: 'Install Dependencies'
         working-directory: './release'
         run: 'npm ci'
+
+      - name: 'Download macOS arm64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-arm64-unsigned'
+          path: 'release/dist/darwin-arm64'
+
+      - name: 'Download macOS x64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-x64-unsigned'
+          path: 'release/dist/darwin-x64'
 
       - name: 'Prepare Release Info'
         id: 'release_info'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -121,14 +121,14 @@ jobs:
         run: 'npm ci'
 
       - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-arm64-unsigned'
           path: 'release/dist/darwin-arm64'
 
       - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-x64-unsigned'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -31,40 +31,10 @@ on:
 
 jobs:
   build-mac:
-    name: 'Build Unsigned (${{ matrix.arch }})'
     if: "github.repository == 'google-gemini/gemini-cli'"
-    runs-on: 'macos-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x64', 'arm64']
-    steps:
-      - name: 'Checkout Ref'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
-        with:
-          ref: '${{ github.event.inputs.ref }}'
-
-      - name: 'Set up Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
-        with:
-          node-version-file: '.nvmrc'
-          architecture: '${{ matrix.arch }}'
-          cache: 'npm'
-
-      - name: 'Install dependencies'
-        run: 'npm ci'
-
-      - name: 'Build Binary'
-        env:
-          SKIP_SIGNING: 'true'
-        run: 'npm run build:binary'
-
-      - name: 'Upload Artifact'
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
-        with:
-          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
-          path: 'dist/darwin-${{ matrix.arch }}/gemini'
-          retention-days: 1
+    uses: './.github/workflows/build-unsigned-mac-binaries.yml'
+    with:
+      ref: '${{ github.event.inputs.ref }}'
 
   release:
     if: "github.repository == 'google-gemini/gemini-cli'"
@@ -99,19 +69,10 @@ jobs:
         working-directory: './release'
         run: 'npm ci'
 
-      - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
+      - name: 'Download macOS Binaries'
+        uses: './.github/actions/download-mac-binaries'
         with:
-          name: 'gemini-darwin-arm64-unsigned'
-          path: 'release/dist/darwin-arm64'
-
-      - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: 'gemini-darwin-x64-unsigned'
-          path: 'release/dist/darwin-x64'
+          path: 'release/dist'
 
       - name: 'Print Inputs'
         shell: 'bash'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -30,8 +30,45 @@ on:
         default: 'prod'
 
 jobs:
+  build-mac:
+    name: 'Build Unsigned (${{ matrix.arch }})'
+    if: "github.repository == 'google-gemini/gemini-cli'"
+    runs-on: 'macos-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x64', 'arm64']
+    steps:
+      - name: 'Checkout Ref'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          ref: '${{ github.event.inputs.ref }}'
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+        with:
+          node-version-file: '.nvmrc'
+          architecture: '${{ matrix.arch }}'
+          cache: 'npm'
+
+      - name: 'Install dependencies'
+        run: 'npm ci'
+
+      - name: 'Build Binary'
+        env:
+          SKIP_SIGNING: 'true'
+        run: 'npm run build:binary'
+
+      - name: 'Upload Artifact'
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
+        with:
+          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
+          path: 'dist/darwin-${{ matrix.arch }}/gemini'
+          retention-days: 1
+
   release:
     if: "github.repository == 'google-gemini/gemini-cli'"
+    needs: ['build-mac']
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:
@@ -61,6 +98,20 @@ jobs:
       - name: 'Install Dependencies'
         working-directory: './release'
         run: 'npm ci'
+
+      - name: 'Download macOS arm64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-arm64-unsigned'
+          path: 'release/dist/darwin-arm64'
+
+      - name: 'Download macOS x64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-x64-unsigned'
+          path: 'release/dist/darwin-x64'
 
       - name: 'Print Inputs'
         shell: 'bash'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -100,14 +100,14 @@ jobs:
         run: 'npm ci'
 
       - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-arm64-unsigned'
           path: 'release/dist/darwin-arm64'
 
       - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-x64-unsigned'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -198,40 +198,10 @@ jobs:
           working-directory: './release'
 
   build-mac:
-    name: 'Build Unsigned (${{ matrix.arch }})'
-    needs: 'calculate-versions'
-    runs-on: 'macos-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x64', 'arm64']
-    steps:
-      - name: 'Checkout Ref'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
-        with:
-          ref: '${{ github.event.inputs.ref }}'
-
-      - name: 'Set up Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
-        with:
-          node-version-file: '.nvmrc'
-          architecture: '${{ matrix.arch }}'
-          cache: 'npm'
-
-      - name: 'Install dependencies'
-        run: 'npm ci'
-
-      - name: 'Build Binary'
-        env:
-          SKIP_SIGNING: 'true'
-        run: 'npm run build:binary'
-
-      - name: 'Upload Artifact'
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
-        with:
-          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
-          path: 'dist/darwin-${{ matrix.arch }}/gemini'
-          retention-days: 1
+    if: "github.repository == 'google-gemini/gemini-cli'"
+    uses: './.github/workflows/build-unsigned-mac-binaries.yml'
+    with:
+      ref: '${{ github.event.inputs.ref }}'
 
   publish-preview:
     name: 'Publish preview'
@@ -265,19 +235,10 @@ jobs:
         working-directory: './release'
         run: 'npm ci'
 
-      - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
+      - name: 'Download macOS Binaries'
+        uses: './.github/actions/download-mac-binaries'
         with:
-          name: 'gemini-darwin-arm64-unsigned'
-          path: 'release/dist/darwin-arm64'
-
-      - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: 'gemini-darwin-x64-unsigned'
-          path: 'release/dist/darwin-x64'
+          path: 'release/dist'
 
       - name: 'Publish Release'
         uses: './.github/actions/publish-release'
@@ -346,19 +307,10 @@ jobs:
         working-directory: './release'
         run: 'npm ci'
 
-      - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
+      - name: 'Download macOS Binaries'
+        uses: './.github/actions/download-mac-binaries'
         with:
-          name: 'gemini-darwin-arm64-unsigned'
-          path: 'release/dist/darwin-arm64'
-
-      - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: 'gemini-darwin-x64-unsigned'
-          path: 'release/dist/darwin-x64'
+          path: 'release/dist'
 
       - name: 'Publish Release'
         uses: './.github/actions/publish-release'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -266,14 +266,14 @@ jobs:
         run: 'npm ci'
 
       - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-arm64-unsigned'
           path: 'release/dist/darwin-arm64'
 
       - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-x64-unsigned'
@@ -347,14 +347,14 @@ jobs:
         run: 'npm ci'
 
       - name: 'Download macOS arm64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-arm64-unsigned'
           path: 'release/dist/darwin-arm64'
 
       - name: 'Download macOS x64 binary'
-        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4
         continue-on-error: true
         with:
           name: 'gemini-darwin-x64-unsigned'

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -197,9 +197,45 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           working-directory: './release'
 
+  build-mac:
+    name: 'Build Unsigned (${{ matrix.arch }})'
+    needs: 'calculate-versions'
+    runs-on: 'macos-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x64', 'arm64']
+    steps:
+      - name: 'Checkout Ref'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          ref: '${{ github.event.inputs.ref }}'
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'
+        with:
+          node-version-file: '.nvmrc'
+          architecture: '${{ matrix.arch }}'
+          cache: 'npm'
+
+      - name: 'Install dependencies'
+        run: 'npm ci'
+
+      - name: 'Build Binary'
+        env:
+          SKIP_SIGNING: 'true'
+        run: 'npm run build:binary'
+
+      - name: 'Upload Artifact'
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
+        with:
+          name: 'gemini-darwin-${{ matrix.arch }}-unsigned'
+          path: 'dist/darwin-${{ matrix.arch }}/gemini'
+          retention-days: 1
+
   publish-preview:
     name: 'Publish preview'
-    needs: ['calculate-versions', 'test']
+    needs: ['calculate-versions', 'test', 'build-mac']
     runs-on: 'ubuntu-latest'
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
@@ -228,6 +264,20 @@ jobs:
       - name: 'Install Dependencies'
         working-directory: './release'
         run: 'npm ci'
+
+      - name: 'Download macOS arm64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-arm64-unsigned'
+          path: 'release/dist/darwin-arm64'
+
+      - name: 'Download macOS x64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-x64-unsigned'
+          path: 'release/dist/darwin-x64'
 
       - name: 'Publish Release'
         uses: './.github/actions/publish-release'
@@ -266,7 +316,7 @@ jobs:
 
   publish-stable:
     name: 'Publish stable'
-    needs: ['calculate-versions', 'test', 'publish-preview']
+    needs: ['calculate-versions', 'test', 'publish-preview', 'build-mac']
     runs-on: 'ubuntu-latest'
     environment: "${{ github.event.inputs.environment || 'prod' }}"
     permissions:
@@ -295,6 +345,20 @@ jobs:
       - name: 'Install Dependencies'
         working-directory: './release'
         run: 'npm ci'
+
+      - name: 'Download macOS arm64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-arm64-unsigned'
+          path: 'release/dist/darwin-arm64'
+
+      - name: 'Download macOS x64 binary'
+        uses: 'actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16'
+        continue-on-error: true
+        with:
+          name: 'gemini-darwin-x64-unsigned'
+          path: 'release/dist/darwin-x64'
 
       - name: 'Publish Release'
         uses: './.github/actions/publish-release'


### PR DESCRIPTION
## Summary

Adds a `build-mac` job to the nightly, manual, and promote release workflows to automatically build unsigned macOS binaries (`x64` and `arm64`) and attach them as release assets.

## Details

- Added the `build-mac` step to `.github/workflows/release-manual.yml`, `.github/workflows/release-nightly.yml`, and `.github/workflows/release-promote.yml`.
- Updated downstream jobs in these workflows to download the `gemini-darwin-arm64-unsigned` and `gemini-darwin-x64-unsigned` artifacts.
- Modified `.github/actions/publish-release/action.yml` to automatically append these macOS binaries to `RELEASE_ASSETS` when creating a GitHub release.

## Related Issues

https://github.com/google-gemini/maintainers-gemini-cli/issues/1649

## How to Validate

1. Trigger a dry-run of the `Release: Manual` workflow on this branch.
2. Verify that the `build-mac` job successfully runs and generates the unsigned artifacts.
3. Validate that the GitHub release step correctly identifies and attaches the macOS artifacts (simulated if dry-run).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
