### PR TITLE
fix(core): add gemini-2.5-flash-lite to default fallback policy chain

### DIFF
--- a/packages/core/src/availability/policyCatalog.test.ts
+++ b/packages/core/src/availability/policyCatalog.test.ts
@@ -11,6 +11,8 @@ import {
   validateModelPolicyChain,
 } from './policyCatalog.js';
 import {
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
@@ -50,7 +52,10 @@ describe('policyCatalog', () => {
   it('returns default chain when preview disabled', () => {
     const chain = getModelPolicyChain({ previewEnabled: false });
     expect(chain[0]?.model).toBe(DEFAULT_GEMINI_MODEL);
-    expect(chain).toHaveLength(2);
+    expect(chain[1]?.model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    expect(chain[2]?.model).toBe(DEFAULT_GEMINI_FLASH_LITE_MODEL);
+    expect(chain[2]?.isLastResort).toBe(true);
+    expect(chain).toHaveLength(3);
   });
 
   it('marks preview transients as sticky retries when auto-selected', () => {

--- a/packages/core/src/availability/policyCatalog.ts
+++ b/packages/core/src/availability/policyCatalog.ts
@@ -122,6 +122,10 @@ export function getModelPolicyChain(
     }),
     definePolicy({
       model: DEFAULT_GEMINI_FLASH_MODEL,
+      maxAttempts: 10,
+    }),
+    definePolicy({
+      model: DEFAULT_GEMINI_FLASH_LITE_MODEL,
       isLastResort: true,
       maxAttempts: 10,
     }),


### PR DESCRIPTION
The default model fallback chain only included gemini-2.5-pro and gemini-2.5-flash, causing free-tier users to hit QUOTA_EXHAUSTED after 350 requests despite having 1,000 flash-lite RPD remaining.

Add gemini-2.5-flash-lite as the final last-resort model so the chain becomes: pro → flash → flash-lite.

Fixes #26841

## Summary

Free-tier users lost ~74% of daily capacity because `gemini-2.5-flash-lite` (1,000 RPD) was missing from the default fallback chain. After Pro (100) and Flash (250) quotas exhausted, CLI errored instead of falling back to Flash-Lite. This adds it as the final last-resort model.

## Details

- `getModelPolicyChain()` in `policyCatalog.ts` now returns a 3-model chain: `gemini-2.5-pro` → `gemini-2.5-flash` → `gemini-2.5-flash-lite`
- Moved `isLastResort: true` from Flash to Flash-Lite
- `DEFAULT_GEMINI_FLASH_LITE_MODEL` was already imported but unused in this chain
- Updated `policyCatalog.test.ts` to verify all 3 models and `isLastResort` on Flash-Lite

## Related Issues

Fixes #26841

## How to Validate

1. Run unit tests: `npx vitest run packages/core/src/availability/policyCatalog.test.ts` — all 12 tests pass
2. Exhaust Pro and Flash quotas, run `gemini -y -p "hello"` — CLI now falls back to Flash-Lite instead of erroring

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker