### PR TITLE
fix(core): prevent silent hang during OAuth auth on headless Linux

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -130,6 +130,24 @@ export async function createContentGeneratorConfig(
   customHeaders?: Record<string, string>,
   vertexAiRouting?: VertexAiRoutingConfig,
 ): Promise<ContentGeneratorConfig> {
+  const contentGeneratorConfig: ContentGeneratorConfig = {
+    authType,
+    proxy: config?.getProxy(),
+    baseUrl,
+    customHeaders,
+    vertexAiRouting,
+  };
+
+  // If we are using Google auth or we are in Cloud Shell, there is nothing else to validate for now.
+  // Return before touching the API-key keychain: on Linux without a Secret Service
+  // (WSL/SSH/Docker/CI) keytar can block indefinitely on its functional probe.
+  if (
+    authType === AuthType.LOGIN_WITH_GOOGLE ||
+    authType === AuthType.COMPUTE_ADC
+  ) {
+    return contentGeneratorConfig;
+  }
+
   const geminiApiKey =
     apiKey ||
     process.env['GEMINI_API_KEY'] ||
@@ -141,22 +159,6 @@ export async function createContentGeneratorConfig(
     process.env['GOOGLE_CLOUD_PROJECT_ID'] ||
     undefined;
   const googleCloudLocation = process.env['GOOGLE_CLOUD_LOCATION'] || undefined;
-
-  const contentGeneratorConfig: ContentGeneratorConfig = {
-    authType,
-    proxy: config?.getProxy(),
-    baseUrl,
-    customHeaders,
-    vertexAiRouting,
-  };
-
-  // If we are using Google auth or we are in Cloud Shell, there is nothing else to validate for now
-  if (
-    authType === AuthType.LOGIN_WITH_GOOGLE ||
-    authType === AuthType.COMPUTE_ADC
-  ) {
-    return contentGeneratorConfig;
-  }
 
   if (authType === AuthType.USE_GEMINI && geminiApiKey) {
     contentGeneratorConfig.apiKey = geminiApiKey;

--- a/packages/core/src/services/keychainService.ts
+++ b/packages/core/src/services/keychainService.ts
@@ -136,11 +136,20 @@ export class KeychainService {
         return null;
       }
 
-      if (await this.isKeychainFunctional(keychainModule)) {
+      // Cap the functional probe so a non-responsive Secret Service (common on
+      // headless Linux: WSL/SSH/Docker without gnome-keyring or D-Bus) falls back
+      // to FileKeychain instead of hanging the CLI indefinitely.
+      const functional = await Promise.race([
+        this.isKeychainFunctional(keychainModule),
+        new Promise<false>((resolve) =>
+          setTimeout(() => resolve(false), 2000).unref(),
+        ),
+      ]);
+      if (functional) {
         return keychainModule;
       }
 
-      debugLogger.debug('Keychain functional verification failed');
+      debugLogger.debug('Keychain functional verification failed or timed out');
       return null;
     } catch (error) {
       // Avoid logging full error objects to prevent PII exposure.

--- a/packages/core/src/services/keychainService.ts
+++ b/packages/core/src/services/keychainService.ts
@@ -136,16 +136,7 @@ export class KeychainService {
         return null;
       }
 
-      // Cap the functional probe so a non-responsive Secret Service (common on
-      // headless Linux: WSL/SSH/Docker without gnome-keyring or D-Bus) falls back
-      // to FileKeychain instead of hanging the CLI indefinitely.
-      const functional = await Promise.race([
-        this.isKeychainFunctional(keychainModule),
-        new Promise<false>((resolve) =>
-          setTimeout(() => resolve(false), 2000).unref(),
-        ),
-      ]);
-      if (functional) {
+      if (await this.isKeychainFunctional(keychainModule)) {
         return keychainModule;
       }
 
@@ -182,18 +173,32 @@ export class KeychainService {
   }
 
   // Performs a set-get-delete cycle to verify keychain functionality.
+  // Capped with a 2s timeout so a non-responsive Secret Service (common on
+  // headless Linux: WSL/SSH/Docker without gnome-keyring or D-Bus) falls back
+  // to FileKeychain instead of hanging the CLI indefinitely.
   private async isKeychainFunctional(keychain: Keychain): Promise<boolean> {
     const testAccount = `${KEYCHAIN_TEST_PREFIX}${crypto.randomBytes(8).toString('hex')}`;
     const testPassword = 'test';
 
-    await keychain.setPassword(this.serviceName, testAccount, testPassword);
-    const retrieved = await keychain.getPassword(this.serviceName, testAccount);
-    const deleted = await keychain.deletePassword(
-      this.serviceName,
-      testAccount,
-    );
+    const probe = async (): Promise<boolean> => {
+      await keychain.setPassword(this.serviceName, testAccount, testPassword);
+      const retrieved = await keychain.getPassword(
+        this.serviceName,
+        testAccount,
+      );
+      const deleted = await keychain.deletePassword(
+        this.serviceName,
+        testAccount,
+      );
+      return deleted && retrieved === testPassword;
+    };
 
-    return deleted && retrieved === testPassword;
+    return Promise.race([
+      probe(),
+      new Promise<false>((resolve) =>
+        setTimeout(() => resolve(false), 2000).unref(),
+      ),
+    ]);
   }
 
   /**


### PR DESCRIPTION
Gemini CLI was hanging in my environment, tested these changes and they fixed it for me. 

AI generated summary below:

=====


## Summary

On headless Linux (WSL, SSH-without-DISPLAY, Docker, CI), `gemini` hangs silently with no output and never exits when the user has selected `oauth-personal` auth and there are no cached credentials. There is no error, no log line, no debug output — the process is just deadlocked early in startup, well before the TUI mounts or `--debug` could help.

Root cause is two compounding issues:

1. **`createContentGeneratorConfig` eagerly awaits `loadApiKey()` for every auth type** — even `LOGIN_WITH_GOOGLE` / `COMPUTE_ADC`, where the resulting `geminiApiKey` is unused (the function returns at the early branch). `loadApiKey()` goes through `HybridTokenStorage` → `KeychainService`, which performs a synchronous-looking probe of the OS keychain.

2. **The keychain functional probe has no timeout on Linux.** On macOS there is an explicit `security default-keychain` pre-check (`isMacOSKeychainAvailable`, lines 193–220) specifically to avoid blocking popups. Linux gets no equivalent. `keytar.setPassword` → libsecret → D-Bus → Secret Service: if no Secret Service is running (typical in WSL/SSH/Docker/CI), the call hangs indefinitely. There is no logging at this layer, hence the silent hang.

## Repro

```sh
# Settings:
$ cat ~/.gemini/settings.json
{ "security": { "auth": { "selectedType": "oauth-personal" } } }
$ ls ~/.gemini/oauth_creds.json
ls: cannot access ...: No such file or directory

# Confirm headless Linux env (no DISPLAY, no Secret Service):
$ env | grep -E '^(DISPLAY|WAYLAND_DISPLAY|SSH_CONNECTION)='
SSH_CONNECTION=...

# Run, observe hang:
$ timeout 15 gemini -p hi
$ echo "Exit: $?"
Exit: 124   # timeout fired; produced 0 bytes of output
```

Workaround that confirms the cause: setting `GEMINI_FORCE_FILE_STORAGE=true` (skips the keytar probe) immediately makes `gemini` produce its real error output instead of hanging.

## Fix

**1. Skip the API-key load for auth types that don't need it.**

`createContentGeneratorConfig` returned early for `LOGIN_WITH_GOOGLE` / `COMPUTE_ADC` *after* awaiting `loadApiKey()`. Move the early-return above the load — these auth types never read `geminiApiKey`, so the work was always wasted, and avoiding it sidesteps the keychain entirely on the OAuth happy path.

**2. Bound the keychain functional probe with a timeout.**

`Promise.race` the `set/get/delete` cycle against a 2s timeout. If the Secret Service doesn't respond, fall back to `FileKeychain` rather than blocking forever. This mirrors the spirit of the existing macOS pre-check and protects every other code path that hits the keychain (MCP token storage, manual API key save, etc.).

## Impact

- OAuth users on headless Linux: the silent hang is gone; OAuth user-code prompt appears within ~2s.
- API-key users on headless Linux: the worst case becomes a 2s startup penalty before falling back to `FileKeychain`, instead of an infinite hang.
- Anyone with a working Secret Service: no observable change (probe completes well under 2s).