### PR TITLE
feat(cli): support git submodules in extension installs

### DIFF
--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -56,6 +56,7 @@ const mockGit = {
   getRemotes: vi.fn(),
   fetch: vi.fn(),
   checkout: vi.fn(),
+  submoduleUpdate: vi.fn(),
   listRemote: vi.fn(),
   revparse: vi.fn(),
   // Not a part of the actual API, but we need to use this to do the correct

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -73,6 +73,7 @@ describe('github.ts', () => {
       getRemotes: ReturnType<typeof vi.fn>;
       fetch: ReturnType<typeof vi.fn>;
       checkout: ReturnType<typeof vi.fn>;
+      submoduleUpdate: ReturnType<typeof vi.fn>;
       listRemote: ReturnType<typeof vi.fn>;
       revparse: ReturnType<typeof vi.fn>;
     };
@@ -83,6 +84,7 @@ describe('github.ts', () => {
         getRemotes: vi.fn(),
         fetch: vi.fn(),
         checkout: vi.fn(),
+        submoduleUpdate: vi.fn(),
         listRemote: vi.fn(),
         revparse: vi.fn(),
       };
@@ -108,6 +110,10 @@ describe('github.ts', () => {
       );
       expect(mockGit.fetch).toHaveBeenCalledWith('origin', 'v1.0.0');
       expect(mockGit.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+      expect(mockGit.submoduleUpdate).toHaveBeenCalledWith([
+        '--init',
+        '--recursive',
+      ]);
     });
 
     it('should throw if no remotes found', async () => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -69,6 +69,10 @@ export async function cloneFromGit(
     // After fetching, checkout FETCH_HEAD to get the content of the fetched ref.
     // This results in a detached HEAD state, which is fine for this purpose.
     await git.checkout('FETCH_HEAD');
+
+    // Some extensions vendor code or assets via git submodules. Initialize
+    // them after checking out the requested ref so they match that commit.
+    await git.submoduleUpdate(['--init', '--recursive']);
   } catch (error) {
     throw new Error(
       `Failed to clone Git repository from ${installMetadata.source} ${getErrorMessage(error)}`,


### PR DESCRIPTION
## Summary

Support Git submodules when installing extensions from Git repositories.

Without this change, `gemini extensions install <git-url>` would clone the top-level repository but leave submodule directories uninitialized, which could result in incomplete or broken extension installs.

## Details

This updates the Git-based extension install flow to initialize and update submodules recursively after checking out the requested ref in `cloneFromGit(...)`.

The change is intentionally narrow:
- update the Git clone helper to run submodule initialization after `checkout('FETCH_HEAD')`
- add/update tests for the helper and the higher-level extension install flow

## Related Issues

Closes #18385

## How to Validate

1. Use thee repo Node version with nvm use
2. Run `npm run build`
3. Run `npm test -w @google/gemini-cli -- src/config/extensions/github.test.ts src/config/extension.test.ts`
4. Install an extension from a Git repo with submodules and verify the submodule contents are present after installation.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [X] Validated on required platforms/methods:
  - [X] MacOS
    - [X] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
