### PR TITLE
fix(core): preserve system PATH in Git environment to fix ENOENT (#25034)

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -338,7 +338,10 @@ describe('GitService', () => {
         await service.setupShadowGitRepository();
 
         const expectedConfigPath = path.join(repoDir, '.gitconfig');
-        const expectedSystemPath = path.join(repoDir, '.gitconfig_system_empty');
+        const expectedSystemPath = path.join(
+          repoDir,
+          '.gitconfig_system_empty',
+        );
 
         expect(hoistedMockEnv).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -305,35 +305,54 @@ describe('GitService', () => {
       expect(systemConfigContent).toBe('');
     });
 
-    it('should preserve system PATH and other env vars in the Git environment', async () => {
+    describe('environment variable preservation', () => {
       const customPath = '/custom/bin';
-      vi.stubEnv('PATH', customPath);
-      vi.stubEnv('OTHER_VAR', 'other-value');
+      const otherVar = 'other-value';
 
-      try {
+      beforeEach(() => {
+        vi.stubEnv('PATH', customPath);
+        vi.stubEnv('OTHER_VAR', otherVar);
         hoistedMockCheckIsRepo.mockResolvedValue(false);
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      it('should preserve system PATH in the Git environment', async () => {
         const service = new GitService(projectRoot, storage);
         await service.setupShadowGitRepository();
 
         expect(hoistedMockEnv).toHaveBeenCalledWith(
           expect.objectContaining({
             PATH: customPath,
-            OTHER_VAR: 'other-value',
             GIT_CONFIG_GLOBAL: expect.any(String),
             GIT_AUTHOR_NAME: SHADOW_REPO_AUTHOR_NAME,
           }),
         );
-      } finally {
-        vi.unstubAllEnvs();
-      }
+      });
+
+      it('should NOT include unrelated environment variables in the Git environment', async () => {
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        const callArgs = hoistedMockEnv.mock.calls[0][0];
+        expect(callArgs.OTHER_VAR).toBeUndefined();
+      });
     });
 
-    it('should override GIT_CONFIG environment variables from process.env', async () => {
-      vi.stubEnv('GIT_CONFIG_GLOBAL', '/user/global/config');
-      vi.stubEnv('GIT_CONFIG_SYSTEM', '/user/system/config');
-
-      try {
+    describe('GIT_CONFIG isolation', () => {
+      beforeEach(() => {
+        vi.stubEnv('GIT_CONFIG_GLOBAL', '/user/global/config');
+        vi.stubEnv('GIT_CONFIG_SYSTEM', '/user/system/config');
         hoistedMockCheckIsRepo.mockResolvedValue(false);
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      it('should override GIT_CONFIG environment variables from process.env', async () => {
         const service = new GitService(projectRoot, storage);
         await service.setupShadowGitRepository();
 
@@ -354,9 +373,7 @@ describe('GitService', () => {
         const callArgs = hoistedMockEnv.mock.calls[0][0];
         expect(callArgs.GIT_CONFIG_GLOBAL).not.toBe('/user/global/config');
         expect(callArgs.GIT_CONFIG_SYSTEM).not.toBe('/user/system/config');
-      } finally {
-        vi.unstubAllEnvs();
-      }
+      });
     });
   });
 

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -304,6 +304,57 @@ describe('GitService', () => {
       );
       expect(systemConfigContent).toBe('');
     });
+
+    it('should preserve system PATH and other env vars in the Git environment', async () => {
+      const customPath = '/custom/bin';
+      vi.stubEnv('PATH', customPath);
+      vi.stubEnv('OTHER_VAR', 'other-value');
+
+      try {
+        hoistedMockCheckIsRepo.mockResolvedValue(false);
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        expect(hoistedMockEnv).toHaveBeenCalledWith(
+          expect.objectContaining({
+            PATH: customPath,
+            OTHER_VAR: 'other-value',
+            GIT_CONFIG_GLOBAL: expect.any(String),
+            GIT_AUTHOR_NAME: SHADOW_REPO_AUTHOR_NAME,
+          }),
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it('should override GIT_CONFIG environment variables from process.env', async () => {
+      vi.stubEnv('GIT_CONFIG_GLOBAL', '/user/global/config');
+      vi.stubEnv('GIT_CONFIG_SYSTEM', '/user/system/config');
+
+      try {
+        hoistedMockCheckIsRepo.mockResolvedValue(false);
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        const expectedConfigPath = path.join(repoDir, '.gitconfig');
+        const expectedSystemPath = path.join(repoDir, '.gitconfig_system_empty');
+
+        expect(hoistedMockEnv).toHaveBeenCalledWith(
+          expect.objectContaining({
+            GIT_CONFIG_GLOBAL: expectedConfigPath,
+            GIT_CONFIG_SYSTEM: expectedSystemPath,
+          }),
+        );
+
+        // Ensure it's not using the values from stubbed process.env
+        const callArgs = hoistedMockEnv.mock.calls[0][0];
+        expect(callArgs.GIT_CONFIG_GLOBAL).not.toBe('/user/global/config');
+        expect(callArgs.GIT_CONFIG_SYSTEM).not.toBe('/user/system/config');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
   });
 
   describe('createFileSnapshot', () => {

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -307,11 +307,14 @@ describe('GitService', () => {
 
     describe('environment variable preservation', () => {
       const customPath = '/custom/bin';
-      const otherVar = 'other-value';
+      const safeHome = '/home/user';
+      const sensitiveKey = 'sk-123456789';
 
       beforeEach(() => {
         vi.stubEnv('PATH', customPath);
-        vi.stubEnv('OTHER_VAR', otherVar);
+        vi.stubEnv('HOME', safeHome);
+        vi.stubEnv('API_KEY', sensitiveKey);
+        vi.stubEnv('UNRELATED_VAR', 'some-value');
         hoistedMockCheckIsRepo.mockResolvedValue(false);
       });
 
@@ -332,12 +335,31 @@ describe('GitService', () => {
         );
       });
 
-      it('should NOT include unrelated environment variables in the Git environment', async () => {
+      it('should preserve safe environment variables like HOME', async () => {
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        expect(hoistedMockEnv).toHaveBeenCalledWith(
+          expect.objectContaining({
+            HOME: safeHome,
+          }),
+        );
+      });
+
+      it('should NOT include sensitive environment variables like API_KEY', async () => {
         const service = new GitService(projectRoot, storage);
         await service.setupShadowGitRepository();
 
         const callArgs = hoistedMockEnv.mock.calls[0][0];
-        expect(callArgs.OTHER_VAR).toBeUndefined();
+        expect(callArgs.API_KEY).toBeUndefined();
+      });
+
+      it('should preserve unrelated environment variables (non-strict mode)', async () => {
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        const callArgs = hoistedMockEnv.mock.calls[0][0];
+        expect(callArgs.UNRELATED_VAR).toBe('some-value');
       });
     });
 
@@ -373,6 +395,40 @@ describe('GitService', () => {
         const callArgs = hoistedMockEnv.mock.calls[0][0];
         expect(callArgs.GIT_CONFIG_GLOBAL).not.toBe('/user/global/config');
         expect(callArgs.GIT_CONFIG_SYSTEM).not.toBe('/user/system/config');
+      });
+    });
+
+    describe('shadowGitRepository prioritization', () => {
+      beforeEach(() => {
+        vi.stubEnv('GIT_DIR', '/user/fake/.git');
+        vi.stubEnv('GIT_WORK_TREE', '/user/fake/worktree');
+        hoistedMockCheckIsRepo.mockResolvedValue(true);
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      it('should prioritize internal GIT_DIR and GIT_WORK_TREE over process.env', async () => {
+        const service = new GitService(projectRoot, storage);
+        // Trigger a call to shadowGitRepository (e.g., via getCurrentCommitHash)
+        hoistedMockRaw.mockResolvedValue('hash');
+        await service.getCurrentCommitHash();
+
+        const expectedRepoDir = storage.getHistoryDir();
+        const expectedGitDir = path.join(expectedRepoDir, '.git');
+
+        expect(hoistedMockEnv).toHaveBeenCalledWith(
+          expect.objectContaining({
+            GIT_DIR: expectedGitDir,
+            GIT_WORK_TREE: projectRoot,
+          }),
+        );
+
+        // Ensure user env was overridden
+        const callArgs = hoistedMockEnv.mock.calls[0][0];
+        expect(callArgs.GIT_DIR).not.toBe('/user/fake/.git');
+        expect(callArgs.GIT_WORK_TREE).not.toBe('/user/fake/worktree');
       });
     });
   });

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -315,6 +315,10 @@ describe('GitService', () => {
         vi.stubEnv('HOME', safeHome);
         vi.stubEnv('API_KEY', sensitiveKey);
         vi.stubEnv('UNRELATED_VAR', 'some-value');
+        // Explicitly unset strict mode triggers to ensure predictable test behavior
+        // across local and CI environments.
+        vi.stubEnv('GITHUB_SHA', '');
+        vi.stubEnv('SURFACE', '');
         hoistedMockCheckIsRepo.mockResolvedValue(false);
       });
 
@@ -354,12 +358,21 @@ describe('GitService', () => {
         expect(callArgs.API_KEY).toBeUndefined();
       });
 
-      it('should preserve unrelated environment variables (non-strict mode)', async () => {
+      it('should preserve unrelated environment variables in non-strict mode', async () => {
         const service = new GitService(projectRoot, storage);
         await service.setupShadowGitRepository();
 
         const callArgs = hoistedMockEnv.mock.calls[0][0];
         expect(callArgs.UNRELATED_VAR).toBe('some-value');
+      });
+
+      it('should explicitly unset GIT_DIR and GIT_WORK_TREE to maintain isolation', async () => {
+        const service = new GitService(projectRoot, storage);
+        await service.setupShadowGitRepository();
+
+        const callArgs = hoistedMockEnv.mock.calls[0][0];
+        expect(callArgs.GIT_DIR).toBeUndefined();
+        expect(callArgs.GIT_WORK_TREE).toBeUndefined();
       });
     });
 

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,6 +58,7 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
+      ...process.env,
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,7 +58,7 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
-      PATH: process.env.PATH,
+      PATH: process.env['PATH'],
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -11,6 +11,10 @@ import { spawnAsync } from '../utils/shell-utils.js';
 import { simpleGit, CheckRepoActions, type SimpleGit } from 'simple-git';
 import type { Storage } from '../config/storage.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import {
+  sanitizeEnvironment,
+  getSecureSanitizationConfig,
+} from './environmentSanitization.js';
 
 export const SHADOW_REPO_AUTHOR_NAME = 'Gemini CLI';
 export const SHADOW_REPO_AUTHOR_EMAIL = 'gemini-cli@google.com';
@@ -58,7 +62,10 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
-      PATH: process.env['PATH'],
+      ...sanitizeEnvironment(
+        process.env,
+        getSecureSanitizationConfig({ enableEnvironmentVariableRedaction: true }),
+      ),
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,
@@ -127,9 +134,9 @@ export class GitService {
   private get shadowGitRepository(): SimpleGit {
     const repoDir = this.getHistoryDir();
     return simpleGit(this.projectRoot).env({
+      ...this.getShadowRepoEnv(repoDir),
       GIT_DIR: path.join(repoDir, '.git'),
       GIT_WORK_TREE: this.projectRoot,
-      ...this.getShadowRepoEnv(repoDir),
     });
   }
 

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,7 +58,7 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
-      ...process.env,
+      PATH: process.env.PATH,
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -69,6 +69,9 @@ export class GitService {
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,
       GIT_CONFIG_SYSTEM: systemConfigPath,
+      // Ensure we don't inherit isolation-breaking variables from the user environment.
+      GIT_DIR: undefined,
+      GIT_WORK_TREE: undefined,
       // Explicitly provide identity to prevent "Author identity unknown" errors
       // inside sandboxed environments like Docker where the gitconfig might not
       // be picked up properly.

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -64,7 +64,9 @@ export class GitService {
     return {
       ...sanitizeEnvironment(
         process.env,
-        getSecureSanitizationConfig({ enableEnvironmentVariableRedaction: true }),
+        getSecureSanitizationConfig({
+          enableEnvironmentVariableRedaction: true,
+        }),
       ),
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,

--- a/packages/core/src/tools/shellBackgroundTools.integration.test.ts
+++ b/packages/core/src/tools/shellBackgroundTools.integration.test.ts
@@ -53,7 +53,7 @@ describe('Background Tools Integration', () => {
     const scriptPath = path.join(tempRootDir, 'log.js');
     fs.writeFileSync(
       scriptPath,
-      "console.log('Log line'); setInterval(() => console.log('Log line'), 100);",
+      "setInterval(() => console.log('Log line'), 100);",
     );
 
     // Using 'node' directly avoids cross-platform shell quoting issues with absolute paths.
@@ -101,8 +101,7 @@ describe('Background Tools Integration', () => {
     );
 
     // 4. Give it time to write output to interval
-    // 5 seconds is safer for slow CI environments like Windows
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // 5. Model decides to read logs
     const readInvocation = readTool.build({ pid, lines: 2 });

--- a/packages/core/src/tools/shellBackgroundTools.integration.test.ts
+++ b/packages/core/src/tools/shellBackgroundTools.integration.test.ts
@@ -53,7 +53,7 @@ describe('Background Tools Integration', () => {
     const scriptPath = path.join(tempRootDir, 'log.js');
     fs.writeFileSync(
       scriptPath,
-      "setInterval(() => console.log('Log line'), 100);",
+      "console.log('Log line'); setInterval(() => console.log('Log line'), 100);",
     );
 
     // Using 'node' directly avoids cross-platform shell quoting issues with absolute paths.
@@ -101,7 +101,8 @@ describe('Background Tools Integration', () => {
     );
 
     // 4. Give it time to write output to interval
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    // 5 seconds is safer for slow CI environments like Windows
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     // 5. Model decides to read logs
     const readInvocation = readTool.build({ pid, lines: 2 });


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Gemini CLI fails to start with `spawn git ENOENT` on systems with custom Git installations (e.g., in `~/bin`). The `GitService` was stripping the system `PATH` when initializing the shadow repository environment.

## Details

The `getShadowRepoEnv` method was creating a clean environment object for Git configuration isolation but forgot to include `process.env`. By merging `process.env` (and spreading it *before* our overrides), we restore access to the user's `PATH` while maintaining the intended isolation of the shadow repo's configuration and identity.

## Related Issues

Fixes #25034

## How to Validate

1. Create a dummy directory with a symlinked git binary.
2. Set a restricted `PATH` that only includes that directory.
3. Run `npm run start` and verify the CLI starts without `ENOENT`.
4. Run `npm test -w @google/gemini-cli-core -- src/services/gitService.test.ts` to verify regression tests.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
