### PR TITLE
fix(ci): preserve executable bit for mac binaries

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -312,11 +312,13 @@ runs:
 
         # Check for and prepare macOS binaries if they exist
         if [[ -f "dist/darwin-arm64/gemini" ]]; then
+          chmod +x dist/darwin-arm64/gemini
           zip -j gemini-darwin-arm64-unsigned.zip dist/darwin-arm64/gemini
           RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned.zip")
         fi
 
         if [[ -f "dist/darwin-x64/gemini" ]]; then
+          chmod +x dist/darwin-x64/gemini
           zip -j gemini-darwin-x64-unsigned.zip dist/darwin-x64/gemini
           RELEASE_ASSETS+=("gemini-darwin-x64-unsigned.zip")
         fi

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -311,17 +311,15 @@ runs:
         RELEASE_ASSETS=("gemini-cli-bundle.zip")
 
         # Check for and prepare macOS binaries if they exist
-        if [[ -f "dist/darwin-arm64/gemini" ]]; then
-          chmod +x dist/darwin-arm64/gemini
-          zip -j gemini-darwin-arm64-unsigned.zip dist/darwin-arm64/gemini
-          RELEASE_ASSETS+=("gemini-darwin-arm64-unsigned.zip")
-        fi
-
-        if [[ -f "dist/darwin-x64/gemini" ]]; then
-          chmod +x dist/darwin-x64/gemini
-          zip -j gemini-darwin-x64-unsigned.zip dist/darwin-x64/gemini
-          RELEASE_ASSETS+=("gemini-darwin-x64-unsigned.zip")
-        fi
+        for arch in arm64 x64; do
+          BINARY_PATH="dist/darwin-${arch}/gemini"
+          if [[ -f "$BINARY_PATH" ]]; then
+            chmod +x "$BINARY_PATH"
+            ZIP_NAME="gemini-darwin-${arch}-unsigned.zip"
+            zip -j "$ZIP_NAME" "$BINARY_PATH"
+            RELEASE_ASSETS+=("$ZIP_NAME")
+          fi
+        done
 
         gh release create "${INPUTS_RELEASE_TAG}" \
           "${RELEASE_ASSETS[@]}" \


### PR DESCRIPTION
## Summary

This PR ensures that macOS binaries downloaded from GitHub Actions artifacts maintain their executable permissions during the release publishing workflow. 

## Details

The `actions/download-artifact` action sometimes fails to properly map and restore macOS file modes (like `+x`) when extracting onto a Linux file system (which happens when transferring from a `macos-latest` builder to an `ubuntu-latest` release runner). This adds a `chmod +x` step immediately after downloading the binaries to manually guarantee the executable bit is set before zipping them for release.

## Related Issues

https://github.com/google-gemini/maintainers-gemini-cli/issues/1649

## How to Validate

1. Run the release workflow.
2. Download the resulting Mac `.zip` files from the artifacts or draft release.
3. Extract the `.zip` file on a Mac.
4. Verify the `gemini` binary has the `+x` bit set and is directly executable.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
