### PR TITLE
fix(scripts): scrub CI / CONTINUOUS_INTEGRATION env vars in dev mode to keep ink interactive

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -71,6 +71,29 @@ if (isInDebugMode) {
   // than the relaunched process making it harder to debug.
   env.GEMINI_CLI_NO_RELAUNCH = 'true';
 }
+
+// Strip CI-related env vars before spawning the dev child. `is-in-ci`
+// (loaded transitively by `ink`) treats `CI`, `CONTINUOUS_INTEGRATION`,
+// and any `CI_*`-prefixed env var as a signal to disable interactive
+// rendering, which makes `npm run start` hang silently after the banner
+// whenever a developer has e.g. `CI_TOKEN` set in their shell. The bundled
+// path closes this via an esbuild alias on `is-in-ci` (#4822); we do the
+// dev-mode equivalent here so the unbundled `npm run start` flow doesn't
+// diverge. See issue #22452.
+const ciVarNames = Object.keys(env).filter(
+  (k) => k === 'CI' || k === 'CONTINUOUS_INTEGRATION' || k.startsWith('CI_'),
+);
+if (ciVarNames.length > 0) {
+  for (const name of ciVarNames) {
+    delete env[name];
+  }
+  process.stderr.write(
+    '[gemini-cli/dev] Cleared CI-related env vars to keep `ink` interactive: ' +
+      ciVarNames.join(', ') +
+      '\n[gemini-cli/dev] These vars are unset in the CLI process and its shell-tool subprocesses. Use the bundled build (`npm run bundle && node bundle/gemini.js`) to preserve them.\n',
+  );
+}
+
 const child = spawn('node', nodeArgs, { stdio: 'inherit', env });
 
 child.on('close', (code) => {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -72,23 +72,26 @@ if (isInDebugMode) {
   env.GEMINI_CLI_NO_RELAUNCH = 'true';
 }
 
-// Strip CI-related env vars before spawning the dev child. `is-in-ci`
-// (loaded transitively by `ink`) treats `CI`, `CONTINUOUS_INTEGRATION`,
-// and any `CI_*`-prefixed env var as a signal to disable interactive
-// rendering, which makes `npm run start` hang silently after the banner
-// whenever a developer has e.g. `CI_TOKEN` set in their shell. The bundled
-// path closes this via an esbuild alias on `is-in-ci` (#4822); we do the
-// dev-mode equivalent here so the unbundled `npm run start` flow doesn't
-// diverge. See issue #22452.
-const ciVarNames = Object.keys(env).filter(
-  (k) => k === 'CI' || k === 'CONTINUOUS_INTEGRATION' || k.startsWith('CI_'),
+// Strip CI-detection env vars before spawning the dev child. `is-in-ci`
+// (loaded transitively by `ink`, v2.0.0 in this repo) returns true when
+// either `CI` or `CONTINUOUS_INTEGRATION` is set to a non-falsy value,
+// and `ink` then disables interactive rendering — leaving `npm run start`
+// hanging silently after the banner. The bundled path closes this via an
+// esbuild alias on `is-in-ci` (#4822); we do the dev-mode equivalent here
+// so the unbundled flow doesn't diverge. The filter is intentionally
+// narrow: `is-in-ci` does not look at any `CI_*`-prefixed variables, so
+// developer-set tokens like `CI_TOKEN` / `CI_BUILD_ID` are preserved.
+// See issue #22452.
+const isFalsy = (v) => v === undefined || v === '0' || v === 'false';
+const ciVarNames = ['CI', 'CONTINUOUS_INTEGRATION'].filter(
+  (k) => !isFalsy(env[k]),
 );
 if (ciVarNames.length > 0) {
   for (const name of ciVarNames) {
     delete env[name];
   }
   process.stderr.write(
-    '[gemini-cli/dev] Cleared CI-related env vars to keep `ink` interactive: ' +
+    '[gemini-cli/dev] Cleared CI-detection env vars to keep `ink` interactive: ' +
       ciVarNames.join(', ') +
       '\n[gemini-cli/dev] These vars are unset in the CLI process and its shell-tool subprocesses. Use the bundled build (`npm run bundle && node bundle/gemini.js`) to preserve them.\n',
   );


### PR DESCRIPTION
## Summary

`npm run start` hangs silently after the banner whenever the developer's shell has `CI=true` or `CONTINUOUS_INTEGRATION=true`. `is-in-ci` — loaded transitively by `ink` inside the spawned child — reads those env vars and makes `ink` disable interactive rendering.

The bundled path closes this via an esbuild alias that replaces `is-in-ci` with a constant `false` (#4822). That alias is **never** applied in the unbundled dev flow, so the silent-hang regression still bites contributors. See #22452 for the report.

This change strips the offending vars from the env passed to the dev child in `scripts/start.js` and prints a one-line stderr warning listing what was removed, plus a short note that the variables are not propagated to shell-tool subprocesses in dev (pointing developers who need them to the bundled build).

Scope is intentionally limited to `scripts/start.js`, so the bundled and production paths are untouched.

## Scope of the filter

The filter targets exactly the two variables `is-in-ci@2.0.0` actually consults:

```js
// node_modules/ink/node_modules/is-in-ci/index.js
const check = (key) =>
  key in env && env[key] !== '0' && env[key] !== 'false';
const isInCi = check('CI') || check('CONTINUOUS_INTEGRATION');
```

Issue #22452 claimed any `CI_*`-prefixed variable also triggered the hang, but the `is-in-ci` source above shows that is **not** the case at the version pinned here. The filter therefore intentionally does **not** touch `CI_TOKEN`, `CI_BUILD_ID`, or any other `CI_*` developer-set token — those continue to propagate to the CLI process and to shell-tool subprocesses, matching the bundled-build behavior.

The filter also mirrors `is-in-ci`'s truthiness rule (skip `0`, `false`, or unset), so a developer who explicitly sets `CI=0` to mark "not in CI" still sees no-op behavior here.

## Why this approach

Two alternatives considered and rejected:

- **Runtime module shim of `is-in-ci`** to mirror the bundled alias: requires a `--import` preloader or ESM loader hook for the dev flow, more moving parts, and still requires changing the spawn invocation.
- **Scrub inside `packages/cli/index.ts`** at process startup: would also run in the bundled binary, duplicating the alias work and printing the warning in production for users who never see a hang.

Scrubbing only in the dev launcher is the smallest change that covers the bug, leaves production semantics untouched, and is naturally gated by the dev-mode entry point.

## Test plan

Verified manually on Windows (the change is platform-neutral; pure env filtering in Node):

- [x] `CI=true CI_TOKEN=x node scripts/start.js --version` → warning lists only `CI`; `CI_TOKEN` preserved
- [x] `CI=0 node scripts/start.js --version` → no warning (matches `is-in-ci` falsy rule)
- [x] `CONTINUOUS_INTEGRATION=1 node scripts/start.js --version` → warning lists `CONTINUOUS_INTEGRATION`
- [x] No `CI` / `CONTINUOUS_INTEGRATION` set → no warning printed
- [x] `node -c scripts/start.js` — syntax OK
- [x] `npx eslint scripts/start.js --max-warnings 0` — clean
- [x] pre-commit hook (prettier + eslint --fix) passes

Note: I did not add an automated test because `scripts/start.js` is a small integration-flavored launcher and exercising it end-to-end would require driving a real interactive Node child. Happy to extract the filter into a tiny pure helper with a unit test if reviewers prefer.

Fixes #22452