### PR TITLE
Fix sandboxing

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -312,7 +312,16 @@ export async function start_sandbox(
 
     // use interactive mode and auto-remove container on exit
     // run init binary inside container to forward signals & reap zombies
-    const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
+    const args = [
+      'run',
+      '-i',
+      '--rm',
+      '--init',
+      '--entrypoint',
+      '',
+      '--workdir',
+      containerWorkdir,
+    ];
 
     // add runsc runtime if using runsc
     if (config.command === 'runsc') {
@@ -716,6 +725,8 @@ export async function start_sandbox(
         'run',
         '--rm',
         '--init',
+        '--entrypoint',
+        '',
         ...(userFlag ? userFlag.split(' ') : []),
         '--name',
         SANDBOX_PROXY_NAME,


### PR DESCRIPTION
## Summary

Fixes the docker commandline when launching gemini in sandboxed mode.  Addresses #26964.

## Details

The default docker image used for sandboxing has an entrypoint set (`gemini`) but gemini-cli tries to then use `bash -c` as the command for the docker container.  Since `gemini bash -c` isn't a valid command, the container fails to start.

## Related Issues

Fixes #26964 

## How to Validate

    GEMINI_SANDBOX=docker npm run start -- --sandbox

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [x] Docker
