### PR TITLE
fix(security): add IPv6 loopback to host header validation

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -535,4 +535,21 @@ describe('IDEServer HTTP endpoints', () => {
     // but it's not a host error, which is what we are testing.
     expect(response.statusCode).toBe(400);
   });
+
+  it('should allow requests with IPv6 loopback host header', async () => {
+    const response = await request(
+      port,
+      {
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          Host: `[::1]:${port}`,
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-auth-token',
+        },
+      },
+      JSON.stringify({ jsonrpc: '2.0', method: 'initialize' }),
+    );
+    expect(response.statusCode).toBe(400);
+  });
 });

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -164,6 +164,7 @@ export class IDEServer {
         const allowedHosts = [
           `localhost:${this.port}`,
           `127.0.0.1:${this.port}`,
+          `[::1]:${this.port}`,
         ];
         if (!allowedHosts.includes(host)) {
           return res.status(403).json({ error: 'Invalid Host header' });


### PR DESCRIPTION
The IDE server host validation only checked localhost and 127.0.0.1, missing the IPv6 loopback address [::1]. This could allow DNS rebinding attacks using alternative loopback aliases.


## Summary

The IDE Companion server's host header validation only accepted `localhost` and `127.0.0.1`, missing the IPv6 loopback `[::1]`. On systems where `localhost` resolves to IPv6, legitimate local requests could be rejected, and attackers could exploit the gap via DNS rebinding using alternative loopback aliases.

## Details

- Added `[::1]:PORT` to the `allowedHosts` array in the host validation middleware in `ide-server.ts`
- Added a test verifying requests with the IPv6 loopback Host header are accepted
- The server still binds to `127.0.0.1` only — this is a defensive hardening of the Host header check

## Related Issues

Fixes #26830

## How to Validate

1. Run the unit tests: `npx vitest run packages/vscode-ide-companion/src/ide-server.test.ts` — all 13 tests pass (1 skipped is Windows-only)
2. Verify the new test: the `should allow requests with IPv6 loopback host header` test sends a request with `Host: [::1]:PORT` and confirms it passes host validation (returns 400 for invalid MCP payload, not 403 for host rejection)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker