### PR TITLE
fix(core): allow redirection in YOLO and AUTO_EDIT modes without sandboxing

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1898,6 +1898,30 @@ describe('PolicyEngine', () => {
       expect(result.decision).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should NOT downgrade to ASK_USER for redirected commands in YOLO mode even without sandbox', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ALLOW,
+          priority: 10,
+        },
+      ];
+
+      engine = new PolicyEngine({
+        rules,
+        approvalMode: ApprovalMode.YOLO,
+        sandboxManager: new NoopSandboxManager(),
+      });
+
+      const command = 'npm test 2>&1 | tail -80';
+      const { decision } = await engine.check(
+        { name: 'run_shell_command', args: { command } },
+        undefined,
+      );
+
+      expect(decision).toBe(PolicyDecision.ALLOW);
+    });
+
     it('should return ALLOW in YOLO mode even if shell command parsing fails', async () => {
       const { splitCommands } = await import('../utils/shell-utils.js');
       const rules: PolicyRule[] = [

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -288,12 +288,11 @@ export class PolicyEngine {
     if (allowRedirection) return false;
     if (!hasRedirection(command)) return false;
 
-    // Do not downgrade (do not ask user) if sandboxing is enabled and in AUTO_EDIT or YOLO
-    const sandboxEnabled = !(this.sandboxManager instanceof NoopSandboxManager);
+    // Do not downgrade (do not ask user) if in AUTO_EDIT or YOLO mode.
+    // These modes trust the agent's actions (YOLO) or specific task (AUTO_EDIT).
     if (
-      sandboxEnabled &&
-      (this.approvalMode === ApprovalMode.AUTO_EDIT ||
-        this.approvalMode === ApprovalMode.YOLO)
+      this.approvalMode === ApprovalMode.AUTO_EDIT ||
+      this.approvalMode === ApprovalMode.YOLO
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary
Fixed a regression where commands with redirection (pipes, redirects) were being downgraded to `ASK_USER` in YOLO and AUTO_EDIT modes when sandboxing was disabled.

## Details
In `PolicyEngine.shouldDowngradeForRedirection`, the logic was checking if sandboxing was enabled before allowing YOLO/AUTO_EDIT modes to bypass the redirection safeguard. This caused unnecessary approval prompts in environments where sandboxing is disabled (e.g., certain git worktrees or specific OS configurations). The fix removes the `sandboxEnabled` requirement for these trusted modes.

## Related Issues
Fixes the reported regression where commands like `npm test ... 2>&1 | tail -80` prompted for approval in YOLO mode.

## How to Validate
Run the new regression test:
`npm test -w @google/gemini-cli-core -- src/policy/policy-engine.test.ts`
The test `should NOT downgrade to ASK_USER for redirected commands in YOLO mode even without sandbox` verifies the fix.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] Seatbelt
