### PR TITLE
Enable NumericalRouter when using dynamic model configs

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -345,7 +345,7 @@ export function isGemini3Model(
 ): boolean {
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     // Legacy behavior resolves the model first.
-    const resolved = resolveModel(model);
+    const resolved = resolveModel(model, false, false, false, true, config);
     return (
       config.modelConfigService.getModelDefinition(resolved)?.family ===
       'gemini-3'


### PR DESCRIPTION
## Summary

Enable the usage of the NumericalClassifierStrategy when using dynamic model configs. NumericalClassifierStrategy is gated on a isGemini3Model call. The isGemini3Model call wasn't passing in the configs param in its resolveModel call, and so the auto aliases added by the dynamic model configs weren't recognized as gemini 3 models. 

## Related Issues

Fixes #26928 