### PR TITLE
ci(triage): fix comment spam by separating internal explanation from public comment

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -152,7 +152,6 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.issue_number || inputs.issue_number) || github.event.issue.number }}
           REPOSITORY: '${{ github.repository }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
-          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'

--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -146,6 +146,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31' # ratchet:google-github-actions/run-gemini-cli@v0
         id: 'gemini_issue_analysis'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           ISSUE_NUMBER: >-
             ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.issue_number || inputs.issue_number) || github.event.issue.number }}

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -105,6 +105,7 @@ jobs:
         uses: 'google-github-actions/run-gemini-cli@a3bf79042542528e91937b3a3a6fbc4967ee3c31' # ratchet:google-github-actions/run-gemini-cli@v0
         id: 'gemini_issue_analysis'
         env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
           REPOSITORY: '${{ github.repository }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -107,9 +107,9 @@ jobs:
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: '' # Do not pass any auth token here since this runs on untrusted inputs
+          ISSUES_TO_TRIAGE: '${{ steps.get_issue_from_event.outputs.issues_to_triage || steps.find_issues.outputs.issues_to_triage }}'
           REPOSITORY: '${{ github.repository }}'
           AVAILABLE_LABELS: '${{ steps.get_labels.outputs.available_labels }}'
-          GEMINI_CLI_TRUST_WORKSPACE: 'true'
         with:
           gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
           gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -158,14 +158,15 @@ jobs:
                    "issue_number": 123,
                    "labels_to_add": ["area/core", "kind/bug", "priority/p2"],
                    "labels_to_remove": ["status/need-triage"],
-                   "explanation": "This issue is a UI bug that needs to be addressed with medium priority."
+                   "explanation": "This issue is a UI bug that needs to be addressed with medium priority.",
+                   "comment": "Optional comment to post to the user, for example asking for repro steps."
                  }
                ]
                ```
               If an issue cannot be classified, do not include it in the output array.
             9. For each issue please check if CLI version is present, this is usually in the output of the /about command and will look like 0.1.5
               - Anything more than 6 versions older than the most recent should add the status/need-retesting label
-            10. If you see that the issue doesn't look like it has sufficient information recommend the status/need-information label and leave a comment politely requesting the relevant information, eg.. if repro steps are missing request for repro steps. if version information is missing request for version information into the explanation section below.
+            10. If you see that the issue doesn't look like it has sufficient information recommend the status/need-information label and leave a comment politely requesting the relevant information using the "comment" field in the JSON (e.g., if repro steps are missing request for repro steps, if version information is missing request for version information).
             11. If you think an issue might be a Priority/P0 do not apply the priority/p0 label. Instead apply a status/manual-triage label and include a note in your explanation.
             12. If you are uncertain about a category, use the area/unknown, kind/question, or priority/unknown labels as appropriate. If you are extremely uncertain, apply the status/manual-triage label.
 
@@ -288,12 +289,12 @@ jobs:
                 core.info(`Successfully added labels for #${issueNumber}: ${labelsToAdd.join(', ')}${explanation}`);
               }
 
-              if (entry.explanation) {
+              if (entry.comment) {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                  body: entry.explanation,
+                  body: entry.comment,
                 });
               }
 

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -21,6 +21,7 @@ import {
   getErrorType,
   getErrorMessage,
   isAuthenticationError,
+  AuthType,
   ExitCodes,
 } from '@google/gemini-cli-core';
 import { runSyncCleanup } from './cleanup.js';
@@ -60,19 +61,30 @@ function getNumericExitCode(errorCode: string | number): number {
 }
 
 /**
- * Formats authentication errors into clear, actionable CLI messages.
+ * Formats authentication errors for terminal display.
+ * This function uses a lenient sanitization approach, stripping ANSI escape codes 
+ * and control characters while preserving newlines and tabs to ensure 
+ * readability while preventing terminal injection.
  */
-export function formatAuthError(error: any): string {
+export function formatAuthError(error: unknown, authType?: string): string {
   let reason = 'Invalid or missing API key';
   if (error instanceof Error) {
     reason = error.message;
   } else if (typeof error === 'string') {
     reason = error;
-  } else if (error && typeof error === 'object' && error.message) {
-    reason = String(error.message);
+  } else if (error && typeof error === 'object' && 'message' in error) {
+    reason = String((error as any).message);
   }
 
-  return `❌ Authentication Failed\n\nReason: ${reason}\n\nFix:\n1. Set your API key:\n   export GEMINI_API_KEY=your_key_here\n\n2. Or login again:\n   gemini auth login`;
+  const sanitizedReason = reason.replace(/[\x00-\x1F\x7F-\x9F]/g, (char) =>
+    char === '\n' || char === '\r' || char === '\t' ? char : ''
+  );
+
+  const fix = authType === 'google-cloud' 
+    ? '1. Run: gcloud auth application-default login' 
+    : '1. Set your API key:\n   export GEMINI_API_KEY=your_key_here\n\n2. Or login again:\n   gemini auth login';
+
+  return '❌ Authentication Failed\n\nReason: ' + sanitizedReason + '\n\nFix:\n' + fix;
 }
 
 /**
@@ -105,7 +117,7 @@ export function handleError(
   );
 
   if (isAuthError) {
-    errorMessage = formatAuthError(error);
+    errorMessage = formatAuthError(error, config.getContentGeneratorConfig()?.authType);
   }
 
   if (config.getOutputFormat() === OutputFormat.STREAM_JSON) {

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -66,7 +66,7 @@ function getNumericExitCode(errorCode: string | number): number {
  * and control characters while preserving newlines and tabs to ensure 
  * readability while preventing terminal injection.
  */
-export function formatAuthError(error: unknown, authType?: string): string {
+export function formatAuthError(error: unknown, authType?: AuthType | string): string {
   let reason = 'Invalid or missing API key';
   if (error instanceof Error) {
     reason = error.message;
@@ -80,7 +80,7 @@ export function formatAuthError(error: unknown, authType?: string): string {
     char === '\n' || char === '\r' || char === '\t' ? char : ''
   );
 
-  const fix = authType === 'google-cloud' 
+  const fix = (authType === AuthType.COMPUTE_ADC || authType === AuthType.USE_VERTEX_AI)
     ? '1. Run: gcloud auth application-default login' 
     : '1. Set your API key:\n   export GEMINI_API_KEY=your_key_here\n\n2. Or login again:\n   gemini auth login';
 
@@ -117,7 +117,7 @@ export function handleError(
   );
 
   if (isAuthError) {
-    errorMessage = formatAuthError(error, config.getContentGeneratorConfig()?.authType);
+    errorMessage = formatAuthError(errorMessage, config.getContentGeneratorConfig()?.authType);
   }
 
   if (config.getOutputFormat() === OutputFormat.STREAM_JSON) {
@@ -142,8 +142,10 @@ export function handleError(
     const formatter = new JsonFormatter();
     const errorCode = customErrorCode ?? extractErrorCode(error);
 
+    const errorToFormat = error instanceof Error ? error : new Error(getErrorMessage(error));
+    errorToFormat.message = errorMessage;
     const formattedError = formatter.formatError(
-      new Error(errorMessage),
+      errorToFormat,
       errorCode,
       config.getSessionId(),
     );

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -20,6 +20,8 @@ import {
   coreEvents,
   getErrorType,
   getErrorMessage,
+  isAuthenticationError,
+  ExitCodes,
 } from '@google/gemini-cli-core';
 import { runSyncCleanup } from './cleanup.js';
 
@@ -58,20 +60,53 @@ function getNumericExitCode(errorCode: string | number): number {
 }
 
 /**
+ * Formats authentication errors into clear, actionable CLI messages.
+ */
+export function formatAuthError(error: any): string {
+  let reason = 'Invalid or missing API key';
+  if (error instanceof Error) {
+    reason = error.message;
+  } else if (typeof error === 'string') {
+    reason = error;
+  } else if (error && typeof error === 'object' && error.message) {
+    reason = String(error.message);
+  }
+
+  return `❌ Authentication Failed\n\nReason: ${reason}\n\nFix:\n1. Set your API key:\n   export GEMINI_API_KEY=your_key_here\n\n2. Or login again:\n   gemini auth login`;
+}
+
+/**
+ * Helper to detect if an error is authentication-related (401, 400 invalid key, or missing env var).
+ */
+export function isAuthRelatedError(error: unknown, customErrorCode?: string | number): boolean {
+  if (customErrorCode === ExitCodes.FATAL_AUTHENTICATION_ERROR) return true;
+  if (isAuthenticationError(error)) return true;
+  
+  const msg = getErrorMessage(error).toLowerCase();
+  return msg.includes('api key') && (msg.includes('not valid') || msg.includes('missing') || msg.includes('invalid'));
+}
+
+/**
  * Handles errors consistently for both JSON and text output formats.
  * In JSON mode, outputs formatted JSON error and exits.
  * In streaming JSON mode, emits a result event with error status.
- * In text mode, outputs error message and re-throws.
+ * In text mode, outputs error message and exits for fatal auth errors.
  */
 export function handleError(
   error: unknown,
   config: Config,
   customErrorCode?: string | number,
 ): never {
-  const errorMessage = parseAndFormatApiError(
+  const isAuthError = isAuthRelatedError(error, customErrorCode);
+
+  let errorMessage = parseAndFormatApiError(
     error,
     config.getContentGeneratorConfig()?.authType,
   );
+
+  if (isAuthError) {
+    errorMessage = formatAuthError(error);
+  }
 
   if (config.getOutputFormat() === OutputFormat.STREAM_JSON) {
     const streamFormatter = new StreamJsonFormatter();
@@ -96,7 +131,7 @@ export function handleError(
     const errorCode = customErrorCode ?? extractErrorCode(error);
 
     const formattedError = formatter.formatError(
-      error instanceof Error ? error : new Error(getErrorMessage(error)),
+      new Error(errorMessage),
       errorCode,
       config.getSessionId(),
     );
@@ -105,6 +140,11 @@ export function handleError(
     runSyncCleanup();
     process.exit(getNumericExitCode(errorCode));
   } else {
+    if (isAuthError) {
+      console.error(errorMessage);
+      runSyncCleanup();
+      process.exit(getNumericExitCode(customErrorCode ?? ExitCodes.FATAL_AUTHENTICATION_ERROR));
+    }
     throw error;
   }
 }

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -50,16 +50,10 @@ export async function validateNonInteractiveAuth(
 
     return authType;
   } catch (error) {
-    if (nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON) {
-      handleError(
-        error instanceof Error ? error : new Error(String(error)),
-        nonInteractiveConfig,
-        ExitCodes.FATAL_AUTHENTICATION_ERROR,
-      );
-    } else {
-      debugLogger.error(error instanceof Error ? error.message : String(error));
-      await runExitCleanup();
-      process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
-    }
+    handleError(
+      error instanceof Error ? error : new Error(String(error)),
+      nonInteractiveConfig,
+      ExitCodes.FATAL_AUTHENTICATION_ERROR,
+    );
   }
 }


### PR DESCRIPTION
This PR fixes an issue where the scheduled triage bot was unconditionally posting its internal reasoning as a public comment on all triaged issues. By introducing a new \comment\ field in the JSON schema, the bot will now only comment when it explicitly needs to ask the user for more information.