### PR TITLE
fix(core): include gemini-2.5-flash-lite in default fallback chain

### DIFF
--- a/packages/core/src/availability/policyCatalog.test.ts
+++ b/packages/core/src/availability/policyCatalog.test.ts
@@ -11,6 +11,8 @@ import {
   validateModelPolicyChain,
 } from './policyCatalog.js';
 import {
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
@@ -50,7 +52,10 @@ describe('policyCatalog', () => {
   it('returns default chain when preview disabled', () => {
     const chain = getModelPolicyChain({ previewEnabled: false });
     expect(chain[0]?.model).toBe(DEFAULT_GEMINI_MODEL);
-    expect(chain).toHaveLength(2);
+    expect(chain[1]?.model).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    expect(chain[2]?.model).toBe(DEFAULT_GEMINI_FLASH_LITE_MODEL);
+    expect(chain[2]?.isLastResort).toBe(true);
+    expect(chain).toHaveLength(3);
   });
 
   it('marks preview transients as sticky retries when auto-selected', () => {

--- a/packages/core/src/availability/policyCatalog.ts
+++ b/packages/core/src/availability/policyCatalog.ts
@@ -127,6 +127,7 @@ export function getModelPolicyChain(
     definePolicy({
       model: DEFAULT_GEMINI_FLASH_LITE_MODEL,
       isLastResort: true,
+      maxAttempts: 10,
     }),
   ];
 }

--- a/packages/core/src/availability/policyCatalog.ts
+++ b/packages/core/src/availability/policyCatalog.ts
@@ -122,8 +122,11 @@ export function getModelPolicyChain(
     }),
     definePolicy({
       model: DEFAULT_GEMINI_FLASH_MODEL,
-      isLastResort: true,
       maxAttempts: 10,
+    }),
+    definePolicy({
+      model: DEFAULT_GEMINI_FLASH_LITE_MODEL,
+      isLastResort: true,
     }),
   ];
 }

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -68,10 +68,11 @@ describe('policyHelpers', () => {
       });
       const chain = resolvePolicyChain(config);
 
-      // Expect default chain [Pro, Flash]
-      expect(chain).toHaveLength(2);
+      // Expect default chain [Pro, Flash, Flash-Lite]
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.model).toBe('gemini-2.5-pro');
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
+      expect(chain[2]?.model).toBe('gemini-2.5-flash-lite');
     });
 
     it('uses auto chain when preferred model is auto', () => {
@@ -79,9 +80,10 @@ describe('policyHelpers', () => {
         getModel: () => 'gemini-2.5-pro',
       });
       const chain = resolvePolicyChain(config, DEFAULT_GEMINI_MODEL_AUTO);
-      expect(chain).toHaveLength(2);
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.model).toBe('gemini-2.5-pro');
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
+      expect(chain[2]?.model).toBe('gemini-2.5-flash-lite');
     });
 
     it('uses auto chain when configured model is auto even if preferred is concrete', () => {
@@ -89,9 +91,10 @@ describe('policyHelpers', () => {
         getModel: () => DEFAULT_GEMINI_MODEL_AUTO,
       });
       const chain = resolvePolicyChain(config, 'gemini-2.5-pro');
-      expect(chain).toHaveLength(2);
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.model).toBe('gemini-2.5-pro');
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
+      expect(chain[2]?.model).toBe('gemini-2.5-flash-lite');
     });
 
     it('starts chain from preferredModel when model is "auto"', () => {
@@ -99,8 +102,9 @@ describe('policyHelpers', () => {
         getModel: () => DEFAULT_GEMINI_MODEL_AUTO,
       });
       const chain = resolvePolicyChain(config, 'gemini-2.5-flash');
-      expect(chain).toHaveLength(1);
+      expect(chain).toHaveLength(2);
       expect(chain[0]?.model).toBe('gemini-2.5-flash');
+      expect(chain[1]?.model).toBe('gemini-2.5-flash-lite');
     });
 
     it('returns flash-lite chain when preferred model is flash-lite', () => {
@@ -130,9 +134,10 @@ describe('policyHelpers', () => {
         getModel: () => DEFAULT_GEMINI_MODEL_AUTO,
       });
       const chain = resolvePolicyChain(config, 'gemini-2.5-flash', true);
-      expect(chain).toHaveLength(2);
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.model).toBe('gemini-2.5-flash');
-      expect(chain[1]?.model).toBe('gemini-2.5-pro');
+      expect(chain[1]?.model).toBe('gemini-2.5-flash-lite');
+      expect(chain[2]?.model).toBe('gemini-2.5-pro');
     });
 
     it('proactively returns Gemini 2.5 chain if Gemini 3 requested but user lacks access', () => {
@@ -142,10 +147,11 @@ describe('policyHelpers', () => {
       });
       const chain = resolvePolicyChain(config);
 
-      // Should downgrade to [Pro 2.5, Flash 2.5]
-      expect(chain).toHaveLength(2);
+      // Should downgrade to [Pro 2.5, Flash 2.5, Flash-Lite 2.5]
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.model).toBe('gemini-2.5-pro');
       expect(chain[1]?.model).toBe('gemini-2.5-flash');
+      expect(chain[2]?.model).toBe('gemini-2.5-flash-lite');
     });
 
     it('returns Gemini 3.1 Pro chain when launched and auto-gemini-3 requested', () => {
@@ -176,9 +182,10 @@ describe('policyHelpers', () => {
       });
       const chain = resolvePolicyChain(config);
 
-      expect(chain).toHaveLength(2);
+      expect(chain).toHaveLength(3);
       expect(chain[0]?.actions).toEqual(SILENT_ACTIONS);
       expect(chain[1]?.actions).toEqual(SILENT_ACTIONS);
+      expect(chain[2]?.actions).toEqual(SILENT_ACTIONS);
     });
   });
 

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -663,6 +663,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       {
         model: 'gemini-2.5-flash-lite',
         isLastResort: true,
+        maxAttempts: 10,
         actions: {
           terminal: 'prompt',
           transient: 'prompt',
@@ -713,6 +714,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       {
         model: 'gemini-2.5-flash-lite',
         isLastResort: true,
+        maxAttempts: 10,
         actions: {
           terminal: 'prompt',
           transient: 'prompt',

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -646,8 +646,23 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
       {
         model: 'gemini-2.5-flash',
-        isLastResort: true,
         maxAttempts: 10,
+        actions: {
+          terminal: 'prompt',
+          transient: 'prompt',
+          not_found: 'prompt',
+          unknown: 'prompt',
+        },
+        stateTransitions: {
+          terminal: 'terminal',
+          transient: 'terminal',
+          not_found: 'terminal',
+          unknown: 'terminal',
+        },
+      },
+      {
+        model: 'gemini-2.5-flash-lite',
+        isLastResort: true,
         actions: {
           terminal: 'prompt',
           transient: 'prompt',
@@ -681,8 +696,23 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       },
       {
         model: 'gemini-2.5-flash',
-        isLastResort: true,
         maxAttempts: 10,
+        actions: {
+          terminal: 'prompt',
+          transient: 'prompt',
+          not_found: 'prompt',
+          unknown: 'prompt',
+        },
+        stateTransitions: {
+          terminal: 'terminal',
+          transient: 'terminal',
+          not_found: 'terminal',
+          unknown: 'terminal',
+        },
+      },
+      {
+        model: 'gemini-2.5-flash-lite',
+        isLastResort: true,
         actions: {
           terminal: 'prompt',
           transient: 'prompt',

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -20,6 +20,7 @@ import type { ModelAvailabilityService } from '../availability/modelAvailability
 import { createAvailabilityServiceMock } from '../availability/testUtils.js';
 import { AuthType } from '../core/contentGenerator.js';
 import {
+  DEFAULT_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
@@ -138,6 +139,7 @@ describe('handleFallback', () => {
 
       expect(availability.selectFirstAvailable).toHaveBeenCalledWith([
         DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
       ]);
     });
 
@@ -154,7 +156,7 @@ describe('handleFallback', () => {
 
       expect(policyHandler).toHaveBeenCalledWith(
         MOCK_PRO_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });
@@ -197,7 +199,7 @@ describe('handleFallback', () => {
     });
 
     it('does not wrap around to upgrade candidates if the current model was selected at the end (e.g. by router)', async () => {
-      // Last-resort failure (Flash) in [Preview, Pro, Flash] checks Preview then Pro (all upstream).
+      // Last-resort failure (Flash-Lite) in [Pro, Flash, Flash-Lite] does not wrap to upstream.
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
       );
@@ -210,14 +212,14 @@ describe('handleFallback', () => {
 
       await handleFallback(
         policyConfig,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         AUTH_OAUTH,
       );
 
       expect(availability.selectFirstAvailable).not.toHaveBeenCalled();
       expect(policyHandler).toHaveBeenCalledWith(
-        DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });
@@ -352,7 +354,7 @@ describe('handleFallback', () => {
 
       const result = await handleFallback(
         policyConfig,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         AUTH_OAUTH,
       );
 
@@ -360,8 +362,8 @@ describe('handleFallback', () => {
 
       expect(result).not.toBeNull();
       expect(policyHandler).toHaveBeenCalledWith(
-        DEFAULT_GEMINI_FLASH_MODEL,
-        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
+        DEFAULT_GEMINI_FLASH_LITE_MODEL,
         undefined,
       );
     });


### PR DESCRIPTION

  ## Summary

  Fixes #26841 — when the default Pro and Flash quotas are exhausted, the
  CLI now falls back to `gemini-2.5-flash-lite` (1000 RPD on the free tier)
  instead of erroring out. Previously free-tier users had to manually
  re-run with `--model gemini-2.5-flash-lite` despite quota remaining.

  The fix is applied symmetrically across both code paths:

  - **Legacy chain:** `packages/core/src/availability/policyCatalog.ts`
  - **Dynamic chain:** `packages/core/src/config/defaultModelConfigs.ts`
    (`modelChains.default` + `modelChains.auto-default`)

  `gemini-2.5-flash` keeps `maxAttempts: 10`; the `isLastResort` marker
  moves to `gemini-2.5-flash-lite` (which the existing `FLASH_LITE_CHAIN`
  already exercises in production for users who explicitly opt in).

  ## Test plan

  - [x] `packages/core/src/availability/policyCatalog.test.ts` — chain length 2→3 + new assertions
  - [x] `packages/core/src/availability/policyHelpers.test.ts` — 6 chain-shape assertions updated + wrap-around order
  - [x] `packages/core/src/fallback/handler.test.ts` — 4 tests updated for new last-resort being Flash-Lite
  - [x] Parity test between dynamic + legacy chains still passes
  - [x] All 86 tests in `src/availability` + `src/fallback` + `src/utils/flashFallback.test.ts` + `src/config/flashFallback.test.ts` +
  `src/services/modelConfig.golden.test.ts` green
  - [x] `npm run typecheck` clean across full workspace
  - [x] Pre-commit hooks (prettier, eslint --fix) clean