### PR TITLE
fix(cli): skip workspace commands when cwd is home dir

### DIFF
--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -6,12 +6,7 @@
 
 import * as glob from 'glob';
 import * as path from 'node:path';
-import {
-  GEMINI_DIR,
-  Storage,
-  type Config,
-  homedir,
-} from '@google/gemini-cli-core';
+import { GEMINI_DIR, Storage, type Config } from '@google/gemini-cli-core';
 import mock from 'mock-fs';
 import { FileCommandLoader } from './FileCommandLoader.js';
 import { assert, vi } from 'vitest';
@@ -320,32 +315,36 @@ describe('FileCommandLoader', () => {
     }
   });
 
-  it('does not duplicate commands when project root is the home directory', async () => {
-    const homeDir = homedir();
+  it('skips workspace commands when project root is the home directory to avoid false conflicts', async () => {
     const userCommandsDir = Storage.getUserCommandsDir();
     mock({
       [userCommandsDir]: {
-        'test.toml': 'prompt = "User prompt"',
+        'my_command.toml': 'prompt = "My command prompt"',
         'another.toml': 'prompt = "Another prompt"',
       },
     });
 
+    // Create a Storage instance with isWorkspaceHomeDir returning true
+    const storageInstance = new Storage(process.cwd());
+    vi.spyOn(storageInstance, 'isWorkspaceHomeDir').mockReturnValue(true);
+
     const mockConfig = {
-      getProjectRoot: vi.fn(() => homeDir),
+      getProjectRoot: vi.fn(() => process.cwd()),
       getExtensions: vi.fn(() => []),
       getFolderTrust: vi.fn(() => false),
       isTrustedFolder: vi.fn(() => false),
+      storage: storageInstance,
     } as unknown as Config;
     const loader = new FileCommandLoader(mockConfig);
     const commands = await loader.loadCommands(signal);
 
-    // Should load each command only once (as user commands), not twice
+    // Should only load user commands, not duplicate workspace commands
     expect(commands).toHaveLength(2);
-    const names = commands.map((c) => c.name);
-    expect(names).toContain('test');
-    expect(names).toContain('another');
-    // Verify they are loaded as user commands, not duplicated as workspace commands
-    expect(commands.every((c) => c.kind === CommandKind.USER_FILE)).toBe(true);
+    expect(commands.every((cmd) => cmd.kind === CommandKind.USER_FILE)).toBe(
+      true,
+    );
+    const names = commands.map((c) => c.name).sort();
+    expect(names).toEqual(['another', 'my_command']);
   });
 
   it('ignores files with TOML syntax errors', async () => {

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -218,8 +218,9 @@ export class FileCommandLoader implements ICommandLoader {
       kind: CommandKind.USER_FILE,
     });
 
-    // 2. Project commands (skip if same directory as user commands, e.g. when
-    //    cwd is the user's home directory, to avoid false conflict warnings)
+    // 2. Project commands — skip if the workspace IS the home directory,
+    // because user and workspace commands would resolve to the same path
+    // and cause false conflict warnings. See: github.com/google-gemini/gemini-cli/issues/22929
     if (!storage.isWorkspaceHomeDir()) {
       dirs.push({
         path: storage.getProjectCommandsDir(),


### PR DESCRIPTION
Resolves #22929 by using Storage.isWorkspaceHomeDir() to prevent duplicate loading of user commands as workspace commands, which caused false conflict warnings.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
