### PR TITLE
fix(core): allow plan mode writes to custom plans directory

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -24,7 +24,7 @@ import { DEFAULT_MAX_ATTEMPTS } from '../utils/retry.js';
 import { ExperimentFlags } from '../code_assist/experiments/flagNames.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
-import { ApprovalMode } from '../policy/types.js';
+import { ApprovalMode, PolicyDecision } from '../policy/types.js';
 import {
   HookType,
   HookEventName,
@@ -4119,6 +4119,126 @@ describe('Plans Directory Initialization', () => {
     // Should still add the fallback plans directory to workspace context if it exists
     const context = config.getWorkspaceContext();
     expect(context.getDirectories()).toContain(plansDir);
+  });
+
+  it('should allow Plan Mode writes only to direct Markdown files in the active plans directory', async () => {
+    vi.spyOn(fs.promises, 'access').mockRejectedValue({ code: 'ENOENT' });
+    const config = new Config({
+      ...baseParams,
+      approvalMode: ApprovalMode.PLAN,
+      plan: true,
+      planSettings: {
+        directory: 'custom-plans',
+      },
+    });
+
+    await config.initialize();
+
+    const plansDir = config.storage.getPlansDir();
+    const engine = config.getPolicyEngine();
+
+    await expect(
+      engine.check(
+        {
+          name: 'write_file',
+          args: {
+            file_path: path.join(plansDir, 'foo.md'),
+            content: 'plan',
+          },
+        },
+        undefined,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ALLOW });
+
+    await expect(
+      engine.check(
+        {
+          name: 'replace',
+          args: {
+            file_path: path.join(plansDir, 'foo.md'),
+            old_string: 'old',
+            new_string: 'new',
+          },
+        },
+        undefined,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ALLOW });
+
+    await expect(
+      engine.check(
+        {
+          name: 'write_file',
+          args: {
+            file_path: path.join(plansDir, 'nested', 'foo.md'),
+            content: 'plan',
+          },
+        },
+        undefined,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ASK_USER });
+
+    await expect(
+      engine.check(
+        {
+          name: 'write_file',
+          args: {
+            file_path: path.join(plansDir, 'foo.txt'),
+            content: 'plan',
+          },
+        },
+        undefined,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ASK_USER });
+
+    await expect(
+      engine.check(
+        {
+          name: 'write_file',
+          args: {
+            file_path: path.join(config.getProjectRoot(), 'src', 'foo.md'),
+            content: 'plan',
+          },
+        },
+        undefined,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ASK_USER });
+  });
+
+  it('should let higher-priority policy denies override active plans directory writes', async () => {
+    vi.spyOn(fs.promises, 'access').mockRejectedValue({ code: 'ENOENT' });
+    const config = new Config({
+      ...baseParams,
+      approvalMode: ApprovalMode.PLAN,
+      plan: true,
+      planSettings: {
+        directory: 'custom-plans',
+      },
+      policyEngineConfig: {
+        rules: [
+          {
+            toolName: 'write_file',
+            decision: PolicyDecision.DENY,
+            priority: 3,
+            modes: [ApprovalMode.PLAN],
+          },
+        ],
+      },
+    });
+
+    await config.initialize();
+
+    const result = await config.getPolicyEngine().check(
+      {
+        name: 'write_file',
+        args: {
+          file_path: path.join(config.storage.getPlansDir(), 'foo.md'),
+          content: 'plan',
+        },
+      },
+      undefined,
+    );
+
+    expect(result.decision).toBe(PolicyDecision.DENY);
   });
 
   it('should NOT create plans directory or add it to workspace context when plan is disabled', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -182,7 +182,11 @@ import { fetchAdminControls } from '../code_assist/admin/admin_controls.js';
 import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 import { InjectionService } from './injectionService.js';
 import { ExecutionLifecycleService } from '../services/executionLifecycleService.js';
-import { WORKSPACE_POLICY_TIER } from '../policy/config.js';
+import {
+  createPlanModePlansDirectoryRules,
+  PLAN_MODE_PLANS_DIR_RULE_SOURCE,
+  WORKSPACE_POLICY_TIER,
+} from '../policy/config.js';
 import { loadPoliciesFromToml } from '../policy/toml-loader.js';
 
 import { CheckerRunner } from '../safety/checker-runner.js';
@@ -1471,6 +1475,8 @@ export class Config implements McpContext, AgentLoopContext {
         // directories must be within the project root, they are automatically
         // covered by the project-wide file discovery once created.
       }
+
+      this.refreshPlanModePlansDirectoryPolicy(plansDir);
     }
 
     // Initialize centralized FileDiscoveryService
@@ -2166,6 +2172,15 @@ export class Config implements McpContext, AgentLoopContext {
       // Ignore invalid or unreadable plans directories here. This mirrors
       // initialization behavior, which only adds the plans directory when it
       // already exists and is readable.
+    }
+
+    this.refreshPlanModePlansDirectoryPolicy(nextPlansDir);
+  }
+
+  private refreshPlanModePlansDirectoryPolicy(plansDir: string): void {
+    this.policyEngine.removeRulesBySource(PLAN_MODE_PLANS_DIR_RULE_SOURCE);
+    for (const rule of createPlanModePlansDirectoryRules(plansDir)) {
+      this.policyEngine.addRule(rule);
     }
   }
 

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -18,9 +18,11 @@ import {
 import { isDirectorySecure } from '../utils/security.js';
 import {
   createPolicyEngineConfig,
+  createPlanModePlansDirectoryRules,
   clearEmittedPolicyWarnings,
   getPolicyDirectories,
 } from './config.js';
+import { PolicyEngine } from './policy-engine.js';
 import { Storage } from '../config/storage.js';
 import * as tomlLoader from './toml-loader.js';
 import { coreEvents } from '../utils/events.js';
@@ -50,6 +52,98 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 afterEach(() => {
   vi.resetAllMocks();
+});
+
+describe('createPlanModePlansDirectoryRules', () => {
+  async function checkWriteFileDecision(plansDir: string, filePath: string) {
+    const engine = new PolicyEngine({
+      approvalMode: ApprovalMode.PLAN,
+      rules: [
+        ...createPlanModePlansDirectoryRules(plansDir),
+        {
+          toolName: 'write_file',
+          decision: PolicyDecision.DENY,
+          priority: 1.065,
+          modes: [ApprovalMode.PLAN],
+        },
+      ],
+    });
+
+    return engine.check(
+      {
+        name: 'write_file',
+        args: { file_path: filePath, content: 'plan' },
+      },
+      undefined,
+    );
+  }
+
+  async function expectOnlyDirectMarkdownFilesAllowed(
+    plansDir: string,
+    directMarkdownPath: string,
+    nestedMarkdownPath: string,
+    nonMarkdownPath: string,
+    traversalPath: string,
+  ) {
+    await expect(
+      checkWriteFileDecision(plansDir, directMarkdownPath),
+    ).resolves.toMatchObject({ decision: PolicyDecision.ALLOW });
+
+    await expect(
+      checkWriteFileDecision(plansDir, nestedMarkdownPath),
+    ).resolves.toMatchObject({ decision: PolicyDecision.DENY });
+
+    await expect(
+      checkWriteFileDecision(plansDir, nonMarkdownPath),
+    ).resolves.toMatchObject({ decision: PolicyDecision.DENY });
+
+    await expect(
+      checkWriteFileDecision(plansDir, traversalPath),
+    ).resolves.toMatchObject({ decision: PolicyDecision.DENY });
+  }
+
+  it('should match only direct Markdown files in a POSIX custom plans directory', async () => {
+    const plansDir = '/project/custom-plans';
+
+    await expectOnlyDirectMarkdownFilesAllowed(
+      plansDir,
+      '/project/custom-plans/foo.md',
+      '/project/custom-plans/nested/foo.md',
+      '/project/custom-plans/foo.txt',
+      '/project/custom-plans/../foo.md',
+    );
+  });
+
+  it('should match only direct Markdown files in a Windows drive custom plans directory', async () => {
+    const plansDir = String.raw`C:\project\custom-plans`;
+
+    await expectOnlyDirectMarkdownFilesAllowed(
+      plansDir,
+      String.raw`C:\project\custom-plans\foo.md`,
+      String.raw`C:\project\custom-plans\nested\foo.md`,
+      String.raw`C:\project\custom-plans\foo.txt`,
+      String.raw`C:\project\custom-plans\..\foo.md`,
+    );
+  });
+
+  it('should match only direct Markdown files in a Windows UNC custom plans directory', async () => {
+    const plansDir = String.raw`\\server\share\project\custom-plans`;
+
+    await expectOnlyDirectMarkdownFilesAllowed(
+      plansDir,
+      String.raw`\\server\share\project\custom-plans\foo.md`,
+      String.raw`\\server\share\project\custom-plans\nested\foo.md`,
+      String.raw`\\server\share\project\custom-plans\foo.txt`,
+      String.raw`\\server\share\project\custom-plans\..\foo.md`,
+    );
+
+    await expect(
+      checkWriteFileDecision(
+        plansDir,
+        String.raw`\server\share\project\custom-plans\foo.md`,
+      ),
+    ).resolves.toMatchObject({ decision: PolicyDecision.DENY });
+  });
 });
 
 describe('createPolicyEngineConfig', () => {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -20,7 +20,7 @@ import {
 } from './types.js';
 import type { PolicyEngine } from './policy-engine.js';
 import { loadPoliciesFromToml, type PolicyFileError } from './toml-loader.js';
-import { buildArgsPatterns, isSafeRegExp } from './utils.js';
+import { buildArgsPatterns, escapeRegex, isSafeRegExp } from './utils.js';
 import toml from '@iarna/toml';
 import {
   MessageBusType,
@@ -31,8 +31,10 @@ import { coreEvents } from '../utils/events.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { SHELL_TOOL_NAMES } from '../utils/shell-utils.js';
 import {
+  EDIT_TOOL_NAME,
   SHELL_TOOL_NAME,
   TOOLS_REQUIRING_NARROWING,
+  WRITE_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
 import { isNodeError } from '../utils/errors.js';
 import { MCP_TOOL_PREFIX } from '../tools/mcp-tool.js';
@@ -84,6 +86,39 @@ export const ALLOWED_MCP_SERVER_PRIORITY = USER_POLICY_TIER + 0.1;
 // Workspace tier (3) + high priority (950/1000) = ALWAYS_ALLOW_PRIORITY
 export const ALWAYS_ALLOW_PRIORITY =
   WORKSPACE_POLICY_TIER + ALWAYS_ALLOW_PRIORITY_OFFSET;
+
+export const PLAN_MODE_PLANS_DIR_RULE_SOURCE =
+  'PlanModePlansDirectory (Dynamic)';
+export const PLAN_MODE_PLANS_DIR_ALLOW_PRIORITY =
+  DEFAULT_POLICY_TIER + 0.066;
+
+function buildDirectMarkdownInDirectoryArgsPattern(dir: string): RegExp {
+  const resolvedDir = path.resolve(dir);
+  const hasRootPrefix =
+    resolvedDir.startsWith(path.sep) || /^[\\/]/.test(resolvedDir);
+  const segments = resolvedDir.split(/[\\/]+/).filter(Boolean);
+  const dirPattern =
+    (hasRootPrefix ? '[\\\\/]+' : '') +
+    segments.map((segment) => escapeRegex(segment)).join('[\\\\/]+');
+
+  return new RegExp(
+    `\\x00${escapeRegex('"file_path":"')}${dirPattern}[\\\\/]+[^"\\\\/]+\\.md${escapeRegex('"')}\\x00`,
+  );
+}
+
+export function createPlanModePlansDirectoryRules(
+  plansDir: string,
+): PolicyRule[] {
+  const argsPattern = buildDirectMarkdownInDirectoryArgsPattern(plansDir);
+  return [WRITE_FILE_TOOL_NAME, EDIT_TOOL_NAME].map((toolName) => ({
+    toolName,
+    argsPattern,
+    decision: PolicyDecision.ALLOW,
+    priority: PLAN_MODE_PLANS_DIR_ALLOW_PRIORITY,
+    modes: [ApprovalMode.PLAN],
+    source: PLAN_MODE_PLANS_DIR_RULE_SOURCE,
+  }));
+}
 
 /**
  * Returns the fractional priority of ALWAYS_ALLOW_PRIORITY scaled to 1000.

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -40,6 +40,7 @@ import { isNodeError } from '../utils/errors.js';
 import { MCP_TOOL_PREFIX } from '../tools/mcp-tool.js';
 
 import { isDirectorySecure } from '../utils/security.js';
+import { resolveToRealPath } from '../utils/paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -92,14 +93,77 @@ export const PLAN_MODE_PLANS_DIR_RULE_SOURCE =
 export const PLAN_MODE_PLANS_DIR_ALLOW_PRIORITY =
   DEFAULT_POLICY_TIER + 0.066;
 
+function resolveToRealPathForPattern(
+  dir: string,
+  fallbackNormalize: (path: string) => string,
+): string {
+  try {
+    return resolveToRealPath(dir);
+  } catch {
+    return fallbackNormalize(dir);
+  }
+}
+
+function resolvePlansDirForPolicyPattern(dir: string): string {
+  if (/^[\\/]{2}[^\\/]+[\\/]+[^\\/]+/.test(dir)) {
+    return process.platform === 'win32'
+      ? resolveToRealPathForPattern(dir, path.win32.normalize)
+      : path.win32.normalize(dir);
+  }
+
+  if (/^[a-zA-Z]:[\\/]/.test(dir)) {
+    return process.platform === 'win32'
+      ? resolveToRealPathForPattern(dir, path.win32.normalize)
+      : path.win32.normalize(dir);
+  }
+
+  if (dir.startsWith('/')) {
+    return process.platform === 'win32'
+      ? path.posix.normalize(dir)
+      : resolveToRealPathForPattern(dir, path.posix.normalize);
+  }
+
+  return resolveToRealPathForPattern(dir, path.normalize);
+}
+
+function joinEscapedPathSegments(segments: string[]): string {
+  return segments.map((segment) => escapeRegex(segment)).join('[\\\\/]+');
+}
+
 function buildDirectMarkdownInDirectoryArgsPattern(dir: string): RegExp {
-  const resolvedDir = path.resolve(dir);
-  const hasRootPrefix =
-    resolvedDir.startsWith(path.sep) || /^[\\/]/.test(resolvedDir);
-  const segments = resolvedDir.split(/[\\/]+/).filter(Boolean);
-  const dirPattern =
-    (hasRootPrefix ? '[\\\\/]+' : '') +
-    segments.map((segment) => escapeRegex(segment)).join('[\\\\/]+');
+  const resolvedDir = resolvePlansDirForPolicyPattern(dir);
+  const uncMatch = resolvedDir.match(
+    /^[\\/]{2}([^\\/]+)[\\/]+([^\\/]+)(?:[\\/]+(.*))?$/,
+  );
+  const driveMatch = resolvedDir.match(/^([a-zA-Z]:)[\\/]*(.*)$/);
+
+  let dirPattern: string;
+  if (uncMatch) {
+    const [, server, share, rest = ''] = uncMatch;
+    dirPattern = [
+      '(?:/{2,}|\\\\{4,})',
+      escapeRegex(server),
+      '[\\\\/]+',
+      escapeRegex(share),
+      ...rest
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .flatMap((segment) => ['[\\\\/]+', escapeRegex(segment)]),
+    ].join('');
+  } else if (driveMatch) {
+    const [, drive, rest] = driveMatch;
+    const segments = rest.split(/[\\/]+/).filter(Boolean);
+    dirPattern =
+      escapeRegex(drive) +
+      (segments.length > 0
+        ? `[\\\\/]+${joinEscapedPathSegments(segments)}`
+        : '');
+  } else {
+    const hasRootPrefix = /^[\\/]/.test(resolvedDir);
+    const segments = resolvedDir.split(/[\\/]+/).filter(Boolean);
+    dirPattern =
+      (hasRootPrefix ? '[\\\\/]+' : '') + joinEscapedPathSegments(segments);
+  }
 
   return new RegExp(
     `\\x00${escapeRegex('"file_path":"')}${dirPattern}[\\\\/]+[^"\\\\/]+\\.md${escapeRegex('"')}\\x00`,

--- a/packages/core/src/policy/toml-loader.test.ts
+++ b/packages/core/src/policy/toml-loader.test.ts
@@ -859,6 +859,53 @@ priority = 100
   });
 
   describe('Built-in Plan Mode Policy', () => {
+    it('should deny custom plans directory writes with static Plan Mode policy alone', async () => {
+      const planTomlPath = path.resolve(__dirname, 'policies', 'plan.toml');
+      const fileContent = await fs.readFile(planTomlPath, 'utf-8');
+      const tempPolicyDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'plan-custom-dir-test-'),
+      );
+      try {
+        await fs.writeFile(path.join(tempPolicyDir, 'plan.toml'), fileContent);
+        const result = await loadPoliciesFromToml([tempPolicyDir], () => 1);
+        expect(result.errors).toHaveLength(0);
+
+        const engine = new PolicyEngine({
+          rules: result.rules,
+          approvalMode: ApprovalMode.PLAN,
+        });
+
+        const defaultPlansPath = path.resolve(
+          '/project/.gemini/tmp/session/plans/foo.md',
+        );
+        const defaultResult = await engine.check(
+          {
+            name: 'write_file',
+            args: { file_path: defaultPlansPath, content: 'plan' },
+          },
+          undefined,
+        );
+        expect(defaultResult.decision).toBe(PolicyDecision.ALLOW);
+
+        const customPlansPath = path.resolve(
+          '/project/custom-plans/foo.md',
+        );
+        const customResult = await engine.check(
+          {
+            name: 'write_file',
+            args: { file_path: customPlansPath, content: 'plan' },
+          },
+          undefined,
+        );
+        expect(customResult.decision).toBe(PolicyDecision.DENY);
+        expect(customResult.rule?.denyMessage).toContain(
+          'You are in Plan Mode and cannot modify source code',
+        );
+      } finally {
+        await fs.rm(tempPolicyDir, { recursive: true, force: true });
+      }
+    });
+
     it('should allow MCP tools with readOnlyHint annotation in Plan Mode (ASK_USER, not DENY)', async () => {
       const planTomlPath = path.resolve(__dirname, 'policies', 'plan.toml');
       const fileContent = await fs.readFile(planTomlPath, 'utf-8');


### PR DESCRIPTION
## Summary

Fixes #26849.

Plan Mode already surfaces the active plans directory through `config.storage.getPlansDir()`, including custom `planSettings.directory` values. However, the static Plan Mode policy only allowed `write_file` / `replace` for the default `.gemini/tmp/.../plans/*.md` path shape.

Because policy checks run before tool validation, writes to a valid custom plans directory could be denied before `write_file` or `replace` could validate them against the active plans directory.

This PR adds a narrow dynamic Plan Mode allow rule for the resolved active plans directory while keeping the existing `plan.toml` rules and catch-all Plan Mode deny unchanged.

## Details

- Adds dynamic Plan Mode allow rules for `write_file` and `replace`
- Applies the rules only in `ApprovalMode.PLAN`
- Allows only direct `.md` files under the resolved active plans directory
- Preserves the existing static Plan Mode policy and deny behavior
- Refreshes the dynamic rule when the active/session plans directory changes
- Adds regression coverage for the static policy behavior and custom plans directory handling

## Validation

- `npm test --workspace @google/gemini-cli-core -- --coverage=false src/policy/toml-loader.test.ts`
- `npm test --workspace @google/gemini-cli-core -- --coverage=false src/config/config.test.ts`
- `npm test --workspace @google/gemini-cli-core -- --coverage=false src/tools/write-file.test.ts`
- `npm test --workspace @google/gemini-cli-core -- --coverage=false src/tools/edit.test.ts`
- `npm test --workspace @google/gemini-cli-core -- --coverage=false src/policy/policy-engine.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run lint --workspace @google/gemini-cli-core`
- `git diff --check`