### PR TITLE
feat(core): add LocalSessionInvocation and SubagentProtocols

### DIFF
--- a/packages/core/src/agents/local-session-invocation.test.ts
+++ b/packages/core/src/agents/local-session-invocation.test.ts
@@ -1,0 +1,815 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+ SubagentProgress ,
+  AgentTerminateMode,
+  type LocalAgentDefinition,
+  type AgentInputs,
+  type SubagentActivityEvent,
+  SubagentActivityErrorType,
+  SUBAGENT_REJECTED_ERROR_PREFIX,
+  SUBAGENT_CANCELLED_ERROR_MESSAGE } from './types.js';
+import { LocalSessionInvocation } from './local-session-invocation.js';
+import { LocalSubagentSession } from './local-subagent-protocol.js';
+import { makeFakeConfig } from '../test-utils/config.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import { MessageBusType } from '../confirmation-bus/types.js';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+vi.mock('./local-subagent-protocol.js');
+
+const MockLocalSubagentSession = vi.mocked(LocalSubagentSession);
+
+let capturedActivityCallback:
+  | ((activity: SubagentActivityEvent) => void)
+  | undefined;
+
+const testDefinition: LocalAgentDefinition = {
+  kind: 'local',
+  name: 'MockAgent',
+  description: 'A mock agent for testing.',
+  inputConfig: {
+    inputSchema: {
+      type: 'object',
+      properties: { task: { type: 'string' } },
+    },
+  },
+  modelConfig: { model: 'test-model', generateContentConfig: {} },
+  runConfig: { maxTimeMinutes: 1 },
+  promptConfig: { systemPrompt: 'test' },
+};
+
+function setupMockSession(config: {
+  output?: { result: string; terminate_reason: AgentTerminateMode };
+  error?: Error;
+}) {
+  const mockSession = {
+    send: vi.fn().mockResolvedValue({ streamId: 'stream-1' }),
+    getResult: config.error
+      ? vi.fn().mockRejectedValue(config.error)
+      : vi.fn().mockResolvedValue(
+          config.output ?? {
+            result: 'done',
+            terminate_reason: AgentTerminateMode.GOAL,
+          },
+        ),
+    abort: vi.fn(),
+    subscribe: vi.fn().mockReturnValue(vi.fn()),
+  };
+  MockLocalSubagentSession.mockImplementation(
+    (
+      _def: LocalAgentDefinition,
+      _ctx: AgentLoopContext,
+      _bus: MessageBus,
+      rawCallback?: (activity: SubagentActivityEvent) => void,
+    ) => {
+      capturedActivityCallback = rawCallback;
+      return mockSession as unknown as LocalSubagentSession;
+    },
+  );
+  return mockSession;
+}
+
+describe('LocalSessionInvocation', () => {
+  let mockContext: AgentLoopContext;
+  let mockMessageBus: MessageBus;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedActivityCallback = undefined;
+    mockContext = makeFakeConfig() as unknown as AgentLoopContext;
+    mockMessageBus = createMockMessageBus();
+  });
+
+  it('should pass the messageBus to the parent constructor', () => {
+    setupMockSession({});
+    const params = { task: 'Analyze data' };
+    const invocation = new LocalSessionInvocation(
+      testDefinition,
+      mockContext,
+      params,
+      mockMessageBus,
+    );
+    expect(
+      (invocation as unknown as { messageBus: MessageBus }).messageBus,
+    ).toBe(mockMessageBus);
+  });
+
+  describe('getDescription', () => {
+    it('should format the description with inputs and truncate long values and overall length', () => {
+      setupMockSession({});
+      const params = { task: 'Analyze data', priority: 5 };
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+      const description = invocation.getDescription();
+      expect(description).toBe(
+        "Running subagent 'MockAgent' with inputs: { task: Analyze data, priority: 5 }",
+      );
+    });
+
+    it('should truncate long input values', () => {
+      setupMockSession({});
+      const longTask = 'A'.repeat(100);
+      const params = { task: longTask };
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+      const description = invocation.getDescription();
+      expect(description).toBe(
+        `Running subagent 'MockAgent' with inputs: { task: ${'A'.repeat(50)} }`,
+      );
+    });
+
+    it('should truncate the overall description if it exceeds the limit', () => {
+      setupMockSession({});
+      const longNameDef: LocalAgentDefinition = {
+        ...testDefinition,
+        name: 'VeryLongAgentNameThatTakesUpSpace',
+      };
+      const params: AgentInputs = {};
+      for (let i = 0; i < 20; i++) {
+        params[`input${i}`] = `value${i}`;
+      }
+      const invocation = new LocalSessionInvocation(
+        longNameDef,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+      const description = invocation.getDescription();
+      expect(description.length).toBe(200);
+    });
+  });
+
+  describe('execute', () => {
+    it('should create session and run successfully', async () => {
+      const mockOutput = {
+        result: 'Analysis complete.',
+        terminate_reason: AgentTerminateMode.GOAL,
+      };
+      const mockSession = setupMockSession({ output: mockOutput });
+      const params = { query: 'Execute task' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const result = await invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      expect(MockLocalSubagentSession).toHaveBeenCalledWith(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+        expect.any(Function),
+      );
+      expect(mockSession.send).toHaveBeenCalledWith({
+        message: { content: [{ type: 'text', text: 'Execute task' }] },
+      });
+      expect(result.llmContent).toEqual([
+        {
+          text: expect.stringContaining(
+            "Subagent 'MockAgent' finished.\nTermination Reason: GOAL\nResult:\nAnalysis complete.",
+          ),
+        },
+      ]);
+      const display = result.returnDisplay as SubagentProgress;
+      expect(display.isSubagentProgress).toBe(true);
+      expect(display.state).toBe('completed');
+      expect(display.result).toBe('Analysis complete.');
+      expect(display.terminateReason).toBe(AgentTerminateMode.GOAL);
+    });
+
+    it('should stream THOUGHT_CHUNK activity', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'think' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      // Wait for send to be called so the activity callback is wired
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      // Emit a thought chunk via captured callback
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'THOUGHT_CHUNK',
+        data: { text: 'Analyzing...' },
+      });
+
+      await executePromise;
+
+      // Find an updateOutput call containing the thought
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      const hasThought = progressCalls.some(
+        (p) =>
+          p.recentActivity &&
+          p.recentActivity.some(
+            (a) => a.type === 'thought' && a.content === 'Analyzing...',
+          ),
+      );
+      expect(hasThought).toBe(true);
+    });
+
+    it('should stream TOOL_CALL_START and TOOL_CALL_END', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'run tool' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'ls', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_END',
+        data: { name: 'ls', data: {} },
+      });
+
+      await executePromise;
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+
+      // After TOOL_CALL_START, the immediate updateOutput call should show running
+      const runningCalls = progressCalls.filter((p) => p.state === 'running');
+      // The first running call with a tool_call should show 'running'
+      const firstToolCall = runningCalls.find((p) =>
+        p.recentActivity?.some(
+          (a) => a.type === 'tool_call' && a.content === 'ls',
+        ),
+      );
+      expect(firstToolCall).toBeDefined();
+
+      // After TOOL_CALL_END, the tool should be completed
+      const hasCompleted = progressCalls.some((p) =>
+        p.recentActivity?.some(
+          (a) =>
+            a.type === 'tool_call' &&
+            a.content === 'ls' &&
+            a.status === 'completed',
+        ),
+      );
+      expect(hasCompleted).toBe(true);
+    });
+
+    it('should handle ERROR activity', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'fail' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'ERROR',
+        data: { error: 'Something broke' },
+      });
+
+      await executePromise;
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      const hasError = progressCalls.some((p) =>
+        p.recentActivity?.some(
+          (a) =>
+            a.type === 'thought' &&
+            a.content === 'Error: Something broke' &&
+            a.status === 'error',
+        ),
+      );
+      expect(hasError).toBe(true);
+    });
+
+    it('should handle cancelled errors', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'cancel' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'ERROR',
+        data: {
+          error: SUBAGENT_CANCELLED_ERROR_MESSAGE,
+          errorType: SubagentActivityErrorType.CANCELLED,
+        },
+      });
+
+      await executePromise;
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      const hasCancelled = progressCalls.some((p) =>
+        p.recentActivity?.some(
+          (a) => a.type === 'thought' && a.status === 'cancelled',
+        ),
+      );
+      expect(hasCancelled).toBe(true);
+    });
+
+    it('should handle rejected errors', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'reject' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'dangerous_tool', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'ERROR',
+        data: {
+          name: 'dangerous_tool',
+          error: `${SUBAGENT_REJECTED_ERROR_PREFIX} Rethink approach.`,
+          errorType: SubagentActivityErrorType.REJECTED,
+        },
+      });
+
+      await executePromise;
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      // Tool call should be marked cancelled
+      const hasToolCancelled = progressCalls.some((p) =>
+        p.recentActivity?.some(
+          (a) =>
+            a.type === 'tool_call' &&
+            a.content === 'dangerous_tool' &&
+            a.status === 'cancelled',
+        ),
+      );
+      expect(hasToolCancelled).toBe(true);
+    });
+
+    it('should trim recentActivity to MAX_RECENT_ACTIVITY', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'trim' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      // Emit 4+ activities to exceed MAX_RECENT_ACTIVITY (3)
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'tool1', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'tool2', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'tool3', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'tool4', args: {} },
+      });
+
+      await executePromise;
+
+      // After the 4th activity, the last updateOutput call before completion
+      // should have only 3 items in recentActivity
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      // Find the call right after the 4th activity (before completion)
+      const afterFourthActivity = progressCalls.filter(
+        (p) => p.state === 'running' && p.recentActivity.length > 0,
+      );
+      const lastRunning = afterFourthActivity[afterFourthActivity.length - 1];
+      expect(lastRunning.recentActivity.length).toBeLessThanOrEqual(3);
+      // Should contain tool4 (the latest)
+      expect(
+        lastRunning.recentActivity.some((a) => a.content === 'tool4'),
+      ).toBe(true);
+      // Should NOT contain tool1 (trimmed away)
+      expect(
+        lastRunning.recentActivity.some((a) => a.content === 'tool1'),
+      ).toBe(false);
+    });
+
+    it('should handle executor errors', async () => {
+      const error = new Error('Model failed during execution.');
+      setupMockSession({ error });
+      const params = { query: 'fail hard' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const result = await invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      expect(result.llmContent).toBe(
+        `Subagent 'MockAgent' failed. Error: ${error.message}`,
+      );
+      const display = result.returnDisplay as SubagentProgress;
+      expect(display.isSubagentProgress).toBe(true);
+      expect(display.state).toBe('error');
+      expect(display.recentActivity).toContainEqual(
+        expect.objectContaining({
+          type: 'thought',
+          content: `Error: ${error.message}`,
+          status: 'error',
+        }),
+      );
+    });
+
+    it('should handle abort', async () => {
+      const mockOutput = {
+        result: '',
+        terminate_reason: AgentTerminateMode.ABORTED,
+      };
+      setupMockSession({ output: mockOutput });
+      const params = { query: 'abort me' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      await expect(
+        invocation.execute({ abortSignal: signal, updateOutput }),
+      ).rejects.toThrow('Operation cancelled by user');
+
+      // Verify cancelled state was published
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      const hasCancelledState = progressCalls.some(
+        (p) => p.state === 'cancelled',
+      );
+      expect(hasCancelledState).toBe(true);
+    });
+
+    it('should wire abort signal to session.abort', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'abort wire' };
+      const controller = new AbortController();
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: controller.signal,
+        updateOutput,
+      });
+
+      // Trigger abort
+      controller.abort();
+
+      // The execute should complete (getResult returned GOAL by default)
+      await executePromise.catch(() => {
+        /* abort may throw */
+      });
+
+      expect(mockSession.abort).toHaveBeenCalled();
+    });
+
+    it('should send non-query params as config update before query', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'Do something', extra_config: 'value123' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      await invocation.execute({ abortSignal: signal, updateOutput });
+
+      // First send: config update with non-query params
+      expect(mockSession.send).toHaveBeenCalledWith({
+        update: { config: { extra_config: 'value123' } },
+      });
+      // Second send: message with query
+      expect(mockSession.send).toHaveBeenCalledWith({
+        message: { content: [{ type: 'text', text: 'Do something' }] },
+      });
+      // Config update should come before message
+      const sendCalls = mockSession.send.mock.calls;
+      const configIdx = sendCalls.findIndex((c) => c[0]?.update?.config);
+      const messageIdx = sendCalls.findIndex((c) => c[0]?.message);
+      expect(configIdx).toBeLessThan(messageIdx);
+    });
+
+    it('should publish SUBAGENT_ACTIVITY on messageBus', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'publish test' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'THOUGHT_CHUNK',
+        data: { text: 'Thinking...' },
+      });
+
+      await executePromise;
+
+      expect(mockMessageBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageBusType.SUBAGENT_ACTIVITY,
+          subagentName: 'MockAgent',
+          activity: expect.objectContaining({
+            type: 'thought',
+            content: 'Thinking...',
+          }),
+        }),
+      );
+    });
+
+    it('should clean up abort listener in finally', async () => {
+      setupMockSession({});
+      const params = { query: 'cleanup' };
+      const controller = new AbortController();
+      const removeEventListenerSpy = vi.spyOn(
+        controller.signal,
+        'removeEventListener',
+      );
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      await invocation.execute({
+        abortSignal: controller.signal,
+        updateOutput,
+      });
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      );
+    });
+
+    it('should unsubscribe parent observer in finally', async () => {
+      const unsubscribeFn = vi.fn();
+      const mockSession = setupMockSession({});
+      mockSession.subscribe.mockReturnValue(unsubscribeFn);
+
+      const params = { query: 'unsub test' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const onAgentEvent = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+        { onAgentEvent },
+      );
+
+      await invocation.execute({ abortSignal: signal, updateOutput });
+
+      expect(mockSession.subscribe).toHaveBeenCalledWith(onAgentEvent);
+      expect(unsubscribeFn).toHaveBeenCalled();
+    });
+
+    it('should handle TOOL_CALL_END with error data', async () => {
+      const mockSession = setupMockSession({});
+      const params = { query: 'tool error' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'failing_tool', args: {} },
+      });
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_END',
+        data: { name: 'failing_tool', data: { isError: true } },
+      });
+
+      await executePromise;
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      const hasToolError = progressCalls.some((p) =>
+        p.recentActivity?.some(
+          (a) =>
+            a.type === 'tool_call' &&
+            a.content === 'failing_tool' &&
+            a.status === 'error',
+        ),
+      );
+      expect(hasToolError).toBe(true);
+    });
+
+    it('should mark running items as cancelled on abort', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      const mockSession = setupMockSession({ error: abortError });
+      const params = { query: 'mark cancelled' };
+      const signal = new AbortController().signal;
+      const updateOutput = vi.fn();
+      const invocation = new LocalSessionInvocation(
+        testDefinition,
+        mockContext,
+        params,
+        mockMessageBus,
+      );
+
+      const executePromise = invocation.execute({
+        abortSignal: signal,
+        updateOutput,
+      });
+
+      await vi.waitFor(() => expect(mockSession.send).toHaveBeenCalled());
+
+      // Emit a running tool call before the abort
+      capturedActivityCallback!({
+        isSubagentActivityEvent: true,
+        agentName: 'MockAgent',
+        type: 'TOOL_CALL_START',
+        data: { name: 'running_tool', args: {} },
+      });
+
+      await expect(executePromise).rejects.toThrow('Aborted');
+
+      const progressCalls = updateOutput.mock.calls.map(
+        (c) => c[0] as SubagentProgress,
+      );
+      // The final progress should show the tool as cancelled
+      const lastProgress = progressCalls[progressCalls.length - 1];
+      expect(lastProgress.state).toBe('cancelled');
+      expect(lastProgress.recentActivity).toContainEqual(
+        expect.objectContaining({
+          type: 'tool_call',
+          content: 'running_tool',
+          status: 'cancelled',
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/agents/local-session-invocation.test.ts
+++ b/packages/core/src/agents/local-session-invocation.test.ts
@@ -5,15 +5,16 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type {
- SubagentProgress ,
+import {
   AgentTerminateMode,
+  SubagentActivityErrorType,
+  SUBAGENT_REJECTED_ERROR_PREFIX,
+  SUBAGENT_CANCELLED_ERROR_MESSAGE,
+  type SubagentProgress,
   type LocalAgentDefinition,
   type AgentInputs,
   type SubagentActivityEvent,
-  SubagentActivityErrorType,
-  SUBAGENT_REJECTED_ERROR_PREFIX,
-  SUBAGENT_CANCELLED_ERROR_MESSAGE } from './types.js';
+} from './types.js';
 import { LocalSessionInvocation } from './local-session-invocation.js';
 import { LocalSubagentSession } from './local-subagent-protocol.js';
 import { makeFakeConfig } from '../test-utils/config.js';

--- a/packages/core/src/agents/local-session-invocation.ts
+++ b/packages/core/src/agents/local-session-invocation.ts
@@ -1,0 +1,411 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type AgentLoopContext } from '../config/agent-loop-context.js';
+import { MessageBusType } from '../confirmation-bus/types.js';
+import {
+  BaseToolInvocation,
+  type ToolResult,
+  type ExecuteOptions,
+} from '../tools/tools.js';
+import {
+  type LocalAgentDefinition,
+  type AgentInputs,
+  type SubagentActivityEvent,
+  type SubagentProgress,
+  type SubagentActivityItem,
+  AgentTerminateMode,
+  SubagentActivityErrorType,
+  SUBAGENT_REJECTED_ERROR_PREFIX,
+  SUBAGENT_CANCELLED_ERROR_MESSAGE,
+  isToolActivityError,
+} from './types.js';
+import { randomUUID } from 'node:crypto';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import {
+  sanitizeThoughtContent,
+  sanitizeToolArgs,
+  sanitizeErrorMessage,
+} from '../utils/agent-sanitization-utils.js';
+import { LocalSubagentSession } from './local-subagent-protocol.js';
+import type { AgentEvent } from '../agent/types.js';
+
+const INPUT_PREVIEW_MAX_LENGTH = 50;
+const DESCRIPTION_MAX_LENGTH = 200;
+const MAX_RECENT_ACTIVITY = 3;
+
+/** Optional configuration for subagent invocations. */
+export interface SubagentInvocationOptions {
+  toolName?: string;
+  toolDisplayName?: string;
+  onAgentEvent?: (event: AgentEvent) => void;
+}
+
+/**
+ * Session-based local subagent invocation.
+ *
+ * This class orchestrates the execution of a defined agent by:
+ * 1. Using {@link LocalSubagentSession} as the execution engine.
+ * 2. Bridging the agent's streaming activity (e.g., thoughts) to the tool's
+ *    live output stream via the session's rawActivityCallback.
+ * 3. Formatting the final result into a {@link ToolResult}.
+ */
+export class LocalSessionInvocation extends BaseToolInvocation<
+  AgentInputs,
+  ToolResult
+> {
+  private readonly _onAgentEvent?: (event: AgentEvent) => void;
+
+  /**
+   * @param definition The definition object that configures the agent.
+   * @param context The agent loop context.
+   * @param params The validated input parameters for the agent.
+   * @param messageBus Message bus for policy enforcement.
+   * @param options Optional overrides for tool name, display name, and event callback.
+   */
+  constructor(
+    private readonly definition: LocalAgentDefinition,
+    private readonly context: AgentLoopContext,
+    params: AgentInputs,
+    messageBus: MessageBus,
+    options?: SubagentInvocationOptions,
+  ) {
+    super(
+      params,
+      messageBus,
+      options?.toolName ?? definition.name,
+      options?.toolDisplayName ?? definition.displayName,
+    );
+    this._onAgentEvent = options?.onAgentEvent;
+  }
+
+  /**
+   * Returns a concise, human-readable description of the invocation.
+   * Used for logging and display purposes.
+   */
+  getDescription(): string {
+    const inputSummary = Object.entries(this.params)
+      .map(
+        ([key, value]) =>
+          `${key}: ${String(value).slice(0, INPUT_PREVIEW_MAX_LENGTH)}`,
+      )
+      .join(', ');
+
+    const description = `Running subagent '${this.definition.name}' with inputs: { ${inputSummary} }`;
+    return description.slice(0, DESCRIPTION_MAX_LENGTH);
+  }
+
+  private publishActivity(activity: SubagentActivityItem): void {
+    void this.messageBus.publish({
+      type: MessageBusType.SUBAGENT_ACTIVITY,
+      subagentName: this.definition.displayName ?? this.definition.name,
+      activity,
+    });
+  }
+
+  /**
+   * Executes the subagent.
+   *
+   * @param options Options for tool execution including signal and output updates.
+   * @returns A `Promise` that resolves with the final `ToolResult`.
+   */
+  async execute(options: ExecuteOptions): Promise<ToolResult> {
+    const { abortSignal: signal, updateOutput } = options;
+    let recentActivity: SubagentActivityItem[] = [];
+
+    // Raw SubagentActivityEvent handler — preserves all existing progress display logic.
+    // Passed as rawActivityCallback to LocalSubagentSession so the protocol can call it
+    // before translating to AgentEvents.
+    const onActivity = (activity: SubagentActivityEvent): void => {
+      if (!updateOutput) return;
+
+      let updated = false;
+
+      switch (activity.type) {
+        case 'THOUGHT_CHUNK': {
+          const text = String(activity.data['text']);
+          const lastItem = recentActivity[recentActivity.length - 1];
+
+          if (
+            lastItem &&
+            lastItem.type === 'thought' &&
+            lastItem.status === 'running'
+          ) {
+            lastItem.content = sanitizeThoughtContent(text);
+          } else {
+            recentActivity.push({
+              id: randomUUID(),
+              type: 'thought',
+              content: sanitizeThoughtContent(text),
+              status: 'running',
+            });
+          }
+          updated = true;
+
+          const latestThought = recentActivity[recentActivity.length - 1];
+          if (latestThought) {
+            this.publishActivity(latestThought);
+          }
+          break;
+        }
+        case 'TOOL_CALL_START': {
+          const name = String(activity.data['name']);
+          const displayName = activity.data['displayName']
+            ? sanitizeErrorMessage(String(activity.data['displayName']))
+            : undefined;
+          const description = activity.data['description']
+            ? sanitizeErrorMessage(String(activity.data['description']))
+            : undefined;
+          const args = JSON.stringify(sanitizeToolArgs(activity.data['args']));
+          recentActivity.push({
+            id: randomUUID(),
+            type: 'tool_call',
+            content: name,
+            displayName,
+            description,
+            args,
+            status: 'running',
+          });
+          updated = true;
+
+          const latestTool = recentActivity[recentActivity.length - 1];
+          if (latestTool) {
+            this.publishActivity(latestTool);
+          }
+          break;
+        }
+        case 'TOOL_CALL_END': {
+          const name = String(activity.data['name']);
+          const data = activity.data['data'];
+          const isError = isToolActivityError(data);
+
+          for (let i = recentActivity.length - 1; i >= 0; i--) {
+            if (
+              recentActivity[i].type === 'tool_call' &&
+              recentActivity[i].content === name &&
+              recentActivity[i].status === 'running'
+            ) {
+              recentActivity[i].status = isError ? 'error' : 'completed';
+              updated = true;
+
+              this.publishActivity(recentActivity[i]);
+              break;
+            }
+          }
+          break;
+        }
+        case 'ERROR': {
+          const error = String(activity.data['error']);
+          const errorType = activity.data['errorType'];
+          const sanitizedError = sanitizeErrorMessage(error);
+          const isCancellation =
+            errorType === SubagentActivityErrorType.CANCELLED ||
+            error === SUBAGENT_CANCELLED_ERROR_MESSAGE;
+          const isRejection =
+            errorType === SubagentActivityErrorType.REJECTED ||
+            error.startsWith(SUBAGENT_REJECTED_ERROR_PREFIX);
+
+          const toolName = activity.data['name']
+            ? String(activity.data['name'])
+            : undefined;
+
+          if (toolName && (isCancellation || isRejection)) {
+            for (let i = recentActivity.length - 1; i >= 0; i--) {
+              if (
+                recentActivity[i].type === 'tool_call' &&
+                recentActivity[i].content === toolName &&
+                recentActivity[i].status === 'running'
+              ) {
+                recentActivity[i].status = 'cancelled';
+                updated = true;
+                break;
+              }
+            }
+          } else if (toolName) {
+            // Mark non-rejection/non-cancellation errors as 'error'
+            for (let i = recentActivity.length - 1; i >= 0; i--) {
+              if (
+                recentActivity[i].type === 'tool_call' &&
+                recentActivity[i].content === toolName &&
+                recentActivity[i].status === 'running'
+              ) {
+                recentActivity[i].status = 'error';
+                updated = true;
+                break;
+              }
+            }
+          }
+
+          recentActivity.push({
+            id: randomUUID(),
+            type: 'thought',
+            content:
+              isCancellation || isRejection
+                ? sanitizedError
+                : `Error: ${sanitizedError}`,
+            status: isCancellation || isRejection ? 'cancelled' : 'error',
+          });
+          updated = true;
+          break;
+        }
+        default:
+          break;
+      }
+
+      if (updated) {
+        // Keep only the last N items
+        if (recentActivity.length > MAX_RECENT_ACTIVITY) {
+          recentActivity = recentActivity.slice(-MAX_RECENT_ACTIVITY);
+        }
+
+        const progress: SubagentProgress = {
+          isSubagentProgress: true,
+          agentName: this.definition.name,
+          recentActivity: [...recentActivity], // Copy to avoid mutation issues
+          state: 'running',
+        };
+
+        updateOutput(progress);
+      }
+    };
+
+    // Create session with the raw activity callback for rich progress display
+    const session = new LocalSubagentSession(
+      this.definition,
+      this.context,
+      this.messageBus,
+      onActivity,
+    );
+
+    // Subscribe for parent session observability
+    let unsubscribeParent: (() => void) | undefined;
+    if (this._onAgentEvent) {
+      unsubscribeParent = session.subscribe(this._onAgentEvent);
+    }
+
+    // Wire external abort signal to session abort
+    const abortListener = () => void session.abort();
+    signal.addEventListener('abort', abortListener, { once: true });
+
+    try {
+      if (updateOutput) {
+        const initialProgress: SubagentProgress = {
+          isSubagentProgress: true,
+          agentName: this.definition.name,
+          recentActivity: [],
+          state: 'running',
+        };
+        updateOutput(initialProgress);
+      }
+
+      // Buffer non-query params, then send query as message to start execution
+      const query = String(this.params['query'] ?? '');
+      const otherParams = { ...this.params } as Record<string, unknown>;
+      delete otherParams['query'];
+      if (Object.keys(otherParams).length > 0) {
+        await session.send({ update: { config: otherParams } });
+      }
+      await session.send({
+        message: { content: [{ type: 'text', text: query }] },
+      });
+
+      const output = await session.getResult();
+
+      if (output.terminate_reason === AgentTerminateMode.ABORTED) {
+        const progress: SubagentProgress = {
+          isSubagentProgress: true,
+          agentName: this.definition.name,
+          recentActivity: [...recentActivity],
+          state: 'cancelled',
+        };
+
+        if (updateOutput) {
+          updateOutput(progress);
+        }
+
+        const cancelError = new Error('Operation cancelled by user');
+        cancelError.name = 'AbortError';
+        throw cancelError;
+      }
+
+      const progress: SubagentProgress = {
+        isSubagentProgress: true,
+        agentName: this.definition.name,
+        recentActivity: [...recentActivity],
+        state: 'completed',
+        result: output.result,
+        terminateReason: output.terminate_reason,
+      };
+
+      if (updateOutput) {
+        updateOutput(progress);
+      }
+
+      const resultContent = `Subagent '${this.definition.name}' finished.
+Termination Reason: ${output.terminate_reason}
+Result:
+${output.result}`;
+
+      return {
+        llmContent: [{ text: resultContent }],
+        returnDisplay: progress,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      const isAbort =
+        (error instanceof Error && error.name === 'AbortError') ||
+        errorMessage.includes('Aborted');
+
+      // Mark any running items as error/cancelled
+      for (const item of recentActivity) {
+        if (item.status === 'running') {
+          item.status = isAbort ? 'cancelled' : 'error';
+        }
+      }
+
+      // Ensure the error is reflected in the recent activity for display
+      if (!isAbort) {
+        const lastActivity = recentActivity[recentActivity.length - 1];
+        if (!lastActivity || lastActivity.status !== 'error') {
+          recentActivity.push({
+            id: randomUUID(),
+            type: 'thought',
+            content: `Error: ${errorMessage}`,
+            status: 'error',
+          });
+          if (recentActivity.length > MAX_RECENT_ACTIVITY) {
+            recentActivity = recentActivity.slice(-MAX_RECENT_ACTIVITY);
+          }
+        }
+      }
+
+      const progress: SubagentProgress = {
+        isSubagentProgress: true,
+        agentName: this.definition.name,
+        recentActivity: [...recentActivity],
+        state: isAbort ? 'cancelled' : 'error',
+      };
+
+      if (updateOutput) {
+        updateOutput(progress);
+      }
+
+      if (isAbort) {
+        throw error;
+      }
+
+      return {
+        llmContent: `Subagent '${this.definition.name}' failed. Error: ${errorMessage}`,
+        returnDisplay: progress,
+      };
+    } finally {
+      signal.removeEventListener('abort', abortListener);
+      unsubscribeParent?.();
+    }
+  }
+}

--- a/packages/core/src/agents/local-subagent-protocol.test.ts
+++ b/packages/core/src/agents/local-subagent-protocol.test.ts
@@ -1,0 +1,967 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LocalSubagentSession } from './local-subagent-protocol.js';
+import { LocalAgentExecutor } from './local-executor.js';
+import {
+  AgentTerminateMode,
+  type LocalAgentDefinition,
+  type SubagentActivityEvent,
+} from './types.js';
+import { makeFakeConfig } from '../test-utils/config.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+import type { AgentEvent } from '../agent/types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type { z } from 'zod';
+import type { Mocked } from 'vitest';
+
+vi.mock('./local-executor.js');
+
+const MockLocalAgentExecutor = vi.mocked(LocalAgentExecutor);
+
+// Captures the onActivity callback passed to LocalAgentExecutor.create().
+// Set via create.mockImplementation in beforeEach to avoid mock.calls index fragility.
+let capturedOnActivity: ((activity: SubagentActivityEvent) => void) | undefined;
+
+const testDefinition: LocalAgentDefinition = {
+  kind: 'local',
+  name: 'TestProtocolAgent',
+  description: 'A test agent for protocol tests.',
+  inputConfig: {
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task: { type: 'string' },
+        priority: { type: 'number' },
+      },
+    },
+  },
+  modelConfig: { model: 'test', generateContentConfig: {} },
+  runConfig: { maxTimeMinutes: 1 },
+  promptConfig: { systemPrompt: 'test' },
+};
+
+const GOAL_OUTPUT = {
+  result: 'Analysis complete.',
+  terminate_reason: AgentTerminateMode.GOAL,
+};
+
+describe('LocalSubagentSession (protocol)', () => {
+  let mockContext: AgentLoopContext;
+  let mockMessageBus: MessageBus;
+  let mockExecutorInstance: Mocked<LocalAgentExecutor<z.ZodUnknown>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOnActivity = undefined;
+
+    mockContext = makeFakeConfig() as unknown as AgentLoopContext;
+    mockMessageBus = createMockMessageBus();
+
+    mockExecutorInstance = {
+      run: vi.fn().mockResolvedValue(GOAL_OUTPUT),
+      definition: testDefinition,
+    } as unknown as Mocked<LocalAgentExecutor<z.ZodUnknown>>;
+
+    // Use mockImplementation (not mockResolvedValue) so we can capture onActivity.
+    MockLocalAgentExecutor.create.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (_def: any, _ctx: any, onActivity: any) => {
+        capturedOnActivity = onActivity;
+
+        return mockExecutorInstance as unknown as LocalAgentExecutor<z.ZodTypeAny>;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle events
+  // ---------------------------------------------------------------------------
+
+  describe('lifecycle events', () => {
+    it('emits agent_start then agent_end(completed) for a GOAL run', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'query' }] },
+      });
+      await session.getResult();
+
+      expect(events[0].type).toBe('agent_start');
+      expect(events[events.length - 1].type).toBe('agent_end');
+      const endEvent = events[events.length - 1];
+      if (endEvent.type === 'agent_end') {
+        expect(endEvent.reason).toBe('completed');
+      }
+    });
+
+    it('emits agent_start exactly once even if ensureAgentStart called twice internally', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'query' }] },
+      });
+      await session.getResult();
+
+      const startEvents = events.filter((e) => e.type === 'agent_start');
+      expect(startEvents).toHaveLength(1);
+    });
+
+    it('emits agent_end exactly once on error path', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      mockExecutorInstance.run.mockRejectedValue(new Error('executor failed'));
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'query' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow('executor failed');
+
+      const endEvents = events.filter((e) => e.type === 'agent_end');
+      expect(endEvents).toHaveLength(1);
+    });
+
+    it('all events share the same streamId', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'query' }] },
+      });
+      await session.getResult();
+
+      const streamIds = new Set(events.map((e) => e.streamId));
+      expect(streamIds.size).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config buffering (update + message pattern)
+  // ---------------------------------------------------------------------------
+
+  describe('config buffering', () => {
+    it('merges buffered config with message query', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        update: { config: { task: 'analyze', priority: 5 } },
+      });
+      await session.send({
+        message: { content: [{ type: 'text', text: 'my query' }] },
+      });
+      await session.getResult();
+
+      expect(mockExecutorInstance.run).toHaveBeenCalledWith(
+        { task: 'analyze', priority: 5, query: 'my query' },
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('omits query key when message text is empty', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({ update: { config: { task: 'no-query-task' } } });
+      await session.send({
+        message: { content: [{ type: 'text', text: '' }] },
+      });
+      await session.getResult();
+
+      const callArgs = mockExecutorInstance.run.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('query');
+      expect(callArgs).toEqual({ task: 'no-query-task' });
+    });
+
+    it('sends only query when no prior update', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'just a query' }] },
+      });
+      await session.getResult();
+
+      expect(mockExecutorInstance.run).toHaveBeenCalledWith(
+        { query: 'just a query' },
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('multiple update calls are merged', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({ update: { config: { field1: 'a' } } });
+      await session.send({ update: { config: { field2: 'b' } } });
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(mockExecutorInstance.run).toHaveBeenCalledWith(
+        { field1: 'a', field2: 'b', query: 'q' },
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('update returns streamId: null; message returns a streamId', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const updateResult = await session.send({ update: { config: {} } });
+      expect(updateResult.streamId).toBeNull();
+
+      const messageResult = await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      expect(messageResult.streamId).not.toBeNull();
+      expect(typeof messageResult.streamId).toBe('string');
+
+      // Await completion to prevent dangling execution affecting subsequent tests
+      await session.getResult();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Activity translation
+  // ---------------------------------------------------------------------------
+
+  describe('activity translation', () => {
+    function makeSession() {
+      const activityEvents: SubagentActivityEvent[] = [];
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      return { session, activityEvents };
+    }
+
+    async function runWithActivities(
+      session: LocalSubagentSession,
+      activities: SubagentActivityEvent[],
+    ) {
+      mockExecutorInstance.run.mockImplementation(async () => {
+        // capturedOnActivity is set by the create.mockImplementation in beforeEach
+        // and updated whenever create() is called. By the time run() is called,
+        // capturedOnActivity holds the onActivity closure for the most-recently
+        // created executor — which is the one associated with this session.
+        for (const act of activities) {
+          capturedOnActivity?.(act);
+        }
+        return GOAL_OUTPUT;
+      });
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+      return events;
+    }
+
+    it('THOUGHT_CHUNK → message event with thought content', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'THOUGHT_CHUNK',
+          data: { text: 'I am thinking...' },
+        },
+      ]);
+
+      const msgEvent = events.find((e) => e.type === 'message');
+      expect(msgEvent).toBeDefined();
+      if (msgEvent?.type === 'message') {
+        expect(msgEvent.role).toBe('agent');
+        expect(msgEvent.content).toContainEqual({
+          type: 'thought',
+          thought: 'I am thinking...',
+        });
+      }
+    });
+
+    it('TOOL_CALL_START → tool_request event', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'TOOL_CALL_START',
+          data: { callId: 'call-123', name: 'read_file', args: { path: '/a' } },
+        },
+      ]);
+
+      const reqEvent = events.find((e) => e.type === 'tool_request');
+      expect(reqEvent).toBeDefined();
+      if (reqEvent?.type === 'tool_request') {
+        expect(reqEvent.requestId).toBe('call-123');
+        expect(reqEvent.name).toBe('read_file');
+        expect(reqEvent.args).toEqual({ path: '/a' });
+      }
+    });
+
+    it('TOOL_CALL_END → tool_response event', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'TOOL_CALL_END',
+          data: { id: 'call-123', name: 'read_file', output: 'file contents' },
+        },
+      ]);
+
+      const respEvent = events.find((e) => e.type === 'tool_response');
+      expect(respEvent).toBeDefined();
+      if (respEvent?.type === 'tool_response') {
+        expect(respEvent.requestId).toBe('call-123');
+        expect(respEvent.name).toBe('read_file');
+        expect(respEvent.content).toContainEqual({
+          type: 'text',
+          text: 'file contents',
+        });
+      }
+    });
+
+    it('ERROR activity → error event with INTERNAL status, fatal: false', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'ERROR',
+          data: { error: 'something went wrong' },
+        },
+      ]);
+
+      const errEvent = events.find((e) => e.type === 'error');
+      expect(errEvent).toBeDefined();
+      if (errEvent?.type === 'error') {
+        expect(errEvent.status).toBe('INTERNAL');
+        expect(errEvent.message).toBe('something went wrong');
+        expect(errEvent.fatal).toBe(false);
+      }
+    });
+
+    it('unknown activity type → no events emitted', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          type: 'UNKNOWN_TYPE' as any,
+          data: {},
+        },
+      ]);
+
+      // Only agent_start and agent_end should be present
+      const nonLifecycle = events.filter(
+        (e) => e.type !== 'agent_start' && e.type !== 'agent_end',
+      );
+      expect(nonLifecycle).toHaveLength(0);
+    });
+
+    it('TOOL_CALL_START with non-object args defaults to {}', async () => {
+      const { session } = makeSession();
+      const events = await runWithActivities(session, [
+        {
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'TOOL_CALL_START',
+          data: { callId: 'x', name: 'tool', args: null },
+        },
+      ]);
+
+      const reqEvent = events.find((e) => e.type === 'tool_request');
+      if (reqEvent?.type === 'tool_request') {
+        expect(reqEvent.args).toEqual({});
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getResult() promise
+  // ---------------------------------------------------------------------------
+
+  describe('getResult()', () => {
+    it('resolves with OutputObject on GOAL termination', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      const output = await session.getResult();
+
+      expect(output.result).toBe('Analysis complete.');
+      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+    });
+
+    it('rejects when executor throws', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      mockExecutorInstance.run.mockRejectedValue(new Error('executor error'));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow('executor error');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // rawActivityCallback
+  // ---------------------------------------------------------------------------
+
+  describe('rawActivityCallback', () => {
+    it('receives raw SubagentActivityEvent before AgentEvent translation', async () => {
+      const rawActivities: SubagentActivityEvent[] = [];
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+        (activity) => rawActivities.push(activity),
+      );
+
+      const thoughtActivity: SubagentActivityEvent = {
+        isSubagentActivityEvent: true,
+        agentName: 'TestProtocolAgent',
+        type: 'THOUGHT_CHUNK',
+        data: { text: 'raw thought' },
+      };
+
+      mockExecutorInstance.run.mockImplementation(async () => {
+        const onActivity = MockLocalAgentExecutor.create.mock.calls[0]?.[2];
+        onActivity?.(thoughtActivity);
+        return GOAL_OUTPUT;
+      });
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(rawActivities).toHaveLength(1);
+      expect(rawActivities[0]).toBe(thoughtActivity);
+    });
+
+    it('is called before AgentEvent translation (raw arrives first)', async () => {
+      const callOrder: string[] = [];
+
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+        () => callOrder.push('raw'),
+      );
+
+      session.subscribe((e) => {
+        if (e.type === 'message') callOrder.push('translated');
+      });
+
+      mockExecutorInstance.run.mockImplementation(async () => {
+        const onActivity = MockLocalAgentExecutor.create.mock.calls[0]?.[2];
+        onActivity?.({
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'THOUGHT_CHUNK',
+          data: { text: 'thought' },
+        });
+        return GOAL_OUTPUT;
+      });
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(callOrder).toEqual(['raw', 'translated']);
+    });
+
+    it('is optional — no callback causes no error', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+        // no rawActivityCallback
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).resolves.toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Subscription
+  // ---------------------------------------------------------------------------
+
+  describe('subscription', () => {
+    it('unsubscribe stops event delivery', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const received: AgentEvent[] = [];
+      const unsub = session.subscribe((e) => received.push(e));
+      unsub();
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(received).toHaveLength(0);
+    });
+
+    it('multiple subscribers all receive events', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const received1: AgentEvent[] = [];
+      const received2: AgentEvent[] = [];
+      session.subscribe((e) => received1.push(e));
+      session.subscribe((e) => received2.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(received1.length).toBeGreaterThan(0);
+      expect(received1).toEqual(received2);
+    });
+
+    it('events array accumulates all emitted events', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(session.events.length).toBeGreaterThanOrEqual(2); // at least agent_start + agent_end
+      expect(session.events[0].type).toBe('agent_start');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Terminate mode mapping
+  // ---------------------------------------------------------------------------
+
+  describe('terminate mode → StreamEndReason mapping', () => {
+    const cases: Array<[AgentTerminateMode, string]> = [
+      [AgentTerminateMode.GOAL, 'completed'],
+      [AgentTerminateMode.TIMEOUT, 'max_time'],
+      [AgentTerminateMode.MAX_TURNS, 'max_turns'],
+      [AgentTerminateMode.ABORTED, 'aborted'],
+      [AgentTerminateMode.ERROR, 'failed'],
+      [AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL, 'failed'],
+    ];
+
+    for (const [terminateMode, expectedReason] of cases) {
+      it(`${terminateMode} → agent_end(reason:'${expectedReason}')`, async () => {
+        mockExecutorInstance.run.mockResolvedValue({
+          result: 'done',
+          terminate_reason: terminateMode,
+        });
+
+        const session = new LocalSubagentSession(
+          testDefinition,
+          mockContext,
+          mockMessageBus,
+        );
+
+        const events: AgentEvent[] = [];
+        session.subscribe((e) => events.push(e));
+
+        await session.send({
+          message: { content: [{ type: 'text', text: 'q' }] },
+        });
+        await session.getResult().catch(() => {
+          // ABORTED results in rejection — catch to let test complete
+        });
+
+        const endEvent = events.find((e) => e.type === 'agent_end');
+        expect(endEvent).toBeDefined();
+        if (endEvent?.type === 'agent_end') {
+          expect(endEvent.reason).toBe(expectedReason);
+        }
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Abort
+  // ---------------------------------------------------------------------------
+
+  describe('abort()', () => {
+    it('abort() causes agent_end(reason:aborted)', async () => {
+      // Make run() wait until aborted
+      let abortSignal: AbortSignal | undefined;
+      mockExecutorInstance.run.mockImplementation(
+        (_params: unknown, signal: AbortSignal) => {
+          abortSignal = signal;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => {
+              const err = new Error('AbortError');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          });
+        },
+      );
+
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      void session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+
+      // Wait for executor to be created and run started
+      await vi.waitFor(() => {
+        expect(abortSignal).toBeDefined();
+      });
+
+      await session.abort();
+
+      const result = await session.getResult();
+      expect(result.result).toBe('');
+      expect(result.terminate_reason).toBe('ABORTED');
+
+      const endEvent = events.find((e) => e.type === 'agent_end');
+      expect(endEvent).toBeDefined();
+      if (endEvent?.type === 'agent_end') {
+        expect(endEvent.reason).toBe('aborted');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Full event sequence
+  // ---------------------------------------------------------------------------
+
+  describe('full event sequence', () => {
+    it('emits agent_start → message(thought) → tool_request → tool_response → agent_end in order', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      mockExecutorInstance.run.mockImplementation(async () => {
+        const onActivity = MockLocalAgentExecutor.create.mock.calls[0]?.[2];
+        onActivity?.({
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'THOUGHT_CHUNK',
+          data: { text: 'thinking' },
+        });
+        onActivity?.({
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'TOOL_CALL_START',
+          data: { callId: 'c1', name: 'tool', args: {} },
+        });
+        onActivity?.({
+          isSubagentActivityEvent: true,
+          agentName: 'TestProtocolAgent',
+          type: 'TOOL_CALL_END',
+          data: { id: 'c1', name: 'tool', output: 'result' },
+        });
+        return GOAL_OUTPUT;
+      });
+
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'go' }] },
+      });
+      await session.getResult();
+
+      const types = events.map((e) => e.type);
+      expect(types).toEqual([
+        'agent_start',
+        'message',
+        'tool_request',
+        'tool_response',
+        'agent_end',
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Concurrent send() guard
+  // ---------------------------------------------------------------------------
+
+  describe('concurrent send() guard', () => {
+    it('calling send() while a stream is active throws', async () => {
+      let abortSignal: AbortSignal | undefined;
+      mockExecutorInstance.run.mockImplementation(
+        (_params: unknown, signal: AbortSignal) => {
+          abortSignal = signal;
+          return new Promise((_resolve, reject) => {
+            // Reject when aborted so getResult() can settle during cleanup
+            signal.addEventListener('abort', () => {
+              const err = new Error('AbortError');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          });
+        },
+      );
+
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      void session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+
+      // Wait for execution to start
+      await vi.waitFor(() => {
+        expect(abortSignal).toBeDefined();
+      });
+
+      // Second send() while first stream is active must throw
+      await expect(
+        session.send({
+          message: { content: [{ type: 'text', text: 'second' }] },
+        }),
+      ).rejects.toThrow('cannot be called while a stream is active');
+
+      // Clean up: abort to unblock the hanging executor
+      await session.abort();
+      await session.getResult().catch(() => {});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-send support
+  // ---------------------------------------------------------------------------
+
+  describe('multi-send', () => {
+    it('supports sequential sends after stream completion', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // First send
+      const result1 = await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      expect(result1.streamId).not.toBeNull();
+
+      const output1 = await session.getResult();
+      expect(output1.result).toBe('Analysis complete.');
+
+      // Second send — should work, not throw
+      const secondOutput = {
+        result: 'Second analysis.',
+        terminate_reason: AgentTerminateMode.GOAL,
+      };
+      mockExecutorInstance.run.mockResolvedValue(secondOutput);
+
+      const result2 = await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      expect(result2.streamId).not.toBeNull();
+      expect(result2.streamId).not.toBe(result1.streamId);
+
+      const output2 = await session.getResult();
+      expect(output2.result).toBe('Second analysis.');
+    });
+
+    it('getResult() returns the latest stream result', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // First send
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      const result1 = await session.getResult();
+
+      // Second send with different output
+      const secondOutput = {
+        result: 'Different result.',
+        terminate_reason: AgentTerminateMode.GOAL,
+      };
+      mockExecutorInstance.run.mockResolvedValue(secondOutput);
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      const result2 = await session.getResult();
+
+      expect(result1.result).toBe('Analysis complete.');
+      expect(result2.result).toBe('Different result.');
+    });
+
+    it('buffered config does not bleed across sends', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // Buffer config, then send first message
+      await session.send({ update: { config: { temperature: 0.5 } } });
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      // The executor.run params include the buffered config
+      const firstRunParams = mockExecutorInstance.run.mock.calls[0]?.[0];
+      expect(firstRunParams).toHaveProperty('temperature', 0.5);
+      expect(firstRunParams).toHaveProperty('query', 'first');
+
+      // Second send without buffered config — temperature should be gone
+      mockExecutorInstance.run.mockResolvedValue(GOAL_OUTPUT);
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      const secondRunParams = mockExecutorInstance.run.mock.calls[1]?.[0];
+      expect(secondRunParams).not.toHaveProperty('temperature');
+      expect(secondRunParams).toHaveProperty('query', 'second');
+    });
+
+    it('getResult() rejects when called before any send', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await expect(session.getResult()).rejects.toThrow(
+        'No active or completed stream',
+      );
+    });
+
+    it('emits fresh agent_start/agent_end per stream', async () => {
+      const session = new LocalSubagentSession(
+        testDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      // First send
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      const firstStreamEvents = events.length;
+      expect(events[0]?.type).toBe('agent_start');
+      expect(events[firstStreamEvents - 1]?.type).toBe('agent_end');
+
+      // Second send
+      mockExecutorInstance.run.mockResolvedValue(GOAL_OUTPUT);
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      // Should have a second agent_start/agent_end pair
+      const secondStreamStart = events[firstStreamEvents];
+      const lastEvent = events[events.length - 1];
+      expect(secondStreamStart?.type).toBe('agent_start');
+      expect(lastEvent?.type).toBe('agent_end');
+      expect(secondStreamStart?.streamId).not.toBe(events[0]?.streamId);
+    });
+  });
+});

--- a/packages/core/src/agents/local-subagent-protocol.ts
+++ b/packages/core/src/agents/local-subagent-protocol.ts
@@ -1,0 +1,438 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview LocalSubagentProtocol — wraps LocalAgentExecutor behind the
+ * AgentProtocol interface, translating SubagentActivityEvent callbacks into
+ * AgentEvents and exposing the executor result via getResult().
+ *
+ * Pattern mirrors LegacyAgentProtocol, but the loop body runs
+ * LocalAgentExecutor instead of GeminiClient.sendMessageStream().
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+import { AgentSession } from '../agent/agent-session.js';
+import type {
+  AgentProtocol,
+  AgentSend,
+  AgentEvent,
+  StreamEndReason,
+  Unsubscribe,
+  ContentPart,
+} from '../agent/types.js';
+import { LocalAgentExecutor } from './local-executor.js';
+import {
+  AgentTerminateMode,
+  type LocalAgentDefinition,
+  type AgentInputs,
+  type OutputObject,
+  type SubagentActivityEvent,
+} from './types.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isAbortLikeError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+function mapTerminateMode(mode: AgentTerminateMode): StreamEndReason {
+  switch (mode) {
+    case AgentTerminateMode.GOAL:
+      return 'completed';
+    case AgentTerminateMode.TIMEOUT:
+      return 'max_time';
+    case AgentTerminateMode.MAX_TURNS:
+      return 'max_turns';
+    case AgentTerminateMode.ABORTED:
+      return 'aborted';
+    case AgentTerminateMode.ERROR:
+    case AgentTerminateMode.ERROR_NO_COMPLETE_TASK_CALL:
+      return 'failed';
+    default: {
+      void (mode satisfies never);
+      return 'failed';
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LocalSubagentProtocol
+// ---------------------------------------------------------------------------
+
+class LocalSubagentProtocol implements AgentProtocol {
+  private _events: AgentEvent[] = [];
+  private _subscribers = new Set<(event: AgentEvent) => void>();
+  private _streamId: string = randomUUID();
+  private _eventCounter = 0;
+  private _agentStartEmitted = false;
+  private _agentEndEmitted = false;
+  private _activeStreamId: string | undefined;
+  private _abortController = new AbortController();
+
+  // Result promise wiring — re-created per stream in _beginNewStream()
+  private _resultResolve!: (output: OutputObject) => void;
+  private _resultReject!: (err: unknown) => void;
+  private _resultPromise: Promise<OutputObject> | undefined;
+
+  // Buffered config from send({update})
+  private _bufferedConfig: Record<string, unknown> = {};
+
+  constructor(
+    private readonly definition: LocalAgentDefinition,
+    private readonly context: AgentLoopContext,
+    // Required for API parity across protocol constructors (local, remote, legacy)
+    _messageBus: MessageBus,
+    private readonly _rawActivityCallback?: (
+      activity: SubagentActivityEvent,
+    ) => void,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // AgentProtocol interface
+  // ---------------------------------------------------------------------------
+
+  get events(): readonly AgentEvent[] {
+    return this._events;
+  }
+
+  subscribe(callback: (event: AgentEvent) => void): Unsubscribe {
+    this._subscribers.add(callback);
+    return () => {
+      this._subscribers.delete(callback);
+    };
+  }
+
+  async send(payload: AgentSend): Promise<{ streamId: string | null }> {
+    if ('update' in payload && payload.update) {
+      // Buffer config for use when message send arrives
+      if (payload.update.config) {
+        this._bufferedConfig = {
+          ...this._bufferedConfig,
+          ...payload.update.config,
+        };
+      }
+      return { streamId: null };
+    }
+
+    if ('message' in payload && payload.message) {
+      if (this._activeStreamId) {
+        throw new Error(
+          'LocalSubagentProtocol.send() cannot be called while a stream is active.',
+        );
+      }
+
+      // Extract query text from the message ContentParts
+      const queryText = payload.message.content
+        .filter((p): p is ContentPart & { type: 'text' } => p.type === 'text')
+        .map((p) => p.text)
+        .join('');
+
+      // Only include 'query' in params when the message text is non-empty,
+      // so that callers that pass all fields via update.config are not affected.
+      const params: AgentInputs = {
+        ...this._bufferedConfig,
+        ...(queryText.length > 0 ? { query: queryText } : {}),
+      };
+      this._bufferedConfig = {};
+
+      this._beginNewStream();
+      const streamId = this._streamId;
+
+      // Schedule execution in a macrotask so send() resolves before agent_start
+      setTimeout(() => {
+        void this._runExecutionInBackground(params);
+      }, 0);
+
+      return { streamId };
+    }
+
+    // action and elicitations are not supported
+    return { streamId: null };
+  }
+
+  async abort(): Promise<void> {
+    this._abortController.abort();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Protocol-specific: result access
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolves when the executor completes, with the raw OutputObject.
+   * Used by LocalSubagentInvocation to build the ToolResult.
+   */
+  getResult(): Promise<OutputObject> {
+    if (!this._resultPromise) {
+      return Promise.reject(new Error('No active or completed stream'));
+    }
+    return this._resultPromise;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core: execution
+  // ---------------------------------------------------------------------------
+
+  private _beginNewStream(): void {
+    this._streamId = randomUUID();
+    this._eventCounter = 0;
+    this._abortController = new AbortController();
+    this._agentStartEmitted = false;
+    this._agentEndEmitted = false;
+    this._activeStreamId = this._streamId;
+    this._resultPromise = new Promise<OutputObject>((resolve, reject) => {
+      this._resultResolve = resolve;
+      this._resultReject = reject;
+    });
+  }
+
+  private async _runExecutionInBackground(params: AgentInputs): Promise<void> {
+    this._ensureAgentStart();
+    try {
+      await this._runExecution(params);
+    } catch (err: unknown) {
+      if (this._abortController.signal.aborted || isAbortLikeError(err)) {
+        this._ensureAgentEnd('aborted');
+        // Abort resolves with an empty result — partial output is intentionally
+        // dropped since the caller requested cancellation.
+        this._resultResolve({
+          result: '',
+          terminate_reason: AgentTerminateMode.ABORTED,
+        });
+      } else {
+        this._emitErrorAndAgentEnd(err);
+        this._resultReject(err);
+      }
+    } finally {
+      this._clearActiveStream();
+    }
+  }
+
+  private async _runExecution(params: AgentInputs): Promise<void> {
+    const signal = this._abortController.signal;
+
+    const onActivity = (activity: SubagentActivityEvent): void => {
+      // Forward raw activity to invocation-level callback (for rich SubagentProgress display)
+      this._rawActivityCallback?.(activity);
+      this._emit(this._translateActivity(activity));
+    };
+
+    const executor = await LocalAgentExecutor.create(
+      this.definition,
+      this.context,
+      onActivity,
+    );
+
+    const output = await executor.run(params, signal);
+
+    if (
+      output.terminate_reason === AgentTerminateMode.ABORTED ||
+      signal.aborted
+    ) {
+      this._finishStream('aborted');
+    } else {
+      this._finishStream(mapTerminateMode(output.terminate_reason));
+    }
+
+    this._resultResolve(output);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Activity → AgentEvent translation
+  // ---------------------------------------------------------------------------
+
+  private _translateActivity(activity: SubagentActivityEvent): AgentEvent[] {
+    switch (activity.type) {
+      case 'THOUGHT_CHUNK': {
+        const rawText = activity.data['text'];
+        const text = String(rawText ?? '');
+        return [
+          this._makeEvent('message', {
+            role: 'agent',
+            content: [{ type: 'thought', thought: text }],
+          }),
+        ];
+      }
+      case 'TOOL_CALL_START': {
+        const rawCallId = activity.data['callId'];
+        const callId = String(rawCallId ?? randomUUID());
+        const rawName = activity.data['name'];
+        const name = String(rawName ?? 'unknown');
+        const rawArgs = activity.data['args'];
+        const args: Record<string, unknown> =
+          rawArgs !== null &&
+          typeof rawArgs === 'object' &&
+          !Array.isArray(rawArgs)
+            ? // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              (rawArgs as Record<string, unknown>)
+            : {};
+        return [
+          this._makeEvent('tool_request', {
+            requestId: callId,
+            name,
+            args,
+          }),
+        ];
+      }
+      case 'TOOL_CALL_END': {
+        const rawId = activity.data['id'];
+        const requestId = String(rawId ?? randomUUID());
+        const rawName = activity.data['name'];
+        const name = String(rawName ?? 'unknown');
+        const rawOutput = activity.data['output'];
+        const output = String(rawOutput ?? '');
+        return [
+          this._makeEvent('tool_response', {
+            requestId,
+            name,
+            content: [{ type: 'text', text: output }],
+          }),
+        ];
+      }
+      case 'ERROR': {
+        const rawError = activity.data['error'];
+        const errorMsg = String(rawError ?? 'Unknown error');
+        return [
+          this._makeEvent('error', {
+            status: 'INTERNAL',
+            message: errorMsg,
+            fatal: false,
+          }),
+        ];
+      }
+      default: {
+        void (activity.type satisfies never);
+        return [];
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers (mirrors LegacyAgentProtocol)
+  // ---------------------------------------------------------------------------
+
+  private _emit(events: AgentEvent[]): void {
+    if (events.length === 0) return;
+    const subscribers = [...this._subscribers];
+    for (const event of events) {
+      this._events.push(event);
+      if (event.type === 'agent_end') {
+        this._agentEndEmitted = true;
+      }
+      for (const sub of subscribers) {
+        sub(event);
+      }
+    }
+  }
+
+  private _clearActiveStream(): void {
+    this._activeStreamId = undefined;
+  }
+
+  private _ensureAgentStart(): void {
+    if (!this._agentStartEmitted) {
+      this._agentStartEmitted = true;
+      this._emit([this._makeEvent('agent_start', {})]);
+    }
+  }
+
+  private _ensureAgentEnd(reason: StreamEndReason = 'completed'): void {
+    if (!this._agentEndEmitted && this._agentStartEmitted) {
+      this._emit([this._makeEvent('agent_end', { reason })]);
+    }
+  }
+
+  private _finishStream(reason: StreamEndReason): void {
+    this._ensureAgentEnd(reason);
+    this._clearActiveStream();
+  }
+
+  private _emitErrorAndAgentEnd(err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    this._ensureAgentStart();
+
+    const meta: Record<string, unknown> = {};
+    if (err instanceof Error) {
+      meta['errorName'] = err.constructor.name;
+      meta['stack'] = err.stack;
+      if ('exitCode' in err && typeof err.exitCode === 'number') {
+        meta['exitCode'] = err.exitCode;
+      }
+      if ('code' in err) {
+        meta['code'] = err.code;
+      }
+      if ('status' in err) {
+        meta['status'] = err.status;
+      }
+    }
+
+    this._emit([
+      this._makeEvent('error', {
+        status: 'INTERNAL',
+        message,
+        fatal: true,
+        ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+      }),
+    ]);
+    this._ensureAgentEnd('failed');
+  }
+
+  private _nextEventFields() {
+    return {
+      id: `${this._streamId}-${this._eventCounter++}`,
+      timestamp: new Date().toISOString(),
+      streamId: this._streamId,
+    };
+  }
+
+  private _makeEvent<T extends AgentEvent['type']>(
+    type: T,
+    payload: Omit<AgentEvent<T>, 'id' | 'timestamp' | 'streamId' | 'type'>,
+  ): AgentEvent {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return {
+      ...this._nextEventFields(),
+      type,
+      ...payload,
+    } as AgentEvent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public export
+// ---------------------------------------------------------------------------
+
+export class LocalSubagentSession extends AgentSession {
+  private readonly _localProtocol: LocalSubagentProtocol;
+
+  constructor(
+    definition: LocalAgentDefinition,
+    context: AgentLoopContext,
+    messageBus: MessageBus,
+    rawActivityCallback?: (activity: SubagentActivityEvent) => void,
+  ) {
+    const protocol = new LocalSubagentProtocol(
+      definition,
+      context,
+      messageBus,
+      rawActivityCallback,
+    );
+    super(protocol);
+    this._localProtocol = protocol;
+  }
+
+  /**
+   * Returns the raw executor OutputObject once execution completes.
+   * Used by LocalSubagentInvocation to build the ToolResult.
+   */
+  getResult(): Promise<OutputObject> {
+    return this._localProtocol.getResult();
+  }
+}

--- a/packages/core/src/agents/remote-subagent-protocol.test.ts
+++ b/packages/core/src/agents/remote-subagent-protocol.test.ts
@@ -1,0 +1,947 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { RemoteSubagentSession } from './remote-subagent-protocol.js';
+
+import { A2AAuthProviderFactory } from './auth-provider/factory.js';
+import type { RemoteAgentDefinition, SubagentProgress } from './types.js';
+import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+import type { AgentEvent } from '../agent/types.js';
+import type { Config } from '../config/config.js';
+import type { A2AAuthProvider } from './auth-provider/types.js';
+
+// Mock A2AClientManager at module level
+vi.mock('./a2a-client-manager.js', () => ({
+  A2AClientManager: vi.fn().mockImplementation(() => ({
+    getClient: vi.fn(),
+    loadAgent: vi.fn(),
+    sendMessageStream: vi.fn(),
+  })),
+}));
+
+// Mock A2AAuthProviderFactory
+vi.mock('./auth-provider/factory.js', () => ({
+  A2AAuthProviderFactory: {
+    create: vi.fn(),
+  },
+}));
+
+const mockDefinition: RemoteAgentDefinition = {
+  name: 'test-remote-agent',
+  kind: 'remote',
+  agentCardUrl: 'http://test-agent/card',
+  displayName: 'Test Remote Agent',
+  description: 'A test remote agent',
+  inputConfig: {
+    inputSchema: { type: 'object' },
+  },
+};
+
+function makeChunk(text: string) {
+  return {
+    kind: 'message' as const,
+    messageId: `msg-${Math.random()}`,
+    role: 'agent' as const,
+    parts: [{ kind: 'text' as const, text }],
+  };
+}
+
+describe('RemoteSubagentSession (protocol)', () => {
+  let mockClientManager: {
+    getClient: Mock;
+    loadAgent: Mock;
+    sendMessageStream: Mock;
+  };
+  let mockContext: AgentLoopContext;
+  let mockMessageBus: ReturnType<typeof createMockMessageBus>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Each test creates fresh session instances. contextId/taskId persist as
+    // instance fields within a session, not via static state.
+
+    mockClientManager = {
+      getClient: vi.fn().mockReturnValue(undefined), // client not yet loaded
+      loadAgent: vi.fn().mockResolvedValue(undefined),
+      sendMessageStream: vi.fn(),
+    };
+
+    const mockConfig = {
+      getA2AClientManager: vi.fn().mockReturnValue(mockClientManager),
+      injectionService: {
+        getLatestInjectionIndex: vi.fn().mockReturnValue(0),
+      },
+    } as unknown as Config;
+
+    mockContext = { config: mockConfig } as unknown as AgentLoopContext;
+    mockMessageBus = createMockMessageBus();
+
+    // Default: sendMessageStream yields one chunk with "Hello"
+    mockClientManager.sendMessageStream.mockImplementation(async function* () {
+      yield makeChunk('Hello');
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Helper: run a session with the default or custom stream and collect events
+  async function runSession(
+    definition: RemoteAgentDefinition = mockDefinition,
+    query = 'test query',
+  ) {
+    const session = new RemoteSubagentSession(
+      definition,
+      mockContext,
+      mockMessageBus,
+    );
+    const events: AgentEvent[] = [];
+    session.subscribe((e) => events.push(e));
+    await session.send({
+      message: { content: [{ type: 'text', text: query }] },
+    });
+    const result = await session.getResult();
+    return { session, events, result };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle events
+  // ---------------------------------------------------------------------------
+
+  describe('lifecycle events', () => {
+    it('emits agent_start then agent_end(completed) on success', async () => {
+      const { events } = await runSession();
+
+      const types = events.map((e) => e.type);
+      expect(types[0]).toBe('agent_start');
+      expect(types[types.length - 1]).toBe('agent_end');
+      const end = events[events.length - 1];
+      if (end.type === 'agent_end') {
+        expect(end.reason).toBe('completed');
+      }
+    });
+
+    it('emits agent_start exactly once', async () => {
+      const { events } = await runSession();
+      expect(events.filter((e) => e.type === 'agent_start')).toHaveLength(1);
+    });
+
+    it('emits agent_end exactly once on error path', async () => {
+      mockClientManager.sendMessageStream.mockReturnValue({
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<never>> {
+              throw new Error('stream error');
+            },
+          };
+        },
+      });
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow('stream error');
+
+      expect(events.filter((e) => e.type === 'agent_end')).toHaveLength(1);
+    });
+
+    it('all events share the same streamId', async () => {
+      const { events } = await runSession();
+      const streamIds = new Set(events.map((e) => e.streamId));
+      expect(streamIds.size).toBe(1);
+    });
+
+    it('message returns a non-null streamId; unsupported payload returns null', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const updateResult = await session.send({
+        update: { config: { key: 'val' } },
+      });
+      expect(updateResult.streamId).toBeNull();
+
+      const messageResult = await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      expect(messageResult.streamId).not.toBeNull();
+      // complete the session to avoid dangling execution
+      await session.getResult();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chunk → AgentEvent translation
+  // ---------------------------------------------------------------------------
+
+  describe('chunk → AgentEvent translation', () => {
+    it('each A2A chunk produces a message event with incremental delta text', async () => {
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          yield makeChunk('Hello');
+          yield makeChunk(' world');
+        },
+      );
+
+      const { events } = await runSession();
+
+      const msgEvents = events.filter((e) => e.type === 'message');
+      expect(msgEvents).toHaveLength(2);
+      // Each message event contains only the delta, not accumulated text
+      if (msgEvents[0]?.type === 'message') {
+        const text = msgEvents[0].content.find((c) => c.type === 'text');
+        expect(text?.type === 'text' && text.text).toBe('Hello');
+      }
+      if (msgEvents[1]?.type === 'message') {
+        const text = msgEvents[1].content.find((c) => c.type === 'text');
+        expect(text?.type === 'text' && text.text).toBe(' world');
+      }
+    });
+
+    it('getLatestProgress() is updated per chunk with state running', async () => {
+      let capturedProgress: SubagentProgress | undefined;
+
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          yield makeChunk('Partial');
+        },
+      );
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      session.subscribe((e) => {
+        if (e.type === 'message') {
+          capturedProgress = session.getLatestProgress();
+        }
+      });
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      // During streaming, progress should be 'running'
+      expect(capturedProgress).toBeDefined();
+      // Note: by the time we check, progress may be 'completed'.
+      // During the message event, it was 'running'.
+      expect(capturedProgress?.isSubagentProgress).toBe(true);
+      expect(capturedProgress?.agentName).toBe('Test Remote Agent');
+    });
+
+    it('getLatestProgress() state is completed after getResult() resolves', async () => {
+      const { session } = await runSession();
+      const progress = session.getLatestProgress();
+      expect(progress?.state).toBe('completed');
+      expect(progress?.result).toBe('Hello');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getResult() promise
+  // ---------------------------------------------------------------------------
+
+  describe('getResult()', () => {
+    it('resolves with ToolResult containing llmContent and SubagentProgress returnDisplay', async () => {
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          yield makeChunk('Result text');
+        },
+      );
+
+      const { result } = await runSession();
+
+      expect(result.llmContent).toEqual([{ text: 'Result text' }]);
+      const display = result.returnDisplay as SubagentProgress;
+      expect(display.isSubagentProgress).toBe(true);
+      expect(display.state).toBe('completed');
+      expect(display.result).toBe('Result text');
+      expect(display.agentName).toBe('Test Remote Agent');
+    });
+
+    it('rejects when stream throws a non-A2A error', async () => {
+      mockClientManager.sendMessageStream.mockReturnValue({
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<never>> {
+              throw new Error('network failure');
+            },
+          };
+        },
+      });
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow();
+    });
+
+    it('resolves even with empty stream (empty final output)', async () => {
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          // yield nothing
+        },
+      );
+
+      const { result } = await runSession();
+      expect(result.llmContent).toEqual([{ text: '' }]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Session state persistence
+  // ---------------------------------------------------------------------------
+
+  describe('session state persistence', () => {
+    it('second send reuses contextId captured from first send', async () => {
+      let callCount = 0;
+      mockClientManager.sendMessageStream.mockImplementation(async function* (
+        _name: string,
+        _query: string,
+        opts: { contextId?: string },
+      ) {
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            kind: 'message' as const,
+            messageId: 'msg-1',
+            role: 'agent' as const,
+            contextId: 'ctx-from-server',
+            parts: [{ kind: 'text' as const, text: 'First response' }],
+          };
+        } else {
+          // Second send on same session should pass the contextId
+          expect(opts.contextId).toBe('ctx-from-server');
+          yield makeChunk('Second response');
+        }
+      });
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // First send — establishes contextId
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      // Second send on same session — should reuse contextId
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      expect(callCount).toBe(2);
+    });
+
+    it('separate session instances have independent state', async () => {
+      const capturedContextIds: Array<string | undefined> = [];
+      mockClientManager.sendMessageStream.mockImplementation(async function* (
+        _name: string,
+        _query: string,
+        opts: { contextId?: string },
+      ) {
+        capturedContextIds.push(opts.contextId);
+        yield {
+          kind: 'message' as const,
+          messageId: 'msg-1',
+          role: 'agent' as const,
+          contextId: 'ctx-from-server',
+          parts: [{ kind: 'text' as const, text: 'ok' }],
+        };
+      });
+
+      // Two separate sessions for the same agent — state is NOT shared
+      const session1 = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      await session1.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session1.getResult();
+
+      const session2 = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      await session2.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session2.getResult();
+
+      // Both start with no contextId — separate instances, no shared state
+      expect(capturedContextIds[0]).toBeUndefined();
+      expect(capturedContextIds[1]).toBeUndefined();
+    });
+
+    it('taskId is cleared when a terminal-state task chunk is received', async () => {
+      let callCount = 0;
+      const capturedTaskIds: Array<string | undefined> = [];
+
+      mockClientManager.sendMessageStream.mockImplementation(async function* (
+        _n: string,
+        _q: string,
+        opts: { taskId?: string },
+      ) {
+        callCount++;
+        capturedTaskIds.push(opts.taskId);
+        if (callCount === 1) {
+          yield {
+            kind: 'task' as const,
+            id: 'task-123',
+            contextId: 'ctx-1',
+            status: { state: 'completed' as const },
+          };
+        } else {
+          yield makeChunk('done');
+        }
+      });
+
+      // Use same session for multi-send
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      expect(callCount).toBe(2);
+      // First call starts with no taskId
+      expect(capturedTaskIds[0]).toBeUndefined();
+      // Second call: taskId was cleared because terminal-state task chunk was received
+      expect(capturedTaskIds[1]).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auth setup
+  // ---------------------------------------------------------------------------
+
+  describe('auth setup', () => {
+    it('no auth → loadAgent called without auth handler', async () => {
+      await runSession();
+
+      expect(mockClientManager.loadAgent).toHaveBeenCalledWith(
+        'test-remote-agent',
+        { type: 'url', url: 'http://test-agent/card' },
+        undefined,
+      );
+    });
+
+    it('definition.auth present → A2AAuthProviderFactory.create called', async () => {
+      const authDef: RemoteAgentDefinition = {
+        ...mockDefinition,
+        name: 'auth-agent',
+        auth: {
+          type: 'http' as const,
+          scheme: 'Bearer' as const,
+          token: 'secret',
+        },
+      };
+
+      const mockProvider = {
+        type: 'http' as const,
+        headers: vi.fn().mockResolvedValue({ Authorization: 'Bearer secret' }),
+        shouldRetryWithHeaders: vi.fn(),
+      } as unknown as A2AAuthProvider;
+      (A2AAuthProviderFactory.create as Mock).mockResolvedValue(mockProvider);
+
+      await runSession(authDef, 'q');
+
+      expect(A2AAuthProviderFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentName: 'auth-agent',
+          agentCardUrl: 'http://test-agent/card',
+        }),
+      );
+      expect(mockClientManager.loadAgent).toHaveBeenCalledWith(
+        'auth-agent',
+        expect.any(Object),
+        mockProvider,
+      );
+    });
+
+    it('auth factory returns undefined → throws error that rejects getResult()', async () => {
+      const authDef: RemoteAgentDefinition = {
+        ...mockDefinition,
+        name: 'failing-auth-agent',
+        auth: {
+          type: 'http' as const,
+          scheme: 'Bearer' as const,
+          token: 'secret',
+        },
+      };
+
+      (A2AAuthProviderFactory.create as Mock).mockResolvedValue(undefined);
+
+      const session = new RemoteSubagentSession(
+        authDef,
+        mockContext,
+        mockMessageBus,
+      );
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow(
+        "Failed to create auth provider for agent 'failing-auth-agent'",
+      );
+    });
+
+    it('agent already loaded → loadAgent not called again', async () => {
+      // Return a client object (truthy) so getClient returns defined
+      mockClientManager.getClient.mockReturnValue({});
+
+      await runSession();
+
+      expect(mockClientManager.loadAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('stream error → error event + agent_end(failed)', async () => {
+      mockClientManager.sendMessageStream.mockReturnValue({
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<never>> {
+              throw new Error('network error');
+            },
+          };
+        },
+      });
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow();
+
+      const errEvent = events.find((e) => e.type === 'error');
+      expect(errEvent).toBeDefined();
+
+      const endEvent = events.find((e) => e.type === 'agent_end');
+      expect(endEvent).toBeDefined();
+      if (endEvent?.type === 'agent_end') {
+        expect(endEvent.reason).toBe('failed');
+      }
+    });
+
+    it('missing A2AClientManager → rejects getResult()', async () => {
+      const mockConfig = {
+        getA2AClientManager: vi.fn().mockReturnValue(undefined),
+        injectionService: {
+          getLatestInjectionIndex: vi.fn().mockReturnValue(0),
+        },
+      } as unknown as Config;
+      const noClientContext = {
+        config: mockConfig,
+      } as unknown as AgentLoopContext;
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        noClientContext,
+        mockMessageBus,
+      );
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await expect(session.getResult()).rejects.toThrow(
+        'A2AClientManager not available',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Subscription
+  // ---------------------------------------------------------------------------
+
+  describe('subscription', () => {
+    it('unsubscribe stops event delivery', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const received: AgentEvent[] = [];
+      const unsub = session.subscribe((e) => received.push(e));
+      unsub();
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(received).toHaveLength(0);
+    });
+
+    it('multiple subscribers all receive events', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events1: AgentEvent[] = [];
+      const events2: AgentEvent[] = [];
+      session.subscribe((e) => events1.push(e));
+      session.subscribe((e) => events2.push(e));
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+      await session.getResult();
+
+      expect(events1.length).toBeGreaterThan(0);
+      expect(events1).toEqual(events2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Abort
+  // ---------------------------------------------------------------------------
+
+  describe('abort()', () => {
+    it('abort() causes agent_end(reason:aborted)', async () => {
+      let rejectWithAbort: ((err: Error) => void) | undefined;
+
+      // Stream that blocks until aborted, then throws AbortError
+      mockClientManager.sendMessageStream.mockImplementation(
+        // eslint-disable-next-line require-yield
+        async function* () {
+          await new Promise<void>((_resolve, reject) => {
+            rejectWithAbort = reject;
+          });
+        },
+      );
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      void session.send({
+        message: { content: [{ type: 'text', text: 'q' }] },
+      });
+
+      // Wait for agent_start to be emitted before aborting
+      await vi.waitFor(() => {
+        expect(events.some((e) => e.type === 'agent_start')).toBe(true);
+      });
+
+      await session.abort();
+
+      // Simulate the transport throwing AbortError when signal fires
+      const abortErr = new Error('AbortError');
+      abortErr.name = 'AbortError';
+      rejectWithAbort?.(abortErr);
+
+      const result = await session.getResult();
+      expect(result.llmContent).toEqual([{ text: '' }]);
+      expect(result.returnDisplay).toBe('');
+
+      const endEvent = events.find((e) => e.type === 'agent_end');
+      expect(endEvent).toBeDefined();
+      if (endEvent?.type === 'agent_end') {
+        expect(endEvent.reason).toBe('aborted');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // sendMessageStream call args
+  // ---------------------------------------------------------------------------
+
+  describe('sendMessageStream call arguments', () => {
+    it('passes the query string from the message payload', async () => {
+      await runSession(mockDefinition, 'my specific query');
+
+      expect(mockClientManager.sendMessageStream).toHaveBeenCalledWith(
+        'test-remote-agent',
+        'my specific query',
+        expect.objectContaining({ signal: expect.any(Object) }),
+      );
+    });
+
+    it('uses DEFAULT_QUERY_STRING when message text is empty', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      await session.send({
+        message: { content: [{ type: 'text', text: '' }] },
+      });
+      await session.getResult();
+
+      // DEFAULT_QUERY_STRING = 'Get Started!'
+      expect(mockClientManager.sendMessageStream).toHaveBeenCalledWith(
+        'test-remote-agent',
+        'Get Started!',
+        expect.objectContaining({ signal: expect.any(Object) }),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Concurrent send() guard
+  // ---------------------------------------------------------------------------
+
+  describe('concurrent send() guard', () => {
+    it('calling send() while a stream is active throws', async () => {
+      let resolveChunk!: () => void;
+
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          // Block until test releases the chunk
+          await new Promise<void>((resolve) => {
+            resolveChunk = resolve;
+          });
+          yield makeChunk('late');
+        },
+      );
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      void session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+
+      // Wait for the stream to actually start (agent_start emitted)
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+      await vi.waitFor(() => {
+        expect(events.some((e) => e.type === 'agent_start')).toBe(true);
+      });
+
+      // Second send() while first stream is active must throw
+      await expect(
+        session.send({
+          message: { content: [{ type: 'text', text: 'second' }] },
+        }),
+      ).rejects.toThrow('cannot be called while a stream is active');
+
+      // Clean up: release the blocked generator so getResult() can settle
+      resolveChunk();
+      await session.getResult().catch(() => {});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-send support
+  // ---------------------------------------------------------------------------
+
+  describe('multi-send', () => {
+    it('supports sequential sends after stream completion', async () => {
+      let callCount = 0;
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          callCount++;
+          yield makeChunk(`Response ${callCount}`);
+        },
+      );
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // First send
+      const result1 = await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      expect(result1.streamId).not.toBeNull();
+      const output1 = await session.getResult();
+      expect(output1.llmContent).toEqual([{ text: 'Response 1' }]);
+
+      // Second send — should work, not throw
+      const result2 = await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      expect(result2.streamId).not.toBeNull();
+      expect(result2.streamId).not.toBe(result1.streamId);
+
+      const output2 = await session.getResult();
+      expect(output2.llmContent).toEqual([{ text: 'Response 2' }]);
+    });
+
+    it('getResult() returns the latest stream result', async () => {
+      let callCount = 0;
+      mockClientManager.sendMessageStream.mockImplementation(
+        async function* () {
+          callCount++;
+          yield makeChunk(`Result ${callCount}`);
+        },
+      );
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      const result1 = await session.getResult();
+
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      const result2 = await session.getResult();
+
+      expect(result1.llmContent).toEqual([{ text: 'Result 1' }]);
+      expect(result2.llmContent).toEqual([{ text: 'Result 2' }]);
+    });
+
+    it('contextId/taskId persist across sends within the same session', async () => {
+      let sendCallCount = 0;
+      mockClientManager.sendMessageStream.mockImplementation(async function* (
+        _name: string,
+        _query: string,
+        _opts: Record<string, unknown>,
+      ) {
+        sendCallCount++;
+        // First call returns ids; second call should receive them
+        yield {
+          kind: 'message' as const,
+          messageId: `msg-${sendCallCount}`,
+          contextId: `ctx-${sendCallCount}`,
+          taskId: `task-${sendCallCount}`,
+          role: 'agent' as const,
+          parts: [{ kind: 'text' as const, text: `Response ${sendCallCount}` }],
+        };
+      });
+
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+
+      // First send — establishes contextId/taskId
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      // Second send — should pass the persisted contextId/taskId
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      // Verify the second call received the contextId/taskId from first call
+      expect(mockClientManager.sendMessageStream).toHaveBeenCalledTimes(2);
+      const secondCallOpts =
+        mockClientManager.sendMessageStream.mock.calls[1]?.[2];
+      expect(secondCallOpts).toHaveProperty('contextId', 'ctx-1');
+      expect(secondCallOpts).toHaveProperty('taskId', 'task-1');
+    });
+
+    it('getResult() rejects when called before any send', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      await expect(session.getResult()).rejects.toThrow(
+        'No active or completed stream',
+      );
+    });
+
+    it('emits fresh agent_start/agent_end per stream', async () => {
+      const session = new RemoteSubagentSession(
+        mockDefinition,
+        mockContext,
+        mockMessageBus,
+      );
+      const events: AgentEvent[] = [];
+      session.subscribe((e) => events.push(e));
+
+      // First send
+      await session.send({
+        message: { content: [{ type: 'text', text: 'first' }] },
+      });
+      await session.getResult();
+
+      const firstStreamEvents = events.length;
+      expect(events[0]?.type).toBe('agent_start');
+      expect(events[firstStreamEvents - 1]?.type).toBe('agent_end');
+
+      // Second send
+      await session.send({
+        message: { content: [{ type: 'text', text: 'second' }] },
+      });
+      await session.getResult();
+
+      // Should have a second agent_start/agent_end pair
+      const secondStreamStart = events[firstStreamEvents];
+      const lastEvent = events[events.length - 1];
+      expect(secondStreamStart?.type).toBe('agent_start');
+      expect(lastEvent?.type).toBe('agent_end');
+      expect(secondStreamStart?.streamId).not.toBe(events[0]?.streamId);
+    });
+  });
+});

--- a/packages/core/src/agents/remote-subagent-protocol.ts
+++ b/packages/core/src/agents/remote-subagent-protocol.ts
@@ -1,0 +1,431 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview RemoteSubagentProtocol — wraps A2A remote agent streaming
+ * behind the AgentProtocol interface.
+ *
+ * Pattern mirrors LocalSubagentProtocol and LegacyAgentProtocol, but the loop
+ * body drives A2AClientManager instead of LocalAgentExecutor.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+import { AgentSession } from '../agent/agent-session.js';
+import type {
+  AgentProtocol,
+  AgentSend,
+  AgentEvent,
+  StreamEndReason,
+  Unsubscribe,
+  ContentPart,
+} from '../agent/types.js';
+import type { ToolResult } from '../tools/tools.js';
+import {
+  DEFAULT_QUERY_STRING,
+  type RemoteAgentDefinition,
+  type SubagentProgress,
+  getRemoteAgentTargetUrl,
+  getAgentCardLoadOptions,
+} from './types.js';
+import { A2AResultReassembler, extractIdsFromResponse } from './a2aUtils.js';
+import type { AuthenticationHandler } from '@a2a-js/sdk/client';
+import { A2AAuthProviderFactory } from './auth-provider/factory.js';
+import { A2AAgentError } from './a2a-errors.js';
+import { debugLogger } from '../utils/debugLogger.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isAbortLikeError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+// ---------------------------------------------------------------------------
+// RemoteSubagentProtocol
+// ---------------------------------------------------------------------------
+
+class RemoteSubagentProtocol implements AgentProtocol {
+  private _events: AgentEvent[] = [];
+  private _subscribers = new Set<(event: AgentEvent) => void>();
+  private _streamId: string = randomUUID();
+  private _eventCounter = 0;
+  private _agentStartEmitted = false;
+  private _agentEndEmitted = false;
+  private _activeStreamId: string | undefined;
+  private _abortController = new AbortController();
+
+  // A2A conversation state — persists across sends within this session instance
+  private contextId: string | undefined;
+  private taskId: string | undefined;
+  private authHandler: AuthenticationHandler | undefined;
+
+  // Agent display name (for SubagentProgress construction)
+  private readonly _agentName: string;
+
+  // Latest SubagentProgress — updated per chunk, used for error recovery
+  private _latestProgress: SubagentProgress | undefined;
+
+  // Result promise wiring — re-created per stream in _beginNewStream()
+  private _resultResolve!: (result: ToolResult) => void;
+  private _resultReject!: (err: unknown) => void;
+  private _resultPromise: Promise<ToolResult> | undefined;
+
+  constructor(
+    private readonly definition: RemoteAgentDefinition,
+    private readonly context: AgentLoopContext,
+    // Required for API parity across protocol constructors (local, remote, legacy)
+    _messageBus: MessageBus,
+  ) {
+    this._agentName = definition.displayName ?? definition.name;
+  }
+
+  // ---------------------------------------------------------------------------
+  // AgentProtocol interface
+  // ---------------------------------------------------------------------------
+
+  get events(): readonly AgentEvent[] {
+    return this._events;
+  }
+
+  subscribe(callback: (event: AgentEvent) => void): Unsubscribe {
+    this._subscribers.add(callback);
+    return () => {
+      this._subscribers.delete(callback);
+    };
+  }
+
+  async send(payload: AgentSend): Promise<{ streamId: string | null }> {
+    if ('message' in payload && payload.message) {
+      if (this._activeStreamId) {
+        throw new Error(
+          'RemoteSubagentProtocol.send() cannot be called while a stream is active.',
+        );
+      }
+
+      const query =
+        payload.message.content
+          .filter((p): p is ContentPart & { type: 'text' } => p.type === 'text')
+          .map((p) => p.text)
+          .join('') || DEFAULT_QUERY_STRING;
+
+      this._beginNewStream();
+      const streamId = this._streamId;
+
+      setTimeout(() => {
+        void this._runStreamInBackground(query);
+      }, 0);
+
+      return { streamId };
+    }
+
+    // update/action/elicitations not used for remote agents
+    return { streamId: null };
+  }
+
+  async abort(): Promise<void> {
+    this._abortController.abort();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Protocol-specific: result access
+  // ---------------------------------------------------------------------------
+
+  getResult(): Promise<ToolResult> {
+    if (!this._resultPromise) {
+      return Promise.reject(new Error('No active or completed stream'));
+    }
+    return this._resultPromise;
+  }
+
+  getLatestProgress(): SubagentProgress | undefined {
+    return this._latestProgress;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core: A2A streaming
+  // ---------------------------------------------------------------------------
+
+  private _beginNewStream(): void {
+    this._streamId = randomUUID();
+    this._eventCounter = 0;
+    this._abortController = new AbortController();
+    this._agentStartEmitted = false;
+    this._agentEndEmitted = false;
+    this._activeStreamId = this._streamId;
+    this._resultPromise = new Promise<ToolResult>((resolve, reject) => {
+      this._resultResolve = resolve;
+      this._resultReject = reject;
+    });
+  }
+
+  private async _runStreamInBackground(query: string): Promise<void> {
+    this._ensureAgentStart();
+    try {
+      await this._runStream(query);
+    } catch (err: unknown) {
+      if (this._abortController.signal.aborted || isAbortLikeError(err)) {
+        this._ensureAgentEnd('aborted');
+        // Abort resolves with an empty result — partial output is intentionally
+        // dropped since the caller requested cancellation.
+        this._resultResolve({
+          llmContent: [{ text: '' }],
+          returnDisplay: '',
+        });
+      } else {
+        this._emitErrorAndAgentEnd(err);
+        this._resultReject(err);
+      }
+    } finally {
+      this._clearActiveStream();
+    }
+  }
+
+  private async _runStream(query: string): Promise<void> {
+    const clientManager = this.context.config.getA2AClientManager();
+    if (!clientManager) {
+      throw new Error(
+        `RemoteSubagentProtocol: A2AClientManager not available for '${this.definition.name}'.`,
+      );
+    }
+
+    const authHandler = await this._getAuthHandler();
+    if (!clientManager.getClient(this.definition.name)) {
+      await clientManager.loadAgent(
+        this.definition.name,
+        getAgentCardLoadOptions(this.definition),
+        authHandler,
+      );
+    }
+
+    const reassembler = new A2AResultReassembler();
+    let prevText = '';
+
+    const stream = clientManager.sendMessageStream(
+      this.definition.name,
+      query,
+      {
+        contextId: this.contextId,
+        taskId: this.taskId,
+        signal: this._abortController.signal,
+      },
+    );
+
+    for await (const chunk of stream) {
+      reassembler.update(chunk);
+
+      const {
+        contextId: newContextId,
+        taskId: newTaskId,
+        clearTaskId,
+      } = extractIdsFromResponse(chunk);
+      if (newContextId) this.contextId = newContextId;
+      this.taskId = clearTaskId ? undefined : (newTaskId ?? this.taskId);
+
+      const currentText = reassembler.toString();
+
+      // Update latest progress snapshot (for invocation's error recovery)
+      this._latestProgress = {
+        isSubagentProgress: true,
+        agentName: this._agentName,
+        state: 'running',
+        recentActivity: reassembler.toActivityItems(),
+        result: currentText,
+      };
+
+      // Emit delta as a message event
+      const delta = currentText.slice(prevText.length);
+      if (delta) {
+        this._emit([
+          this._makeEvent('message', {
+            role: 'agent',
+            content: [{ type: 'text', text: delta }],
+          }),
+        ]);
+        prevText = currentText;
+      }
+    }
+
+    const finalOutput = reassembler.toString();
+    debugLogger.debug(
+      `[RemoteSubagentProtocol] ${this.definition.name} finished, output length: ${finalOutput.length}`,
+    );
+
+    const finalProgress: SubagentProgress = {
+      isSubagentProgress: true,
+      agentName: this._agentName,
+      state: 'completed',
+      result: finalOutput,
+      recentActivity: reassembler.toActivityItems(),
+    };
+    this._latestProgress = finalProgress;
+
+    this._finishStream('completed');
+
+    this._resultResolve({
+      llmContent: [{ text: finalOutput }],
+      returnDisplay: finalProgress,
+    });
+  }
+
+  private async _getAuthHandler(): Promise<AuthenticationHandler | undefined> {
+    if (this.authHandler) return this.authHandler;
+    if (!this.definition.auth) return undefined;
+
+    const targetUrl = getRemoteAgentTargetUrl(this.definition);
+    const provider = await A2AAuthProviderFactory.create({
+      authConfig: this.definition.auth,
+      agentName: this.definition.name,
+      targetUrl,
+      agentCardUrl: this.definition.agentCardUrl,
+    });
+    if (!provider) {
+      throw new Error(
+        `Failed to create auth provider for agent '${this.definition.name}'`,
+      );
+    }
+    this.authHandler = provider;
+    return this.authHandler;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private _emit(events: AgentEvent[]): void {
+    if (events.length === 0) return;
+    const subscribers = [...this._subscribers];
+    for (const event of events) {
+      this._events.push(event);
+      if (event.type === 'agent_end') {
+        this._agentEndEmitted = true;
+      }
+      for (const sub of subscribers) {
+        sub(event);
+      }
+    }
+  }
+
+  private _clearActiveStream(): void {
+    this._activeStreamId = undefined;
+  }
+
+  private _ensureAgentStart(): void {
+    if (!this._agentStartEmitted) {
+      this._agentStartEmitted = true;
+      this._emit([this._makeEvent('agent_start', {})]);
+    }
+  }
+
+  private _ensureAgentEnd(reason: StreamEndReason = 'completed'): void {
+    if (!this._agentEndEmitted && this._agentStartEmitted) {
+      this._emit([this._makeEvent('agent_end', { reason })]);
+    }
+  }
+
+  private _finishStream(reason: StreamEndReason): void {
+    this._ensureAgentEnd(reason);
+    this._clearActiveStream();
+  }
+
+  private _emitErrorAndAgentEnd(err: unknown): void {
+    const message = this._formatError(err);
+    this._ensureAgentStart();
+
+    const meta: Record<string, unknown> = {};
+    if (err instanceof Error) {
+      meta['errorName'] = err.constructor.name;
+      meta['stack'] = err.stack;
+    }
+
+    this._emit([
+      this._makeEvent('error', {
+        status: 'INTERNAL',
+        message,
+        fatal: true,
+        ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+      }),
+    ]);
+    this._ensureAgentEnd('failed');
+  }
+
+  private _formatError(error: unknown): string {
+    if (error instanceof A2AAgentError) {
+      return error.userMessage;
+    }
+    return `Error calling remote agent: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  private _nextEventFields() {
+    return {
+      id: `${this._streamId}-${this._eventCounter++}`,
+      timestamp: new Date().toISOString(),
+      streamId: this._streamId,
+    };
+  }
+
+  private _makeEvent<T extends AgentEvent['type']>(
+    type: T,
+    payload: Omit<AgentEvent<T>, 'id' | 'timestamp' | 'streamId' | 'type'>,
+  ): AgentEvent {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return {
+      ...this._nextEventFields(),
+      type,
+      ...payload,
+    } as AgentEvent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public export
+// ---------------------------------------------------------------------------
+
+export class RemoteSubagentSession extends AgentSession {
+  private readonly _remoteProtocol: RemoteSubagentProtocol;
+
+  constructor(
+    definition: RemoteAgentDefinition,
+    context: AgentLoopContext,
+    messageBus: MessageBus,
+  ) {
+    const protocol = new RemoteSubagentProtocol(
+      definition,
+      context,
+      messageBus,
+    );
+    super(protocol);
+    this._remoteProtocol = protocol;
+  }
+
+  /**
+   * Returns the ToolResult once the remote agent stream completes.
+   * Used by RemoteAgentInvocation to return the result.
+   */
+  getResult(): Promise<ToolResult> {
+    return this._remoteProtocol.getResult();
+  }
+
+  /**
+   * Returns the most recent SubagentProgress snapshot, updated per streaming
+   * chunk. Useful for constructing error progress when getResult() rejects.
+   */
+  getLatestProgress(): SubagentProgress | undefined {
+    return this._remoteProtocol.getLatestProgress();
+  }
+
+  /**
+   * Convenience: start execution with a query string.
+   * Equivalent to send({message: {content: [{type:'text', text: query}]}}).
+   */
+  async startWithQuery(query: string): Promise<{ streamId: string | null }> {
+    return this.send({
+      message: { content: [{ type: 'text', text: query }] },
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -264,9 +264,6 @@ export * from './hooks/index.js';
 // Export hook types
 export * from './hooks/types.js';
 
-// Export agent types
-export * from './agents/types.js';
-
 // Export stdio utils
 export * from './utils/stdio.js';
 export * from './utils/terminal.js';


### PR DESCRIPTION
## Summary

This PR adds `LocalSessionInvocation` for session-based local subagent invocation, and introduces `RemoteSubagentProtocol` and `LocalSubagentProtocol` to wrap A2A client and LocalAgentExecutor behind `AgentProtocol`.

## Details

- `LocalSessionInvocation`: Implements session-based invocation for local agents.
- `RemoteSubagentProtocol`: Wraps A2A client.
- `LocalSubagentProtocol`: Wraps LocalAgentExecutor.
- Part of the ADK integration effort.

## Related Issues

Related to ADK migration.

## How to Validate

Run preflight checks (build, lint, test). Tests added in `packages/core/src/agents/local-session-invocation.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
