### PR TITLE
feat(cli): support GEMINI_CLI_ENABLE_AUTO_UPDATE env var

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -126,7 +126,9 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `false`
 
 - **`general.enableAutoUpdate`** (boolean):
-  - **Description:** Enable automatic updates.
+  - **Description:** Enable automatic updates. Can also be controlled via the
+    `GEMINI_CLI_ENABLE_AUTO_UPDATE` environment variable, which takes precedence
+    over this setting when set to a recognized value.
   - **Default:** `true`
 
 - **`general.enableAutoUpdateNotification`** (boolean):
@@ -2321,6 +2323,15 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
   - Overrides the hardcoded default
   - Example: `export GEMINI_MODEL="gemini-3-flash-preview"` (Windows PowerShell:
     `$env:GEMINI_MODEL="gemini-3-flash-preview"`)
+- **`GEMINI_CLI_ENABLE_AUTO_UPDATE`**:
+  - Overrides the `general.enableAutoUpdate` setting from `settings.json`.
+  - Recognized values: `true` / `1` to enable, `false` / `0` to disable (case
+    insensitive). Any other value is ignored and the setting is used.
+  - Useful for disabling auto-update in environments where `settings.json` is
+    not present or cannot be modified (for example, ephemeral containers or
+    CI/CD pipelines).
+  - Example: `export GEMINI_CLI_ENABLE_AUTO_UPDATE="false"` (Windows PowerShell:
+    `$env:GEMINI_CLI_ENABLE_AUTO_UPDATE="false"`)
 - **`GEMINI_CLI_TRUST_WORKSPACE`**:
   - If set to `"true"`, trusts the current workspace for the duration of the
     session, bypassing the folder trust check.

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -23,6 +23,7 @@ import {
   handleAutoUpdate,
   setUpdateHandler,
   isUpdateInProgress,
+  isAutoUpdateEnabled,
   waitForUpdateCompletion,
   _setUpdateStateForTesting,
 } from './handleAutoUpdate.js';
