### PR TITLE
fix(cli): auto-approve shell redirections in AUTO_EDIT mode

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2451,7 +2451,11 @@ describe('useGeminiStream', () => {
     });
 
     it('should auto-approve shell commands with redirection when switching to AUTO_EDIT mode', async () => {
-      const shellCall = createMockToolCall(SHELL_TOOL_NAME, 'call-shell', 'info');
+      const shellCall = createMockToolCall(
+        SHELL_TOOL_NAME,
+        'call-shell',
+        'info',
+      );
       shellCall.request.args = { command: 'ls > files.txt' };
 
       const { result } = await renderTestHook([shellCall]);
@@ -2467,7 +2471,11 @@ describe('useGeminiStream', () => {
     });
 
     it('should NOT auto-approve shell commands without redirection when switching to AUTO_EDIT mode', async () => {
-      const shellCall = createMockToolCall(SHELL_TOOL_NAME, 'call-shell', 'info');
+      const shellCall = createMockToolCall(
+        SHELL_TOOL_NAME,
+        'call-shell',
+        'info',
+      );
       shellCall.request.args = { command: 'ls -la' };
 
       const { result } = await renderTestHook([shellCall]);

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -49,6 +49,7 @@ import {
   debugLogger,
   coreEvents,
   CoreEvent,
+  SHELL_TOOL_NAME,
   MCPDiscoveryState,
   GeminiCliOperation,
   getPlanModeExitMessage,
@@ -2447,6 +2448,36 @@ describe('useGeminiStream', () => {
       expect(mockMessageBus.publish).not.toHaveBeenCalledWith(
         expect.objectContaining({ correlationId: 'corr-call3' }),
       );
+    });
+
+    it('should auto-approve shell commands with redirection when switching to AUTO_EDIT mode', async () => {
+      const shellCall = createMockToolCall(SHELL_TOOL_NAME, 'call-shell', 'info');
+      shellCall.request.args = { command: 'ls > files.txt' };
+
+      const { result } = await renderTestHook([shellCall]);
+
+      await act(async () => {
+        await result.current.handleApprovalModeChange(ApprovalMode.AUTO_EDIT);
+      });
+
+      // Shell command with redirection should be auto-approved
+      expect(mockMessageBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ correlationId: 'corr-call-shell' }),
+      );
+    });
+
+    it('should NOT auto-approve shell commands without redirection when switching to AUTO_EDIT mode', async () => {
+      const shellCall = createMockToolCall(SHELL_TOOL_NAME, 'call-shell', 'info');
+      shellCall.request.args = { command: 'ls -la' };
+
+      const { result } = await renderTestHook([shellCall]);
+
+      await act(async () => {
+        await result.current.handleApprovalModeChange(ApprovalMode.AUTO_EDIT);
+      });
+
+      // Regular shell command should NOT be auto-approved
+      expect(mockMessageBus.publish).not.toHaveBeenCalled();
     });
 
     it('should not auto-approve any tools when switching to REQUIRE_CONFIRMATION mode', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -26,6 +26,8 @@ import {
   debugLogger,
   runInDevTraceSpan,
   EDIT_TOOL_NAMES,
+  SHELL_TOOL_NAME,
+  hasRedirection,
   processRestorableToolCalls,
   recordToolCallInteractions,
   ToolErrorType,
@@ -1820,10 +1822,21 @@ export const useGeminiStream = (
         );
 
         // For AUTO_EDIT mode, only approve edit tools (replace, write_file)
+        // or shell commands with redirection (which act as edits).
         if (newApprovalMode === ApprovalMode.AUTO_EDIT) {
-          awaitingApprovalCalls = awaitingApprovalCalls.filter((call) =>
-            EDIT_TOOL_NAMES.has(call.request.name),
-          );
+          awaitingApprovalCalls = awaitingApprovalCalls.filter((call) => {
+            if (EDIT_TOOL_NAMES.has(call.request.name)) {
+              return true;
+            }
+
+            if (call.request.name === SHELL_TOOL_NAME) {
+              const command = (call.request.args as { command?: string })
+                .command;
+              return command && hasRedirection(command);
+            }
+
+            return false;
+          });
         }
 
         // Process pending tool calls sequentially to reduce UI chaos


### PR DESCRIPTION
Fixes #17189.

This PR updates the `handleApprovalModeChange` hook in the CLI to correctly auto-approve `run_shell_command` calls that involve redirections (e.g., `ls > file.txt`) when switching to `AUTO_EDIT` mode.

Previously, these commands were ignored by the auto-approval logic despite the UI providing hints that they would be approved.

Changes:
- Added `SHELL_TOOL_NAME` and `hasRedirection` to `useGeminiStream.ts`.
- Expanded `AUTO_EDIT` filter to include shell commands with redirections.
- Added unit tests to verify the new behavior and ensure standard shell commands still require confirmation.