### PR TITLE
fix(core): reject numeric project IDs in GOOGLE_CLOUD_PROJECT (#24695)

### DIFF
--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -8,6 +8,7 @@ import {
   ProjectIdRequiredError,
   setupUser,
   ValidationCancelledError,
+  InvalidNumericProjectIdError,
   resetUserDataCacheForTesting,
 } from './setup.js';
 import { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
@@ -216,6 +217,13 @@ describe('setupUser', () => {
 
       await expect(setupUser({} as OAuth2Client, mockConfig)).rejects.toThrow(
         ProjectIdRequiredError,
+      );
+    });
+
+    it('should throw InvalidNumericProjectIdError when GOOGLE_CLOUD_PROJECT is numeric', async () => {
+      vi.stubEnv('GOOGLE_CLOUD_PROJECT', '1234567890');
+      await expect(setupUser({} as OAuth2Client, mockConfig)).rejects.toThrow(
+        InvalidNumericProjectIdError,
       );
     });
   });

--- a/packages/core/src/code_assist/setup.test.ts
+++ b/packages/core/src/code_assist/setup.test.ts
@@ -226,6 +226,13 @@ describe('setupUser', () => {
         InvalidNumericProjectIdError,
       );
     });
+
+    it('should throw InvalidNumericProjectIdError when GOOGLE_CLOUD_PROJECT_ID is numeric', async () => {
+      vi.stubEnv('GOOGLE_CLOUD_PROJECT_ID', '1234567890');
+      await expect(setupUser({} as OAuth2Client, mockConfig)).rejects.toThrow(
+        InvalidNumericProjectIdError,
+      );
+    });
   });
 
   describe('new user', () => {

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -36,6 +36,15 @@ export class ProjectIdRequiredError extends Error {
   }
 }
 
+export class InvalidNumericProjectIdError extends Error {
+  constructor(projectId: string) {
+    super(
+      `Invalid Google Cloud Project ID: "${projectId}". The GOOGLE_CLOUD_PROJECT environment variable must be set to your string-based Project ID (e.g., "my-project-123"), not your numeric Project Number. Please update your environment variables.`,
+    );
+    this.name = 'InvalidNumericProjectIdError';
+  }
+}
+
 /**
  * Error thrown when user cancels the validation process.
  * This is a non-recoverable error that should result in auth failure.
@@ -121,6 +130,10 @@ export async function setupUser(
     process.env['GOOGLE_CLOUD_PROJECT'] ||
     process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
     undefined;
+
+  if (projectId && /^\d+$/.test(projectId)) {
+    throw new InvalidNumericProjectIdError(projectId);
+  }
 
   const projectCache = userDataCache.getOrCreate(client, () =>
     createCache<string | undefined, Promise<UserData>>({

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -39,7 +39,7 @@ export class ProjectIdRequiredError extends Error {
 export class InvalidNumericProjectIdError extends Error {
   constructor(projectId: string) {
     super(
-      `Invalid Google Cloud Project ID: "${projectId}". The GOOGLE_CLOUD_PROJECT environment variable must be set to your string-based Project ID (e.g., "my-project-123"), not your numeric Project Number. Please update your environment variables.`,
+      `Invalid Google Cloud Project ID: "${projectId}". The GOOGLE_CLOUD_PROJECT (or GOOGLE_CLOUD_PROJECT_ID) environment variable must be set to your string-based Project ID (e.g., "my-project-123"), not your numeric Project Number. Please update your environment variables.`,
     );
     this.name = 'InvalidNumericProjectIdError';
   }


### PR DESCRIPTION
## Summary

This PR adds validation to reject numeric-only project IDs in the `GOOGLE_CLOUD_PROJECT` (and `GOOGLE_CLOUD_PROJECT_ID`) environment variables. 

## Details

Setting a numeric Project Number instead of a string-based Project ID caused the Gemini API to fail with a generic `400 INVALID_ARGUMENT` error. This change introduces an `InvalidNumericProjectIdError` that is thrown early during setup, providing clear guidance to the user on how to fix their configuration.

## Related Issues

Fixes #24695

## How to Validate

1. Set `GOOGLE_CLOUD_PROJECT` to a numeric value (e.g., `export GOOGLE_CLOUD_PROJECT=123456789`).
2. Run any command (e.g., `gemini help`).
3. Observe the clear error message instead of an API failure.
4. Run tests: `npm test -w @google/gemini-cli-core -- src/code_assist/setup.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
