### PR TITLE
fix: resolve "function response turn must come immediately after function call" error

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2796,4 +2796,27 @@ describe('GeminiChat', () => {
       ]);
     });
   });
+
+  describe('getHistory with curated: true', () => {
+    it('should not drop model turns with function calls and empty text', () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'Hello' }] },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'test_tool', args: {} }, text: '' }],
+        },
+        {
+          role: 'user',
+          parts: [{ functionResponse: { name: 'test_tool', response: {} } }],
+        },
+      ];
+      const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
+      
+      const curatedHistory = chatWithHistory.getHistory(true);
+      
+      expect(curatedHistory.length).toBe(3);
+      expect(curatedHistory[1].role).toBe('model');
+      expect(curatedHistory[1].parts![0].functionCall).toBeDefined();
+    });
+  });
 });

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2818,5 +2818,39 @@ describe('GeminiChat', () => {
       expect(curatedHistory[1].role).toBe('model');
       expect(curatedHistory[1].parts![0].functionCall).toBeDefined();
     });
+
+    it('should not drop model turns with inlineData and empty text', () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'Hello' }] },
+        {
+          role: 'model',
+          parts: [{ inlineData: { mimeType: 'image/jpeg', data: 'base64...' }, text: '' }],
+        },
+      ];
+      const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
+      
+      const curatedHistory = chatWithHistory.getHistory(true);
+      
+      expect(curatedHistory.length).toBe(2);
+      expect(curatedHistory[1].role).toBe('model');
+      expect(curatedHistory[1].parts![0].inlineData).toBeDefined();
+    });
+
+    it('should not drop model turns with fileData and empty text', () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'Hello' }] },
+        {
+          role: 'model',
+          parts: [{ fileData: { mimeType: 'image/jpeg', fileUri: 'https://...' }, text: '' }],
+        },
+      ];
+      const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
+      
+      const curatedHistory = chatWithHistory.getHistory(true);
+      
+      expect(curatedHistory.length).toBe(2);
+      expect(curatedHistory[1].role).toBe('model');
+      expect(curatedHistory[1].parts![0].fileData).toBeDefined();
+    });
   });
 });

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2811,9 +2811,9 @@ describe('GeminiChat', () => {
         },
       ];
       const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
-      
+
       const curatedHistory = chatWithHistory.getHistory(true);
-      
+
       expect(curatedHistory.length).toBe(3);
       expect(curatedHistory[1].role).toBe('model');
       expect(curatedHistory[1].parts![0].functionCall).toBeDefined();
@@ -2824,13 +2824,18 @@ describe('GeminiChat', () => {
         { role: 'user', parts: [{ text: 'Hello' }] },
         {
           role: 'model',
-          parts: [{ inlineData: { mimeType: 'image/jpeg', data: 'base64...' }, text: '' }],
+          parts: [
+            {
+              inlineData: { mimeType: 'image/jpeg', data: 'base64...' },
+              text: '',
+            },
+          ],
         },
       ];
       const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
-      
+
       const curatedHistory = chatWithHistory.getHistory(true);
-      
+
       expect(curatedHistory.length).toBe(2);
       expect(curatedHistory[1].role).toBe('model');
       expect(curatedHistory[1].parts![0].inlineData).toBeDefined();
@@ -2841,13 +2846,18 @@ describe('GeminiChat', () => {
         { role: 'user', parts: [{ text: 'Hello' }] },
         {
           role: 'model',
-          parts: [{ fileData: { mimeType: 'image/jpeg', fileUri: 'https://...' }, text: '' }],
+          parts: [
+            {
+              fileData: { mimeType: 'image/jpeg', fileUri: 'https://...' },
+              text: '',
+            },
+          ],
         },
       ];
       const chatWithHistory = new GeminiChat(mockConfig, '', [], history);
-      
+
       const curatedHistory = chatWithHistory.getHistory(true);
-      
+
       expect(curatedHistory.length).toBe(2);
       expect(curatedHistory[1].role).toBe('model');
       expect(curatedHistory[1].parts![0].fileData).toBeDefined();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -150,6 +150,8 @@ function isValidContent(content: Content): boolean {
       !part.thought &&
       !part.functionCall &&
       !part.functionResponse &&
+      !part.inlineData &&
+      !part.fileData &&
       part.text !== undefined &&
       part.text === ''
     ) {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -146,7 +146,13 @@ function isValidContent(content: Content): boolean {
     if (part === undefined || Object.keys(part).length === 0) {
       return false;
     }
-    if (!part.thought && part.text !== undefined && part.text === '') {
+    if (
+      !part.thought &&
+      !part.functionCall &&
+      !part.functionResponse &&
+      part.text !== undefined &&
+      part.text === ''
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
  ## Summary
  
  Fixes the error "Please ensure that function response turn comes immediately after a function call turn." which was occurring frequently when using `gemini-3.1-flash-lite-preview`. This issue was caused by the `extractCuratedHistory` function inadvertently dropping valid model turns that contained function calls but no text (or empty text), thereby breaking the strict call-response sequence required by the Gemini API.
  
  ## Details
  
  -   **Fix in `geminiChat.ts`:** Modified `isValidContent` to consider a part valid if it contains a `functionCall` or `functionResponse`, even if its `text` property is an empty string. This prevents valid tool calls from being filtered out of the history sent to the API.
  -   **New Test:** Added a test case in `geminiChat.test.ts` to verify that `getHistory(true)` (curated history) correctly retains model turns with function calls and empty text.
  
  ## How to Validate
  
  1.  Run the tests in the `packages/core` directory to ensure the new test passes and no regressions occurred:
      ```bash
      npx vitest run packages/core/src/core/geminiChat.test.ts
      ```
  2.  Verify that the tests `should fail if the stream ends with an empty part and has no finishReason` passes successfully.
  
  ## Pre-Merge Checklist
  
  - [ ] Updated relevant documentation and README (if needed)
  - [x] Added/updated tests (if needed)
  - [ ] Noted breaking changes (if any)
  - [ ] Validated on required platforms/methods:
    - [ ] MacOS
      - [x] npm run
      - [ ] npx
      - [ ] Docker
      - [ ] Podman
      - [ ] Seatbelt
    - [ ] Windows
      - [ ] npm run
      - [ ] npx
      - [ ] Docker
    - [ ] Linux
      - [ ] npm run
      - [ ] npx
      - [ ] Docker