@@ -408,6 +409,116 @@ describe('handleAutoUpdate', () => {
       message: `${mockUpdateInfo.message}\nAutomatic update is not available in sandbox mode.`,
     });
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('should not update when GEMINI_CLI_ENABLE_AUTO_UPDATE=false even if setting is true', () => {
+    vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', 'false');
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm i -g @google/gemini-cli@latest',
+      updateMessage: 'Please update manually.',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
+
+    expect(updateEventEmitter.emit).toHaveBeenCalledTimes(1);
+    expect(updateEventEmitter.emit).toHaveBeenCalledWith('update-received', {
+      ...mockUpdateInfo,
+      message: 'An update is available!\nPlease update manually.',
+      isUpdating: false,
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('should update when GEMINI_CLI_ENABLE_AUTO_UPDATE=true even if setting is false', () => {
+    vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', 'true');
+    mockSettings.merged.general.enableAutoUpdate = false;
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm i -g @google/gemini-cli@latest',
+      updateMessage: 'This is an additional message.',
+      isGlobal: false,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+  });
+
+  it('should fall back to setting when GEMINI_CLI_ENABLE_AUTO_UPDATE is unrecognized', () => {
+    vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', 'maybe');
+    mockSettings.merged.general.enableAutoUpdate = false;
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm i -g @google/gemini-cli@latest',
+      updateMessage: 'Please update manually.',
+      isGlobal: true,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', false, mockSpawn);
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAutoUpdateEnabled', () => {
+  let mockSettings: LoadedSettings;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
+    delete process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
+    mockSettings = {
+      merged: {
+        general: {
+          enableAutoUpdate: true,
+        },
+      },
+    } as LoadedSettings;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
+    } else {
+      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = originalEnv;
+    }
+  });
+
+  it.each(['true', 'TRUE', '1', '  true  '])(
+    'returns true when env var is %s',
+    (value) => {
+      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = value;
+      mockSettings.merged.general.enableAutoUpdate = false;
+      expect(isAutoUpdateEnabled(mockSettings)).toBe(true);
+    },
+  );
+
+  it.each(['false', 'FALSE', '0'])(
+    'returns false when env var is %s',
+    (value) => {
+      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = value;
+      mockSettings.merged.general.enableAutoUpdate = true;
+      expect(isAutoUpdateEnabled(mockSettings)).toBe(false);
+    },
+  );
+
+  it('falls back to setting when env var has an unrecognized value', () => {
+    process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = 'yes';
+    mockSettings.merged.general.enableAutoUpdate = false;
+    expect(isAutoUpdateEnabled(mockSettings)).toBe(false);
+  });
+
+  it('falls back to setting when env var is unset', () => {
+    mockSettings.merged.general.enableAutoUpdate = false;
+    expect(isAutoUpdateEnabled(mockSettings)).toBe(false);
+  });
+
+  it('defaults to true when env var is unset and setting is missing', () => {
+    delete (mockSettings.merged.general as { enableAutoUpdate?: boolean })
+      .enableAutoUpdate;
+    expect(isAutoUpdateEnabled(mockSettings)).toBe(true);
   });
 });
 

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -464,11 +464,8 @@ describe('handleAutoUpdate', () => {
 
 describe('isAutoUpdateEnabled', () => {
   let mockSettings: LoadedSettings;
-  let originalEnv: string | undefined;
 
   beforeEach(() => {
-    originalEnv = process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
-    delete process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
     mockSettings = {
       merged: {
         general: {
@@ -479,17 +476,13 @@ describe('isAutoUpdateEnabled', () => {
   });
 
   afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
-    } else {
-      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = originalEnv;
-    }
+    vi.unstubAllEnvs();
   });
 
   it.each(['true', 'TRUE', '1', '  true  '])(
     'returns true when env var is %s',
     (value) => {
-      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = value;
+      vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', value);
       mockSettings.merged.general.enableAutoUpdate = false;
       expect(isAutoUpdateEnabled(mockSettings)).toBe(true);
     },
@@ -498,14 +491,14 @@ describe('isAutoUpdateEnabled', () => {
   it.each(['false', 'FALSE', '0'])(
     'returns false when env var is %s',
     (value) => {
-      process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = value;
+      vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', value);
       mockSettings.merged.general.enableAutoUpdate = true;
       expect(isAutoUpdateEnabled(mockSettings)).toBe(false);
     },
   );
 
   it('falls back to setting when env var has an unrecognized value', () => {
-    process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'] = 'yes';
+    vi.stubEnv('GEMINI_CLI_ENABLE_AUTO_UPDATE', 'yes');
     mockSettings.merged.general.enableAutoUpdate = false;
     expect(isAutoUpdateEnabled(mockSettings)).toBe(false);
   });

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -29,6 +29,27 @@ export function isUpdateInProgress() {
 }
 
 /**
+ * Returns whether automatic updates are enabled, taking the
+ * `GEMINI_CLI_ENABLE_AUTO_UPDATE` environment variable into account. When set,
+ * the env var overrides `general.enableAutoUpdate` from settings. Recognized
+ * truthy values are `1` / `true`; falsy values are `0` / `false` (case
+ * insensitive). Any other value is ignored and the setting is used.
+ */
+export function isAutoUpdateEnabled(settings: LoadedSettings): boolean {
+  const envValue = process.env['GEMINI_CLI_ENABLE_AUTO_UPDATE'];
+  if (envValue !== undefined) {
+    const normalized = envValue.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+  return settings.merged.general.enableAutoUpdate ?? true;
+}
+
+/**
  * Returns a promise that resolves when the update process completes or times out.
  */
 export async function waitForUpdateCompletion(
@@ -86,10 +107,9 @@ export function handleAutoUpdate(
     return;
   }
 
-  const installationInfo = getInstallationInfo(
-    projectRoot,
-    settings.merged.general.enableAutoUpdate,
-  );
+  const autoUpdateEnabled = isAutoUpdateEnabled(settings);
+
+  const installationInfo = getInstallationInfo(projectRoot, autoUpdateEnabled);
 
   if (
     [
@@ -107,10 +127,7 @@ export function handleAutoUpdate(
     combinedMessage += `\n${installationInfo.updateMessage}`;
   }
 
-  if (
-    !installationInfo.updateCommand ||
-    !settings.merged.general.enableAutoUpdate
-  ) {
+  if (!installationInfo.updateCommand || !autoUpdateEnabled) {
     updateEventEmitter.emit('update-received', {
       ...info,
       message: combinedMessage,


### PR DESCRIPTION
## Problem

Closes #26291.

`general.enableAutoUpdate` could only be controlled via `settings.json`. There was no way to disable auto-update from the shell when launching `gemini` outside a project that contains a `.gemini/settings.json` file (or when the settings file shouldn't be touched, e.g. ephemeral containers, CI runners, shared hosts).

## Solution

Adds an `isAutoUpdateEnabled(settings)` helper in `packages/cli/src/utils/handleAutoUpdate.ts` that resolves the effective flag from the new `GEMINI_CLI_ENABLE_AUTO_UPDATE` environment variable, falling back to `general.enableAutoUpdate` when the env var is unset or has an unrecognized value.

- Recognized truthy values: `true`, `1` (case insensitive, surrounding whitespace ignored)
- Recognized falsy values: `false`, `0` (case insensitive)
- Anything else → fall back to `general.enableAutoUpdate` (default `true`)

Both reads of `settings.merged.general.enableAutoUpdate` inside `handleAutoUpdate` now go through this helper, so the env var both blocks and forces auto-update regardless of the setting.

`general.enableAutoUpdateNotification` is intentionally untouched — the issue specifically asks for an `enableAutoUpdate` env var.

Docs updated in `docs/reference/configuration.md`: a new entry under the env var list and a cross-reference on the `general.enableAutoUpdate` setting.

## Testing

- New unit tests for `isAutoUpdateEnabled` covering truthy / falsy / unrecognized / unset / missing-setting cases (`packages/cli/src/utils/handleAutoUpdate.test.ts`).
- New `handleAutoUpdate` cases verifying:
  - `GEMINI_CLI_ENABLE_AUTO_UPDATE=false` blocks the spawn even when the setting is `true`.
  - `GEMINI_CLI_ENABLE_AUTO_UPDATE=true` triggers the spawn even when the setting is `false`.
  - An unrecognized value (`maybe`) falls through to the setting.
- Full `handleAutoUpdate.test.ts` suite passes locally (41 tests).