### PR TITLE
ci: suppress bot comments during standard triage maintenance

### DIFF
--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -166,7 +166,10 @@ module.exports = async ({ github, context, core }) => {
       );
     }
 
-    if (entry.explanation || entry.effort_analysis) {
+    if (
+      !process.env.SUPPRESS_COMMENT &&
+      (entry.explanation || entry.effort_analysis)
+    ) {
       let commentBody = '';
       if (entry.explanation) {
         commentBody += entry.explanation;

--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -212,12 +212,39 @@ module.exports = async ({ github, context, core }) => {
         commentBody += `**Effort Analysis:**\n${entry.effort_analysis}`;
       }
 
-      await github.rest.issues.createComment({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: issueNumber,
-        body: commentBody,
-      });
+      // Check for duplicate comments to prevent spam
+      let isDuplicate = false;
+      try {
+        const { data: existingComments } = await github.rest.issues.listComments({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: issueNumber,
+          per_page: 20,
+          sort: 'created',
+          direction: 'desc'
+        });
+        
+        for (const comment of existingComments) {
+          if (comment.user.type === 'Bot' && comment.body === commentBody) {
+            isDuplicate = true;
+            break;
+          }
+        }
+      } catch (e) {
+        core.warning(`Failed to fetch existing comments for #${issueNumber}: ${e.message}`);
+      }
+
+      if (isDuplicate) {
+        core.info(`Skipping duplicate comment for #${issueNumber}.`);
+      } else {
+        await github.rest.issues.createComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: issueNumber,
+          body: commentBody,
+        });
+        core.info(`Successfully posted comment for #${issueNumber}.`);
+      }
     }
 
     if (

--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -200,11 +200,11 @@ module.exports = async ({ github, context, core }) => {
     }
 
     if (
-      !process.env.SUPPRESS_COMMENT &&
-      (entry.explanation || entry.effort_analysis)
+      (entry.explanation && process.env.SUPPRESS_COMMENT !== 'true') ||
+      entry.effort_analysis
     ) {
       let commentBody = '';
-      if (entry.explanation) {
+      if (entry.explanation && process.env.SUPPRESS_COMMENT !== 'true') {
         commentBody += entry.explanation;
       }
       if (entry.effort_analysis) {

--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -212,39 +212,12 @@ module.exports = async ({ github, context, core }) => {
         commentBody += `**Effort Analysis:**\n${entry.effort_analysis}`;
       }
 
-      // Check for duplicate comments to prevent spam
-      let isDuplicate = false;
-      try {
-        const { data: existingComments } = await github.rest.issues.listComments({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: issueNumber,
-          per_page: 20,
-          sort: 'created',
-          direction: 'desc'
-        });
-        
-        for (const comment of existingComments) {
-          if (comment.user.type === 'Bot' && comment.body === commentBody) {
-            isDuplicate = true;
-            break;
-          }
-        }
-      } catch (e) {
-        core.warning(`Failed to fetch existing comments for #${issueNumber}: ${e.message}`);
-      }
-
-      if (isDuplicate) {
-        core.info(`Skipping duplicate comment for #${issueNumber}.`);
-      } else {
-        await github.rest.issues.createComment({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: issueNumber,
-          body: commentBody,
-        });
-        core.info(`Successfully posted comment for #${issueNumber}.`);
-      }
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issueNumber,
+        body: commentBody,
+      });
     }
 
     if (

--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -104,6 +104,39 @@ module.exports = async ({ github, context, core }) => {
     labelsToAdd = [...new Set(labelsToAdd)];
     labelsToRemove = [...new Set(labelsToRemove)];
 
+    // Fetch existing labels to auto-resolve conflicts
+    try {
+      const { data: issueData } = await github.rest.issues.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issueNumber,
+      });
+      const existingLabels = issueData.labels.map((l) => typeof l === 'string' ? l : l.name);
+
+      const hasNewArea = labelsToAdd.some((l) => l.startsWith('area/'));
+      if (hasNewArea) {
+        const existingAreas = existingLabels.filter((l) => l.startsWith('area/'));
+        labelsToRemove.push(...existingAreas);
+      }
+
+      const hasNewPriority = labelsToAdd.some((l) => l.startsWith('priority/'));
+      if (hasNewPriority) {
+        const existingPriorities = existingLabels.filter((l) => l.startsWith('priority/'));
+        labelsToRemove.push(...existingPriorities);
+      }
+
+      const hasNewKind = labelsToAdd.some((l) => l.startsWith('kind/'));
+      if (hasNewKind) {
+        const existingKinds = existingLabels.filter((l) => l.startsWith('kind/'));
+        labelsToRemove.push(...existingKinds);
+      }
+
+      // Re-deduplicate and filter out labels we are trying to add
+      labelsToRemove = [...new Set(labelsToRemove)].filter(l => !labelsToAdd.includes(l));
+    } catch (e) {
+      core.warning(`Failed to fetch existing labels for #${issueNumber}: ${e.message}`);
+    }
+
     // Enforce mutually exclusive area labels
     const areaLabelsToAdd = labelsToAdd.filter((l) => l.startsWith('area/'));
     if (areaLabelsToAdd.length > 1) {

--- a/.github/scripts/apply-issue-labels.cjs
+++ b/.github/scripts/apply-issue-labels.cjs
@@ -111,30 +111,42 @@ module.exports = async ({ github, context, core }) => {
         repo: context.repo.repo,
         issue_number: issueNumber,
       });
-      const existingLabels = issueData.labels.map((l) => typeof l === 'string' ? l : l.name);
+      const existingLabels = issueData.labels.map((l) =>
+        typeof l === 'string' ? l : l.name,
+      );
 
       const hasNewArea = labelsToAdd.some((l) => l.startsWith('area/'));
       if (hasNewArea) {
-        const existingAreas = existingLabels.filter((l) => l.startsWith('area/'));
+        const existingAreas = existingLabels.filter((l) =>
+          l.startsWith('area/'),
+        );
         labelsToRemove.push(...existingAreas);
       }
 
       const hasNewPriority = labelsToAdd.some((l) => l.startsWith('priority/'));
       if (hasNewPriority) {
-        const existingPriorities = existingLabels.filter((l) => l.startsWith('priority/'));
+        const existingPriorities = existingLabels.filter((l) =>
+          l.startsWith('priority/'),
+        );
         labelsToRemove.push(...existingPriorities);
       }
 
       const hasNewKind = labelsToAdd.some((l) => l.startsWith('kind/'));
       if (hasNewKind) {
-        const existingKinds = existingLabels.filter((l) => l.startsWith('kind/'));
+        const existingKinds = existingLabels.filter((l) =>
+          l.startsWith('kind/'),
+        );
         labelsToRemove.push(...existingKinds);
       }
 
       // Re-deduplicate and filter out labels we are trying to add
-      labelsToRemove = [...new Set(labelsToRemove)].filter(l => !labelsToAdd.includes(l));
+      labelsToRemove = [...new Set(labelsToRemove)].filter(
+        (l) => !labelsToAdd.includes(l),
+      );
     } catch (e) {
-      core.warning(`Failed to fetch existing labels for #${issueNumber}: ${e.message}`);
+      core.warning(
+        `Failed to fetch existing labels for #${issueNumber}: ${e.message}`,
+      );
     }
 
     // Enforce mutually exclusive area labels

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -1,10 +1,6 @@
 name: '📋 Gemini Scheduled Issue Triage'
 
 on:
