### PR TITLE
fix(ci): require nudge label before closing old PRs

### DIFF
--- a/.github/scripts/gemini-lifecycle-manager.cjs
+++ b/.github/scripts/gemini-lifecycle-manager.cjs
@@ -176,17 +176,13 @@ module.exports = async ({ github, context, core }) => {
 
   // 4. Handle PR Contribution Policy (Nudge at 7d, Close at 14d)
   const PR_NUDGE_DAYS = 7;
-  const PR_CLOSE_DAYS = 14;
   const nudgeThreshold = new Date(
     now.getTime() - PR_NUDGE_DAYS * 24 * 60 * 60 * 1000,
-  );
-  const prCloseThreshold = new Date(
-    now.getTime() - PR_CLOSE_DAYS * 24 * 60 * 60 * 1000,
   );
 
   // Nudge
   await processItems(
-    `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" -label:"status/pr-nudge-sent" created:${prCloseThreshold.toISOString()}..${nudgeThreshold.toISOString()}`,
+    `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" -label:"status/pr-nudge-sent" created:<${nudgeThreshold.toISOString()}`,
     async (pr) => {
       if (
         ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association) ||
@@ -214,7 +210,7 @@ module.exports = async ({ github, context, core }) => {
 
   // Close
   await processItems(
-    `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" created:<${prCloseThreshold.toISOString()}`,
+    `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" label:"status/pr-nudge-sent" updated:<${nudgeThreshold.toISOString()}`,
     async (pr) => {
       if (
         ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association) ||


### PR DESCRIPTION
## Summary

Updates the PR Contribution Policy in the `gemini-lifecycle-manager` to ensure PRs are only closed 7 days *after* they receive a warning nudge, protecting older un-nudged backlog PRs from being abruptly closed.

## Details

Previously, the "Close" query unconditionally targeted PRs older than 14 days. Since the "Nudge" query only targets PRs between 7 and 14 days old, an existing backlog PR that is 15+ days old would be completely skipped by the nudge query and immediately closed by the close query without any warning. 

This change:
1.  Removes the upper bound on the Nudge query so old PRs get properly nudged.
2.  Requires the `status/pr-nudge-sent` label to be present before closing.
3.  Changes the closure time metric from "created at" to "updated at". Since adding the nudge label updates the PR, this ensures the PR will not be closed until 7 days of inactivity have passed *after* the nudge was applied.

## Related Issues

None.

## How to Validate

Review the source code change in `.github/scripts/gemini-lifecycle-manager.cjs`. The Close block now requires `label:"status/pr-nudge-sent"` and uses `updated:<${nudgeThreshold.toISOString()}`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker