### PR TITLE
fix(core): detect zsh from $SHELL to prevent shopt errors

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -466,14 +466,34 @@ describe('getShellConfiguration', () => {
 
   it('should return bash configuration on Linux', () => {
     mockPlatform.mockReturnValue('linux');
+    process.env['SHELL'] = '/bin/bash';
     const config = getShellConfiguration();
-    expect(config.executable).toBe('bash');
+    expect(config.executable).toBe('/bin/bash');
     expect(config.argsPrefix).toEqual(['-c']);
     expect(config.shell).toBe('bash');
   });
 
   it('should return bash configuration on macOS (darwin)', () => {
     mockPlatform.mockReturnValue('darwin');
+    process.env['SHELL'] = '/bin/bash';
+    const config = getShellConfiguration();
+    expect(config.executable).toBe('/bin/bash');
+    expect(config.argsPrefix).toEqual(['-c']);
+    expect(config.shell).toBe('bash');
+  });
+
+  it('should return zsh configuration when SHELL is zsh', () => {
+    mockPlatform.mockReturnValue('darwin');
+    process.env['SHELL'] = '/bin/zsh';
+    const config = getShellConfiguration();
+    expect(config.executable).toBe('/bin/zsh');
+    expect(config.argsPrefix).toEqual(['-c']);
+    expect(config.shell).toBe('zsh');
+  });
+
+  it('should fall back to bash when SHELL is not set', () => {
+    mockPlatform.mockReturnValue('linux');
+    delete process.env['SHELL'];
     const config = getShellConfiguration();
     expect(config.executable).toBe('bash');
     expect(config.argsPrefix).toEqual(['-c']);

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -60,7 +60,7 @@ export const SHELL_TOOL_NAMES = ['run_shell_command', 'ShellTool'];
 /**
  * An identifier for the shell type.
  */
-export type ShellType = 'cmd' | 'powershell' | 'bash';
+export type ShellType = 'cmd' | 'powershell' | 'bash' | 'zsh';
 
 /**
  * Defines the configuration required to execute a command string within a specific shell.
@@ -631,7 +631,8 @@ export function parseCommandDetails(
     return result;
   }
 
-  if (configuration.shell === 'bash') {
+  if (configuration.shell === 'bash' || configuration.shell === 'zsh') {
+    // Use bash parser for both bash and zsh (syntax is similar enough)
     return parseBashCommandDetails(command);
   }
 
@@ -672,7 +673,27 @@ export function getShellConfiguration(): ShellConfiguration {
   }
 
   // Unix-like systems (Linux, macOS)
-  return { executable: 'bash', argsPrefix: ['-c'], shell: 'bash' };
+  // Detect the user's shell from the SHELL environment variable
+  const shellEnv = process.env['SHELL'];
+  const executable = shellEnv || 'bash';
+
+  // Determine shell type from the executable path
+  let shellType: ShellType = 'bash';
+  if (shellEnv) {
+    const basename = path.basename(shellEnv);
+    if (basename.includes('zsh')) {
+      shellType = 'zsh';
+    } else if (basename.includes('bash')) {
+      shellType = 'bash';
+    }
+    // Default to bash for unknown shells to maintain compatibility
+  }
+
+  return {
+    executable,
+    argsPrefix: ['-c'],
+    shell: shellType,
+  };
 }
 
 /**
@@ -745,7 +766,10 @@ export function hasRedirection(command: string): boolean {
       : fallbackCheck();
   }
 
-  if (configuration.shell === 'bash' && bashLanguage) {
+  if (
+    (configuration.shell === 'bash' || configuration.shell === 'zsh') &&
+    bashLanguage
+  ) {
     const tree = parseCommandTree(command);
     if (!tree) return fallbackCheck();
 


### PR DESCRIPTION
## Summary

- Reads `$SHELL` env var in `getShellConfiguration()` to detect the user's actual shell instead of hardcoding `bash`
- Adds `zsh` to the `ShellType` union so zsh users get their shell invoked directly (prevents `shopt` errors when bash is not the default shell)
- Reuses the bash parser for zsh command parsing since the syntax overlap is sufficient
- Updates `hasRedirection` to handle zsh alongside bash

Fixes #26754

## Test plan

- Added test: "should return zsh configuration when SHELL is zsh"
- Added test: "should fall back to bash when SHELL is not set"
- Updated existing tests to mock `process.env.SHELL` for deterministic behavior
- All shell-utils tests pass (65 passed, 1 skipped)
- All shell.test.ts tests pass (78 passed)