### PR TITLE
fix(core): throttle shell text output and bound live UI buffer

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -756,6 +756,28 @@ EOF`;
         await promise;
       });
 
+      it('should not start the bounded live text buffer with a low surrogate', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+        const emoji = '\uD83D\uDE00';
+
+        mockShellOutputCallback({
+          type: 'data',
+          chunk: `${emoji}${'x'.repeat(LIVE_OUTPUT_MAX_BUFFER_CHARS - 1)}`,
+        });
+
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        const displayedOutput = updateOutputMock.mock.calls[0][0] as string;
+        expect(displayedOutput.charCodeAt(0)).not.toBe(0xde00);
+        expect(displayedOutput).toHaveLength(LIVE_OUTPUT_MAX_BUFFER_CHARS - 1);
+
+        resolveShellExecution();
+        await promise;
+      });
+
       it('should not throttle PTY AnsiOutput snapshots in the shell tool', async () => {
         const firstAnsiOutput = [[{ text: 'first' }]] as AnsiOutput;
         const secondAnsiOutput = [[{ text: 'second' }]] as AnsiOutput;
@@ -792,6 +814,32 @@ EOF`;
 
         await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
 
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecond');
+
+        resolveShellExecution({ output: 'firstsecond' });
+        await promise;
+      });
+
+      it('should trailing-flush throttled text output after only the remaining interval', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith('first');
+
+        await vi.advanceTimersByTimeAsync(750);
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(249);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(1);
         expect(updateOutputMock).toHaveBeenCalledTimes(2);
         expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecond');
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -705,14 +705,14 @@ EOF`;
         mockShellOutputCallback({ type: 'data', chunk: 'second' });
         expect(updateOutputMock).toHaveBeenCalledOnce();
 
-        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
         mockShellOutputCallback({ type: 'data', chunk: 'third' });
-
-        expect(updateOutputMock).toHaveBeenCalledTimes(2);
-        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecondthird');
+        expect(updateOutputMock).toHaveBeenCalledOnce();
 
         resolveShellExecution({ output: 'firstsecondthird' });
         await promise;
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecondthird');
       });
 
       it('should flush trailing throttled text output when the command completes', async () => {
@@ -774,6 +774,52 @@ EOF`;
 
         resolveShellExecution({ ansiOutput: secondAnsiOutput });
         await promise;
+      });
+
+      it('should trailing-flush throttled text output when the command goes silent', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith('first');
+
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecond');
+
+        resolveShellExecution({ output: 'firstsecond' });
+        await promise;
+      });
+
+      it('should cancel the scheduled trailing flush when the command exits', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        resolveShellExecution({ output: 'firstsecond' });
+        await promise;
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecond');
+
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 5);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
       });
 
       it('should NOT call updateOutput if the command is backgrounded', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -45,7 +45,11 @@ vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
 import { initializeShellParsers } from '../utils/shell-utils.js';
-import { ShellTool, OUTPUT_UPDATE_INTERVAL_MS } from './shell.js';
+import {
+  ShellTool,
+  OUTPUT_UPDATE_INTERVAL_MS,
+  LIVE_OUTPUT_MAX_BUFFER_CHARS,
+} from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
 import { NoopSandboxManager } from '../services/sandboxManager.js';
@@ -77,6 +81,7 @@ import {
 } from '../confirmation-bus/types.js';
 import { type MessageBus } from '../confirmation-bus/message-bus.js';
 import { type SandboxManager } from '../services/sandboxManager.js';
+import type { AnsiOutput } from '../utils/terminalSerializer.js';
 
 interface TestableMockMessageBus extends MessageBus {
   defaultToolDecision: 'allow' | 'deny' | 'ask_user';
@@ -683,6 +688,91 @@ EOF`;
           pid: 12345,
           executionMethod: 'child_process',
         });
+        await promise;
+      });
+
+      it('should show the first text output immediately and throttle subsequent text updates', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith('first');
+
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+        mockShellOutputCallback({ type: 'data', chunk: 'third' });
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecondthird');
+
+        resolveShellExecution({ output: 'firstsecondthird' });
+        await promise;
+      });
+
+      it('should flush trailing throttled text output when the command completes', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        resolveShellExecution({ output: 'firstsecond' });
+        await promise;
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('firstsecond');
+      });
+
+      it('should keep only a bounded text buffer for live display', async () => {
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({
+          type: 'data',
+          chunk: `older${'x'.repeat(LIVE_OUTPUT_MAX_BUFFER_CHARS)}`,
+        });
+
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith(
+          'x'.repeat(LIVE_OUTPUT_MAX_BUFFER_CHARS),
+        );
+
+        resolveShellExecution({
+          output: `older${'x'.repeat(LIVE_OUTPUT_MAX_BUFFER_CHARS)}`,
+        });
+        await promise;
+      });
+
+      it('should not throttle PTY AnsiOutput snapshots in the shell tool', async () => {
+        const firstAnsiOutput = [[{ text: 'first' }]] as AnsiOutput;
+        const secondAnsiOutput = [[{ text: 'second' }]] as AnsiOutput;
+        const invocation = shellTool.build({ command: 'printf output' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: firstAnsiOutput });
+        mockShellOutputCallback({ type: 'data', chunk: secondAnsiOutput });
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenNthCalledWith(1, firstAnsiOutput);
+        expect(updateOutputMock).toHaveBeenNthCalledWith(2, secondAnsiOutput);
+
+        resolveShellExecution({ ansiOutput: secondAnsiOutput });
         await promise;
       });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -58,6 +58,7 @@ import {
 } from '../sandbox/utils/proactivePermissions.js';
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
+export const LIVE_OUTPUT_MAX_BUFFER_CHARS = 100_000;
 
 // Delay so user does not see the output of the process before the process is moved to the background.
 const BACKGROUND_DELAY_MS = 200;
@@ -502,8 +503,36 @@ export class ShellToolInvocation extends BaseToolInvocation<
         };
       }
       let cumulativeOutput: string | AnsiOutput = '';
-      let lastUpdateTime = Date.now();
+      let lastUpdateTime = 0;
+      let hasFlushedOutput = false;
+      let hasPendingOutput = false;
       let isBinaryStream = false;
+
+      const appendToLiveOutputBuffer = (chunk: string) => {
+        const currentOutput =
+          typeof cumulativeOutput === 'string' ? cumulativeOutput : '';
+        if (chunk.length >= LIVE_OUTPUT_MAX_BUFFER_CHARS) {
+          cumulativeOutput = chunk.slice(-LIVE_OUTPUT_MAX_BUFFER_CHARS);
+          return;
+        }
+
+        const nextOutput = currentOutput + chunk;
+        cumulativeOutput =
+          nextOutput.length > LIVE_OUTPUT_MAX_BUFFER_CHARS
+            ? nextOutput.slice(-LIVE_OUTPUT_MAX_BUFFER_CHARS)
+            : nextOutput;
+      };
+
+      const flushOutput = () => {
+        if (!hasPendingOutput || !updateOutput || this.params.is_background) {
+          return;
+        }
+
+        updateOutput(cumulativeOutput);
+        hasPendingOutput = false;
+        hasFlushedOutput = true;
+        lastUpdateTime = Date.now();
+      };
 
       const resetTimeout = () => {
         if (timeoutMs <= 0) {
@@ -529,22 +558,28 @@ export class ShellToolInvocation extends BaseToolInvocation<
           cwd,
           (event: ShellOutputEvent) => {
             resetTimeout(); // Reset timeout on any event
-            if (!updateOutput) {
-              return;
-            }
 
             let shouldUpdate = false;
 
             switch (event.type) {
               case 'data':
                 if (isBinaryStream) break;
-                cumulativeOutput = event.chunk;
-                shouldUpdate = true;
+                if (typeof event.chunk === 'string') {
+                  appendToLiveOutputBuffer(event.chunk);
+                  shouldUpdate =
+                    !hasFlushedOutput ||
+                    Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS;
+                } else {
+                  cumulativeOutput = event.chunk;
+                  shouldUpdate = true;
+                }
+                hasPendingOutput = true;
                 break;
               case 'binary_detected':
                 isBinaryStream = true;
                 cumulativeOutput =
                   '[Binary output detected. Halting stream...]';
+                hasPendingOutput = true;
                 shouldUpdate = true;
                 break;
               case 'binary_progress':
@@ -552,11 +587,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
                 cumulativeOutput = `[Receiving binary output... ${formatBytes(
                   event.bytesReceived,
                 )} received]`;
+                hasPendingOutput = true;
                 if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
                   shouldUpdate = true;
                 }
                 break;
               case 'exit':
+                flushOutput();
                 break;
               default: {
                 throw new Error('An unhandled ShellOutputEvent was found.');
@@ -564,8 +601,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
             }
 
             if (shouldUpdate && !this.params.is_background) {
-              updateOutput(cumulativeOutput);
-              lastUpdateTime = Date.now();
+              flushOutput();
             }
           },
           combinedController.signal,
@@ -639,6 +675,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }
 
       const result = await resultPromise;
+      if (!result.backgrounded) {
+        flushOutput();
+      }
 
       const backgroundPIDs: number[] = [];
       if (os.platform() !== 'win32') {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -63,6 +63,24 @@ export const LIVE_OUTPUT_MAX_BUFFER_CHARS = 100_000;
 // Delay so user does not see the output of the process before the process is moved to the background.
 const BACKGROUND_DELAY_MS = 200;
 const SHOW_NL_DESCRIPTION_THRESHOLD = 150;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+
+function trimLiveOutputBuffer(output: string): string {
+  if (output.length <= LIVE_OUTPUT_MAX_BUFFER_CHARS) {
+    return output;
+  }
+
+  let startIndex = output.length - LIVE_OUTPUT_MAX_BUFFER_CHARS;
+  const firstCodeUnit = output.charCodeAt(startIndex);
+  if (
+    firstCodeUnit >= LOW_SURROGATE_START &&
+    firstCodeUnit <= LOW_SURROGATE_END
+  ) {
+    startIndex += 1;
+  }
+  return output.slice(startIndex);
+}
 
 export interface ShellToolParams {
   command: string;
@@ -513,15 +531,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
         const currentOutput =
           typeof cumulativeOutput === 'string' ? cumulativeOutput : '';
         if (chunk.length >= LIVE_OUTPUT_MAX_BUFFER_CHARS) {
-          cumulativeOutput = chunk.slice(-LIVE_OUTPUT_MAX_BUFFER_CHARS);
+          cumulativeOutput = trimLiveOutputBuffer(chunk);
           return;
         }
 
         const nextOutput = currentOutput + chunk;
-        cumulativeOutput =
-          nextOutput.length > LIVE_OUTPUT_MAX_BUFFER_CHARS
-            ? nextOutput.slice(-LIVE_OUTPUT_MAX_BUFFER_CHARS)
-            : nextOutput;
+        cumulativeOutput = trimLiveOutputBuffer(nextOutput);
       };
 
       const cancelTrailingFlush = () => {
@@ -551,10 +566,15 @@ export class ShellToolInvocation extends BaseToolInvocation<
         ) {
           return;
         }
+        const elapsedSinceLastUpdate = Date.now() - lastUpdateTime;
+        const trailingDelayMs = Math.max(
+          OUTPUT_UPDATE_INTERVAL_MS - elapsedSinceLastUpdate,
+          0,
+        );
         trailingFlushTimer = setTimeout(() => {
           trailingFlushTimer = null;
           flushOutput();
-        }, OUTPUT_UPDATE_INTERVAL_MS);
+        }, trailingDelayMs);
       };
 
       const resetTimeout = () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -471,6 +471,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const timeoutMs = this.context.config.getShellToolInactivityTimeout();
     const timeoutController = new AbortController();
     let timeoutTimer: NodeJS.Timeout | undefined;
+    let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
     // Handle signal combination manually to avoid TS issues or runtime missing features
     const combinedController = new AbortController();
@@ -523,7 +524,15 @@ export class ShellToolInvocation extends BaseToolInvocation<
             : nextOutput;
       };
 
+      const cancelTrailingFlush = () => {
+        if (trailingFlushTimer !== null) {
+          clearTimeout(trailingFlushTimer);
+          trailingFlushTimer = null;
+        }
+      };
+
       const flushOutput = () => {
+        cancelTrailingFlush();
         if (!hasPendingOutput || !updateOutput || this.params.is_background) {
           return;
         }
@@ -532,6 +541,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
         hasPendingOutput = false;
         hasFlushedOutput = true;
         lastUpdateTime = Date.now();
+      };
+
+      const scheduleTrailingFlush = () => {
+        if (
+          trailingFlushTimer !== null ||
+          !updateOutput ||
+          this.params.is_background
+        ) {
+          return;
+        }
+        trailingFlushTimer = setTimeout(() => {
+          trailingFlushTimer = null;
+          flushOutput();
+        }, OUTPUT_UPDATE_INTERVAL_MS);
       };
 
       const resetTimeout = () => {
@@ -569,6 +592,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
                   shouldUpdate =
                     !hasFlushedOutput ||
                     Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS;
+                  if (!shouldUpdate) {
+                    scheduleTrailingFlush();
+                  }
                 } else {
                   cumulativeOutput = event.chunk;
                   shouldUpdate = true;
@@ -1005,6 +1031,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
       };
     } finally {
       if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (trailingFlushTimer) {
+        clearTimeout(trailingFlushTimer);
+        trailingFlushTimer = null;
+      }
       signal.removeEventListener('abort', onAbort);
       timeoutController.signal.removeEventListener('abort', onAbort);
       if (tempFilePath) {


### PR DESCRIPTION
## Summary

Throttles shell tool text `data` events to `OUTPUT_UPDATE_INTERVAL_MS` (1s), matching
the existing `binary_progress` cadence, and caps the live UI buffer to
`LIVE_OUTPUT_MAX_BUFFER_CHARS` (100k chars). Without throttling, every chunk
triggered a full React re-render of the shell output panel; commands emitting
thousands of lines (build warnings, manifest generation, verbose test runs)
pinned the UI until the command exited.

## Details

This PR builds on the feedback @jacob314 left on the previous attempt (#25461)
and resolves the three concerns raised there:

1. **No initial 1s delay** — `lastUpdateTime` starts at `0` and the first text
   chunk renders immediately. Subsequent chunks are throttled.
2. **Bounded live buffer** — the new `appendToLiveOutputBuffer` keeps only the
   last `LIVE_OUTPUT_MAX_BUFFER_CHARS` characters for the live preview, removing
   the unbounded-string growth risk. The complete output is unaffected: it is
   still rendered from the full result returned by `shellExecutionService` after
   the command exits.
3. **PTY snapshots not throttled** — `AnsiOutput` (PTY mode) chunks bypass the
   throttle entirely, preserving responsiveness for progress bars and
   curses-style UIs.

Final-state guarantee: `flushOutput()` runs on the `exit` event and again after
`resultPromise` resolves (non-background path), so the last frame is always
flushed without delay.

## Related Issues

Fixes #25459

Supersedes #22843 (closed under the help-wanted policy) and #25461 (closed for
inactivity after change requests).

## How to Validate

1. Build the bundle: `npm run bundle`
2. Run a high-volume shell command from inside the CLI:
   `for i in $(seq 1 20000); do echo "line $i"; done`
3. Verify the UI stays responsive while the command runs (no freeze, input
   stays interactive) and the final output is complete and correct.
4. Run a PTY-style command (e.g. anything that emits ANSI progress) and verify
   updates still appear at full rate (no throttle on PTY).
5. Run the regression tests:
   `npm test -w @google/gemini-cli-core -- src/tools/shell.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (n/a — internal throttle, no
      user-facing API change)
- [x] Added/updated tests (4 new regression tests in `shell.test.ts`)
- [ ] Noted breaking changes (none)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
