### PR TITLE
fix: Alpine Linux (musl) compatibility in CLI entrypoint

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -17,16 +17,17 @@ import {
 
 // --- Global Entry Point ---
 
-// Suppress known race condition error in node-pty on Windows
+// Suppress known race condition error in node-pty
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827
+// Alpine Linux (musl libc) also triggers this error, not only Windows.
 process.on('uncaughtException', (error) => {
   if (
-    process.platform === 'win32' &&
     error instanceof Error &&
     error.message === 'Cannot resize a pty that has already exited'
   ) {
-    // This error happens on Windows with node-pty when resizing a pty that has just exited.
+    // This error happens with node-pty when resizing a pty that has just exited.
     // It is a race condition in node-pty that we cannot prevent, so we silence it.
+    // Affects Windows and Alpine Linux (musl libc) alike.
     return;
   }
 
@@ -75,6 +76,18 @@ async function getMemoryNodeArgs(): Promise<string[]> {
 }
 
 async function run() {
+  // Alpine Linux (musl libc): the child-process relaunch mechanism fails silently
+  // due to musl's different handling of stdio inheritance and IPC channels.
+  // Disable it automatically when running on Alpine.
+  if (
+    process.platform === 'linux' &&
+    (await import('node:fs')).existsSync('/etc/alpine-release') &&
+    !process.env['GEMINI_CLI_NO_RELAUNCH'] &&
+    !process.env['GEMINI_CLI_FORCE_RELAUNCH']
+  ) {
+    process.env['GEMINI_CLI_NO_RELAUNCH'] = 'true';
+  }
+
   if (!process.env['GEMINI_CLI_NO_RELAUNCH'] && !process.env['SANDBOX']) {
     // --- Lightweight Parent Process / Daemon ---
     // We avoid importing heavy dependencies here to save ~1.5s of startup time.

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -81,9 +81,9 @@ async function run() {
   // Disable it automatically when running on Alpine.
   if (
     process.platform === 'linux' &&
-    (await import('node:fs')).existsSync('/etc/alpine-release') &&
     !process.env['GEMINI_CLI_NO_RELAUNCH'] &&
-    !process.env['GEMINI_CLI_FORCE_RELAUNCH']
+    !process.env['GEMINI_CLI_FORCE_RELAUNCH'] &&
+    (await import('node:fs')).existsSync('/etc/alpine-release')
   ) {
     process.env['GEMINI_CLI_NO_RELAUNCH'] = 'true';
   }


### PR DESCRIPTION
## Summary

Fixes Alpine Linux (musl libc) compatibility by addressing two crash-causing issues in `packages/cli/index.ts`.

Fixes #26690

## Root Causes

### 1. PTY resize uncaught exception not suppressed on non-Windows

The existing `uncaughtException` handler suppresses PTY resize race-condition errors only on `win32`. On Alpine Linux the same race can occur, crashing the process with an unhandled exception.

**Fix:** Remove the `process.platform === 'win32'` guard so the suppression applies on all platforms.

### 2. Child-process relaunch via IPC fails on Alpine/musl

The CLI relaunch mechanism uses `{ipc: true}` when spawning a child process. On Alpine Linux with musl libc, this IPC channel fails silently, causing the CLI to crash or hang at startup.

**Fix:** At startup, check for `/etc/alpine-release` and set `GEMINI_CLI_NO_RELAUNCH=true` to skip the IPC-based relaunch path.

## Changes

- `packages/cli/index.ts`: Alpine detection + unconditional PTY resize error suppression

## Testing

Verified manually on Alpine Linux 3.21 with Node.js v24 — CLI starts and runs normally after the fix.