### PR TITLE
fix(core): add platform-aware shell guidance

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -147,6 +147,11 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -332,6 +337,11 @@ An approved plan is available for this task at \`../plans/feature-x.md\`.
 - **New Plan:** Only create a new plan file if the user explicitly asks for a "new plan".
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -628,6 +638,11 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -792,6 +807,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -942,6 +962,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -1074,6 +1099,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 4. **Verify:** Review work against the original request. Fix bugs and deviations. **Build the application and ensure there are no compile errors.**
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -1734,6 +1764,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -1897,6 +1932,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -2066,6 +2106,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2234,6 +2279,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2398,6 +2448,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2556,6 +2611,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2687,6 +2747,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 3. **Implementation:** Once the plan is approved, follow the standard **Execution** cycle to build the application, utilizing platform-native primitives to realize the rich aesthetic you planned.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -2851,6 +2916,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -3156,6 +3226,11 @@ You are operating with a persistent file-based task tracking system located at \
 9.  **TURN EFFICIENCY**: Update the tracker immediately when a step is completed. Combine \`tracker_update_task\` calls with other tool calls in the same turn to save turns.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -3566,6 +3641,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -3729,6 +3809,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -4008,6 +4093,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -4171,6 +4261,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -673,6 +673,21 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     });
 
+    it('should include Windows host platform guidance for preview models on win32', () => {
+      mockPlatform('win32');
+      vi.mocked(mockConfig.getActiveModel).mockReturnValue(
+        PREVIEW_GEMINI_MODEL,
+      );
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).toContain('The host platform is Windows (win32)');
+      expect(prompt).toContain(
+        "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)",
+      );
+      expect(prompt).not.toContain(
+        "using commands like 'grep', 'tail', 'head'",
+      );
+    });
+
     it('should include generic shell efficiency commands on non-Windows', () => {
       mockPlatform('linux');
       vi.mocked(mockConfig.getActiveModel).mockReturnValue(

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -84,6 +84,7 @@ export interface PrimaryWorkflowsOptions {
 export interface OperationalGuidelinesOptions {
   interactive: boolean;
   interactiveShellEnabled: boolean;
+  enableShellEfficiency?: boolean;
   topicUpdateNarration: boolean;
   memoryV2Enabled: boolean;
   /**
@@ -395,6 +396,8 @@ export function renderOperationalGuidelines(
   return `
 # Operational Guidelines
 
+${shellEfficiencyGuidelines(options.enableShellEfficiency ?? false)}
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -432,6 +435,20 @@ export function renderOperationalGuidelines(
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
 `.trim();
+}
+
+function shellEfficiencyGuidelines(enabled: boolean): string {
+  if (!enabled) return '';
+  const isWindows = process.platform === 'win32';
+  const platformName = isWindows ? 'Windows' : 'Unix-like';
+  const inspectExample = isWindows
+    ? "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)"
+    : "using commands like 'grep', 'tail', 'head'";
+  return `
+## Shell tool usage
+
+- The host platform is ${platformName} (${process.platform}). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection ${inspectExample}.`;
 }
 
 export function renderSandbox(options?: SandboxOptions): string {


### PR DESCRIPTION
## Summary

Adds platform-aware shell guidance to the modern Gemini CLI system prompt so the model is reminded which host OS it is running on before choosing shell commands.

This keeps Windows users from getting nudged toward Unix-only commands in the modern prompt path, while preserving the existing Unix-style examples on non-Windows hosts.

## Details

- Adds a small `Shell tool usage` section to the modern operational guidelines when shell output efficiency guidance is enabled.
- Uses `process.platform` to render Windows-specific inspection examples (`type`, `findstr`, `Get-Content`, `Select-String`) on `win32`.
- Keeps direct renderer tests backward-compatible by making the option optional, while the real prompt provider continues to pass the configured value.
- Adds coverage for the modern preview-model Windows prompt path and updates prompt snapshots.

## Related Issues

Fixes #26591

## How to Validate

- `npm test --workspace @google/gemini-cli-core -- prompts.test.ts promptProvider.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run lint --workspace @google/gemini-cli-core -- src/prompts/snippets.ts src/core/prompts.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker