### PR TITLE
fix(ci): configure git remote with token for authentication

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -114,13 +114,14 @@ runs:
         BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
         DRY_RUN: '${{ inputs.dry-run }}'
         RELEASE_TAG: '${{ inputs.release-tag }}'
+        GIT_PUSH_TOKEN: '${{ inputs.github-release-token || inputs.github-token }}'
       run: |-
         set -e
         git add package.json package-lock.json packages/*/package.json
         git commit -m "chore(release): ${RELEASE_TAG}"
         if [[ "${DRY_RUN}" == "false" ]]; then
           echo "Pushing release branch to remote..."
-          git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
+          git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
         else
           echo "Dry run enabled. Skipping push."
         fi
@@ -336,7 +337,8 @@ runs:
       shell: 'bash'
       run: |
         echo "Cleaning up release branch ${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}..."
-        git push origin --delete "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}"
+        git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" --delete "${STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME}"
 
       env:
+        GIT_PUSH_TOKEN: '${{ inputs.github-release-token || inputs.github-token }}'
         STEPS_RELEASE_BRANCH_OUTPUTS_BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -121,7 +121,7 @@ runs:
         git commit -m "chore(release): ${RELEASE_TAG}"
         if [[ "${DRY_RUN}" == "false" ]]; then
           echo "Pushing release branch to remote..."
-          git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
+          git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${BRANCH_NAME}" --follow-tags
         else
           echo "Dry run enabled. Skipping push."
         fi

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -403,6 +403,7 @@ jobs:
           BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
           DRY_RUN: '${{ github.event.inputs.dry_run }}'
           NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION: '${{ needs.calculate-versions.outputs.NEXT_NIGHTLY_VERSION }}'
+          GIT_PUSH_TOKEN: '${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}'
         run: |-
           git add package.json packages/*/package.json
           if [ -f package-lock.json ]; then
@@ -411,7 +412,7 @@ jobs:
           git commit -m "chore(release): bump version to ${NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION}"
           if [[ "${DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
-            git push "https://x-access-token:${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
+            git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
           else
             echo "Dry run enabled. Skipping push."
           fi

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -411,7 +411,7 @@ jobs:
           git commit -m "chore(release): bump version to ${NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION}"
           if [[ "${DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
-            git push --set-upstream origin "${BRANCH_NAME}"
+            git push "https://x-access-token:${{ secrets.GEMINI_CLI_ROBOT_GITHUB_PAT }}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
           else
             echo "Dry run enabled. Skipping push."
           fi

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -412,7 +412,7 @@ jobs:
           git commit -m "chore(release): bump version to ${NEEDS_CALCULATE_VERSIONS_OUTPUTS_NEXT_NIGHTLY_VERSION}"
           if [[ "${DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
-            git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:${BRANCH_NAME} --follow-tags
+            git push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${BRANCH_NAME}" --follow-tags
           else
             echo "Dry run enabled. Skipping push."
           fi

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           echo "ROLLBACK_TAG=$ROLLBACK_TAG_NAME" >> "$GITHUB_OUTPUT"
           git tag "$ROLLBACK_TAG_NAME" "${ORIGIN_HASH}"
-          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" --tags
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" --tags
 
       - name: 'Verify Rollback Tag Added'
         if: "${{ github.event.inputs.dry-run == 'false' }}"

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           echo "ROLLBACK_TAG=$ROLLBACK_TAG_NAME" >> "$GITHUB_OUTPUT"
           git tag "$ROLLBACK_TAG_NAME" "${ORIGIN_HASH}"
-          git push origin --tags
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" --tags
 
       - name: 'Verify Rollback Tag Added'
         if: "${{ github.event.inputs.dry-run == 'false' }}"


### PR DESCRIPTION
## Summary

This PR fixes a critical CI failure where release workflows were failing to authenticate with GitHub during `git push` operations. 

## Details

The issue was introduced in #26897, which added `persist-credentials: false` to various workflows. This prevents `actions/checkout` from storing the GitHub token in the local git configuration, causing subsequent steps to fail when attempting remote operations.

By explicitly setting the remote URL to `https://x-access-token:${TOKEN}@github.com/${REPOSITORY}.git`, we ensure that these operations remain authenticated without needing to revert the security hardening of `persist-credentials: false`.

## Related Issues

Fixes the release job failure in run [25760929873](https://github.com/google-gemini/gemini-cli/actions/runs/25760929873/job/75662582291).
