### PR TITLE
fix(core): accept null MCP resource lists

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -881,15 +881,37 @@ describe('mcp-client', () => {
     it('treats null resources from resources/list as empty', async () => {
       const mockedClient = {
         getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
-        request: vi.fn().mockResolvedValue({
-          resources: null,
-        }),
+        request: vi.fn().mockImplementation((_request, resultSchema) =>
+          Promise.resolve(
+            (resultSchema as { parse: (result: unknown) => unknown }).parse({
+              resources: null,
+            }),
+          ),
+        ),
       } as unknown as ClientLib.Client;
 
       await expect(
         discoverResources('test-server', mockedClient, MOCK_CONTEXT),
       ).resolves.toEqual([]);
       expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
+    });
+
+    it('still rejects invalid resource list shapes', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
+        request: vi.fn().mockImplementation((_request, resultSchema) =>
+          Promise.resolve(
+            (resultSchema as { parse: (result: unknown) => unknown }).parse({
+              resources: 123,
+            }),
+          ),
+        ),
+      } as unknown as ClientLib.Client;
+
+      await expect(
+        discoverResources('test-server', mockedClient, MOCK_CONTEXT),
+      ).rejects.toThrow();
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).toHaveBeenCalledOnce();
     });
 
     it('refreshes registry when resource list change notification is received', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -37,6 +37,7 @@ import {
   isEnabled,
   McpClient,
   populateMcpServerCommand,
+  discoverResources,
   discoverPrompts,
   type McpContext,
 } from './mcp-client.js';
@@ -875,6 +876,20 @@ describe('mcp-client', () => {
           }),
         ],
       );
+    });
+
+    it('treats null resources from resources/list as empty', async () => {
+      const mockedClient = {
+        getServerCapabilities: vi.fn().mockReturnValue({ resources: {} }),
+        request: vi.fn().mockResolvedValue({
+          resources: null,
+        }),
+      } as unknown as ClientLib.Client;
+
+      await expect(
+        discoverResources('test-server', mockedClient, MOCK_CONTEXT),
+      ).resolves.toEqual([]);
+      expect(MOCK_CONTEXT.emitMcpDiagnostic).not.toHaveBeenCalled();
     });
 
     it('refreshes registry when resource list change notification is received', async () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -37,6 +37,7 @@ import {
   type Resource,
   type Tool as McpTool,
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod/v4';
 import { parse } from 'shell-quote';
 import {
   AuthProviderType,
@@ -88,6 +89,18 @@ import {
 } from '../services/shellExecutionService.js';
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
+
+const LenientListResourcesResultSchema = z.preprocess((result) => {
+  if (
+    result !== null &&
+    typeof result === 'object' &&
+    'resources' in result &&
+    (result as { resources?: unknown }).resources === null
+  ) {
+    return { ...result, resources: [] };
+  }
+  return result;
+}, ListResourcesResultSchema);
 
 export type DiscoveredMCPPrompt = Prompt & {
   serverName: string;
@@ -1501,7 +1514,7 @@ async function listResources(
           method: 'resources/list',
           params: cursor ? { cursor } : {},
         },
-        ListResourcesResultSchema,
+        LenientListResourcesResultSchema,
       );
       resources.push(...(response.resources ?? []));
       cursor = response.nextCursor ?? undefined;


### PR DESCRIPTION
## Summary

Fix MCP resource discovery when a server returns `resources: null` from `resources/list` instead of an empty array.

## Details

Some MCP servers can respond with `{ resources: null }` when they have no resources. The SDK schema rejects that shape before Gemini CLI can treat it as an empty resource list, which causes MCP discovery to fail.

This keeps the normal `ListResourcesResultSchema` validation in place, but preprocesses only that specific `resources: null` case to `resources: []` for the `resources/list` response. Other invalid resource-list responses still go through the SDK schema unchanged.

## Related Issues

Fixes #20363

## How to Validate

I validated locally on Windows with:

```bash
npm run typecheck -w @google/gemini-cli-core
npm run build -w @google/gemini-cli-core
npm test -w @google/gemini-cli-core -- src/tools/mcp-client.test.ts
npm run lint -w @google/gemini-cli-core -- src/tools/mcp-client.ts src/tools/mcp-client.test.ts
git diff --check
```

Expected results:

- Core typecheck passes.
- Core build passes.
- `src/tools/mcp-client.test.ts` passes, including the new `resources: null` regression test.
- Lint and whitespace checks pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker