### PR TITLE
fix(cli): handle refreshAuth rejection in non-interactive prompt path

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1432,6 +1432,51 @@ describe('gemini.tsx main function exit codes', () => {
 
     expect(refreshAuthSpy).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
+
+  it('should exit with FATAL_AUTHENTICATION_ERROR when refreshAuth rejects in non-interactive mode', async () => {
+    const refreshAuthSpy = vi
+      .fn()
+      .mockRejectedValue(new Error('ECONNRESET while listing experiments'));
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      createMockConfig({
+        isInteractive: () => false,
+        getQuestion: () => 'test prompt',
+        getSandbox: () => undefined,
+        refreshAuth: refreshAuthSpy,
+      }),
+    );
+    vi.mocked(validateNonInteractiveAuth).mockResolvedValue(
+      AuthType.USE_GEMINI,
+    );
+    vi.mocked(loadSettings).mockReturnValue(
+      createMockSettings({
+        merged: { security: { auth: { selectedType: undefined } }, ui: {} },
+      }),
+    );
+    vi.mocked(parseArguments).mockResolvedValue({
+      enabled: true,
+      allowedPaths: [],
+      networkAccess: false,
+    } as unknown as CliArgs);
+
+    runNonInteractiveSpy.mockImplementation(() => Promise.resolve());
+
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    try {
+      await main();
+      expect.fail('Should have thrown MockProcessExitError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(MockProcessExitError);
+      expect((e as MockProcessExitError).code).toBe(
+        ExitCodes.FATAL_AUTHENTICATION_ERROR,
+      );
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
+    }
+
+    expect(refreshAuthSpy).toHaveBeenCalledWith(AuthType.USE_GEMINI);
+    expect(runNonInteractiveSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('validateDnsResolutionOrder', () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1461,7 +1461,7 @@ describe('gemini.tsx main function exit codes', () => {
 
     runNonInteractiveSpy.mockImplementation(() => Promise.resolve());
 
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
     try {
       await main();
       expect.fail('Should have thrown MockProcessExitError');
@@ -1470,8 +1470,6 @@ describe('gemini.tsx main function exit codes', () => {
       expect((e as MockProcessExitError).code).toBe(
         ExitCodes.FATAL_AUTHENTICATION_ERROR,
       );
-    } finally {
-      delete process.env['GEMINI_API_KEY'];
     }
 
     expect(refreshAuthSpy).toHaveBeenCalledWith(AuthType.USE_GEMINI);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -865,7 +865,18 @@ export async function main() {
       config,
       settings,
     );
-    await config.refreshAuth(authType);
+    try {
+      await config.refreshAuth(authType);
+    } catch (err) {
+      // Surface auth/network errors (e.g. ECONNRESET while fetching experiments
+      // or refreshing OAuth tokens) instead of letting the rejection bubble out
+      // as an unhandled crash with a raw stack trace.
+      const message = err instanceof Error ? err.message : String(err);
+      writeToStderr(`Failed to authenticate: ${message}\n`);
+      debugLogger.error('refreshAuth failed in non-interactive mode:', err);
+      await runExitCleanup();
+      process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
+    }
 
     if (config.getDebugMode()) {
       debugLogger.log('Session ID: %s', sessionId);


### PR DESCRIPTION
 ## Summary
  The second `refreshAuth` call inside `main()`'s non-interactive prompt flow ran unguarded, so a transient network error during OAuth token refresh or the
  experiments fetch (e.g. `ECONNRESET` against `cloudcode-pa.googleapis.com`) surfaced as an unhandled promise rejection and crashed the CLI before any
  user-facing message could be printed.

  Wrap the call in a try/catch that reports the error to stderr, logs the full detail via `debugLogger`, and exits with `FATAL_AUTHENTICATION_ERROR` after
  running the registered cleanup hooks — matching the existing pattern used by the earlier pre-sandbox `refreshAuth` attempt.

  Fixes #25739

  ## Test plan
  - [x] New test `"should exit with FATAL_AUTHENTICATION_ERROR when refreshAuth rejects in non-interactive mode"` passes — asserts exit code, that
  `runNonInteractive` is not reached, and that refreshAuth was called with the resolved auth type
  - [x] 41/44 gemini.test.tsx pass (2 pre-existing timeouts unrelated to this change reproduce on `main` without the fix)
  - [x] `npm run preflight` exit 0

  ---