### PR TITLE
fix(core): allow HTTP custom base URLs for private/local proxies

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -851,7 +851,7 @@ describe('createContentGenerator', () => {
     ).rejects.toThrow('Invalid custom base URL: not-a-url');
   });
 
-  it('should reject non-https remote custom baseUrl values', async () => {
+  it('should allow http remote custom baseUrl values', async () => {
     await expect(
       createContentGenerator(
         {
@@ -861,7 +861,7 @@ describe('createContentGenerator', () => {
         },
         mockConfig,
       ),
-    ).rejects.toThrow('Custom base URL must use HTTPS unless it is localhost.');
+    ).resolves.toBeDefined();
   });
 });
 

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -123,8 +123,13 @@ function validateBaseUrl(baseUrl: string): void {
     throw new Error(`Invalid custom base URL: ${baseUrl}`);
   }
 
-  if (url.protocol !== 'https:' && !LOCAL_HOSTNAMES.includes(url.hostname)) {
-    throw new Error('Custom base URL must use HTTPS unless it is localhost.');
+  // Allow both HTTP and HTTPS for custom base URLs (e.g. local/private proxies)
+  if (
+    url.protocol !== 'https:' &&
+    url.protocol !== 'http:' &&
+    !LOCAL_HOSTNAMES.includes(url.hostname)
+  ) {
+    throw new Error('Custom base URL must use HTTP or HTTPS.');
   }
 }
 


### PR DESCRIPTION
## Problem

Gemini CLI v0.41.2+ enforces HTTPS for custom base URLs, blocking users who use private/local HTTP proxies or mirrors via `GOOGLE_GEMINI_BASE_URL`.

## Solution

Allow both HTTP and HTTPS protocols in `validateBaseUrl()`, removing the HTTPS-only restriction for non-localhost addresses.

## Changes

- Modified `packages/core/src/core/contentGenerator.ts`
  - Updated `validateBaseUrl` to accept `http:` and `https:` protocols
- Updated corresponding test in `contentGenerator.test.ts`

## Related

Fixes the "Custom base URL must use HTTPS unless it is localhost" error when using HTTP proxies.