### PR TITLE
fix: externalize https-proxy-agent in bundle

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -64,6 +64,7 @@ const external = [
   '@lydell/node-pty-win32-x64',
   '@github/keytar',
   '@google/gemini-cli-devtools',
+  'https-proxy-agent',
 ];
 
 const baseConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "https-proxy-agent": "^7.0.6",
         "ink": "npm:@jrichman/ink@6.6.9",
         "latest-version": "^9.0.0",
         "node-fetch-native": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "https-proxy-agent": "^7.0.6",
     "ink": "npm:@jrichman/ink@6.6.9",
     "latest-version": "^9.0.0",
     "node-fetch-native": "^1.6.7",


### PR DESCRIPTION
## Summary

Fixes #26533.

Externalizes `https-proxy-agent` from the main esbuild bundle so the Vertex AI / gaxios proxy path can load it through Node's runtime module resolver instead of using the bundled copy.

This avoids proxy-agent runtime failures when `HTTP_PROXY` / `HTTPS_PROXY` are set.

## Details

The proxy path in gaxios lazily imports `https-proxy-agent`. When bundled into the CLI output, that dependency can hit bundling/runtime interop problems. Keeping it external preserves the package's normal runtime export shape.

This PR also adds `https-proxy-agent` to the root runtime dependencies so the published CLI package can resolve the externalized import after installation.

## Related Issues

Fixes #26533

## How to Validate

- `npx prettier --check esbuild.config.js package.json package-lock.json`
- `npm run bundle`
- `npm pack`
- Installed the packed tarball into a clean temp project
- Verified `require.resolve('https-proxy-agent')` succeeds from the clean installed package
- `npm run preflight`
- `git diff --check`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — no breaking changes
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker