### PR TITLE
fix(cli): enable adk non-interactive session

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -5,7 +5,10 @@
     "autoMemory": true,
     "memoryManager": true,
     "topicUpdateNarration": true,
-    "voiceMode": true
+    "voiceMode": true,
+    "adk": {
+      "agentSessionNoninteractiveEnabled": true
+    }
   },
   "general": {
     "devtools": true

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -68,7 +68,9 @@ export async function runNonInteractive(
 ): Promise<void> {
   const useAgentSession = params.config.getAgentSessionNoninteractiveEnabled();
   if (useAgentSession) {
-    debugLogger.debug('[ADK] Running non-interactive mode with ADK agent session');
+    debugLogger.debug(
+      '[ADK] Running non-interactive mode with ADK agent session',
+    );
     return runNonInteractiveAgentSession(params);
   }
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -68,6 +68,7 @@ export async function runNonInteractive(
 ): Promise<void> {
   const useAgentSession = params.config.getAgentSessionNoninteractiveEnabled();
   if (useAgentSession) {
+    debugLogger.debug('[ADK] Running non-interactive mode with ADK agent session');
     return runNonInteractiveAgentSession(params);
   }
 


### PR DESCRIPTION
## Summary

This PR enables the ADK agent session for non-interactive mode by default in settings and logs its usage.

## Details

- Added `adk.agentSessionNoninteractiveEnabled: true` to `.gemini/settings.json`.
- Added a debug log in `nonInteractiveCli.ts` when using the ADK agent session.

## Related Issues

None.

## How to Validate

1. Run the CLI in non-interactive mode.
2. Check the debug logs to see `[ADK] Running non-interactive mode with ADK agent session`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
