### PR TITLE
fix(browser): reset actionCounter between sequential browser_agent invocations

### DIFF
--- a/packages/core/src/agents/browser/browserManager.test.ts
+++ b/packages/core/src/agents/browser/browserManager.test.ts
@@ -1264,7 +1264,6 @@ describe('BrowserManager', () => {
       await manager.callTool('take_snapshot', {});
       await manager.callTool('take_snapshot', { some: 'args' });
       await manager.callTool('take_snapshot', { other: 'args' });
-      await manager.callTool('take_snapshot', { other: 'new args' });
 
       // 4th call should throw
       await expect(manager.callTool('take_snapshot', {})).rejects.toThrow(
@@ -1306,15 +1305,14 @@ describe('BrowserManager', () => {
       });
       const manager = new BrowserManager(limitedConfig);
 
-      // Exhaust the action limit
+      // Exhaust the action limit (3 calls allowed)
       await manager.callTool('take_snapshot', {});
       await manager.callTool('take_snapshot', { some: 'args' });
       await manager.callTool('take_snapshot', { other: 'args' });
-      await manager.callTool('take_snapshot', { other: 'new args' });
 
-      await expect(manager.callTool('take_snapshot', {})).rejects.toThrow(
-        /maximum action limit \(3\)/,
-      );
+      await expect(
+        manager.callTool('take_snapshot', { other: 'new args' }),
+      ).rejects.toThrow(/maximum action limit \(3\)/);
 
       // Simulate a new browser_agent invocation acquiring the manager
       manager.release();
@@ -1323,6 +1321,7 @@ describe('BrowserManager', () => {
       // Should succeed again with a fresh counter
       await manager.callTool('take_snapshot', {});
       await manager.callTool('take_snapshot', { some: 'args2' });
+      await manager.callTool('take_snapshot', { other: 'args2' });
     });
   });
 

--- a/packages/core/src/agents/browser/browserManager.test.ts
+++ b/packages/core/src/agents/browser/browserManager.test.ts
@@ -1295,6 +1295,35 @@ describe('BrowserManager', () => {
         /maximum action limit \(1\)/,
       );
     });
+
+    it('should reset action counter on acquire() for new task invocations', async () => {
+      const limitedConfig = makeFakeConfig({
+        agents: {
+          browser: {
+            maxActionsPerTask: 3,
+          },
+        },
+      });
+      const manager = new BrowserManager(limitedConfig);
+
+      // Exhaust the action limit
+      await manager.callTool('take_snapshot', {});
+      await manager.callTool('take_snapshot', { some: 'args' });
+      await manager.callTool('take_snapshot', { other: 'args' });
+      await manager.callTool('take_snapshot', { other: 'new args' });
+
+      await expect(manager.callTool('take_snapshot', {})).rejects.toThrow(
+        /maximum action limit \(3\)/,
+      );
+
+      // Simulate a new browser_agent invocation acquiring the manager
+      manager.release();
+      manager.acquire();
+
+      // Should succeed again with a fresh counter
+      await manager.callTool('take_snapshot', {});
+      await manager.callTool('take_snapshot', { some: 'args2' });
+    });
   });
 
   describe('sandbox behavior', () => {

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -249,6 +249,7 @@ export class BrowserManager {
    */
   acquire(): void {
     this.inUse = true;
+    this.actionCounter = 0;
   }
 
   /**

--- a/packages/core/src/agents/browser/browserManager.ts
+++ b/packages/core/src/agents/browser/browserManager.ts
@@ -753,8 +753,6 @@ export class BrowserManager {
           await this.rawMcpClient!.connect(this.mcpTransport!);
           debugLogger.log('MCP client connected to chrome-devtools-mcp');
           await this.discoverTools();
-          // clear the action counter for each connection
-          this.actionCounter = 0;
 
           logBrowserAgentConnection(this.config, Date.now() - connectStartMs, {
             session_mode: sessionMode,


### PR DESCRIPTION
## Summary

- Fix `actionCounter` not being reset when a new `browser_agent` task acquires the singleton `BrowserManager`, causing sequential invocations to immediately hit `maxActionsPerTask` limit.
- Reset counter in `acquire()` so each task gets a fresh action budget regardless of connection reuse.

## Root Cause

`BrowserManager` is a singleton. The `actionCounter` was only reset during `connect()`. When a second `browser_agent` is invoked sequentially, `ensureConnection()` sees the existing connection is healthy and returns early — the counter stays at 100 (exhausted), and the new agent's first tool call is immediately rejected.

## Test plan

- [x] Added unit test: `should reset action counter on acquire() for new task invocations`
- [ ] Manual verification: invoke two sequential `browser_agent` tasks — second agent should operate normally

Fixes https://github.com/google-gemini/gemini-cli/issues/26629