### PR TITLE
Tighten private Auto Memory patch allowlist

### DIFF
--- a/packages/core/src/commands/memory.test.ts
+++ b/packages/core/src/commands/memory.test.ts
@@ -325,6 +325,8 @@ describe('memory commands', () => {
     let projectRoot: string;
     let globalMemoryDir: string;
     let patchConfig: Config;
+    const isCaseInsensitivePathPlatform =
+      process.platform === 'win32' || process.platform === 'darwin';
 
     function buildUpdatePatch(
       absoluteTargetPath: string,
@@ -370,6 +372,12 @@ describe('memory commands', () => {
         ...additions,
         '',
       ].join('\n');
+    }
+
+    function swapAsciiPathCase(filePath: string): string {
+      return filePath.replace(/[a-z]/gi, (char) =>
+        char === char.toLowerCase() ? char.toUpperCase() : char.toLowerCase(),
+      );
     }
 
     beforeEach(async () => {
@@ -569,6 +577,39 @@ describe('memory commands', () => {
       ).rejects.toThrow();
     });
 
+    it.runIf(isCaseInsensitivePathPlatform)(
+      'accepts private memory patch targets with different path casing',
+      async () => {
+        const target = path.join(memoryTempDir, 'MEMORY.md');
+        await fs.writeFile(target, '- old\n');
+
+        const patchDir = path.join(memoryTempDir, '.inbox', 'private');
+        await fs.mkdir(patchDir, { recursive: true });
+        await fs.writeFile(
+          path.join(patchDir, 'MEMORY.patch'),
+          buildUpdatePatch(
+            swapAsciiPathCase(target),
+            '- old\n',
+            '- accepted\n',
+          ),
+        );
+
+        const patches = await listInboxMemoryPatches(patchConfig);
+        expect(patches).toHaveLength(1);
+
+        const result = await applyInboxMemoryPatch(
+          patchConfig,
+          'private',
+          'MEMORY.patch',
+        );
+
+        expect(result.success).toBe(true);
+        await expect(fs.readFile(target, 'utf-8')).resolves.toBe(
+          '- accepted\n',
+        );
+      },
+    );
+
     it('applies a private creation patch with a paired MEMORY.md pointer', async () => {
       // The auto-memory contract: creating a sibling .md file requires a
       // hunk that adds a pointer to MEMORY.md (so the sibling becomes
@@ -762,6 +803,39 @@ describe('memory commands', () => {
         fs.access(path.join(patchDir, 'GEMINI.patch')),
       ).rejects.toThrow();
     });
+
+    it.runIf(isCaseInsensitivePathPlatform)(
+      'accepts global memory patch targets with different path casing',
+      async () => {
+        const target = path.join(globalMemoryDir, 'GEMINI.md');
+        await fs.writeFile(target, '- prefer X\n');
+
+        const patchDir = path.join(memoryTempDir, '.inbox', 'global');
+        await fs.mkdir(patchDir, { recursive: true });
+        await fs.writeFile(
+          path.join(patchDir, 'GEMINI.patch'),
+          buildUpdatePatch(
+            swapAsciiPathCase(target),
+            '- prefer X\n',
+            '- prefer Y\n',
+          ),
+        );
+
+        const patches = await listInboxMemoryPatches(patchConfig);
+        expect(patches).toHaveLength(1);
+
+        const result = await applyInboxMemoryPatch(
+          patchConfig,
+          'global',
+          'GEMINI.patch',
+        );
+
+        expect(result.success).toBe(true);
+        await expect(fs.readFile(target, 'utf-8')).resolves.toBe(
+          '- prefer Y\n',
+        );
+      },
+    );
 
     it('dismisses a single memory patch from the inbox (legacy single-file mode)', async () => {
       const patchDir = path.join(memoryTempDir, '.inbox', 'global');

--- a/packages/core/src/commands/memory.test.ts
+++ b/packages/core/src/commands/memory.test.ts
@@ -466,6 +466,49 @@ describe('memory commands', () => {
       expect(result.message).toMatch(/outside the private memory root/i);
     });
 
+    it('rejects private patches that target in-root non-memory documents', async () => {
+      const patchDir = path.join(memoryTempDir, '.inbox', 'private');
+      await fs.mkdir(patchDir, { recursive: true });
+
+      const rejectedTargets = [
+        ['state.patch', path.join(memoryTempDir, '.extraction-state.json')],
+        ['lock.patch', path.join(memoryTempDir, '.extraction.lock')],
+        [
+          'inbox.patch',
+          path.join(memoryTempDir, '.inbox', 'private', 'review.md'),
+        ],
+        [
+          'skills.patch',
+          path.join(memoryTempDir, 'skills', 'generated', 'SKILL.md'),
+        ],
+        ['text.patch', path.join(memoryTempDir, 'notes.txt')],
+        ['nested.patch', path.join(memoryTempDir, 'nested', 'topic.md')],
+      ] as const;
+
+      for (const [fileName, targetPath] of rejectedTargets) {
+        await fs.writeFile(
+          path.join(patchDir, fileName),
+          buildCreationPatch(targetPath, 'rejected\n'),
+        );
+      }
+
+      const patches = await listInboxMemoryPatches(patchConfig);
+      expect(patches).toHaveLength(0);
+
+      for (const [fileName, targetPath] of rejectedTargets) {
+        const result = await applyInboxMemoryPatch(
+          patchConfig,
+          'private',
+          fileName,
+        );
+        expect(result.success).toBe(false);
+        expect(result.message).toMatch(
+          /outside the private memory root or target allowlist/i,
+        );
+        await expect(fs.access(targetPath)).rejects.toThrow();
+      }
+    });
+
     it('omits global patches with disallowed targets from the listing', async () => {
       // Same defense for the global tier: only ~/.gemini/GEMINI.md is allowed.
       // memory.md (legacy lowercase), sibling .md files, and settings.json all
@@ -489,6 +532,13 @@ describe('memory commands', () => {
       await fs.writeFile(
         path.join(patchDir, 'settings.patch'),
         buildCreationPatch(path.join(globalMemoryDir, 'settings.json'), '{}\n'),
+      );
+      await fs.writeFile(
+        path.join(patchDir, 'nested.patch'),
+        buildCreationPatch(
+          path.join(globalMemoryDir, 'GEMINI.md', 'nested.md'),
+          'rejected\n',
+        ),
       );
 
       const patches = await listInboxMemoryPatches(patchConfig);
@@ -871,10 +921,20 @@ describe('memory commands', () => {
         ),
       );
 
+      // Child paths under the single allowed file path are not allowed either.
+      await fs.writeFile(
+        path.join(patchDir, 'nested.patch'),
+        buildCreationPatch(
+          path.join(globalMemoryDir, 'GEMINI.md', 'nested.md'),
+          'Should be rejected.\n',
+        ),
+      );
+
       for (const fileName of [
         'wrong-name.patch',
         'sibling.patch',
         'settings.patch',
+        'nested.patch',
       ]) {
         const result = await applyInboxMemoryPatch(
           patchConfig,
@@ -891,6 +951,9 @@ describe('memory commands', () => {
           fs.access(path.join(globalMemoryDir, orphan)),
         ).rejects.toThrow();
       }
+      await expect(
+        fs.access(path.join(globalMemoryDir, 'GEMINI.md', 'nested.md')),
+      ).rejects.toThrow();
     });
 
     it('rejects invalid memory patch paths', async () => {

--- a/packages/core/src/commands/memory.ts
+++ b/packages/core/src/commands/memory.ts
@@ -496,11 +496,11 @@ function isAllowedPrivateMemoryFileName(fileName: string): boolean {
   if (fileName === PROJECT_MEMORY_INDEX_FILENAME) {
     return true;
   }
-  return (
-    fileName.length > '.md'.length &&
-    !fileName.startsWith('.') &&
-    hasMarkdownExtension(fileName)
-  );
+  return !fileName.startsWith('.') && hasMarkdownExtension(fileName);
+}
+
+function uniqueResolvedPaths(paths: readonly string[]): string[] {
+  return Array.from(new Set(paths.map((filePath) => path.resolve(filePath))));
 }
 
 function isAllowedPrivateMemoryDocumentPath(
@@ -509,10 +509,7 @@ function isAllowedPrivateMemoryDocumentPath(
 ): boolean {
   const resolvedTargetPath = path.resolve(targetPath);
   const targetDir = path.dirname(resolvedTargetPath);
-  const isDirectChild = memoryDirs.some(
-    (memoryDir) => path.resolve(memoryDir) === targetDir,
-  );
-  if (!isDirectChild) {
+  if (!memoryDirs.includes(targetDir)) {
     return false;
   }
   return isAllowedPrivateMemoryFileName(path.basename(resolvedTargetPath));
@@ -523,9 +520,7 @@ function isAllowedGlobalMemoryDocumentPath(
   globalMemoryFiles: readonly string[],
 ): boolean {
   const resolvedTargetPath = path.resolve(targetPath);
-  return globalMemoryFiles.some(
-    (memoryFile) => path.resolve(memoryFile) === resolvedTargetPath,
-  );
+  return globalMemoryFiles.includes(resolvedTargetPath);
 }
 
 async function getMemoryPatchTargetValidationContext(
@@ -545,9 +540,10 @@ async function getMemoryPatchTargetValidationContext(
       kind,
       allowedRoots,
       privateMemoryDirs: [],
-      globalMemoryFiles: Array.from(
-        new Set([rawGlobalMemoryFile, ...canonicalGlobalMemoryFiles]),
-      ),
+      globalMemoryFiles: uniqueResolvedPaths([
+        rawGlobalMemoryFile,
+        ...canonicalGlobalMemoryFiles,
+      ]),
     };
   }
 
@@ -557,9 +553,10 @@ async function getMemoryPatchTargetValidationContext(
   const canonicalPrivateMemoryDirs = await canonicalizeAllowedPatchRoots([
     rawPrivateMemoryDir,
   ]);
-  const privateMemoryDirs = Array.from(
-    new Set([rawPrivateMemoryDir, ...canonicalPrivateMemoryDirs]),
-  );
+  const privateMemoryDirs = uniqueResolvedPaths([
+    rawPrivateMemoryDir,
+    ...canonicalPrivateMemoryDirs,
+  ]);
 
   return { kind, allowedRoots, privateMemoryDirs, globalMemoryFiles: [] };
 }

--- a/packages/core/src/commands/memory.ts
+++ b/packages/core/src/commands/memory.ts
@@ -17,6 +17,7 @@ import {
   getGlobalMemoryFilePath,
   PROJECT_MEMORY_INDEX_FILENAME,
 } from '../tools/memoryTool.js';
+import { isSubpath } from '../utils/paths.js';
 import {
   type AppliedSkillPatchTarget,
   applyParsedPatchesWithAllowedRoots,
@@ -427,11 +428,7 @@ function getMemoryPatchRoot(
 }
 
 function isSubpathOrSame(childPath: string, parentPath: string): boolean {
-  const relativePath = path.relative(parentPath, childPath);
-  return (
-    relativePath === '' ||
-    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
-  );
+  return isSubpath(parentPath, childPath);
 }
 
 function normalizeInboxMemoryPatchPath(
@@ -503,13 +500,24 @@ function uniqueResolvedPaths(paths: readonly string[]): string[] {
   return Array.from(new Set(paths.map((filePath) => path.resolve(filePath))));
 }
 
+function isSamePath(leftPath: string, rightPath: string): boolean {
+  return isSubpath(leftPath, rightPath) && isSubpath(rightPath, leftPath);
+}
+
+function includesSamePath(
+  paths: readonly string[],
+  targetPath: string,
+): boolean {
+  return paths.some((candidate) => isSamePath(candidate, targetPath));
+}
+
 function isAllowedPrivateMemoryDocumentPath(
   targetPath: string,
   memoryDirs: readonly string[],
 ): boolean {
   const resolvedTargetPath = path.resolve(targetPath);
   const targetDir = path.dirname(resolvedTargetPath);
-  if (!memoryDirs.includes(targetDir)) {
+  if (!includesSamePath(memoryDirs, targetDir)) {
     return false;
   }
   return isAllowedPrivateMemoryFileName(path.basename(resolvedTargetPath));
@@ -520,7 +528,7 @@ function isAllowedGlobalMemoryDocumentPath(
   globalMemoryFiles: readonly string[],
 ): boolean {
   const resolvedTargetPath = path.resolve(targetPath);
-  return globalMemoryFiles.includes(resolvedTargetPath);
+  return includesSamePath(globalMemoryFiles, resolvedTargetPath);
 }
 
 async function getMemoryPatchTargetValidationContext(

--- a/packages/core/src/commands/memory.ts
+++ b/packages/core/src/commands/memory.ts
@@ -13,7 +13,10 @@ import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { flattenMemory } from '../config/memory.js';
 import { loadSkillFromFile, loadSkillsFromDir } from '../skills/skillLoader.js';
-import { getGlobalMemoryFilePath } from '../tools/memoryTool.js';
+import {
+  getGlobalMemoryFilePath,
+  PROJECT_MEMORY_INDEX_FILENAME,
+} from '../tools/memoryTool.js';
 import {
   type AppliedSkillPatchTarget,
   applyParsedPatchesWithAllowedRoots,
@@ -455,11 +458,11 @@ function normalizeInboxMemoryPatchPath(
 }
 
 /**
- * Returns the directory roots (or single-file allowlists) that a memory patch
- * of the given kind is allowed to modify. Memory patch headers must reference
- * paths inside / equal to one of these entries after canonical resolution.
+ * Returns coarse directory roots (or single-file roots) used for canonical
+ * containment checks before the kind-specific target validator runs.
  *
- * - `private` allows any markdown file inside the project memory directory.
+ * - `private` is rooted at the project memory directory, then narrowed to
+ *   direct memory markdown documents by `isAllowedPrivateMemoryDocumentPath`.
  * - `global` is intentionally a single-file allowlist: the only writeable
  *   global file is the personal `~/.gemini/GEMINI.md`. Other files under
  *   `~/.gemini/` (settings, credentials, oauth, keybindings, etc.) are off-limits.
@@ -476,6 +479,170 @@ export function getAllowedMemoryPatchRoots(
     default:
       throw new Error(`Unknown memory patch kind: ${kind as string}`);
   }
+}
+
+interface MemoryPatchTargetValidationContext {
+  kind: InboxMemoryPatchKind;
+  allowedRoots: string[];
+  privateMemoryDirs: string[];
+  globalMemoryFiles: string[];
+}
+
+function hasMarkdownExtension(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith('.md');
+}
+
+function isAllowedPrivateMemoryFileName(fileName: string): boolean {
+  if (fileName === PROJECT_MEMORY_INDEX_FILENAME) {
+    return true;
+  }
+  return (
+    fileName.length > '.md'.length &&
+    !fileName.startsWith('.') &&
+    hasMarkdownExtension(fileName)
+  );
+}
+
+function isAllowedPrivateMemoryDocumentPath(
+  targetPath: string,
+  memoryDirs: readonly string[],
+): boolean {
+  const resolvedTargetPath = path.resolve(targetPath);
+  const targetDir = path.dirname(resolvedTargetPath);
+  const isDirectChild = memoryDirs.some(
+    (memoryDir) => path.resolve(memoryDir) === targetDir,
+  );
+  if (!isDirectChild) {
+    return false;
+  }
+  return isAllowedPrivateMemoryFileName(path.basename(resolvedTargetPath));
+}
+
+function isAllowedGlobalMemoryDocumentPath(
+  targetPath: string,
+  globalMemoryFiles: readonly string[],
+): boolean {
+  const resolvedTargetPath = path.resolve(targetPath);
+  return globalMemoryFiles.some(
+    (memoryFile) => path.resolve(memoryFile) === resolvedTargetPath,
+  );
+}
+
+async function getMemoryPatchTargetValidationContext(
+  config: Config,
+  kind: InboxMemoryPatchKind,
+): Promise<MemoryPatchTargetValidationContext> {
+  const allowedRoots = await canonicalizeAllowedPatchRoots(
+    getAllowedMemoryPatchRoots(config, kind),
+  );
+
+  if (kind === 'global') {
+    const rawGlobalMemoryFile = path.resolve(getGlobalMemoryFilePath());
+    const canonicalGlobalMemoryFiles = await canonicalizeAllowedPatchRoots([
+      rawGlobalMemoryFile,
+    ]);
+    return {
+      kind,
+      allowedRoots,
+      privateMemoryDirs: [],
+      globalMemoryFiles: Array.from(
+        new Set([rawGlobalMemoryFile, ...canonicalGlobalMemoryFiles]),
+      ),
+    };
+  }
+
+  const rawPrivateMemoryDir = path.resolve(
+    config.storage.getProjectMemoryTempDir(),
+  );
+  const canonicalPrivateMemoryDirs = await canonicalizeAllowedPatchRoots([
+    rawPrivateMemoryDir,
+  ]);
+  const privateMemoryDirs = Array.from(
+    new Set([rawPrivateMemoryDir, ...canonicalPrivateMemoryDirs]),
+  );
+
+  return { kind, allowedRoots, privateMemoryDirs, globalMemoryFiles: [] };
+}
+
+function isResolvedMemoryPatchTargetAllowed(
+  resolvedTargetPath: string,
+  context: MemoryPatchTargetValidationContext,
+): boolean {
+  if (context.kind === 'global') {
+    return isAllowedGlobalMemoryDocumentPath(
+      resolvedTargetPath,
+      context.globalMemoryFiles,
+    );
+  }
+  if (context.kind === 'private') {
+    return isAllowedPrivateMemoryDocumentPath(
+      resolvedTargetPath,
+      context.privateMemoryDirs,
+    );
+  }
+  return true;
+}
+
+async function resolveMemoryPatchTargetWithinAllowedSet(
+  targetPath: string,
+  context: MemoryPatchTargetValidationContext,
+): Promise<string | undefined> {
+  const resolvedTargetPath = await resolveTargetWithinAllowedRoots(
+    targetPath,
+    context.allowedRoots,
+  );
+  if (!resolvedTargetPath) {
+    return undefined;
+  }
+  if (
+    context.kind === 'private' &&
+    (!isAllowedPrivateMemoryDocumentPath(
+      targetPath,
+      context.privateMemoryDirs,
+    ) ||
+      !isAllowedPrivateMemoryDocumentPath(
+        resolvedTargetPath,
+        context.privateMemoryDirs,
+      ))
+  ) {
+    return undefined;
+  }
+  if (
+    context.kind === 'global' &&
+    (!isAllowedGlobalMemoryDocumentPath(
+      targetPath,
+      context.globalMemoryFiles,
+    ) ||
+      !isAllowedGlobalMemoryDocumentPath(
+        resolvedTargetPath,
+        context.globalMemoryFiles,
+      ))
+  ) {
+    return undefined;
+  }
+  return resolvedTargetPath;
+}
+
+async function findDisallowedMemoryPatchTarget(
+  parsedPatches: Diff.StructuredPatch[],
+  context: MemoryPatchTargetValidationContext,
+): Promise<string | undefined> {
+  const validated = validateParsedSkillPatchHeaders(parsedPatches);
+  if (!validated.success) {
+    return undefined;
+  }
+
+  for (const header of validated.patches) {
+    if (
+      !(await resolveMemoryPatchTargetWithinAllowedSet(
+        header.targetPath,
+        context,
+      ))
+    ) {
+      return header.targetPath;
+    }
+  }
+  return undefined;
 }
 
 async function getFileMtimeIso(filePath: string): Promise<string | undefined> {
@@ -585,8 +752,8 @@ async function listInboxPatchFiles(
 
 /**
  * Returns only the inbox patch files that pass the same validation as the
- * inbox listing (parseable, has hunks, valid headers, targets in the
- * kind's allowed root). Used by aggregate apply so the user only ever sees
+ * inbox listing (parseable, has hunks, valid headers, targets in the kind's
+ * allowed target set). Used by aggregate apply so the user only ever sees
  * results for patches the inbox actually surfaced.
  */
 async function listValidInboxPatchFiles(
@@ -598,8 +765,9 @@ async function listValidInboxPatchFiles(
     return [];
   }
 
-  const allowedRoots = await canonicalizeAllowedPatchRoots(
-    getAllowedMemoryPatchRoots(config, kind),
+  const validationContext = await getMemoryPatchTargetValidationContext(
+    config,
+    kind,
   );
 
   const valid: string[] = [];
@@ -629,9 +797,9 @@ async function listValidInboxPatchFiles(
     const targetsAllAllowed = await Promise.all(
       validated.patches.map(
         async (header) =>
-          (await resolveTargetWithinAllowedRoots(
+          (await resolveMemoryPatchTargetWithinAllowedSet(
             header.targetPath,
-            allowedRoots,
+            validationContext,
           )) !== undefined,
       ),
     );
@@ -648,8 +816,8 @@ async function listValidInboxPatchFiles(
  * Scans `<memoryDir>/.inbox/{private,global}/` and returns ONE consolidated
  * inbox entry per kind. Each entry aggregates all hunks from every valid
  * underlying `.patch` file. Patches that fail validation (unparseable, no
- * hunks, target outside allowed root) are silently skipped so they don't
- * pollute the inbox UI.
+ * hunks, target outside the allowed target set) are silently skipped so they
+ * don't pollute the inbox UI.
  */
 export async function listInboxMemoryPatches(
   config: Config,
@@ -658,8 +826,9 @@ export async function listInboxMemoryPatches(
   const aggregated: InboxMemoryPatch[] = [];
 
   for (const kind of kinds) {
-    const allowedRoots = await canonicalizeAllowedPatchRoots(
-      getAllowedMemoryPatchRoots(config, kind),
+    const validationContext = await getMemoryPatchTargetValidationContext(
+      config,
+      kind,
     );
     const patchFiles = await listInboxPatchFiles(config, kind);
 
@@ -691,13 +860,13 @@ export async function listInboxMemoryPatches(
       }
 
       // Skip the entire source file if ANY of its targets escapes the kind's
-      // allowed root.
+      // allowed target set.
       const targetsAllAllowed = await Promise.all(
         validated.patches.map(
           async (header) =>
-            (await resolveTargetWithinAllowedRoots(
+            (await resolveMemoryPatchTargetWithinAllowedSet(
               header.targetPath,
-              allowedRoots,
+              validationContext,
             )) !== undefined,
         ),
       );
@@ -1015,12 +1184,31 @@ async function applyMemoryPatchFile(
     };
   }
 
-  const allowedRoots = await canonicalizeAllowedPatchRoots(
-    getAllowedMemoryPatchRoots(config, kind),
+  const validationContext = await getMemoryPatchTargetValidationContext(
+    config,
+    kind,
   );
+  const disallowedTargetPath = await findDisallowedMemoryPatchTarget(
+    parsed,
+    validationContext,
+  );
+  if (disallowedTargetPath) {
+    return {
+      success: false,
+      message: `Memory patch "${displayName}" targets a file outside the ${kind} memory root or target allowlist: ${disallowedTargetPath}`,
+    };
+  }
+
   const applied = await applyParsedPatchesWithAllowedRoots(
     parsed,
-    allowedRoots,
+    validationContext.allowedRoots,
+    {
+      isResolvedTargetAllowed: (resolvedTargetPath) =>
+        isResolvedMemoryPatchTargetAllowed(
+          resolvedTargetPath,
+          validationContext,
+        ),
+    },
   );
   if (!applied.success) {
     switch (applied.reason) {
@@ -1037,7 +1225,7 @@ async function applyMemoryPatchFile(
       case 'outsideAllowedRoots':
         return {
           success: false,
-          message: `Memory patch "${displayName}" targets a file outside the ${kind} memory root: ${applied.targetPath}`,
+          message: `Memory patch "${displayName}" targets a file outside the ${kind} memory root or target allowlist: ${applied.targetPath}`,
         };
       case 'newFileAlreadyExists':
         return {

--- a/packages/core/src/services/memoryPatchUtils.ts
+++ b/packages/core/src/services/memoryPatchUtils.ts
@@ -252,15 +252,24 @@ export async function applyParsedSkillPatches(
   return applyParsedPatchesWithAllowedRoots(parsedPatches, allowedRoots);
 }
 
+export interface ApplyParsedPatchesWithAllowedRootsOptions {
+  /**
+   * Optional fine-grained allowlist for callers whose allowed root is broader
+   * than their actual target surface. Receives the canonical target path after
+   * root containment has already passed.
+   */
+  isResolvedTargetAllowed?: (resolvedTargetPath: string) => boolean;
+}
+
 /**
  * Applies parsed unified diff patches against any caller-supplied set of
  * allowed root directories. This is the kind-agnostic core used by both the
  * skill patch flow and the memory patch flow.
  *
  * The patch headers must reference absolute paths inside one of the allowed
- * roots (after canonical resolution). Update patches must reference an
- * existing target; creation patches (`/dev/null` source) must reference a path
- * that does not yet exist.
+ * roots (after canonical resolution) and pass any caller-supplied fine-grained
+ * target predicate. Update patches must reference an existing target; creation
+ * patches (`/dev/null` source) must reference a path that does not yet exist.
  *
  * Returns the per-target before/after content so callers can stage commits
  * and roll back on failure.
@@ -268,6 +277,7 @@ export async function applyParsedSkillPatches(
 export async function applyParsedPatchesWithAllowedRoots(
   parsedPatches: StructuredPatch[],
   allowedRoots: string[],
+  options: ApplyParsedPatchesWithAllowedRootsOptions = {},
 ): Promise<ApplyParsedSkillPatchesResult> {
   const results = new Map<string, AppliedSkillPatchTarget>();
   const patchedContentByTarget = new Map<string, string>();
@@ -285,7 +295,11 @@ export async function applyParsedPatchesWithAllowedRoots(
       targetPath,
       allowedRoots,
     );
-    if (!resolvedTargetPath) {
+    if (
+      !resolvedTargetPath ||
+      (options.isResolvedTargetAllowed &&
+        !options.isResolvedTargetAllowed(resolvedTargetPath))
+    ) {
       return {
         success: false,
         reason: 'outsideAllowedRoots',


### PR DESCRIPTION
## Summary

Tightens Auto Memory private patch validation so private memory patches can only target the project memory document set: `MEMORY.md` and direct sibling markdown files in the project memory directory.

## Details

Private memory patch listing, aggregate apply/dismiss, and direct apply now share a kind-aware target validator. The validator rejects in-root but non-memory targets such as extraction state files, locks, `.inbox/`, `skills/`, nested paths, and non-markdown files.

The shared parsed-patch applicator now accepts an optional resolved-target predicate so memory patches can narrow a coarse root allowlist without changing skill patch behavior.

Also tightened the global memory single-file contract so child paths under `~/.gemini/GEMINI.md/` are rejected.

## Related Issues

Fixes #26520

## How to Validate

Run:

```sh
npx vitest run packages/core/src/commands/memory.test.ts
npm run typecheck --workspace @google/gemini-cli-core
npx prettier --check packages/core/src/commands/memory.ts packages/core/src/services/memoryPatchUtils.ts packages/core/src/commands/memory.test.ts
npm run build --workspace @google/gemini-cli-core
npm run lint --workspace @google/gemini-cli-core
env RUN_EVALS=1 npx vitest run --config evals/vitest.config.ts evals/skill_extraction.eval.ts
```

Expected results:

- Memory command tests pass.
- Core typecheck, formatting, build, and lint pass.
- `skill_extraction.eval.ts` reports 4 passed and 1 skipped. The skipped case is gated behind `RUN_SCRATCHPAD_STATS=1`.
- Private patch attempts for `.extraction-state.json`, `.extraction.lock`, `.inbox/*`, `skills/*`, non-markdown files, and nested markdown paths are omitted from listing and rejected on direct apply.
- Valid private patch flows for `MEMORY.md` and direct sibling `*.md` files still pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
