### PR TITLE
feat(bot): add actions spend metric script

### DIFF
--- a/tools/gemini-cli-bot/brain/metrics.md
+++ b/tools/gemini-cli-bot/brain/metrics.md
@@ -47,7 +47,10 @@ synchronize with previous sessions:
   than closure rates).
 - **Proactive Opportunities**: Even if metrics are stable, identify areas where
   maintainability or productivity could be improved.
-- **Cost Savings (Lowest Priority)**: Monitor `actions_spend_minutes` and Gemini usage for significant anomalies. You may proactively recommend cost savings for both Actions and Gemini usage, provided that other repository health and latency priorities are satisfied first.
+- **Cost Savings (Lowest Priority)**: Monitor `actions_spend_minutes` and Gemini
+  usage for significant anomalies. You may proactively recommend cost savings
+  for both Actions and Gemini usage, provided that other repository health and
+  latency priorities are satisfied first.
 
 ### 2. Hypothesis Testing & Deep Dive
 

--- a/tools/gemini-cli-bot/brain/metrics.md
+++ b/tools/gemini-cli-bot/brain/metrics.md
@@ -47,7 +47,7 @@ synchronize with previous sessions:
   than closure rates).
 - **Proactive Opportunities**: Even if metrics are stable, identify areas where
   maintainability or productivity could be improved.
-- **Actions Spend (Lowest Priority)**: Monitor `actions_spend_minutes` for significant anomalies or runaway workflows, but prioritize other repository health and latency metrics first.
+- **Cost Savings (Lowest Priority)**: Monitor `actions_spend_minutes` and Gemini usage for significant anomalies. You may proactively recommend cost savings for both Actions and Gemini usage, provided that other repository health and latency priorities are satisfied first.
 
 ### 2. Hypothesis Testing & Deep Dive
 

--- a/tools/gemini-cli-bot/brain/metrics.md
+++ b/tools/gemini-cli-bot/brain/metrics.md
@@ -47,6 +47,7 @@ synchronize with previous sessions:
   than closure rates).
 - **Proactive Opportunities**: Even if metrics are stable, identify areas where
   maintainability or productivity could be improved.
+- **Actions Spend (Lowest Priority)**: Monitor `actions_spend_minutes` for significant anomalies or runaway workflows, but prioritize other repository health and latency metrics first.
 
 ### 2. Hypothesis Testing & Deep Dive
 

--- a/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
+++ b/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
@@ -6,7 +6,11 @@
 
 import { execFileSync } from 'node:child_process';
 
-function getWorkflowMinutes(): Record<string, number> {
+async function getWorkflowMinutes(): Promise<Record<string, number>> {
+  const sevenDaysAgoDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
+
   const output = execFileSync(
     'gh',
     [
@@ -14,50 +18,100 @@ function getWorkflowMinutes(): Record<string, number> {
       'list',
       '--limit',
       '1000',
+      '--created',
+      `>=${sevenDaysAgoDate}`,
       '--json',
-      'workflowName,startedAt,updatedAt',
+      'databaseId,workflowName',
     ],
     { encoding: 'utf-8' },
   );
+
   const runs = JSON.parse(output);
-
   const workflowMinutes: Record<string, number> = {};
-  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const token = execFileSync('gh', ['auth', 'token'], {
+    encoding: 'utf-8',
+  }).trim();
+  const repoInfo = JSON.parse(
+    execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner'], {
+      encoding: 'utf-8',
+    }),
+  );
+  const repoName = repoInfo.nameWithOwner;
 
-  for (const r of runs) {
-    if (!r.startedAt || !r.updatedAt) continue;
+  const chunkSize = 20;
+  for (let i = 0; i < runs.length; i += chunkSize) {
+    const chunk = runs.slice(i, i + chunkSize);
+    await Promise.all(
+      chunk.map(async (r: { databaseId: number; workflowName?: string }) => {
+        try {
+          const res = await fetch(
+            `https://api.github.com/repos/${repoName}/actions/runs/${r.databaseId}/jobs`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/vnd.github.v3+json',
+              },
+            },
+          );
 
-    const start = new Date(r.startedAt).getTime();
-    if (start < sevenDaysAgo) continue;
-    const end = new Date(r.updatedAt).getTime();
-    const durationMinutes = (end - start) / (1000 * 60);
+          if (!res.ok) return;
 
-    if (durationMinutes >= 0) {
-      const name = r.workflowName || 'Unknown';
-      workflowMinutes[name] = (workflowMinutes[name] || 0) + durationMinutes;
-    }
+          const { jobs } = await res.json();
+          let runBillableMinutes = 0;
+
+          for (const job of jobs || []) {
+            if (!job.started_at || !job.completed_at) continue;
+            const start = new Date(job.started_at).getTime();
+            const end = new Date(job.completed_at).getTime();
+            const durationMs = end - start;
+
+            if (durationMs > 0) {
+              runBillableMinutes += Math.ceil(durationMs / (1000 * 60));
+            }
+          }
+
+          if (runBillableMinutes > 0) {
+            const name = r.workflowName || 'Unknown';
+            workflowMinutes[name] =
+              (workflowMinutes[name] || 0) + runBillableMinutes;
+          }
+        } catch {
+          // Ignore failures for individual runs
+        }
+      }),
+    );
   }
 
   return workflowMinutes;
 }
 
