### PR TITLE
fix(core): update read_file schema for v1 compatibility (#22183)

### DIFF
--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -416,7 +416,8 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
     "properties": {
       "end_line": {
         "description": "Optional: The 1-based line number to end reading at (inclusive).",
-        "type": "number",
+        "minimum": 1,
+        "type": "integer",
       },
       "file_path": {
         "description": "The path to the file to read.",
@@ -424,7 +425,8 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
       },
       "start_line": {
         "description": "Optional: The 1-based line number to start reading from.",
-        "type": "number",
+        "minimum": 1,
+        "type": "integer",
       },
     },
     "required": [
@@ -1246,7 +1248,8 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
     "properties": {
       "end_line": {
         "description": "Optional: The 1-based line number to end reading at (inclusive).",
-        "type": "number",
+        "minimum": 1,
+        "type": "integer",
       },
       "file_path": {
         "description": "The path to the file to read.",
@@ -1254,7 +1257,8 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
       },
       "start_line": {
         "description": "Optional: The 1-based line number to start reading from.",
-        "type": "number",
+        "minimum": 1,
+        "type": "integer",
       },
     },
     "required": [

--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -319,6 +319,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
       },
       "context": {
         "description": "Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.",
+        "minimum": 0,
         "type": "integer",
       },
       "dir_path": {
@@ -1151,6 +1152,7 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
       },
       "context": {
         "description": "Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.",
+        "minimum": 0,
         "type": "integer",
       },
       "dir_path": {

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -97,12 +97,14 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
         [READ_FILE_PARAM_START_LINE]: {
           description:
             'Optional: The 1-based line number to start reading from.',
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
         },
         [READ_FILE_PARAM_END_LINE]: {
           description:
             'Optional: The 1-based line number to end reading at (inclusive).',
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
         },
       },
       required: [PARAM_FILE_PATH],

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -225,6 +225,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
           description:
             'Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.',
           type: 'integer',
+          minimum: 0,
         },
         [GREP_PARAM_AFTER]: {
           description:

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -106,12 +106,14 @@ export const GEMINI_3_SET: CoreToolSet = {
         [READ_FILE_PARAM_START_LINE]: {
           description:
             'Optional: The 1-based line number to start reading from.',
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
         },
         [READ_FILE_PARAM_END_LINE]: {
           description:
             'Optional: The 1-based line number to end reading at (inclusive).',
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
         },
       },
       required: [PARAM_FILE_PATH],

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -232,6 +232,7 @@ export const GEMINI_3_SET: CoreToolSet = {
           description:
             'Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.',
           type: 'integer',
+          minimum: 0,
         },
         [GREP_PARAM_AFTER]: {
           description:

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -148,18 +148,20 @@ describe('ReadFileTool', () => {
 
     it('should throw error if start_line is less than 1', () => {
       const params: ReadFileToolParams = {
-        file_path: path.join(tempRootDir, 'test.txt'),
+        file_path: 'test.txt',
         start_line: 0,
       };
-      expect(() => tool.build(params)).toThrow('start_line must be at least 1');
+      expect(() => tool.build(params)).toThrow(
+        'params/start_line must be >= 1',
+      );
     });
 
     it('should throw error if end_line is less than 1', () => {
       const params: ReadFileToolParams = {
-        file_path: path.join(tempRootDir, 'test.txt'),
+        file_path: 'test.txt',
         end_line: 0,
       };
-      expect(() => tool.build(params)).toThrow('end_line must be at least 1');
+      expect(() => tool.build(params)).toThrow('params/end_line must be >= 1');
     });
 
     it('should throw error if start_line is greater than end_line', () => {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -255,12 +255,6 @@ export class ReadFileTool extends BaseDeclarativeTool<
       return validationError;
     }
 
-    if (params.start_line !== undefined && params.start_line < 1) {
-      return 'start_line must be at least 1';
-    }
-    if (params.end_line !== undefined && params.end_line < 1) {
-      return 'end_line must be at least 1';
-    }
     if (
       params.start_line !== undefined &&
       params.end_line !== undefined &&


### PR DESCRIPTION
## Summary

This PR fixes a schema incompatibility in the `read_file` tool that caused `400 Invalid JSON` errors when using the Gemini `v1` API endpoint (`GOOGLE_GENAI_API_VERSION=v1`).

## Details

- Changed `read_file` parameter types for `start_line` and `end_line` from `number` to `integer` in `default-legacy.ts` and `gemini-3.ts`.
- Added `minimum: 1` to `start_line` and `end_line` for stricter validation.
- Updated `read-file.test.ts` expectations to match the new AJV error messages.
- Updated snapshots for core tool definitions.

## Related Issues

Fixes #22183

## How to Validate

1. Checkout the branch.
2. Build the project: `npm run build`.
3. Set API version: `export GOOGLE_GENAI_API_VERSION=v1`.
4. Run the CLI: `node bundle/gemini.js --prompt "read package.json" --yolo`.
5. Verify that the tool executes correctly without a 400 error.
6. Run unit tests: `npm test -w @google/gemini-cli-core -- read-file.test.ts`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run