### PR TITLE
fix(cli/acp): prevent infinite thought loop in ACP mode by disablig nextSpeakerCheck

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1043,6 +1043,28 @@ describe('loadCliConfig', () => {
 
     expect(config.isInteractive()).toBe(false);
   });
+
+  describe('isAcpMode', () => {
+    it('should force skipNextSpeakerCheck to true when in ACP mode', async () => {
+      process.argv = ['node', 'script.js', '--acp'];
+      const argv = await parseArguments(createTestMergedSettings());
+      const settings = createTestMergedSettings({
+        model: { skipNextSpeakerCheck: false },
+      });
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.getSkipNextSpeakerCheck()).toBe(true);
+    });
+
+    it('should respect settings.model.skipNextSpeakerCheck when not in ACP mode', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments(createTestMergedSettings());
+      const settings = createTestMergedSettings({
+        model: { skipNextSpeakerCheck: false },
+      });
+      const config = await loadCliConfig(settings, 'test-session', argv);
+      expect(config.getSkipNextSpeakerCheck()).toBe(false);
+    });
+  });
 });
 
 describe('Hierarchical Memory Loading (config.ts) - Placeholder Suite', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1105,7 +1105,11 @@ export async function loadCliConfig(
     shellToolInactivityTimeout: settings.tools?.shell?.inactivityTimeout,
     enableShellOutputEfficiency:
       settings.tools?.shell?.enableShellOutputEfficiency ?? true,
-    skipNextSpeakerCheck: settings.model?.skipNextSpeakerCheck,
+    // In ACP mode, always skip the next-speaker check. This check triggers
+    // recursive continuation turns inside GeminiClient.processTurn() that
+    // conflict with ACP's explicit turn management via session/prompt,
+    // causing infinite agent_thought_chunk loops.
+    skipNextSpeakerCheck: isAcpMode || settings.model?.skipNextSpeakerCheck,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
     eventEmitter: coreEvents,
     useWriteTodos: argv.useWriteTodos ?? settings.useWriteTodos,


### PR DESCRIPTION
## Summary

Forces `skipNextSpeakerCheck` to `true` when the CLI is running in ACP mode. This prevents the core GeminiClient from recursively initiating synthetic continuation turns, which previously resulted in unbounded `agent_thought_chunk` loops during ACP sessions.

## Details

Why this happened:
The `nextSpeakerCheck` mechanism in `GeminiClient` was designed for the interactive terminal TUI. When a model returns a turn without explicit content or tools (e.g., thought-only responses), this mechanism makes a separate LLM call to evaluate if the model was cut off or expects to continue. If it decides the model should continue, it automatically injects a "Please continue." prompt and recurses the turn inside the generator.

However, in ACP mode, turn boundaries are explicit and strictly managed by the IDE client via the `session/prompt` protocol. The core client's internal recursive continuation bypasses the ACP session's `while(true)` outer loop. Because the ACP protocol expects the stream to end so it can evaluate tools or wait for the next user input, the internal continuation traps the agent in a loop where it perpetually emits thoughts without returning control to the client.

How we are fixing it:
Modified `loadCliConfig` in `packages/cli/src/config/config.ts` to apply an explicit override: `skipNextSpeakerCheck: isAcpMode || settings.model?.skipNextSpeakerCheck`

This ensures that regardless of the user's local `settings.json`, ACP sessions will always bypass the `checkNextSpeaker` flow. As a result, when an invalid or thought-only stream ends, the `GeminiClient` correctly yields control back to `acpSession.ts`, which emits an `end_turn` stop reason and allows the IDE protocol to gracefully handle the next step.

## Related Issues

Fixes google-gemini/maintainers-gemini-cli#1662

## How to Validate

There is no loop anymore. This is hard to repro so harder to validate.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
