### PR TITLE
feat(acp): allow ask_user tool in ACP mode for some ACP complaint IDEs

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2506,6 +2506,19 @@ describe('loadCliConfig tool exclusions', () => {
     expect(config.getExcludeTools()).toContain('ask_user');
   });
 
+  it('should NOT exclude ask_user in interactive mode when --acp is provided and Xcode is detected', async () => {
+    process.stdin.isTTY = true;
+    process.argv = ['node', 'script.js', '--acp'];
+    vi.stubEnv('XCODE_VERSION_ACTUAL', '15.0');
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(
+      createTestMergedSettings(),
+      'test-session',
+      argv,
+    );
+    expect(config.getExcludeTools()).not.toContain('ask_user');
+  });
+
   it('should not exclude shell tool in non-interactive mode when --allowed-tools="ShellTool" is set', async () => {
     process.stdin.isTTY = false;
     process.argv = [

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -809,12 +809,13 @@ export async function loadCliConfig(
 
   // In non-interactive mode, exclude tools that require a prompt.
   const extraExcludes: string[] = [];
-  if (!interactive || isAcpMode) {
+  const isXcode = detectIdeFromEnv().name === 'xcode';
+  if (!interactive || (isAcpMode && !isXcode)) {
     // The Policy Engine natively handles headless safety by translating ASK_USER
     // decisions to DENY. However, we explicitly block ask_user here to guarantee
     // it can never be allowed via a high-priority policy rule when no human is present.
     // We also exclude it in ACP mode as IDEs intercept tool calls and ask for permission,
-    // breaking conversational flows.
+    // breaking conversational flows (except for Xcode).
     extraExcludes.push(ASK_USER_TOOL_NAME);
   }
 


### PR DESCRIPTION
## Summary

In ACP (Agent Client Protocol) mode, the `ask_user` tool is generally excluded because most IDE clients intercept tool executions, which can disrupt conversational flows. However, Xcode integrations rely on this tool being available for interactive human-in-the-loop prompts.

## Details

This change:
- Evaluates the host IDE using `detectIdeFromEnv().name`.
- Exempts Xcode ('xcode') from the `ask_user` exclusion block during configuration loading.
- Adds a unit test to `config.test.ts` to verify that the tool is not excluded when the editor is detected as Xcode.


## Related Issues

Fixes google-gemini/maintainers-gemini-cli#1660

## How to Validate

No regressions. The UI needs to be validated by Xcode team.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
