### PR TITLE
fix(acp): move tool explanation from thought stream to tool call content

### DIFF
--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -586,4 +586,125 @@ describe('Session', () => {
       },
     });
   });
+
+  it('should add explanation to tool call content instead of thought chunk', async () => {
+    mockTool.build.mockReturnValue({
+      getDescription: () => 'Test Tool',
+      getExplanation: () => 'Test Explanation',
+      toolLocations: () => [],
+      shouldConfirmExecute: vi
+        .fn()
+        .mockResolvedValue({ type: 'info', onConfirm: vi.fn() }),
+      execute: vi.fn().mockResolvedValue({ llmContent: 'Tool Result' }),
+    });
+
+    mockConnection.requestPermission.mockResolvedValue({
+      outcome: {
+        outcome: 'selected',
+        optionId: 'proceed_once',
+      },
+    });
+
+    const stream1 = createMockStream([
+      {
+        type: GeminiEventType.ToolCallRequest,
+        value: {
+          callId: 'call-1',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+      },
+    ]);
+    const stream2 = createMockStream([
+      {
+        type: GeminiEventType.Content,
+        value: '',
+      },
+    ]);
+
+    mockSendMessageStream
+      .mockReturnValueOnce(stream1)
+      .mockReturnValueOnce(stream2);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Call tool' }],
+    });
+
+    expect(mockConnection.sessionUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'Test Explanation' },
+        }),
+      }),
+    );
+
+    expect(mockConnection.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          content: expect.arrayContaining([
+            {
+              type: 'content',
+              content: { type: 'text', text: 'Test Explanation' },
+            },
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it('should add explanation to tool_call update content instead of thought chunk when no permission required', async () => {
+    mockTool.build.mockReturnValue({
+      getDescription: () => 'Test Tool',
+      getExplanation: () => 'Test Explanation',
+      toolLocations: () => [],
+      shouldConfirmExecute: vi.fn().mockResolvedValue(null),
+      execute: vi.fn().mockResolvedValue({ llmContent: 'Tool Result' }),
+    });
+
+    const stream1 = createMockStream([
+      {
+        type: GeminiEventType.ToolCallRequest,
+        value: {
+          callId: 'call-1',
+          name: 'test_tool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-1',
+        },
+      },
+    ]);
+    const stream2 = createMockStream([
+      {
+        type: GeminiEventType.Content,
+        value: '',
+      },
+    ]);
+
+    mockSendMessageStream
+      .mockReturnValueOnce(stream1)
+      .mockReturnValueOnce(stream2);
+
+    await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Call tool' }],
+    });
+
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'tool_call',
+          content: expect.arrayContaining([
+            {
+              type: 'content',
+              content: { type: 'text', text: 'Test Explanation' },
+            },
+          ]),
+        }),
+      }),
+    );
+  });
 });

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -619,13 +619,6 @@ export class Session {
           ? invocation.getExplanation()
           : '';
 
-      if (explanation) {
-        await this.sendUpdate({
-          sessionUpdate: 'agent_thought_chunk',
-          content: { type: 'text', text: explanation },
-        });
-      }
-
       const confirmationDetails =
         await invocation.shouldConfirmExecute(abortSignal);
 
@@ -645,6 +638,13 @@ export class Session {
                   ? 'delete'
                   : 'modify',
             },
+          });
+        }
+
+        if (content.length === 0 && explanation) {
+          content.push({
+            type: 'content',
+            content: { type: 'text', text: explanation },
           });
         }
 
@@ -707,6 +707,13 @@ export class Session {
         }
       } else {
         const content: acp.ToolCallContent[] = [];
+
+        if (explanation) {
+          content.push({
+            type: 'content',
+            content: { type: 'text', text: explanation },
+          });
+        }
 
         await this.sendUpdate({
           sessionUpdate: 'tool_call',


### PR DESCRIPTION

## Summary
Address an issue where raw input parameters for MCP tools were emitted as JSON strings in the agent's thought stream, creating noise in the chat UI.

## Details:
- Stop sending `invocation.getExplanation()` as an `agent_thought_chunk` in `acpSession.ts`.
- Include the explanation in the `content` field of the `toolCall` payload in both `RequestPermissionRequest` and `tool_call` (in_progress) updates, provided the content is not already populated (e.g., by a diff).
- This ensures that tool parameters remain visible to the client (e.g., JetBrains or Xcode) in the structured payload without cluttering the chat stream or breaking the title field, thus avoiding regression for issue [maintainers-gemini-cli#1572](https://github.com/google-gemini/maintainers-gemini-cli/issues/1572).
- Add unit tests in `acpSession.test.ts` to verify that the explanation is correctly placed in the content and not emitted as a thought chunk.


## Related Issues

google-gemini/maintainers-gemini-cli#1659

## How to Validate

Ensure no regressions. Issue testing is being done by an external team.

The PR that introduced this issue was meant for JB - as the explanation was appearing as part of the command run before original fix. Checked that - it's still not part of the actual run command tool box. The slight change is that it's no longer part of the thinking. It is shown in the main message area. (not part of the commmand run) as shown below:

<img width="662" height="412" alt="image" src="https://github.com/user-attachments/assets/a8266bb7-4951-418e-8245-9e6a3e2a7397" />


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
