### PR TITLE
fix(ci): respect exempt labels when closing stale items

### DIFF
--- a/.github/scripts/gemini-lifecycle-manager.cjs
+++ b/.github/scripts/gemini-lifecycle-manager.cjs
@@ -154,7 +154,7 @@ module.exports = async ({ github, context, core }) => {
 
   // 3. Handle Stale Close (14 days with stale label)
   await processItems(
-    `repo:${owner}/${repo} is:open label:"${STALE_LABEL}" updated:<${closeThreshold.toISOString()}`,
+    `repo:${owner}/${repo} is:open label:"${STALE_LABEL}" ${exemptQuery} updated:<${closeThreshold.toISOString()}`,
     async (item) => {
       core.info(`Closing stale item #${item.number}.`);
       if (!dryRun) {


### PR DESCRIPTION
## Summary

Adds `exemptQuery` to the "Stale Close" step of the lifecycle manager to ensure that items marked with exempt labels (like `🔒 maintainer only` and `help wanted`) are protected from being closed, even if they were previously marked as `stale`.

## Details

Previously, the `exemptQuery` was correctly applied when marking inactive items as stale, preventing exempt items from being automatically marked as stale. However, the query used to *close* stale items was missing this check. This meant that if an item had both the `stale` and `🔒 maintainer only` labels (e.g. if a maintainer manually added the exempt label later to save it), the item could still be closed. This PR brings the close logic into alignment with the stale logic.

## Related Issues

None.

## How to Validate

Review the source code change in `.github/scripts/gemini-lifecycle-manager.cjs`. The query for "Handle Stale Close" now includes `${exemptQuery}`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker