### PR TITLE
chore: update checkout action configuration in workflows

### DIFF
--- a/.github/workflows/build-unsigned-mac-binaries.yml
+++ b/.github/workflows/build-unsigned-mac-binaries.yml
@@ -30,6 +30,7 @@ jobs:
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
         with:
           ref: '${{ inputs.ref || github.ref }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4

--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           ref: '${{ needs.parse_run_context.outputs.sha }}'
           repository: '${{ needs.parse_run_context.outputs.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
@@ -193,6 +194,7 @@ jobs:
         with:
           ref: '${{ needs.parse_run_context.outputs.sha }}'
           repository: '${{ needs.parse_run_context.outputs.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js 20.x'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
@@ -233,6 +235,7 @@ jobs:
         with:
           ref: '${{ needs.parse_run_context.outputs.sha }}'
           repository: '${{ needs.parse_run_context.outputs.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js 20.x'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
@@ -314,6 +317,7 @@ jobs:
         with:
           ref: '${{ needs.parse_run_context.outputs.sha }}'
           repository: '${{ needs.parse_run_context.outputs.repository }}'
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 'Set up Node.js 20.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
           fetch-depth: 0
 
@@ -130,6 +131,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: 'Link Checker'
         uses: 'lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2' # ratchet: lycheeverse/lychee-action@v2.6.1
         with:
@@ -157,6 +160,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
@@ -252,6 +257,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
@@ -339,6 +346,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
 
       - name: 'Initialize CodeQL'
@@ -363,6 +371,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
           fetch-depth: 1
 
@@ -390,6 +399,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
 
       - name: 'Set up Node.js 20.x'

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
           repository: '${{ github.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
@@ -86,6 +87,7 @@ jobs:
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
           repository: '${{ github.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js 20.x'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4
@@ -125,6 +127,7 @@ jobs:
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
           repository: '${{ github.repository }}'
+          persist-credentials: false
 
       - name: 'Set up Node.js 20.x'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions-node@v4

--- a/.github/workflows/docs-audit.yml
+++ b/.github/workflows/docs-audit.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: 'main'
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/workflows/docs-page-action.yml
+++ b/.github/workflows/docs-page-action.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Setup Pages'
         uses: 'actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b' # ratchet:actions/configure-pages@v5

--- a/.github/workflows/eval-pr.yml
+++ b/.github/workflows/eval-pr.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           # Check out the trusted code from main for detection
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Detect Steering Changes'
         id: 'detect'
@@ -102,6 +103,7 @@ jobs:
           # This only runs AFTER manual approval
           ref: '${{ github.event.pull_request.head.sha }}'
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Remove Approval Notification'
         # Run even if other steps fail, to ensure we clean up the "Action Required" message

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
@@ -105,6 +107,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Download Logs'
         uses: 'actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806' # ratchet:actions/download-artifact@v4

--- a/.github/workflows/gemini-automated-issue-dedup.yml
+++ b/.github/workflows/gemini-automated-issue-dedup.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Log in to GitHub Container Registry'
         uses: 'docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1' # ratchet:docker/login-action@v3

--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'

--- a/.github/workflows/gemini-cli-bot-pulse.yml
+++ b/.github/workflows/gemini-cli-bot-pulse.yml
@@ -23,6 +23,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 'Setup Node.js'

--- a/.github/workflows/gemini-lifecycle-manager.yml
+++ b/.github/workflows/gemini-lifecycle-manager.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: 'Lifecycle Management'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'

--- a/.github/workflows/gemini-scheduled-issue-dedup.yml
+++ b/.github/workflows/gemini-scheduled-issue-dedup.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Log in to GitHub Container Registry'
         uses: 'docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1' # ratchet:docker/login-action@v3

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'

--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Generate GitHub App Token'
         id: 'generate_token'

--- a/.github/workflows/label-backlog-child-issues.yml
+++ b/.github/workflows/label-backlog-child-issues.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
@@ -41,6 +43,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Link Checker'
         id: 'lychee'

