### PR TITLE
feat(mcp): auto-discover .mcp.json from project root

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -805,31 +805,6 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
     workspaceResult = load(workspaceSettingsPath);
   }
 
-  // Auto-discover .mcp.json in project root (compatible with Claude Code / MCP standard).
-  // mcpServers defined in .gemini/settings.json take precedence over .mcp.json.
-  if (!storage.isWorkspaceHomeDir()) {
-    const mcpJsonPath = path.join(workspaceDir, '.mcp.json');
-    try {
-      if (fs.existsSync(mcpJsonPath)) {
-        const mcpJsonContent = fs.readFileSync(mcpJsonPath, 'utf-8');
-        const mcpJson = JSON.parse(mcpJsonContent) as Record<string, unknown>;
-        if (
-          mcpJson &&
-          typeof mcpJson.mcpServers === 'object' &&
-          mcpJson.mcpServers !== null
-        ) {
-          const mcpJsonServers = mcpJson.mcpServers as Record<string, unknown>;
-          workspaceResult.settings.mcpServers = {
-            ...mcpJsonServers,
-            ...(workspaceResult.settings.mcpServers ?? {}),
-          } as Settings['mcpServers'];
-        }
-      }
-    } catch {
-      // Ignore malformed or unreadable .mcp.json
-    }
-  }
-
   const systemOriginalSettings = structuredClone(systemResult.rawSettings);
   const systemDefaultsOriginalSettings = structuredClone(
     systemDefaultsResult.rawSettings,
@@ -868,6 +843,108 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   const isTrusted =
     isWorkspaceTrusted(initialTrustCheckSettings as Settings, workspaceDir)
       .isTrusted ?? false;
+
+  // Auto-discover .mcp.json from project root (Claude Code / MCP-standard format).
+  // Security constraints: trusted workspaces only; no symlinks; size-capped;
+  // env-var-expanded; Zod-validated; trust field stripped (cannot be granted via project files).
+  // .gemini/settings.json mcpServers take precedence over .mcp.json.
+  if (isTrusted && !storage.isWorkspaceHomeDir()) {
+    const mcpJsonPath = path.join(workspaceDir, '.mcp.json');
+    const MAX_MCP_JSON_BYTES = 1024 * 1024; // 1 MiB
+    try {
+      let stat: fs.Stats | null = null;
+      try {
+        stat = fs.lstatSync(mcpJsonPath);
+      } catch {
+        // file does not exist
+      }
+      if (stat?.isFile()) {
+        if (stat.size > MAX_MCP_JSON_BYTES) {
+          settingsErrors.push({
+            message: `.mcp.json exceeds the 1 MiB size limit and was not loaded.`,
+            path: mcpJsonPath,
+            severity: 'warning',
+          });
+        } else {
+          const mcpJsonContent = fs.readFileSync(mcpJsonPath, 'utf-8');
+          const parsed = JSON.parse(stripJsonComments(mcpJsonContent)) as unknown;
+          if (
+            parsed !== null &&
+            typeof parsed === 'object' &&
+            !Array.isArray(parsed) &&
+            typeof (parsed as Record<string, unknown>).mcpServers === 'object' &&
+            (parsed as Record<string, unknown>).mcpServers !== null
+          ) {
+            const rawServers = (parsed as Record<string, unknown>)
+              .mcpServers as Record<string, unknown>;
+
+            // Filter prototype-poisoning keys before any spread
+            const DANGEROUS_KEYS = new Set([
+              '__proto__',
+              'constructor',
+              'prototype',
+            ]);
+            const safeServers: Record<string, unknown> = {};
+            for (const [key, val] of Object.entries(rawServers)) {
+              if (!DANGEROUS_KEYS.has(key)) {
+                safeServers[key] = val;
+              }
+            }
+
+            // Expand environment variables (same pipeline as settings.json)
+            const expandedServers = resolveEnvVarsInObject(safeServers);
+
+            // Validate against the settings schema
+            const validationResult = validateSettings({
+              mcpServers: expandedServers,
+            });
+            if (!validationResult.success && validationResult.error) {
+              settingsErrors.push({
+                message: formatValidationError(
+                  validationResult.error,
+                  mcpJsonPath,
+                ),
+                path: mcpJsonPath,
+                severity: 'warning',
+              });
+            }
+
+            const validatedServers = validationResult.success
+              ? (validationResult.data as Settings)?.mcpServers
+              : (expandedServers as Settings['mcpServers']);
+
+            if (validatedServers) {
+              // Strip the `trust` field: trust elevation cannot be granted via
+              // project-scoped files — only via user or system settings.
+              const sanitizedServers: Settings['mcpServers'] = {};
+              for (const [name, cfg] of Object.entries(validatedServers)) {
+                if (cfg) {
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  const { trust: _trust, ...rest } = cfg as typeof cfg & {
+                    trust?: unknown;
+                  };
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+                  sanitizedServers[name] = rest as (typeof sanitizedServers)[string];
+                }
+              }
+
+              // Merge: .gemini/settings.json wins on name collision
+              workspaceSettings.mcpServers = {
+                ...sanitizedServers,
+                ...(workspaceSettings.mcpServers ?? {}),
+              };
+            }
+          }
+        }
+      }
+    } catch (err) {
+      settingsErrors.push({
+        message: `Failed to load .mcp.json: ${getErrorMessage(err)}`,
+        path: mcpJsonPath,
+        severity: 'warning',
+      });
+    }
+  }
 
   // Create a temporary merged settings object to pass to loadEnvironment.
   const tempMergedSettings = mergeSettings(

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -805,6 +805,31 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
     workspaceResult = load(workspaceSettingsPath);
   }
 
+  // Auto-discover .mcp.json in project root (compatible with Claude Code / MCP standard).
+  // mcpServers defined in .gemini/settings.json take precedence over .mcp.json.
+  if (!storage.isWorkspaceHomeDir()) {
+    const mcpJsonPath = path.join(workspaceDir, '.mcp.json');
+    try {
+      if (fs.existsSync(mcpJsonPath)) {
+        const mcpJsonContent = fs.readFileSync(mcpJsonPath, 'utf-8');
+        const mcpJson = JSON.parse(mcpJsonContent) as Record<string, unknown>;
+        if (
+          mcpJson &&
+          typeof mcpJson.mcpServers === 'object' &&
+          mcpJson.mcpServers !== null
+        ) {
+          const mcpJsonServers = mcpJson.mcpServers as Record<string, unknown>;
+          workspaceResult.settings.mcpServers = {
+            ...mcpJsonServers,
+            ...(workspaceResult.settings.mcpServers ?? {}),
+          } as Settings['mcpServers'];
+        }
+      }
+    } catch {
+      // Ignore malformed or unreadable .mcp.json
+    }
+  }
+
   const systemOriginalSettings = structuredClone(systemResult.rawSettings);
   const systemDefaultsOriginalSettings = structuredClone(
     systemDefaultsResult.rawSettings,

--- a/packages/core/src/context/graph/render.ts
+++ b/packages/core/src/context/graph/render.ts
@@ -48,13 +48,15 @@ export async function render(
     isOverBudget: currentTokens > maxTokens,
   });
 
-  tracer.logEvent('Render', 'Estimation Calibration', {
-    breakdown: env.tokenCalculator.calculateTokenBreakdown(nodes),
-  });
+  if (tracer.isEnabled) {
+    tracer.logEvent('Render', 'Estimation Calibration', {
+      breakdown: env.tokenCalculator.calculateTokenBreakdown(nodes),
+    });
 
-  tracer.logEvent('Render', 'Protection Audit', {
-    reasons: Object.fromEntries(protectionReasons),
-  });
+    tracer.logEvent('Render', 'Protection Audit', {
+      reasons: Object.fromEntries(protectionReasons),
+    });
+  }
 
   if (currentTokens <= maxTokens) {
     tracer.logEvent(

--- a/packages/core/src/context/tracer.ts
+++ b/packages/core/src/context/tracer.ts
@@ -43,6 +43,10 @@ export class ContextTracer {
     }
   }
 
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
   logEvent(
     component: string,
     action: string,


### PR DESCRIPTION
## Problem

Gemini CLI ignores `.mcp.json` files in the project root. Users who already have MCP servers configured via `.mcp.json` (standard format used by Claude Code and other tools) must duplicate the entire config inside `.gemini/settings.json`. This creates config drift and extra friction.

## Solution

Auto-discover `.mcp.json` in `_doLoadSettings()` and merge its `mcpServers` into workspace settings with the following precedence:

```
.gemini/settings.json mcpServers  ← wins (higher priority)
.mcp.json mcpServers              ← fills in missing servers
```

**Format supported** (same as Claude Code / MCP standard):
```json
{
  "mcpServers": {
    "my-server": {
      "command": "npx",
      "args": ["-y", "my-mcp-package"]
    }
  }
}
```

## Behavior

- File missing → no-op, no error
- File malformed / unread → silently ignored  
- Server defined in both files → `.gemini/settings.json` wins
- Only applies when workspace ≠ home dir (same guard as workspace settings)

## Test plan

- [ ] Place `.mcp.json` in project root → servers appear in `gemini mcp list`
- [ ] Define same server in both `.mcp.json` and `.gemini/settings.json` → settings.json version wins
- [ ] Malformed `.mcp.json` → CLI starts normally, no crash
- [ ] Missing `.mcp.json` → no change in behavior