-function run() {
+async function run() {
   try {
-    const workflowMinutes = getWorkflowMinutes();
+    const workflowMinutes = await getWorkflowMinutes();
     let totalMinutes = 0;
 
     for (const minutes of Object.values(workflowMinutes)) {
       totalMinutes += minutes;
     }
 
-    process.stdout.write(
-      `actions_spend_overall_minutes,${Math.round(totalMinutes * 100) / 100}\n`,
+    const now = new Date().toISOString();
+    console.log(
+      JSON.stringify({
+        metric: 'actions_spend_minutes',
+        value: totalMinutes,
+        timestamp: now,
+        details: workflowMinutes,
+      }),
     );
 
     for (const [name, minutes] of Object.entries(workflowMinutes)) {
       const safeName = name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
-      process.stdout.write(
-        `actions_spend_workflow_${safeName}_minutes,${Math.round(minutes * 100) / 100}\n`,
+      console.log(
+        JSON.stringify({
+          metric: `actions_spend_minutes_workflow:${safeName}`,
+          value: minutes,
+          timestamp: now,
+        }),
       );
     }
   } catch (error) {

--- a/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
+++ b/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
@@ -5,7 +5,6 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import type { MetricOutput } from '../types.js';
 
 function getWorkflowMinutes(): Record<string, number> {
   const output = execFileSync(
@@ -51,16 +50,20 @@ function run() {
       totalMinutes += minutes;
     }
 
-    const result: MetricOutput = {
-      metric: 'actions_spend_minutes',
-      value: totalMinutes,
-      timestamp: new Date().toISOString(),
-      details: workflowMinutes,
-    };
+    process.stdout.write(
+      `actions_spend_overall_minutes,${Math.round(totalMinutes * 100) / 100}\n`,
+    );
 
-    console.log(JSON.stringify(result));
+    for (const [name, minutes] of Object.entries(workflowMinutes)) {
+      const safeName = name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
+      process.stdout.write(
+        `actions_spend_workflow_${safeName}_minutes,${Math.round(minutes * 100) / 100}\n`,
+      );
+    }
   } catch (error) {
-    console.error('Error calculating actions spend:', error);
+    process.stderr.write(
+      error instanceof Error ? error.message : String(error),
+    );
     process.exit(1);
   }
 }

--- a/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
+++ b/tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import type { MetricOutput } from '../types.js';
+
+function getWorkflowMinutes(): Record<string, number> {
+  const output = execFileSync(
+    'gh',
+    [
+      'run',
+      'list',
+      '--limit',
+      '1000',
+      '--json',
+      'workflowName,startedAt,updatedAt',
+    ],
+    { encoding: 'utf-8' },
+  );
+  const runs = JSON.parse(output);
+
+  const workflowMinutes: Record<string, number> = {};
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+
+  for (const r of runs) {
+    if (!r.startedAt || !r.updatedAt) continue;
+
+    const start = new Date(r.startedAt).getTime();
+    if (start < sevenDaysAgo) continue;
+    const end = new Date(r.updatedAt).getTime();
+    const durationMinutes = (end - start) / (1000 * 60);
+
+    if (durationMinutes >= 0) {
+      const name = r.workflowName || 'Unknown';
+      workflowMinutes[name] = (workflowMinutes[name] || 0) + durationMinutes;
+    }
+  }
+
+  return workflowMinutes;
+}
+
+function run() {
+  try {
+    const workflowMinutes = getWorkflowMinutes();
+    let totalMinutes = 0;
+
+    for (const minutes of Object.values(workflowMinutes)) {
+      totalMinutes += minutes;
+    }
+
+    const result: MetricOutput = {
+      metric: 'actions_spend_minutes',
+      value: totalMinutes,
+      timestamp: new Date().toISOString(),
+      details: workflowMinutes,
+    };
+
+    console.log(JSON.stringify(result));
+  } catch (error) {
+    console.error('Error calculating actions spend:', error);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary

Adds a new metric script to track total GitHub Actions spend. It fetches the last 1000 workflow runs, filters for those within the last 7 days, and calculates the total execution time in minutes.

## Details

- Uses `gh run list` to fetch workflow runs.
- Calculates total spend in minutes over a rolling 7-day window.
- Outputs the data in the `MetricOutput` JSON format used by the `gemini-cli-bot`.
- Provides a per-workflow breakdown of the spent minutes.

## Related Issues

None.

## How to Validate

Run the script locally to see the metrics output:
```bash
npx tsx tools/gemini-cli-bot/metrics/scripts/actions_spend.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker