### PR TITLE
fix(core): handle EISDIR on virtual drives in memory discovery

### DIFF
--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -46,6 +46,15 @@ import { Config, type GeminiCLIExtension } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { SimpleExtensionLoader } from './extensionLoader.js';
 import { CoreEvent, coreEvents } from './events.js';
+import * as fs from 'node:fs';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    realpathSync: vi.fn(actual.realpathSync),
+  };
+});
 
 vi.mock('os', async (importOriginal) => {
   const actualOs = await importOriginal<typeof os>();
@@ -741,6 +750,40 @@ included directory memory
       // projectRoot is still discovered and loaded normally.
       expect(result.memoryContent).toContain('Project root memory content');
       expect(result.filePaths).toContain(projectContextFile);
+    });
+
+    it('should not crash when fs.realpathSync throws EISDIR on virtual drive roots', async () => {
+      // Mock realpathSync to throw EISDIR for a specific path, simulating
+      // the Windows virtual drive issue (#25216).
+      vi.mocked(fs.realpathSync).mockImplementation((p: fs.PathLike) => {
+        const pathStr = p.toString();
+        if (pathStr.includes('virtual-drive')) {
+          const error = new Error(
+            "EISDIR: illegal operation on a directory, realpath 'A:\\a'",
+          );
+
+          (error as NodeJS.ErrnoException).code = 'EISDIR';
+          throw error;
+        }
+        // For other paths, we need to return something sensible.
+        // Since it's a mock, we can just return the path string itself.
+        return pathStr;
+      });
+
+      const virtualDriveCwd = path.join(testRootDir, 'virtual-drive');
+      await fsPromises.mkdir(virtualDriveCwd, { recursive: true });
+
+      // This should now succeed instead of throwing
+      const result = await loadServerHierarchicalMemory(
+        virtualDriveCwd,
+        [],
+        new FileDiscoveryService(projectRoot),
+        new SimpleExtensionLoader([]),
+        DEFAULT_FOLDER_TRUST,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.fileCount).toBe(0);
     });
 
     it('silently skips a GEMINI.md symlink that points to a directory', async () => {

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -24,6 +24,7 @@ import {
   isSubpath,
   normalizePath,
   toAbsolutePath,
+  resolveToRealPath,
 } from './paths.js';
 import type { ExtensionLoader } from './extensionLoader.js';
 import { debugLogger } from './debugLogger.js';
@@ -702,10 +703,8 @@ export async function loadServerHierarchicalMemory(
   boundaryMarkers: readonly string[] = ['.git'],
 ): Promise<LoadServerHierarchicalMemoryResponse> {
   // FIX: Use real, canonical paths for a reliable comparison to handle symlinks.
-  const realCwd = normalizePath(
-    await fs.realpath(path.resolve(currentWorkingDirectory)),
-  );
-  const realHome = normalizePath(await fs.realpath(path.resolve(homedir())));
+  const realCwd = normalizePath(resolveToRealPath(currentWorkingDirectory));
+  const realHome = normalizePath(resolveToRealPath(homedir()));
   const isHomeDirectory = realCwd === realHome;
 
   // If it is the home directory, pass an empty string to the core memory


### PR DESCRIPTION
## Summary

Fixes a crash when the Gemini CLI is launched from a virtual drive root (e.g., `A:\`) on Windows. The crash was caused by an unhandled `EISDIR` error from `fs.realpath` in the memory discovery logic.

## Details

In `loadServerHierarchicalMemory`, the code was calling `fs.realpath` directly on the current working directory and home directory. On some Windows setups with virtual drives, this call can throw `EISDIR` for directory roots. This PR replaces these direct calls with the robust `resolveToRealPath` utility from `packages/core/src/utils/paths.ts`, which already handles `EISDIR` and `ENOENT` by falling back to manual path resolution.

## Related Issues

Closes #25216

## How to Validate

1. Run the CLI in a mock environment where `fs.realpathSync` throws `EISDIR` for certain paths.
2. Verified with a targeted test case (manually run and confirmed) that the CLI now handles this error gracefully.
3. Verified existing memory discovery tests pass: `npm test -w @google/gemini-cli-core -- src/utils/memoryDiscovery.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run