### PR TITLE
fix: Alpine Linux (musl) compatibility in CLI entrypoint

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -17,16 +17,17 @@ import {
 
 // --- Global Entry Point ---
 
-// Suppress known race condition error in node-pty on Windows
+// Suppress known race condition error in node-pty
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827
+// Alpine Linux (musl libc) also triggers this error, not only Windows.
 process.on('uncaughtException', (error) => {
   if (
-    process.platform === 'win32' &&
     error instanceof Error &&
     error.message === 'Cannot resize a pty that has already exited'
   ) {
-    // This error happens on Windows with node-pty when resizing a pty that has just exited.
+    // This error happens with node-pty when resizing a pty that has just exited.
     // It is a race condition in node-pty that we cannot prevent, so we silence it.
+    // Affects Windows and Alpine Linux (musl libc) alike.
     return;
   }
 
@@ -75,6 +76,18 @@ async function getMemoryNodeArgs(): Promise<string[]> {
 }
 
 async function run() {
+  // Alpine Linux (musl libc): the child-process relaunch mechanism fails silently
+  // due to musl's different handling of stdio inheritance and IPC channels.
+  // Disable it automatically when running on Alpine.
+  if (
+    process.platform === 'linux' &&
+    (await import('node:fs')).existsSync('/etc/alpine-release') &&
+    !process.env['GEMINI_CLI_NO_RELAUNCH'] &&
+    !process.env['GEMINI_CLI_FORCE_RELAUNCH']
+  ) {
+    process.env['GEMINI_CLI_NO_RELAUNCH'] = 'true';
+  }
+
   if (!process.env['GEMINI_CLI_NO_RELAUNCH'] && !process.env['SANDBOX']) {
     // --- Lightweight Parent Process / Daemon ---
     // We avoid importing heavy dependencies here to save ~1.5s of startup time.


### PR DESCRIPTION
## Problem

Gemini CLI crashes or terminates unexpectedly on Alpine Linux (which uses musl libc instead of glibc). Two distinct issues cause this:

### 1. PTY resize race condition not suppressed on Alpine

The `uncaughtException` handler in `packages/cli/index.ts` silences the `Cannot resize a pty that has already exited` error **only on Windows** (`process.platform === 'win32'`), referencing [node-pty#827](https://github.com/microsoft/node-pty/issues/827).

The same race condition occurs on **Alpine Linux with musl libc**, causing the process to crash via `process.exit(1)` whenever the terminal is resized or a PTY subprocess exits while a resize is in flight.

### 2. Child-process relaunch mechanism fails silently on Alpine

The relaunch mechanism (used for memory auto-configuration) spawns a child process with `stdio: ['inherit', 'inherit', 'inherit', 'ipc']`. On Alpine/musl, the IPC channel handling differs from glibc-based systems, causing the child to silently terminate mid-session — which is the primary cause of the CLI appearing to "freeze" after running a tool call.

## Fix

1. **PTY guard**: remove the `process.platform === 'win32'` check so the race condition error is silenced on all platforms.
2. **Alpine relaunch guard**: auto-detect Alpine at startup via `/etc/alpine-release` and set `GEMINI_CLI_NO_RELAUNCH=true`, bypassing the relaunch entirely (same env var that already exists for sandbox and CI environments).

## Testing

Verified on Alpine Linux 3.21 with musl libc, Node.js v24, running `gemini --approval-mode yolo` interactively through multi-step tool-calling sessions without termination.