### PR TITLE
fix(core): prevent unhandled promise rejection on IDE MCP fetch failure

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -495,6 +495,30 @@ export class IdeClient {
     }
   }
 
+  // Must be invoked before client.connect so that errors surfaced during
+  // connection setup or by a long-lived SSE stream are routed through
+  // onerror instead of becoming unhandled promise rejections.
+  private registerTransportHandlers() {
+    if (!this.client) {
+      return;
+    }
+    this.client.onerror = (_error) => {
+      const errorMessage = _error instanceof Error ? _error.message : `_error`;
+      this.setState(
+        IDEConnectionStatus.Disconnected,
+        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable\n${errorMessage}`,
+        true,
+      );
+    };
+    this.client.onclose = () => {
+      this.setState(
+        IDEConnectionStatus.Disconnected,
+        `IDE connection closed. To reconnect, run /ide enable.`,
+        true,
+      );
+    };
+  }
+
   private registerClientHandlers() {
     if (!this.client) {
       return;
@@ -512,21 +536,6 @@ export class IdeClient {
         }
       },
     );
-    this.client.onerror = (_error) => {
-      const errorMessage = _error instanceof Error ? _error.message : `_error`;
-      this.setState(
-        IDEConnectionStatus.Disconnected,
-        `IDE connection error. The connection was lost unexpectedly. Please try reconnecting by running /ide enable\n${errorMessage}`,
-        true,
-      );
-    };
-    this.client.onclose = () => {
-      this.setState(
-        IDEConnectionStatus.Disconnected,
-        `IDE connection closed. To reconnect, run /ide enable.`,
-        true,
-      );
-    };
     this.client.setNotificationHandler(
       IdeDiffAcceptedNotificationSchema,
       (notification) => {
@@ -597,6 +606,7 @@ export class IdeClient {
           headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
         },
       });
+      this.registerTransportHandlers();
       await this.client.connect(transport);
       this.registerClientHandlers();
       await this.discoverTools();
@@ -630,6 +640,7 @@ export class IdeClient {
         command,
         args,
       });
+      this.registerTransportHandlers();
       await this.client.connect(transport);
       this.registerClientHandlers();
       await this.discoverTools();


### PR DESCRIPTION
## Summary

Register the MCP client's transport-level `onerror`/`onclose` handlers before calling `client.connect(transport)` so that fetch failures from the streamable-HTTP SSE listener are routed through the client's error handler instead of escaping as unhandled promise rejections.

## Details

Issue #25751 reports a `CRITICAL: Unhandled Promise Rejection!` with `TypeError: fetch failed` whose `cause` is undici's `HeadersTimeoutError (UND_ERR_HEADERS_TIMEOUT)`. The fetch in question is the long-lived SSE listening request opened by `StreamableHTTPClientTransport` against the local IDE companion at `http://127.0.0.1:<port>/mcp`. When that stream's headers timer fires (e.g. the IDE companion stops responding), the rejection bubbles up through undici with no `.catch` in the chain.

In `ide-client.ts`, the existing `registerClientHandlers()` was called *after* `await client.connect(transport)`. That left a window, covering both the connect handshake and any post-connect SSE failure routed via `transport.onerror`, in which the client had no `onerror`/`onclose` defined, so the SDK had nowhere to forward the failure.

This change splits handler registration in two:

- `registerTransportHandlers()`: assigns `client.onerror` / `client.onclose`, invoked *before* `client.connect(transport)`. These map to transport-level errors and route them through `setState(Disconnected, ...)`.
- `registerClientHandlers()`: registers the notification handlers (which require an active session), invoked *after* connect, as before.

Both `establishHttpConnection` and `establishStdioConnection` call the new helper before connect.

## Related Issues

Fixes #25751

## How to Validate

1. Start the gemini-cli with `/ide enable` connected to a VS Code companion extension.
2. Stop responding from the IDE side (e.g. suspend the extension host) so the SSE stream stalls beyond undici's headers timeout.
3. Before this change: a `CRITICAL: Unhandled Promise Rejection!` panel is rendered with `TypeError: fetch failed` / `HeadersTimeoutError`.
4. After this change: the IDE connection state transitions to `Disconnected` with the standard "IDE connection error" message and the user is prompted to run `/ide enable` to reconnect.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run