-  issues:
-    types:
-      - 'opened'
-      - 'reopened'
   schedule:
     - cron: '0 * * * *' # Runs every hour
   workflow_dispatch:

--- a/.github/workflows/gemini-scheduled-issue-triage.yml
+++ b/.github/workflows/gemini-scheduled-issue-triage.yml
@@ -391,6 +391,7 @@ jobs:
         env:
           REPOSITORY: '${{ github.repository }}'
           LABELS_OUTPUT: '${{ steps.gemini_standard_issue_analysis.outputs.summary }}'
+          SUPPRESS_COMMENT: 'true'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'
         with:
           github-token: '${{ steps.generate_token.outputs.token }}'


### PR DESCRIPTION
This PR addresses a severe bot spamming issue (reported in #26862) caused by an infinite triage loop and incorrect workflow triggers.

### Changes Included:
1. **Silent Janitorial Triage:** Standard label conflict resolution is now silent. The bot will no longer post repetitive 'Assigned kind...' comments when running its scheduled backlog sweeps.
2. **Preserved Effort Analysis:** High-value architectural and effort analysis comments remain enabled, ensuring contributors still receive crucial context.
3. **Robust Conflict Resolution:** The `apply-issue-labels.cjs` script now automatically strips all existing labels within a category (e.g., all existing `priority/*` labels) before applying a new one suggested by the AI. This definitively breaks the infinite loop where issues remained in a conflicted state.
4. **Corrected Workflow Triggers:** Removed the `opened` and `reopened` event triggers from `gemini-scheduled-issue-triage.yml`. This heavy, backlog-scanning workflow will now strictly run on its hourly cron schedule as intended, rather than firing unnecessarily on individual issue updates (which are already handled by `gemini-automated-issue-triage.yml`).