### PR TITLE
fix(security): set restrictive permissions (0o600) on background process log files

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -768,6 +768,44 @@ describe('ShellExecutionService', () => {
       (ShellExecutionService as any).backgroundLogStreams.clear();
     });
 
+    it('should create background log file with restrictive permissions (0o600)', async () => {
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'permission-test',
+        '/',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        shellExecutionConfig,
+      );
+
+      // Use the registered onData listener to produce some output
+      const onDataListener = mockPtyProcess.onData.mock.calls[0][0];
+      onDataListener('sensitive output');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      mockSerializeTerminalToObject.mockReturnValue([
+        [{ text: 'sensitive output', fg: '', bg: '' }],
+      ]);
+
+      // Background the process — this triggers createWriteStream
+      ShellExecutionService.background(
+        handle.pid!,
+        'default',
+        'permission-test',
+      );
+
+      // Verify that createWriteStream was called with mode: 0o600
+      expect(mockCreateWriteStream).toHaveBeenCalledWith(
+        expect.stringContaining('background-'),
+        expect.objectContaining({
+          flags: 'wx',
+          mode: 0o600,
+        }),
+      );
+
+      await ShellExecutionService.kill(handle.pid!);
+    });
+
     it('should move a running pty process to the background and start logging', async () => {
       const abortController = new AbortController();
       const handle = await ShellExecutionService.execute(

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1417,7 +1417,10 @@ export class ShellExecutionService {
     const logDir = this.getLogDir();
     try {
       mkdirSync(logDir, { recursive: true, mode: 0o700 });
-      const stream = fs.createWriteStream(logPath, { flags: 'wx' });
+      const stream = fs.createWriteStream(logPath, {
+        flags: 'wx',
+        mode: 0o600,
+      });
       stream.on('error', (err) => {
         debugLogger.warn('Background log stream error:', err);
       });


### PR DESCRIPTION
## Summary

Background process log files were created via `fs.createWriteStream` without an
explicit `mode`, causing them to inherit the process umask (typically `0o022`).
On a standard Linux/macOS system this results in `0o644` (`rw-r--r--`) —
world-readable — even though the parent directory is correctly restricted to
`0o700`.

This PR fixes the issue by explicitly passing `mode: 0o600` to
`createWriteStream`, ensuring log files are always created with owner-only
read/write permissions regardless of the environment's umask.

## Details

The root cause is a single missing option in `ShellExecutionService.background()`:

```diff
- const stream = fs.createWriteStream(logPath, { flags: 'wx' });
+ const stream = fs.createWriteStream(logPath, {
+   flags: 'wx',
+   mode: 0o600,
+ });
```

**Why `0o600`?**
- Consistent with the parent directory's `0o700` policy: owner-only access.
- Log files need read + write (`rw-`), but no execute bit.
- Explicitly setting `mode` prevents the permissions from depending on the
  caller's umask.

**Defense-in-depth**: relying solely on the parent directory's `0o700` is
insufficient — umask values vary across environments, and directory permissions
can be changed independently of the files inside.

A regression test is included to verify that `createWriteStream` is always
called with `{ flags: 'wx', mode: 0o600 }`.

## Related Issues

Fixes #26779

## How to Validate

1. **Unit tests** (mock-based, verifies correct arguments are passed):
   ```bash
   npm test -w @google/gemini-cli-core -- src/services/shellExecutionService.test.ts
   ```
   Expected: all 67 tests pass, including
   `should create background log file with restrictive permissions (0o600)`.

2. **Lint & typecheck**:
   ```bash
   npm run lint -w @google/gemini-cli-core
   npm run typecheck -w @google/gemini-cli-core
   ```
   Both exit with code 0.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker