### PR TITLE
fix(core): prevent SSRF via open redirect in web-fetch tool

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -53,6 +53,9 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
     ...actual,
     fetchWithTimeout: vi.fn(),
     isPrivateIp: vi.fn(),
+    // Default to false (public) so unit tests don't make real DNS lookups;
+    // individual tests override this when DNS-based SSRF behaviour is under test.
+    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
   };
 });
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,11 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithSafeRedirects, isPrivateIp } from '../utils/fetch.js';
+import {
+  fetchWithSafeRedirects,
+  isPrivateIp,
+  isPrivateIpAsync,
+} from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -280,12 +284,28 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     }
   }
 
+  /**
+   * Async variant of isBlockedHost that also resolves hostnames via DNS.
+   * Prevents SSRF via domains that resolve to private/link-local addresses
+   * (e.g. 169.254.169.254.nip.io → AWS IMDS).
+   */
+  private async isBlockedHostAsync(urlStr: string): Promise<boolean> {
+    if (this.isBlockedHost(urlStr)) {
+      return true;
+    }
+    try {
+      return await isPrivateIpAsync(urlStr);
+    } catch {
+      return true; // fail closed on DNS errors
+    }
+  }
+
   private async executeFallbackForUrl(
     urlStr: string,
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHostAsync(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
@@ -295,7 +315,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     const response = await retryWithBackoff(
       async () => {
         const res = await fetchWithSafeRedirects(
-          this.isBlockedHost.bind(this),
+          this.isBlockedHostAsync.bind(this),
           url,
           URL_FETCH_TIMEOUT_MS,
           {
@@ -620,7 +640,7 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHostAsync(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -639,7 +659,7 @@ ${aggregatedContent}
       const response = await retryWithBackoff(
         async () => {
           const res = await fetchWithSafeRedirects(
-            this.isBlockedHost.bind(this),
+            this.isBlockedHostAsync.bind(this),
             url,
             URL_FETCH_TIMEOUT_MS,
             {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import { fetchWithSafeRedirects, isPrivateIp } from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -294,12 +294,17 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-          signal,
-          headers: {
-            'User-Agent': USER_AGENT,
+        const res = await fetchWithSafeRedirects(
+          this.isBlockedHost.bind(this),
+          url,
+          URL_FETCH_TIMEOUT_MS,
+          {
+            signal,
+            headers: {
+              'User-Agent': USER_AGENT,
+            },
           },
-        });
+        );
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -633,14 +638,19 @@ ${aggregatedContent}
     try {
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-            signal,
-            headers: {
-              Accept:
-                'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
-              'User-Agent': USER_AGENT,
+          const res = await fetchWithSafeRedirects(
+            this.isBlockedHost.bind(this),
+            url,
+            URL_FETCH_TIMEOUT_MS,
+            {
+              signal,
+              headers: {
+                Accept:
+                  'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
+                'User-Agent': USER_AGENT,
+              },
             },
-          });
+          );
           return res;
         },
         {

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -231,7 +231,7 @@ const MAX_SAFE_REDIRECTS = 10;
  * @param hopsLeft Remaining redirect budget (default MAX_SAFE_REDIRECTS).
  */
 export async function fetchWithSafeRedirects(
-  isBlockedHost: (url: string) => boolean,
+  isBlockedHost: (url: string) => boolean | Promise<boolean>,
   url: string,
   timeout: number,
   options?: Omit<RequestInit, 'redirect'>,
@@ -262,7 +262,7 @@ export async function fetchWithSafeRedirects(
         'ERR_INVALID_REDIRECT',
       );
     }
-    if (isBlockedHost(redirectUrl)) {
+    if (await isBlockedHost(redirectUrl)) {
       throw new FetchError(
         `SSRF protection: redirect destination "${redirectUrl}" resolves to a blocked or private host`,
         'ERR_SSRF_REDIRECT',

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -211,6 +211,75 @@ export async function fetchWithTimeout(
   }
 }
 
+/**
+ * Maximum number of redirects followed by fetchWithSafeRedirects.
+ */
+const MAX_SAFE_REDIRECTS = 10;
+
+/**
+ * Fetches a URL while re-validating each redirect destination for SSRF risk.
+ *
+ * fetchWithTimeout follows redirects automatically (WHATWG default), which
+ * means the initial isBlockedHost check is bypassed for redirect destinations.
+ * This function opts-out of automatic redirect following and re-validates each
+ * Location header value before following it, preventing open-redirect SSRF.
+ *
+ * @param isBlockedHost Predicate returning true for URLs that must not be fetched.
+ * @param url The URL to fetch.
+ * @param timeout Per-hop timeout in milliseconds.
+ * @param options Fetch options. Must NOT include a `redirect` key.
+ * @param hopsLeft Remaining redirect budget (default MAX_SAFE_REDIRECTS).
+ */
+export async function fetchWithSafeRedirects(
+  isBlockedHost: (url: string) => boolean,
+  url: string,
+  timeout: number,
+  options?: Omit<RequestInit, 'redirect'>,
+  hopsLeft = MAX_SAFE_REDIRECTS,
+): Promise<Response> {
+  const response = await fetchWithTimeout(url, timeout, {
+    ...(options as RequestInit),
+    redirect: 'manual',
+  });
+
+  const { status } = response;
+  if (status >= 300 && status < 400) {
+    if (hopsLeft <= 0) {
+      throw new FetchError('Too many redirects', 'ERR_TOO_MANY_REDIRECTS');
+    }
+    const location = response.headers.get('location');
+    if (!location) {
+      // No Location header — return the redirect response as-is.
+      return response;
+    }
+    // Resolve relative Location values against the current URL.
+    let redirectUrl: string;
+    try {
+      redirectUrl = new URL(location, url).href;
+    } catch {
+      throw new FetchError(
+        `Invalid redirect location: ${location}`,
+        'ERR_INVALID_REDIRECT',
+      );
+    }
+    if (isBlockedHost(redirectUrl)) {
+      throw new FetchError(
+        `SSRF protection: redirect destination "${redirectUrl}" resolves to a blocked or private host`,
+        'ERR_SSRF_REDIRECT',
+      );
+    }
+    return fetchWithSafeRedirects(
+      isBlockedHost,
+      redirectUrl,
+      timeout,
+      options,
+      hopsLeft - 1,
+    );
+  }
+
+  return response;
+}
+
 export function setGlobalProxy(proxy: string) {
   currentProxy = proxy;
   setGlobalDispatcher(


### PR DESCRIPTION
## Summary

The `web-fetch` tool validates the initial URL against a private-IP blocklist (`isBlockedHost`) before fetching. However, `fetchWithTimeout` is called without `redirect: 'manual'`, so Node.js fetch follows HTTP redirects automatically (WHATWG spec default). An attacker-controlled server can respond with a 3xx redirect to a private or cloud-metadata IP and bypass the protection entirely.

**Affected paths**: `executeFallbackForUrl()` and `executeExperimental()` in `web-fetch.ts`.

## Root Cause

```typescript
// Before: check is on initial URL only
if (this.isBlockedHost(url)) { throw ... }
const res = await fetchWithTimeout(url, timeout, { ... });
//                                                ^^^
//  No redirect:'manual' — 302 to 169.254.169.254 followed transparently
```

## Attack Example

```
Attacker server at http://attacker.com/ responds:
  HTTP/1.1 302 Found
  Location: http://169.254.169.254/latest/meta-data/iam/security-credentials/

1. isBlockedHost('http://attacker.com/') → false (public IP, passes)
2. fetchWithTimeout follows redirect silently
3. AWS IMDS returns IAM role credentials (no headers required for IMDSv1)
4. Credentials appear in the conversation
```

## Fix

Add `fetchWithSafeRedirects()` in `fetch.ts` that:
- calls `fetchWithTimeout` with `redirect: 'manual'`
- on a 3xx response, resolves the `Location` header (including relative URLs)
- re-validates the redirect destination via the caller-supplied `isBlockedHost` predicate
- enforces a 10-hop redirect limit

Replace both `fetchWithTimeout` call-sites in `web-fetch.ts` with `fetchWithSafeRedirects`.

## Impact

- **Affected environments**: users running gemini-cli on AWS EC2 (IMDSv1 enabled), or any environment with an internal HTTP service reachable via a redirect chain
- **Attack vector**: fetch a URL the user provides or triggers via prompt injection; attacker server returns a redirect to a private IP
- **Without fix**: cloud credentials or internal service responses are returned to the conversation

## Testing

Existing `web-fetch.test.ts` tests for `private_ip_skipped` continue to pass.
A dedicated redirect-SSRF test should be added in a follow-up (mocking a redirect server).