### PR TITLE
fix(cli): resolve permission denied in sandbox on NixOS and other distros

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -787,12 +787,67 @@ describe('sandbox', () => {
         expect.arrayContaining(['--user', 'root', '--env', 'HOME=/home/user']),
         expect.any(Object),
       );
-      // Check that the entrypoint command includes useradd/groupadd
+      // Check that the entrypoint command includes the defensive useradd check
       const args = vi.mocked(spawn).mock.calls[1][1] as string[];
       const entrypointCmd = args[args.length - 1];
-      expect(entrypointCmd).toContain('groupadd');
-      expect(entrypointCmd).toContain('useradd');
-      expect(entrypointCmd).toContain('su -p gemini');
+      expect(entrypointCmd).toContain('if command -v useradd');
+      expect(entrypointCmd).toContain('groupadd -g 1000 -o gemini');
+      expect(entrypointCmd).toContain('id 1000');
+      expect(entrypointCmd).toContain('useradd -o -u 1000');
+      expect(entrypointCmd).toContain('USER_NAME=$(id -nu 1000 2>/dev/null);');
+      expect(entrypointCmd).toContain('if [ -n "$USER_NAME" ]; then');
+      expect(entrypointCmd).toContain('su -p "$USER_NAME"');
+      expect(entrypointCmd).toContain('else');
+      expect(entrypointCmd).toContain('Error: Failed to map host UID 1000');
+      expect(entrypointCmd).toContain('exit 1');
+      expect(entrypointCmd).toContain("Error: 'useradd' not found");
+    });
+
+    it('should correctly escape home directory with spaces and special characters', async () => {
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'docker',
+        image: 'gemini-cli-sandbox',
+      });
+      process.env['SANDBOX_SET_UID_GID'] = 'true';
+      vi.mocked(os.platform).mockReturnValue('linux');
+
+      const specialHome = '/home/user name `$(id)`';
+      mockedHomedir.mockReturnValue(specialHome);
+      mockedGetContainerPath.mockImplementation((p: string) => p);
+
+      // Mock image check to return true
+      interface MockProcessWithStdout extends EventEmitter {
+        stdout: EventEmitter;
+      }
+      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
+      mockImageCheckProcess.stdout = new EventEmitter();
+      vi.mocked(spawn).mockImplementationOnce(() => {
+        setTimeout(() => {
+          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
+          mockImageCheckProcess.emit('close', 0);
+        }, 1);
+        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+      });
+
+      const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
+      mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+        if (event === 'close') {
+          setTimeout(() => cb(0), 10);
+        }
+        return mockSpawnProcess;
+      });
+      vi.mocked(spawn).mockImplementationOnce(() => mockSpawnProcess);
+
+      await start_sandbox(config);
+
+      const args = vi.mocked(spawn).mock.calls[1][1] as string[];
+      const entrypointCmd = args[args.length - 1];
+
+      // Verify that the special home directory is properly quoted/escaped
+      // The quote tool should handle spaces and backticks
+      expect(entrypointCmd).toContain("'/home/user name `$(id)`'");
     });
 
     it('should register and unregister proxy exit handlers', async () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -676,22 +676,34 @@ export async function start_sandbox(
       // container's /etc/passwd file, which is required by os.userInfo().
       const username = 'gemini';
       const homeDir = getContainerPath(homedir());
-
-      const setupUserCommands = [
-        // Use -f with groupadd to avoid errors if the group already exists.
-        `groupadd -f -g ${gid} ${username}`,
-        // Create user only if it doesn't exist. Use -o for non-unique UID.
-        `id -u ${username} &>/dev/null || useradd -o -u ${uid} -g ${gid} -d ${homeDir} -s /bin/bash ${username}`,
-      ].join(' && ');
+      const quotedHomeDir = quote([homeDir]);
 
       const originalCommand = finalEntrypoint[2];
       const escapedOriginalCommand = originalCommand.replace(/'/g, "'\\''");
 
-      // Use `su -p` to preserve the environment.
-      const suCommand = `su -p ${username} -c '${escapedOriginalCommand}'`;
+      // Use defensive entrypoint logic that checks for useradd availability.
+      // This ensures we can support UID/GID mapping on distros that have these
+      // tools. If useradd is missing (e.g. on minimal images), we fail explicitly
+      // to avoid insecurely falling back to root execution with host mounts.
+      const defensiveEntrypoint = [
+        `if command -v useradd >/dev/null 2>&1; then`,
+        `  (groupadd -g ${gid} -o ${username} 2>/dev/null || true) &&`,
+        `  (id ${uid} >/dev/null 2>&1 || useradd -o -u ${uid} -g ${gid} -d ${quotedHomeDir} -s /bin/bash ${username} 2>/dev/null || true) &&`,
+        `  USER_NAME=$(id -nu ${uid} 2>/dev/null);`,
+        `  if [ -n "$USER_NAME" ]; then`,
+        `    su -p "$USER_NAME" -c '${escapedOriginalCommand}';`,
+        `  else`,
+        `    echo "Error: Failed to map host UID ${uid} to a user in the container." >&2;`,
+        `    exit 1;`,
+        `  fi`,
+        `else`,
+        `  echo "Error: 'useradd' not found in container. UID/GID mapping is required for Linux distros like NixOS/Arch to avoid permission issues. Please use a container image that includes standard user management tools (like 'ubuntu' or 'debian')." >&2;`,
+        `  exit 1;`,
+        `fi`,
+      ].join('\n');
 
       // The entrypoint is always `['bash', '-c', '<command>']`, so we modify the command part.
-      finalEntrypoint[2] = `${setupUserCommands} && ${suCommand}`;
+      finalEntrypoint[2] = defensiveEntrypoint;
 
       // We still need userFlag for the simpler proxy container, which does not have this issue.
       userFlag = `--user ${uid}:${gid}`;

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -143,6 +143,95 @@ describe('sandboxUtils', () => {
       expect(await shouldUseCurrentUserInSandbox()).toBe(true);
     });
 
+    it('should return true on NixOS', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue('ID=nixos\n');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(true);
+    });
+
+    it('should return true on NixOS with quotes', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue('ID="nixos"\n');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(true);
+    });
+
+    it('should return true on Ubuntu with single quotes', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue("ID='ubuntu'\n");
+      expect(await shouldUseCurrentUserInSandbox()).toBe(true);
+    });
+
+    it('should return true on Arch Linux', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue('ID=arch\n');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(true);
+    });
+
+    it('should return false on unrecognized Linux and warn on UID mismatch', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue('ID=unknown\n');
+      vi.mocked(os.userInfo).mockReturnValue({
+        uid: 1234,
+        username: 'test',
+        gid: 1234,
+        shell: '/bin/bash',
+        homedir: '/home/test',
+      });
+
+      const { debugLogger } = await import('@google/gemini-cli-core');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(false);
+      expect(debugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Host UID mismatch detected (current UID: 1234)',
+        ),
+      );
+    });
+
+    it('should return true on Pop!_OS (via ID_LIKE)', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue(
+        'ID=pop\nID_LIKE="ubuntu debian"\n',
+      );
+      expect(await shouldUseCurrentUserInSandbox()).toBe(true);
+    });
+
+    it('should return false and NOT warn for host root user (UID 0)', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockResolvedValue('ID=unknown\n');
+      vi.mocked(os.userInfo).mockReturnValue({
+        uid: 0,
+        username: 'root',
+        gid: 0,
+        shell: '/bin/bash',
+        homedir: '/root',
+      });
+
+      const { debugLogger } = await import('@google/gemini-cli-core');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(false);
+      expect(debugLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Host UID mismatch detected'),
+      );
+    });
+
+    it('should warn and return false if /etc/os-release is unreadable', async () => {
+      delete process.env['SANDBOX_SET_UID_GID'];
+      vi.mocked(os.platform).mockReturnValue('linux');
+      vi.mocked(readFile).mockRejectedValue(new Error('EACCES'));
+
+      const { debugLogger } = await import('@google/gemini-cli-core');
+      expect(await shouldUseCurrentUserInSandbox()).toBe(false);
+      expect(debugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not read /etc/os-release'),
+      );
+    });
+
     it('should return false on non-Linux', async () => {
       delete process.env['SANDBOX_SET_UID_GID'];
       vi.mocked(os.platform).mockReturnValue('darwin');

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -49,22 +49,35 @@ export async function shouldUseCurrentUserInSandbox(): Promise<boolean> {
   if (os.platform() === 'linux') {
     try {
       const osReleaseContent = await readFile('/etc/os-release', 'utf8');
-      if (
-        osReleaseContent.includes('ID=debian') ||
-        osReleaseContent.includes('ID=ubuntu') ||
-        osReleaseContent.match(/^ID_LIKE=.*debian.*/m) || // Covers derivatives
-        osReleaseContent.match(/^ID_LIKE=.*ubuntu.*/m) // Covers derivatives
-      ) {
+      const isSupportedDistro =
+        osReleaseContent.match(
+          /^ID=["']?(?:debian|ubuntu|nixos|arch|fedora|suse|opensuse)/m,
+        ) ||
+        osReleaseContent.match(
+          /^ID_LIKE=["']?.*(?:debian|ubuntu|arch|fedora|suse).*/m,
+        );
+
+      if (isSupportedDistro) {
         debugLogger.log(
-          'Defaulting to use current user UID/GID for Debian/Ubuntu-based Linux.',
+          'Defaulting to use current user UID/GID for supported Linux distribution.',
         );
         return true;
+      }
+
+      // If we're on Linux but the distro is unrecognized, check for a UID mismatch
+      // that might cause permission issues in the sandbox.
+      const uid = os.userInfo().uid;
+      if (uid !== 1000 && uid !== 0) {
+        debugLogger.warn(
+          `Warning: Host UID mismatch detected (current UID: ${uid}). ` +
+            'If you encounter permission errors in the sandbox, try setting SANDBOX_SET_UID_GID=true.',
+        );
       }
     } catch {
       // Silently ignore if /etc/os-release is not found or unreadable.
       // The default (false) will be applied in this case.
       debugLogger.warn(
-        'Warning: Could not read /etc/os-release to auto-detect Debian/Ubuntu for UID/GID default.',
+        'Warning: Could not read /etc/os-release to auto-detect Linux distribution for UID/GID default.',
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes a 'permission denied' (EACCES) error when running in sandbox mode on Linux distributions like NixOS where the host user's UID is not 1000.

## Details

The issue was caused by a UID/GID mismatch between the host user and the container user when mounting the configuration directory.

### Key Changes:

- **Expanded OS Support**: Updated distribution heuristics to automatically enable UID/GID mapping for NixOS, Arch, Fedora, and Suse/OpenSUSE. Improved detection regex to support quoted values in `/etc/os-release`.
- **Robust User Mapping**: 
    - Overhauled the entrypoint logic to handle UID/GID collisions by checking for ID existence rather than just the 'gemini' username.
    - Used `groupadd -o` to support non-unique GIDs (common for GID 1000).
    - Dynamically resolve the container username using `id -nu ${uid}` for switching via `su`.
- **Security Hardening**:
    - Removed insecure fallback to root execution. If `useradd` is missing or mapping fails, the container now fails explicitly with a clear error message.
    - Implemented robust shell quoting for the host's home directory path and the resolved username to prevent command injection.
- **Improved UX**: Added a proactive warning for unrecognized Linux distributions with a UID mismatch, guiding users to manually enable the fix via environment variables.

## Impact on Users

- **Linux Users (NixOS, Arch, etc.)**: Fixes persistent 'Permission Denied' errors by automatically mapping host users into the container.
- **macOS/Windows Users**: Zero impact; logic is strictly Linux-specific with no performance overhead.
- **Security**: Hardens host-to-container boundaries by preventing insecure root fallback and sanitizing shell inputs.
- **Minimal Images**: Provides clearer error messages for images lacking user management tools (like Alpine), ensuring users don't inadvertently run as root with host mounts.

## Related Issues

Fixes #16968

## How to Validate

1. **Unit Tests**: Run `npm test -w @google/gemini-cli -- src/utils/sandboxUtils.test.ts src/utils/sandbox.test.ts` (46 tests).
2. **Manual (Linux)**: On a non-Debian/Ubuntu system with a non-1000 UID, run `gemini -s 'Say hello'`.
3. **Manual (Minimal Container)**: Run with a minimal image (e.g., Alpine) and verify it fails securely.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] Docker