### PR TITLE
perf(context): skip O(N) calculateTokenBreakdown when tracer is disabled

### DIFF
--- a/packages/core/src/context/graph/render.ts
+++ b/packages/core/src/context/graph/render.ts
@@ -48,13 +48,15 @@ export async function render(
     isOverBudget: currentTokens > maxTokens,
   });
 
-  tracer.logEvent('Render', 'Estimation Calibration', {
-    breakdown: env.tokenCalculator.calculateTokenBreakdown(nodes),
-  });
+  if (tracer.isEnabled) {
+    tracer.logEvent('Render', 'Estimation Calibration', {
+      breakdown: env.tokenCalculator.calculateTokenBreakdown(nodes),
+    });
 
-  tracer.logEvent('Render', 'Protection Audit', {
-    reasons: Object.fromEntries(protectionReasons),
-  });
+    tracer.logEvent('Render', 'Protection Audit', {
+      reasons: Object.fromEntries(protectionReasons),
+    });
+  }
 
   if (currentTokens <= maxTokens) {
     tracer.logEvent(

--- a/packages/core/src/context/tracer.ts
+++ b/packages/core/src/context/tracer.ts
@@ -43,6 +43,10 @@ export class ContextTracer {
     }
   }
 
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
   logEvent(
     component: string,
     action: string,


### PR DESCRIPTION
## Summary

- **Bug:** `render.ts` eagerly evaluated `env.tokenCalculator.calculateTokenBreakdown(nodes)` as an argument to `tracer.logEvent(...)` on every API turn, even though `logEvent` immediately returns `if (!this.enabled)`. JS evaluates arguments before the function call, so the O(N×parts) computation always ran.
- **Fix:** Added `get isEnabled(): boolean` to `ContextTracer` and guarded the two expensive calls behind `if (tracer.isEnabled)`:
  - `calculateTokenBreakdown(nodes)` — iterates all nodes, calls `estimateTokenCountSync` per part for categorization
  - `Object.fromEntries(protectionReasons)` — O(N) map copy
- Both calls now execute only when `GEMINI_CONTEXT_TRACE_DIR` is set (tracing opt-in, off by default).

**Impact:** Applies to users with `contextManagement.enabled: true`. The `generalistProfile` budget is configured, so the budget branch of `render()` fires on every turn for those users.

## Test plan

- [ ] Existing context pipeline tests pass (no behavior change when tracing disabled)
- [ ] When `GEMINI_CONTEXT_TRACE_DIR` is set, trace logs still contain `Estimation Calibration` and `Protection Audit` events
- [ ] Nightly perf CI should show improvement for long-conversation scenarios with context management enabled