--- a/.github/workflows/memory-nightly.yml
+++ b/.github/workflows/memory-nightly.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 'Set up Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4

--- a/.github/workflows/release-change-tags.yml
+++ b/.github/workflows/release-change-tags.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           ref: '${{ github.ref }}'
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -65,11 +65,13 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 'Checkout Release Code'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
           path: 'release'
           fetch-depth: 0

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -50,11 +50,13 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 'Checkout Release Code'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
           path: 'release'
           fetch-depth: 0

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -31,6 +31,7 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
         with:
+          persist-credentials: false
           # The user-level skills need to be available to the workflow
           fetch-depth: 0
           ref: 'main'

--- a/.github/workflows/release-patch-0-from-comment.yml
+++ b/.github/workflows/release-patch-0-from-comment.yml
@@ -17,6 +17,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: 'Slash Command Dispatch'

--- a/.github/workflows/release-patch-1-create-pr.yml
+++ b/.github/workflows/release-patch-1-create-pr.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref }}'
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Setup Node.js'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4

--- a/.github/workflows/release-patch-2-trigger.yml
+++ b/.github/workflows/release-patch-2-trigger.yml
@@ -64,6 +64,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: "${{ github.event.inputs.workflow_ref || 'main' }}"
           fetch-depth: 1
 

--- a/.github/workflows/release-patch-3-release.yml
+++ b/.github/workflows/release-patch-3-release.yml
@@ -53,12 +53,14 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 
       - name: 'Checkout Release Code'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.release_ref }}'
           path: 'release'
           fetch-depth: 0

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -55,6 +55,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 
@@ -171,11 +172,13 @@ jobs:
       - name: 'Checkout Ref'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
 
       - name: 'Checkout correct SHA'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ matrix.sha }}'
           path: 'release'
           fetch-depth: 0
@@ -216,11 +219,13 @@ jobs:
       - name: 'Checkout Ref'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
 
       - name: 'Checkout correct SHA'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ needs.calculate-versions.outputs.PREVIEW_SHA }}'
           path: 'release'
           fetch-depth: 0
@@ -288,11 +293,13 @@ jobs:
       - name: 'Checkout Ref'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
 
       - name: 'Checkout correct SHA'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ needs.calculate-versions.outputs.STABLE_SHA }}'
           path: 'release'
           fetch-depth: 0
@@ -360,6 +367,7 @@ jobs:
       - name: 'Checkout Ref'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
 
       - name: 'Setup Node.js'

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -52,6 +52,7 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v4
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref }}'
           fetch-depth: 0
 

--- a/.github/workflows/release-sandbox.yml
+++ b/.github/workflows/release-sandbox.yml
@@ -26,6 +26,7 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
         with:
+          persist-credentials: false
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
       - name: 'Push'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
+          persist-credentials: false
       - name: 'Install Dependencies'
         run: 'npm ci'
       - name: 'Build bundle'

--- a/.github/workflows/test-build-binary.yml
+++ b/.github/workflows/test-build-binary.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: 'Optimize Windows Performance'
         if: "matrix.os == 'windows-latest'"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -44,6 +44,8 @@ jobs:
         shell: 'bash'
         run: 'echo "${{ toJSON(vars) }}"'
       - uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          persist-credentials: false
       - name: 'Verify release'
         uses: './.github/actions/verify-release'
         with:


### PR DESCRIPTION
## Summary

This PR updates the `actions/checkout` configuration across multiple GitHub workflow files.

## Details

The `persist-credentials` parameter has been set to `false` in all instances where `actions/checkout` is used. This is a generic update to standardize the checkout step configuration across the repository's CI/CD pipelines. 33 workflow files were updated in total.

## Related Issues

N/A

## How to Validate

Review the changed YAML files in the `.github/workflows/` directory to ensure the `persist-credentials: false` parameter is correctly added to the `with` block of the `actions/checkout` step.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
