### PR TITLE
fix(test): use auto-gemini-3 in plan-mode model switch test

### DIFF
--- a/integration-tests/plan-mode.test.ts
+++ b/integration-tests/plan-mode.test.ts
@@ -239,7 +239,7 @@ describe('Plan Mode', () => {
     await rig.setup('should-switch-to-flash', {
       settings: {
         model: {
-          name: 'auto-gemini-2.5',
+          name: 'auto-gemini-3',
         },
         experimental: { plan: true },
         tools: {


### PR DESCRIPTION
Summary
Fix a failing integration test caused by [gemini-2.5-flash](vscode-file://vscode-app/c:/Users/avitd/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) no longer being available in the Gemini API (v1beta).

Details
The test should switch from a pro model to a flash model after exiting plan mode used auto-gemini-2.5 as the model, which resolves to gemini-2.5-flash as the flash classifier target. That model now returns a ModelNotFoundError (404) from the API.

Changed the model to auto-gemini-3 and marked the test as pending a more stable long-term fix.

## Related Issues
issue number: #26704

## How to Validate

Run the integration test suite — should no longer fail with ModelNotFoundError.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [✅ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
