### PR TITLE
docs: update sandbox image command

### DIFF
--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -111,8 +111,8 @@ You can also run Gemini CLI using one of the following advanced methods:
     directly. This is useful for environments where you only have Docker and want
     to run the CLI.
     ```bash
-    # Run the published sandbox image
-    docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.1.1
+    # Run the published sandbox image for the current CLI version
+    docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.42.0-nightly.20260428.g59b2dea0e
     ```
   - **Using the `--sandbox` flag:** If you have Gemini CLI installed locally
     (using the standard installation described above), you can instruct it to run

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -111,7 +111,7 @@ You can also run Gemini CLI using one of the following advanced methods:
     directly. This is useful for environments where you only have Docker and want
     to run the CLI.
     ```bash
-    # Run the published sandbox image for the current CLI version
+    # Run the published sandbox image for a specified CLI version
     docker run --rm -it us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.42.0-nightly.20260428.g59b2dea0e
     ```
   - **Using the `--sandbox` flag:** If you have Gemini CLI installed locally


### PR DESCRIPTION
## Summary
- Update the Docker/Podman Sandbox example to use the current published sandbox image tag from the repo package metadata.
- Clarify that the command is for the current CLI version rather than the old `0.1.1` image.

Closes #23143.

## Testing
- `git diff --check`