### PR TITLE
fix(core): add system PATH fallback for ripgrep discovery

### DIFF
--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -25,6 +25,7 @@ import { PassThrough, Readable } from 'node:stream';
 import EventEmitter from 'node:events';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { fileExists } from '../utils/fileUtils.js';
+import commandExists from 'command-exists';
 
 vi.mock('../utils/fileUtils.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/fileUtils.js')>();
@@ -33,6 +34,8 @@ vi.mock('../utils/fileUtils.js', async (importOriginal) => {
     fileExists: vi.fn(),
   };
 });
+
+vi.mock('command-exists');
 
 // Mock child_process for ripgrep calls
 vi.mock('child_process', () => ({
@@ -54,6 +57,7 @@ describe('canUseRipgrep', () => {
 
   it('should return false if file does not exist', async () => {
     vi.mocked(fileExists).mockResolvedValue(false);
+    vi.mocked(commandExists).mockRejectedValue(new Error('not found'));
     const result = await canUseRipgrep();
     expect(result).toBe(false);
   });
@@ -72,6 +76,7 @@ describe('ensureRgPath', () => {
 
   it('should throw an error if ripgrep cannot be used', async () => {
     vi.mocked(fileExists).mockResolvedValue(false);
+    vi.mocked(commandExists).mockRejectedValue(new Error('not found'));
     await expect(ensureRgPath()).rejects.toThrow(
       /Cannot find bundled ripgrep binary/,
     );
@@ -700,6 +705,7 @@ describe('RipGrepTool', () => {
 
     it('should throw an error if ripgrep is not available', async () => {
       vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(commandExists).mockRejectedValue(new Error('not found'));
 
       const params: RipGrepToolParams = { pattern: 'world' };
       const invocation = grepTool.build(params);
@@ -709,6 +715,7 @@ describe('RipGrepTool', () => {
 
       // restore the mock for subsequent tests
       vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(commandExists).mockReset();
     });
   });
 
@@ -2006,6 +2013,7 @@ describe('getRipgrepPath', () => {
 
     it('should return null if binary is missing from both paths', async () => {
       vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(commandExists).mockRejectedValue(new Error('not found'));
 
       const resolvedPath = await getRipgrepPath();
       expect(resolvedPath).toBeNull();

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import commandExists from 'command-exists';
 import { fileURLToPath } from 'node:url';
 import {
   BaseDeclarativeTool,
@@ -59,6 +60,15 @@ export async function getRipgrepPath(): Promise<string | null> {
     if (await fileExists(candidate)) {
       return candidate;
     }
+  }
+
+  // 3. System PATH fallback for non-SEA distributions (e.g. npm install -g)
+  try {
+    if (await commandExists('rg')) {
+      return 'rg';
+    }
+  } catch {
+    // Command does not exist or error checking
   }
 
   return null;


### PR DESCRIPTION
### Description

This PR re-introduces a fallback to the system `PATH` for `ripgrep` discovery, resolving the performance degradation reported in #26409.

When the CLI was refactored to bundle `ripgrep` for SEA distribution (PR #25342), the fallback logic that checked the system `PATH` for `rg` (or `rg.exe`) was removed. This effectively disabled `ripgrep` for users who install the CLI via `npm` or version managers (like `nvm` or `fnm`) but already have `rg` available globally on their systems.

### Solution

This patch introduces a 3-tier fallback inside `packages/core/src/tools/ripGrep.ts`:
1. **SEA layout:** Explicitly checks bundled path for the exact architecture binary (`rg-win32-x64.exe`).
2. **Dev/Dist layout:** Checks the development paths.
3. **System `PATH` (New):** Uses `command-exists` to detect if `rg` is available globally as a last resort.

By making the `PATH` check the final fallback, the CLI preserves its secure, self-contained guarantees for compiled SEA binaries while remaining performant and functional for Node/NPM developers.

### Testing
- `canUseRipgrep` tests updated with `command-exists` mocks.
- Verified that `npm run test -w @google/gemini-cli-core` passes successfully.

Fixes #26409