### PR TITLE
feat(acp/core): prefix tool call IDs with tool names to support tool rendering in ACP compliant IDEs.

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -18,6 +18,7 @@ import {
   StreamEventType,
   SYNTHETIC_THOUGHT_SIGNATURE,
   type StreamEvent,
+  stripToolCallIdPrefixes,
 } from './geminiChat.js';
 import {
   type CompletedToolCall,
@@ -2967,6 +2968,129 @@ describe('GeminiChat', () => {
       expect(curatedHistory.length).toBe(2);
       expect(curatedHistory[1].role).toBe('model');
       expect(curatedHistory[1].parts![0].fileData).toBeDefined();
+    });
+  });
+
+  describe('stripToolCallIdPrefixes', () => {
+    it('should strip tool name prefix matching the tool name', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'my_tool__call_123',
+                name: 'my_tool',
+                args: {},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'my_tool__call_123',
+                name: 'my_tool',
+                response: { result: 'success' },
+              },
+            },
+          ],
+        },
+      ];
+
+      const stripped = stripToolCallIdPrefixes(contents);
+      expect(stripped[0].parts![0].functionCall!.id).toBe('call_123');
+      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_123');
+    });
+
+    it('should correctly handle tool names that contain double underscores', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'my__custom__tool__call_abc',
+                name: 'my__custom__tool',
+                args: {},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'my__custom__tool__call_abc',
+                name: 'my__custom__tool',
+                response: { result: 'success' },
+              },
+            },
+          ],
+        },
+      ];
+
+      const stripped = stripToolCallIdPrefixes(contents);
+      expect(stripped[0].parts![0].functionCall!.id).toBe('call_abc');
+      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_abc');
+    });
+
+    it('should not strip if prefix does not match the tool name', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'other_tool__call_123',
+                name: 'my_tool',
+                args: {},
+              },
+            },
+          ],
+        },
+      ];
+
+      const stripped = stripToolCallIdPrefixes(contents);
+      expect(stripped[0].parts![0].functionCall!.id).toBe(
+        'other_tool__call_123',
+      );
+    });
+
+    it('should correctly handle fallback to generic_tool when name is missing or has whitespace', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'generic_tool__call_123',
+                name: '  ',
+                args: {},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'generic_tool__call_123',
+                name: undefined as unknown as string,
+                response: { result: 'success' },
+              },
+            },
+          ],
+        },
+      ];
+
+      const stripped = stripToolCallIdPrefixes(contents);
+      expect(stripped[0].parts![0].functionCall!.id).toBe('call_123');
+      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_123');
     });
   });
 });

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -746,10 +746,12 @@ export class GeminiChat {
       lastConfig = config;
       lastContentsToUse = contentsToUse;
 
+      const finalContents = stripToolCallIdPrefixes(contentsToUse);
+
       return this.context.config.getContentGenerator().generateContentStream(
         {
           model: modelToUse,
-          contents: contentsToUse,
+          contents: finalContents,
           config,
         },
         prompt_id,
@@ -1016,10 +1018,20 @@ export class GeminiChat {
               }
               fnCall.id = id;
             }
+            const name = fnCall.name?.trim() || 'generic_tool';
+            if (fnCall.id && !fnCall.id.startsWith(`${name}__`)) {
+              fnCall.id = `${name}__${fnCall.id}`;
+            }
             finalFunctionCallsMap.set(fnCall.id, fnCall);
           }
           runningFunctionCallCounter += chunk.functionCalls.length;
         } else {
+          for (const fnCall of chunk.functionCalls) {
+            const name = fnCall.name?.trim() || 'generic_tool';
+            if (fnCall.id && !fnCall.id.startsWith(`${name}__`)) {
+              fnCall.id = `${name}__${fnCall.id}`;
+            }
+          }
           legacyFunctionCalls.push(...chunk.functionCalls);
         }
       }
@@ -1287,4 +1299,36 @@ export function isSchemaDepthError(errorMessage: string): boolean {
 
 export function isInvalidArgumentError(errorMessage: string): boolean {
   return errorMessage.includes('Request contains an invalid argument');
+}
+
+export function stripToolCallIdPrefixes(contents: Content[]): Content[] {
+  return contents.map((content) => ({
+    ...content,
+    parts: (content.parts || []).map((part) => {
+      const newPart = { ...part };
+      if (newPart.functionCall) {
+        const fc = newPart.functionCall;
+        const name = fc.name?.trim() || 'generic_tool';
+        if (fc.id && fc.id.startsWith(`${name}__`)) {
+          newPart.functionCall = {
+            name: fc.name,
+            args: fc.args,
+            id: fc.id.substring(name.length + 2),
+          };
+        }
+      }
+      if (newPart.functionResponse) {
+        const fr = newPart.functionResponse;
+        const name = fr.name?.trim() || 'generic_tool';
+        if (fr.id && fr.id.startsWith(`${name}__`)) {
+          newPart.functionResponse = {
+            name: fr.name,
+            response: fr.response,
+            id: fr.id.substring(name.length + 2),
+          };
+        }
+      }
+      return newPart;
+    }),
+  }));
 }

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -172,7 +172,7 @@ describe('Turn', () => {
       expect(event1.type).toBe(GeminiEventType.ToolCallRequest);
       expect(event1.value).toEqual(
         expect.objectContaining({
-          callId: 'fc1',
+          callId: 'tool1__fc1',
           name: 'tool1',
           args: { arg1: 'val1' },
           isClientInitiated: false,
@@ -190,7 +190,7 @@ describe('Turn', () => {
         }),
       );
       expect(event2.value.callId).toEqual(
-        expect.stringMatching(/^tool2_\d{13}_\d+$/),
+        expect.stringMatching(/^tool2__tool2_\d{13}_\d+$/),
       );
       expect(turn.pendingToolCalls[1]).toEqual(event2.value);
       expect(turn.getDebugResponses().length).toBe(1);
@@ -326,22 +326,22 @@ describe('Turn', () => {
       // Assertions for each specific tool call event
       const event1 = events[0] as ServerGeminiToolCallRequestEvent;
       expect(event1.value).toMatchObject({
-        callId: 'fc1',
-        name: 'undefined_tool_name',
+        callId: 'generic_tool__fc1',
+        name: 'generic_tool',
         args: { arg1: 'val1' },
       });
 
       const event2 = events[1] as ServerGeminiToolCallRequestEvent;
       expect(event2.value).toMatchObject({
-        callId: 'fc2',
+        callId: 'tool2__fc2',
         name: 'tool2',
         args: {},
       });
 
       const event3 = events[2] as ServerGeminiToolCallRequestEvent;
       expect(event3.value).toMatchObject({
-        callId: 'fc3',
-        name: 'undefined_tool_name',
+        callId: 'generic_tool__fc3',
+        name: 'generic_tool',
         args: {},
       });
     });
@@ -858,7 +858,7 @@ describe('Turn', () => {
       expect(toolCallEvent).toMatchObject({
         type: GeminiEventType.ToolCallRequest,
         value: expect.objectContaining({
-          callId: 'fc1',
+          callId: 'ReadFile__fc1',
           name: 'ReadFile',
           args: { path: 'file.txt' },
         }),

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -408,14 +408,21 @@ export class Turn {
     fnCall: FunctionCall,
     traceId?: string,
   ): ServerGeminiStreamEvent | null {
-    const name = fnCall.name || 'undefined_tool_name';
+    const name = fnCall.name?.trim() || 'generic_tool';
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const args = (fnCall.args as Record<string, unknown>) || {};
-    const callId =
+    const rawCallId =
       fnCall.id ??
       (this.chat.context.config.isContextManagementEnabled()
         ? `synth_${this.prompt_id}_${Date.now()}_${this.callCounter++}`
         : `${name}_${Date.now()}_${this.callCounter++}`);
+
+    const callId = rawCallId.startsWith(`${name}__`)
+      ? rawCallId
+      : `${name}__${rawCallId}`;
+
+    // Mutate the function call object ID so that history consolidation inherits it
+    fnCall.id = callId;
 
     const tool = this.chat.loopContext.toolRegistry.getTool(name);
     let display;


### PR DESCRIPTION
## Summary

Prefixes the internal `toolCallId` with the name of the active tool (`${toolName}__${originalId}`) when transmitting tool calls over the Agent Client Protocol (ACP). This gives ACP compliant IDEs a stable, reliable way to identify which tool is executing and render tool-specific UIs.

## Details

- Modifies `Turn.run()` (`turn.ts`) and `processStreamResponse()` (`geminiChat.ts`) to prefix the internal `callId` and mutate `fnCall.id`.
- Trims optional `fnCall.name` values and applies a consistent, trimmed `'generic_tool'` fallback schema to avoid whitespace issues.
- Adds `stripToolCallIdPrefixes` right before network transmission in `makeApiCallAndProcessStream()` to dynamically strip the prefix from outgoing `functionCall.id` and `functionResponse.id` payloads, ensuring undocumented formats are never sent to the Gemini API.
- The stripping logic dynamically slices exact prefixes based on the specific tool name, rather than using naive splitting, making the design fully robust against tool names that contain double underscores.
- **Test Coverage**: Updates standard assertions in `turn.test.ts` to align with the new format, and adds comprehensive unit tests in `geminiChat.test.ts` to verify prefixing, stripping, and robust double-underscore/whitespace fallback handling.

## Related Issues

Fixes google-gemini/maintainers-gemini-cli#1661


## How to Validate

No regressions.
To be completely validated by the ACP IDE who requested it.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
