### PR TITLE
fix(core): throw explicit error on dropped tool responses

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -2397,7 +2397,15 @@ describe('LocalAgentExecutor', () => {
           },
           response: {
             resultDisplay: 'ls result',
-            responseParts: [],
+            responseParts: [
+              {
+                functionResponse: {
+                  name: LS_TOOL_NAME,
+                  id: 'call1',
+                  response: { ok: true },
+                },
+              },
+            ],
             data: {},
           },
         },

--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -2227,6 +2227,69 @@ describe('LocalAgentExecutor', () => {
       // Agent should terminate with ABORTED status
       expect(output.terminate_reason).toBe(AgentTerminateMode.ABORTED);
     });
+
+    it('should throw a critical error when a tool response is dropped by the scheduler', async () => {
+      const definition = createTestDefinition([LS_TOOL_NAME]);
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      // Turn 1: Model calls two tools
+      mockModelResponse([
+        { name: LS_TOOL_NAME, args: { path: 'dir1' }, id: 'call1' },
+        { name: LS_TOOL_NAME, args: { path: 'dir2' }, id: 'call2' },
+      ]);
+
+      // Simulate scheduler returning only ONE result for TWO calls (dropped response)
+      mockScheduleAgentTools.mockResolvedValueOnce([
+        {
+          status: 'success',
+          request: { callId: 'call1', name: LS_TOOL_NAME },
+          response: {
+            responseParts: [
+              {
+                functionResponse: {
+                  name: LS_TOOL_NAME,
+                  id: 'call1',
+                  response: { ok: true },
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      await expect(
+        executor.run({ goal: 'Protocol test' }, signal),
+      ).rejects.toThrow(
+        'Critical System Failure: Tool execution result was lost/dropped by the scheduler',
+      );
+    });
+
+    it('should throw a critical error when all scheduler results are missing/dropped', async () => {
+      const definition = createTestDefinition([LS_TOOL_NAME]);
+      const executor = await LocalAgentExecutor.create(
+        definition,
+        mockConfig,
+        onActivity,
+      );
+
+      // Turn 1: Model calls one tool
+      mockModelResponse([
+        { name: LS_TOOL_NAME, args: { path: 'dir1' }, id: 'call1' },
+      ]);
+
+      // Simulate scheduler returning NO results (dropped response)
+      mockScheduleAgentTools.mockResolvedValueOnce([]);
+
+      await expect(
+        executor.run({ goal: 'Protocol test 2' }, signal),
+      ).rejects.toThrow(
+        'Critical System Failure: Tool execution result was lost/dropped by the scheduler',
+      );
+    });
   });
 
   describe('Model Routing', () => {

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -1287,25 +1287,29 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       }
     }
 
-    // Reconstruct toolResponseParts in the original order
+    // Ensure exactly one response per function call to satisfy the Gemini API protocol.
     const toolResponseParts: Part[] = [];
     for (const [index, functionCall] of functionCalls.entries()) {
       const callId = functionCall.id ?? `${promptId}-${index}`;
       const part = syncResults.get(callId);
+
       if (part) {
         toolResponseParts.push(part);
+        continue;
       }
-    }
 
-    // If all authorized tool calls failed (and task isn't complete), provide a generic error.
-    if (
-      functionCalls.length > 0 &&
-      toolResponseParts.length === 0 &&
-      !taskCompleted
-    ) {
-      toolResponseParts.push({
-        text: 'All tool calls failed or were unauthorized. Please analyze the errors and try an alternative approach.',
-      });
+      const isAborted = signal.aborted;
+      const isTaskComplete =
+        functionCall.name === COMPLETE_TASK_TOOL_NAME && taskCompleted;
+
+      // Safely skip missing responses if the run was interrupted or the turn won't be sent back.
+      if (isAborted || isTaskComplete) {
+        continue;
+      }
+
+      throw new Error(
+        `[LocalAgentExecutor] Critical System Failure: Tool execution result was lost/dropped by the scheduler for callId ${callId} (${functionCall.name}). This indicates an internal race condition or scheduler bug.`,
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Refactors `LocalAgentExecutor` to throw a fail-fast system `Error` when a tool response is dropped by the scheduler. This resolves two critical Gemini API protocol violations on `main` that caused immediate `400 Bad Request` crashes:

1. **Invalid Text Fallback**: Returning a generic `text` part (`{ text: "All tool calls failed..." }`) instead of the required `functionResponse` parts when all tool calls failed.
2. **Mismatched Count**: Silently omitting dropped parallel tool responses, causing the response turn ($N-1$ responses) to mismatch the call turn ($N$ calls).

Allows agent / developer to see the actual error, and gives it a chance to recover.

## Details

* **The Problem**: The Gemini API strictly requires that a tool response turn contains exclusively `functionResponse` parts matching the exact count of requested tool calls. `main` violated this by returning a `text` fallback on total failure, and silently ignoring dropped parallel responses. Both triggered backend `400 Bad Request` rejections.
* **The Fix**:
  * Reconstructs `toolResponseParts` strictly. Throws an explicit system `Error` if any requested response is missing/dropped.
  * Removes the invalid `text` fallback block entirely.
  * Skips checking during expected exceptions:
    1. **Successful `complete_task`**: No response turn is sent when the task completes successfully.
    2. **Abort/Timeout**: Interrupted turns (`signal.aborted === true`) are bypassed.
  * Updates unit tests in `local-executor.test.ts` to assert critical throwing behavior.

## Related Issues

Fixes #25359

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/agents/local-executor.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux (npm run)
