### PR TITLE
fix(routing): fix resolveClassifierModel argument mismatch in ApprovalModeStrategy

### DIFF
--- a/packages/core/src/routing/strategies/approvalModeStrategy.test.ts
+++ b/packages/core/src/routing/strategies/approvalModeStrategy.test.ts
@@ -43,6 +43,8 @@ describe('ApprovalModeStrategy', () => {
       getApprovedPlanPath: vi.fn().mockReturnValue(undefined),
       getPlanModeRoutingEnabled: vi.fn().mockResolvedValue(true),
       getGemini31Launched: vi.fn().mockResolvedValue(false),
+      getGemini31FlashLiteLaunched: vi.fn().mockResolvedValue(false),
+      getHasAccessToPreviewModel: vi.fn().mockReturnValue(true),
       getUseCustomToolModel: vi.fn().mockImplementation(async () => {
         const launched = await mockConfig.getGemini31Launched();
         const authType = mockConfig.getContentGeneratorConfig?.()?.authType;

--- a/packages/core/src/routing/strategies/approvalModeStrategy.ts
+++ b/packages/core/src/routing/strategies/approvalModeStrategy.ts
@@ -48,9 +48,16 @@ export class ApprovalModeStrategy implements RoutingStrategy {
     const approvalMode = config.getApprovalMode();
     const approvedPlanPath = config.getApprovedPlanPath();
 
-    const [useGemini3_1, useCustomToolModel] = await Promise.all([
+    const [
+      useGemini3_1,
+      useGemini3_1FlashLite,
+      useCustomToolModel,
+      hasAccessToPreview,
+    ] = await Promise.all([
       config.getGemini31Launched(),
+      config.getGemini31FlashLiteLaunched(),
       config.getUseCustomToolModel(),
+      config.getHasAccessToPreviewModel(),
     ]);
 
     // 1. Planning Phase: If ApprovalMode === PLAN, explicitly route to the Pro model.
@@ -59,7 +66,10 @@ export class ApprovalModeStrategy implements RoutingStrategy {
         model,
         GEMINI_MODEL_ALIAS_PRO,
         useGemini3_1,
+        useGemini3_1FlashLite,
         useCustomToolModel,
+        hasAccessToPreview,
+        config,
       );
       return {
         model: proModel,
@@ -75,7 +85,10 @@ export class ApprovalModeStrategy implements RoutingStrategy {
         model,
         GEMINI_MODEL_ALIAS_FLASH,
         useGemini3_1,
+        useGemini3_1FlashLite,
         useCustomToolModel,
+        hasAccessToPreview,
+        config,
       );
       return {
         model: flashModel,

--- a/packages/core/src/routing/strategies/gemmaClassifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/gemmaClassifierStrategy.test.ts
@@ -38,6 +38,10 @@ describe('GemmaClassifierStrategy', () => {
       }),
       getModel: () => DEFAULT_GEMINI_MODEL,
       getPreviewFeatures: () => false,
+      getGemini31Launched: vi.fn().mockResolvedValue(false),
+      getGemini31FlashLiteLaunched: vi.fn().mockResolvedValue(false),
+      getUseCustomToolModel: vi.fn().mockResolvedValue(false),
+      getHasAccessToPreviewModel: vi.fn().mockReturnValue(true),
     } as unknown as Config;
 
     strategy = new GemmaClassifierStrategy();

--- a/packages/core/src/routing/strategies/gemmaClassifierStrategy.ts
+++ b/packages/core/src/routing/strategies/gemmaClassifierStrategy.ts
@@ -209,9 +209,27 @@ ${formattedHistory}
 
       const reasoning = routerResponse.reasoning;
       const latencyMs = Date.now() - startTime;
+
+      const [
+        useGemini3_1,
+        useGemini3_1FlashLite,
+        useCustomToolModel,
+        hasAccessToPreview,
+      ] = await Promise.all([
+        config.getGemini31Launched(),
+        config.getGemini31FlashLiteLaunched(),
+        config.getUseCustomToolModel(),
+        config.getHasAccessToPreviewModel?.() ?? true,
+      ]);
+
       const selectedModel = resolveClassifierModel(
         context.requestedModel ?? config.getModel(),
         routerResponse.model_choice,
+        useGemini3_1,
+        useGemini3_1FlashLite,
+        useCustomToolModel,
+        hasAccessToPreview,
+        config,
       );
 
       return {


### PR DESCRIPTION
# Problem
In `ApprovalModeStrategy`, there was an argument mismatch when calling `resolveClassifierModel` to resolve the target model ID (for `proModel` and `flashModel` during planning/implementation phases):
```typescript
const proModel = resolveClassifierModel(
  model,
  GEMINI_MODEL_ALIAS_PRO,
  useGemini3_1,
  useCustomToolModel, // BUG: useCustomToolModel passed into useGemini3_1FlashLite position
);
```
The `useCustomToolModel` boolean flag was passed into the 4th position (which maps to `useGemini3_1FlashLite` in the signature), effectively forcing `useGemini3_1FlashLite` to whatever `useCustomToolModel` resolved to, and omitting the actual `useGemini3_1FlashLite` and `hasAccessToPreview` flags.

This caused auto-routed models during planning/implementation phases to incorrectly fallback to older model generations (like `gemini-2.5-flash-lite`) in configurations where `hasAccessToPreview` or dynamic flags resolved differently, leading to unexpected errors if those fallback models are not supported or accessible.

# Solution
We fix the strategy to correctly retrieve all necessary routing flags (`useGemini3_1`, `useGemini3_1FlashLite`, `useCustomToolModel`, `hasAccessToPreview`) from the `config` context and pass them in the correct positions to `resolveClassifierModel`.