### PR TITLE
fix(core): trigger silent fallback in headless mode on quota exhaustion

### DIFF
--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -349,10 +349,8 @@ export class BaseLlmClient {
         maxAttempts:
           availabilityMaxAttempts ?? maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
         getAvailabilityContext,
-        onPersistent429: this.config.isInteractive()
-          ? (authType, error) =>
-              handleFallback(this.config, currentModel, authType, error)
-          : undefined,
+        onPersistent429: (authType, error) =>
+          handleFallback(this.config, currentModel, authType, error),
         authType:
           this.authType ?? this.config.getContentGeneratorConfig()?.authType,
         retryFetchErrors: this.config.getRetryFetchErrors(),

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -76,7 +76,7 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     getActiveModel: vi.fn(() => MOCK_PRO_MODEL),
     getModel: vi.fn(() => MOCK_PRO_MODEL),
     getUserTier: vi.fn(() => undefined),
-    isInteractive: vi.fn(() => false),
+    isInteractive: vi.fn(() => true),
     ...overrides,
   }) as unknown as Config;
 
@@ -156,6 +156,26 @@ describe('handleFallback', () => {
         MOCK_PRO_MODEL,
         DEFAULT_GEMINI_FLASH_MODEL,
         undefined,
+      );
+    });
+
+    it('silently falls back without calling handler in non-interactive (headless) mode', async () => {
+      vi.mocked(policyConfig.isInteractive).mockReturnValue(false);
+      vi.mocked(policyConfig.getModel).mockReturnValue(
+        DEFAULT_GEMINI_MODEL_AUTO,
+      );
+
+      const result = await handleFallback(
+        policyConfig,
+        MOCK_PRO_MODEL,
+        AUTH_OAUTH,
+      );
+
+      // Verify it fell back silently
+      expect(result).toBe(true);
+      expect(policyHandler).not.toHaveBeenCalled();
+      expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
+        DEFAULT_GEMINI_FLASH_MODEL,
       );
     });
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -69,7 +69,7 @@ export async function handleFallback(
     // failureKind is already declared and calculated above
     const action = resolvePolicyAction(failureKind, selectedPolicy);
 
-    if (action === 'silent') {
+    if (action === 'silent' || !config.isInteractive()) {
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
       return processIntent(config, 'retry_always', fallbackModel);
     }


### PR DESCRIPTION
Fixes #26840

## Summary

Enable automatic model fallback in headless (`-p`) mode when persistent quota exhaustion (`TerminalQuotaError` / `QUOTA_EXHAUSTED`) occurs for OAuth users.

Previously, fallback handling was gated behind `isInteractive()` in `BaseLlmClient`, causing headless executions to exit immediately instead of retrying with an available fallback model such as Flash or Flash-Lite.

This change aligns headless behavior with the existing interactive fallback flow while preserving non-interactive execution guarantees (no prompts or blocking UI interactions).

## Details

This PR makes three targeted changes:

1. `BaseLlmClient`
   - Always provides the `onPersistent429` callback to `handleFallback`.
   - This ensures quota exhaustion handling is available in both interactive and headless execution paths.

2. `handleFallback`
   - Automatically executes the fallback transition in non-interactive mode without invoking UI handlers.
   - Interactive mode behavior remains unchanged.

3. Tests
   - Updates existing fallback tests to explicitly mock interactive mode where required.
   - Adds regression coverage for silent fallback behavior in headless mode.

## Related Issues

Fixes #26840

## How to Validate

### Reproduction Flow

1. Authenticate using OAuth:
   ```bash
   gemini login
   ```

2. Exhaust the quota for `gemini-2.5-pro`.

3. Run:
   ```bash
   gemini -y -p "hello"
   ```

### Expected Result

- The CLI should automatically fall back to an available fallback model (for example `gemini-2.5-flash`).
- No interactive prompts should appear.
- The command should continue successfully instead of exiting immediately with `TerminalQuotaError`.

### Test Suite

Run:

```bash
npm run build
npm test -w @google/gemini-cli-core
```

Validated successfully with:
- 385 test files passed
- 7306 tests passed

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Validated locally with `npm test -w @google/gemini-cli-core`
- [x] Preserved existing interactive fallback behavior
- [x] Ensured no prompts/blocking behavior in headless mode