### PR TITLE
fix(core): handle invalid custom plans directory gracefully

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4091,7 +4091,7 @@ describe('Plans Directory Initialization', () => {
     expect(context.getDirectories()).not.toContain(plansDir);
   });
 
-  it('should gracefully fallback to default plans directory if custom directory is outside project root', async () => {
+  it('should gracefully fallback to default plans directory if retrieving custom directory throw an error', async () => {
     vi.spyOn(coreEvents, 'emitFeedback');
     vi.spyOn(fs.promises, 'access').mockResolvedValue(undefined);
     const config = new Config({
@@ -4112,7 +4112,7 @@ describe('Plans Directory Initialization', () => {
     // Should emit a warning feedback
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'warning',
-      expect.stringContaining('outside the project root'),
+      expect.stringContaining('Invalid custom plans directory'),
     );
 
     // Should still add the fallback plans directory to workspace context if it exists

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4113,6 +4113,7 @@ describe('Plans Directory Initialization', () => {
     expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
       'warning',
       expect.stringContaining('Invalid custom plans directory'),
+      expect.any(Error),
     );
 
     // Should still add the fallback plans directory to workspace context if it exists

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4091,6 +4091,35 @@ describe('Plans Directory Initialization', () => {
     expect(context.getDirectories()).not.toContain(plansDir);
   });
 
+  it('should gracefully fallback to default plans directory if custom directory is outside project root', async () => {
+    vi.spyOn(coreEvents, 'emitFeedback');
+    vi.spyOn(fs.promises, 'access').mockResolvedValue(undefined);
+    const config = new Config({
+      ...baseParams,
+      plan: true,
+      planSettings: {
+        directory: '/outside/project/root',
+      },
+    });
+
+    await config.initialize();
+
+    const plansDir = config.storage.getPlansDir();
+    // Should fallback to default project temp plans dir
+    expect(plansDir).toContain('plans');
+    expect(plansDir).not.toContain('/outside/project/root');
+
+    // Should emit a warning feedback
+    expect(coreEvents.emitFeedback).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('outside the project root'),
+    );
+
+    // Should still add the fallback plans directory to workspace context if it exists
+    const context = config.getWorkspaceContext();
+    expect(context.getDirectories()).toContain(plansDir);
+  });
+
   it('should NOT create plans directory or add it to workspace context when plan is disabled', async () => {
     const config = new Config({
       ...baseParams,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1448,11 +1448,8 @@ export class Config implements McpContext, AgentLoopContext {
       try {
         plansDir = this.storage.getPlansDir();
       } catch (error) {
-        // Gracefully handle the case where the project root is outside of the project
-        if (
-          error instanceof Error &&
-          error.message.includes('outside the project root')
-        ) {
+        // Fallback to the default plan dir if any error occurs
+        if (error instanceof Error) {
           coreEvents.emitFeedback(
             'warning',
             `Invalid custom plans directory: ${error.message}. Falling back to default project temp directory.`,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1448,11 +1448,11 @@ export class Config implements McpContext, AgentLoopContext {
       try {
         plansDir = this.storage.getPlansDir();
       } catch (error) {
+        // Gracefully handle the case where the project root is outside of the project
         if (
           error instanceof Error &&
           error.message.includes('outside the project root')
         ) {
-          // Emit a user-friendly warning
           coreEvents.emitFeedback(
             'warning',
             `Invalid custom plans directory: ${error.message}. Falling back to default project temp directory.`,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1449,17 +1449,17 @@ export class Config implements McpContext, AgentLoopContext {
         plansDir = this.storage.getPlansDir();
       } catch (error) {
         // Fallback to the default plan dir if any error occurs
-        if (error instanceof Error) {
-          coreEvents.emitFeedback(
-            'warning',
-            `Invalid custom plans directory: ${error.message}. Falling back to default project temp directory.`,
-          );
-          // Unset the invalid directory for this session to ensure subsequent tool calls use the fallback
-          this.storage.setCustomPlansDir(undefined);
-          plansDir = this.storage.getPlansDir();
-        } else {
-          throw error;
-        }
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        coreEvents.emitFeedback(
+          'warning',
+          'Invalid custom plans directory: ' +
+            errorMessage +
+            '. Falling back to default project temp directory.',
+          error,
+        );
+        this.storage.setCustomPlansDir(undefined);
+        plansDir = this.storage.getPlansDir();
       }
 
       try {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1444,7 +1444,27 @@ export class Config implements McpContext, AgentLoopContext {
 
     // Add plans directory to workspace context for plan file storage
     if (this.planEnabled) {
-      const plansDir = this.storage.getPlansDir();
+      let plansDir: string;
+      try {
+        plansDir = this.storage.getPlansDir();
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes('outside the project root')
+        ) {
+          // Emit a user-friendly warning
+          coreEvents.emitFeedback(
+            'warning',
+            `Invalid custom plans directory: ${error.message}. Falling back to default project temp directory.`,
+          );
+          // Unset the invalid directory for this session to ensure subsequent tool calls use the fallback
+          this.storage.setCustomPlansDir(undefined);
+          plansDir = this.storage.getPlansDir();
+        } else {
+          throw error;
+        }
+      }
+
       try {
         await fs.promises.access(plansDir);
         this.workspaceContext.addDirectory(plansDir);


### PR DESCRIPTION
## Summary

This PR addresses a crash in the Gemini CLI (issue #25566) caused by an unhandled promise rejection during startup. The crash occurred when a customPlansDir was configured outside the project root, triggering a validation error that wasn't caught in Config._initialize().

## Details

Updated Config._initialize() in `packages/core/src/config/config.ts` to wrap the this.storage.getPlansDir() call in a try/catch block. If an error occurs, the CLI now:
1. Emits a user-friendly warning via coreEvents.                                                           
2. Resets the customPlansDir for the session to undefined.                                                 
3. Falls back to the default project temporary plans directory. 

## Related Issues

Fixes #25566 

## How to Validate

1. Configure a customPlansDir in your settings that is outside your project root (e.g., in your home directory while the project is elsewhere).                                  
2. Start the cli and observe that the CLI starts successfully, shows a warning message about the invalid directory, and uses the default plans path instead of crashing.                 
3. Run unit tests: `npm test -w @google/gemini-cli-core -- src/config/config.test.ts`.   

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
