### PR TITLE
fix(ci): replace brittle --no-tag with explicit staging-tmp tag

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -174,9 +174,9 @@ runs:
         npm publish \
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_CORE_PACKAGE_NAME}" \
-          --no-tag
+          --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} false
+          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} staging-tmp
         fi
 
     - name: '🔗 Install latest core package'
@@ -222,9 +222,9 @@ runs:
         npm publish \
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_CLI_PACKAGE_NAME}" \
-          --no-tag
+          --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} false
+          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} staging-tmp
         fi
 
     - name: 'Get a2a-server Token'
@@ -249,9 +249,9 @@ runs:
         npm publish \
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
-          --no-tag
+          --tag staging-tmp
           if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-            npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} false
+            npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} staging-tmp
           fi
 
     - name: '🔬 Verify NPM release by version'


### PR DESCRIPTION
## Summary

This PR fixes a brittle failure in the CI release pipeline by replacing `npm publish --no-tag` with an explicit `--tag staging-tmp`.

## Details

The use of `--no-tag` in `npm publish` was being interpreted by the npm CLI as setting the tag property to the boolean `false`, which then stringified to `"false"` on the registry. Subsequent attempts to remove this tag using `npm dist-tag rm <package> false` failed because the npm CLI misinterprets the word `false` as a boolean argument rather than a literal string tag name, leading to the error `false is not a dist-tag`. 

Using an explicit, non-reserved string like `staging-tmp` ensures that the tag is always treated as a string by the npm argument parser, avoiding type coercion issues.

## Related Issues

Fixes https://github.com/google-gemini/gemini-cli/issues/26936

## How to Validate

See [this successful run](https://github.com/google-gemini/gemini-cli/actions/runs/25759062649)
