### PR TITLE
fix(ci): fix maintainer identification in lifecycle manager

### DIFF
--- a/.github/scripts/gemini-lifecycle-manager.cjs
+++ b/.github/scripts/gemini-lifecycle-manager.cjs
@@ -41,6 +41,41 @@ module.exports = async ({ github, context, core }) => {
     now.getTime() - NO_RESPONSE_DAYS * 24 * 60 * 60 * 1000,
   );
 
+  const maintainerCache = new Map();
+  async function isMaintainer(user, association) {
+    if (user?.type === 'Bot') return true;
+    if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association)) return true;
+
+    const username = user?.login;
+    if (!username) return false;
+
+    if (maintainerCache.has(username)) {
+      return maintainerCache.get(username);
+    }
+
+    try {
+      const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+        owner,
+        repo,
+        username,
+      });
+      // Permission can be admin, write, read, none.
+      // Roles like 'maintain' or 'triage' often map to 'write' or 'read' in the top-level field.
+      const isM =
+        ['admin', 'write'].includes(data.permission) ||
+        ['admin', 'maintain', 'write'].includes(data.role_name);
+
+      maintainerCache.set(username, isM);
+      return isM;
+    } catch (err) {
+      core.warning(
+        `Could not check permissions for ${username}: ${err.message}`,
+      );
+      maintainerCache.set(username, false);
+      return false;
+    }
+  }
+
   async function processItems(query, callback) {
     core.info(`Searching: ${query}`);
     try {
@@ -83,10 +118,7 @@ module.exports = async ({ github, context, core }) => {
       const lastComment = comments[0];
       if (
         lastComment &&
-        !['OWNER', 'MEMBER', 'COLLABORATOR'].includes(
-          lastComment.author_association,
-        ) &&
-        lastComment.user?.type !== 'Bot'
+        !(await isMaintainer(lastComment.user, lastComment.author_association))
       ) {
         core.info(
           `Removing ${NEED_INFO_LABEL} from #${item.number} due to contributor response.`,
@@ -188,11 +220,7 @@ module.exports = async ({ github, context, core }) => {
   await processItems(
     `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" -label:"status/pr-nudge-sent" created:${prCloseThreshold.toISOString()}..${nudgeThreshold.toISOString()}`,
     async (pr) => {
-      if (
-        ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association) ||
-        pr.user?.type === 'Bot'
-      )
-        return;
+      if (await isMaintainer(pr.user, pr.author_association)) return;
 
       core.info(`Nudging PR #${pr.number} for contribution policy.`);
       if (!dryRun) {
@@ -216,11 +244,7 @@ module.exports = async ({ github, context, core }) => {
   await processItems(
     `repo:${owner}/${repo} is:open is:pr -label:"help wanted" -label:"🔒 maintainer only" created:<${prCloseThreshold.toISOString()}`,
     async (pr) => {
-      if (
-        ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association) ||
-        pr.user?.type === 'Bot'
-      )
-        return;
+      if (await isMaintainer(pr.user, pr.author_association)) return;
 
       core.info(
         `Closing PR #${pr.number} per contribution policy (no 'help wanted').`,


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `gemini-lifecycle-manager.cjs` script where maintainers were being incorrectly identified as contributors, leading to their pull requests being nudged or closed per the contribution policy.

## Details

The GitHub search API's `author_association` field can default to `CONTRIBUTOR` or `NONE` for users with private organization memberships or those who access the repository via team permissions. This PR introduces a more robust `isMaintainer` helper that:
- Fast-paths known maintainer associations (`OWNER`, `MEMBER`, `COLLABORATOR`) and bots.
- Falls back to checking the user's explicit repository permission level (`getCollaboratorPermissionLevel`) for other users.
- Caches results to ensure efficiency and avoid redundant API calls.

## Related Issues

Fixes an issue where maintainers like `joshualitt` and `cocosheng-g` were being incorrectly targeted by the bot.

## How to Validate

The changes were validated by:
1. Identifying specific maintainers (`joshualitt`, `cocosheng-g`) who were being reported as `CONTRIBUTOR` in search results.
2. Verifying their actual repository permission level is `write` or `maintain`.
3. Testing the script logic with a mock script to ensure the new `isMaintainer` helper correctly handles these cases and exempts them from the policy.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
