### PR TITLE
fix(core): throttle shell text output to prevent UI jank on high-volu…

### DIFF
--- a/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
+++ b/packages/cli/src/ui/hooks/useExecutionLifecycle.ts
@@ -366,6 +366,8 @@ export const useExecutionLifecycle = (
         let cumulativeStdout: string | AnsiOutput = '';
         let isBinaryStream = false;
         let binaryBytesReceived = 0;
+        let lastUpdateTime = 0;
+        let trailingFlushTimer: NodeJS.Timeout | null = null;
 
         const initialToolDisplay: IndividualToolCallDisplay = {
           callId,
@@ -434,11 +436,22 @@ export const useExecutionLifecycle = (
                       } else {
                         cumulativeStdout = event.chunk;
                       }
+                      if (
+                        Date.now() - lastUpdateTime >
+                        OUTPUT_UPDATE_INTERVAL_MS
+                      ) {
+                        shouldUpdate = true;
+                      } else if (trailingFlushTimer === null) {
+                        trailingFlushTimer = setTimeout(() => {
+                          trailingFlushTimer = null;
+                          flushDisplayUpdate();
+                        }, OUTPUT_UPDATE_INTERVAL_MS);
+                      }
                     } else {
-                      // AnsiOutput (PTY) is always the full state
+                      // AnsiOutput (PTY) is always the full state — no throttle
                       cumulativeStdout = event.chunk;
+                      shouldUpdate = true;
                     }
-                    shouldUpdate = true;
                     break;
                   case 'binary_detected':
                     isBinaryStream = true;
@@ -450,7 +463,11 @@ export const useExecutionLifecycle = (
                     shouldUpdate = true;
                     break;
                   case 'exit':
-                    // No action needed for exit event during streaming
+                    if (trailingFlushTimer !== null) {
+                      clearTimeout(trailingFlushTimer);
+                      trailingFlushTimer = null;
+                    }
+                    flushDisplayUpdate();
                     break;
                   default:
                     throw new Error('An unhandled ShellOutputEvent was found.');
@@ -467,18 +484,27 @@ export const useExecutionLifecycle = (
                   return;
                 }
 
-                let currentDisplayOutput: string | AnsiOutput;
-                if (isBinaryStream) {
-                  currentDisplayOutput =
-                    binaryBytesReceived > 0
-                      ? `[Receiving binary output... ${formatBytes(binaryBytesReceived)} received]`
-                      : '[Binary output detected. Halting stream...]';
-                } else {
-                  currentDisplayOutput = cumulativeStdout;
+                if (shouldUpdate) {
+                  if (trailingFlushTimer !== null) {
+                    clearTimeout(trailingFlushTimer);
+                    trailingFlushTimer = null;
+                  }
+                  flushDisplayUpdate();
                 }
 
-                if (shouldUpdate) {
-                  dispatch({ type: 'SET_OUTPUT_TIME', time: Date.now() });
+                function flushDisplayUpdate() {
+                  let currentDisplayOutput: string | AnsiOutput;
+                  if (isBinaryStream) {
+                    currentDisplayOutput =
+                      binaryBytesReceived > 0
+                        ? `[Receiving binary output... ${formatBytes(binaryBytesReceived)} received]`
+                        : '[Binary output detected. Halting stream...]';
+                  } else {
+                    currentDisplayOutput = cumulativeStdout;
+                  }
+
+                  lastUpdateTime = Date.now();
+                  dispatch({ type: 'SET_OUTPUT_TIME', time: lastUpdateTime });
                   setPendingHistoryItem((prevItem) => {
                     if (prevItem?.type === 'tool_group') {
                       return {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -713,6 +713,137 @@ EOF`;
 
         await promise;
       });
+
+      it('should render the first text data event immediately', async () => {
+        const invocation = shellTool.build({ command: 'echo hello' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        mockShellOutputCallback({ type: 'data', chunk: 'hello\n' });
+        expect(updateOutputMock).toHaveBeenCalledExactlyOnceWith('hello\n');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('hello\n'),
+          output: 'hello\n',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should throttle rapid text data events to OUTPUT_UPDATE_INTERVAL_MS', async () => {
+        const invocation = shellTool.build({ command: 'build' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        // First event renders immediately (lastUpdateTime starts at 0)
+        mockShellOutputCallback({ type: 'data', chunk: 'line 1\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Rapid subsequent events are throttled
+        mockShellOutputCallback({ type: 'data', chunk: 'line 2\n' });
+        mockShellOutputCallback({ type: 'data', chunk: 'line 3\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Advance past twice the throttle interval to ensure trailing flush
+        // fires AND enough time passes for the next event to render
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2 + 1);
+
+        // Trailing flush should have rendered with the last buffered value
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 3\n');
+
+        // Next event after the interval should render immediately
+        mockShellOutputCallback({ type: 'data', chunk: 'line 4\n' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(3);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 4\n');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from(''),
+          output: 'line 1\nline 2\nline 3\nline 4\n',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should trailing-flush throttled text when the command goes silent', async () => {
+        const invocation = shellTool.build({ command: 'build' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        // First event renders immediately
+        mockShellOutputCallback({ type: 'data', chunk: 'line 1\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Second event is throttled
+        mockShellOutputCallback({ type: 'data', chunk: 'line 2\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // After OUTPUT_UPDATE_INTERVAL_MS, trailing flush fires
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 2\n');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from(''),
+          output: 'line 1\nline 2\n',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should flush remaining output on exit event', async () => {
+        const invocation = shellTool.build({ command: 'build' });
+        const promise = invocation.execute({
+          abortSignal: mockAbortSignal,
+          updateOutput: updateOutputMock,
+        });
+
+        // First event renders immediately
+        mockShellOutputCallback({ type: 'data', chunk: 'line 1\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Second event is throttled
+        mockShellOutputCallback({ type: 'data', chunk: 'final\n' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Exit event flushes remaining output immediately
+        mockShellOutputCallback({ type: 'exit', exitCode: 0, signal: null });
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('final\n');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from(''),
+          output: 'line 1\nfinal\n',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
     });
   });
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -502,8 +502,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
         };
       }
       let cumulativeOutput: string | AnsiOutput = '';
-      let lastUpdateTime = Date.now();
+      let lastUpdateTime = 0;
       let isBinaryStream = false;
+      let trailingFlushTimer: NodeJS.Timeout | null = null;
 
       const resetTimeout = () => {
         if (timeoutMs <= 0) {
@@ -539,7 +540,25 @@ export class ShellToolInvocation extends BaseToolInvocation<
               case 'data':
                 if (isBinaryStream) break;
                 cumulativeOutput = event.chunk;
-                shouldUpdate = true;
+                if (typeof event.chunk !== 'string') {
+                  // AnsiOutput (PTY) — already debounced in the service layer
+                  shouldUpdate = true;
+                } else if (
+                  Date.now() - lastUpdateTime >
+                  OUTPUT_UPDATE_INTERVAL_MS
+                ) {
+                  shouldUpdate = true;
+                } else {
+                  if (trailingFlushTimer === null) {
+                    trailingFlushTimer = setTimeout(() => {
+                      trailingFlushTimer = null;
+                      if (!this.params.is_background) {
+                        updateOutput(cumulativeOutput);
+                        lastUpdateTime = Date.now();
+                      }
+                    }, OUTPUT_UPDATE_INTERVAL_MS);
+                  }
+                }
                 break;
               case 'binary_detected':
                 isBinaryStream = true;
@@ -557,6 +576,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
                 }
                 break;
               case 'exit':
+                if (trailingFlushTimer !== null) {
+                  clearTimeout(trailingFlushTimer);
+                  trailingFlushTimer = null;
+                }
+                if (cumulativeOutput && !this.params.is_background) {
+                  updateOutput(cumulativeOutput);
+                  lastUpdateTime = Date.now();
+                }
                 break;
               default: {
                 throw new Error('An unhandled ShellOutputEvent was found.');
@@ -564,6 +591,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
             }
 
             if (shouldUpdate && !this.params.is_background) {
+              if (trailingFlushTimer !== null) {
+                clearTimeout(trailingFlushTimer);
+                trailingFlushTimer = null;
+              }
               updateOutput(cumulativeOutput);
               lastUpdateTime = Date.now();
             }


### PR DESCRIPTION
Shell tool `data` events triggered a React re-render on every chunk while `binary_progress` was already throttled to 1s intervals. Commands emitting thousands of lines pinned the UI until exit.

Apply OUTPUT_UPDATE_INTERVAL_MS (1s) throttling to text data events, matching the existing binary_progress throttle. This prevents thousands of React re-renders when commands emit high-volume output (builds, verbose test runs, npm install warnings).

Key changes:
- First text chunk renders immediately (lastUpdateTime starts at 0)
- PTY (AnsiOutput) snapshots bypass throttle (already debounced at 68ms)
- Trailing-edge flush ensures buffered output appears when command goes silent
- Exit event flushes remaining output and cancels pending timers

Fixes #25459

## Summary

Apply `OUTPUT_UPDATE_INTERVAL_MS` (1s) throttling to shell text `data` events in both the core tool (`shell.ts`) and the CLI UI hook (`useExecutionLifecycle.ts`), matching the existing `binary_progress` cadence. High-volume commands (builds, verbose test runs) no longer pin the terminal UI with thousands of React re-renders.

## Details

- `lastUpdateTime` starts at `0` so the very first text chunk renders immediately (no initial 1s blank)
- PTY `AnsiOutput` snapshots bypass the throttle entirely — they are already debounced at 68ms in `shellExecutionService`
- A trailing-edge `setTimeout` flush ensures buffered output appears even when a command emits a burst then goes silent
- The `exit` event flushes remaining output and cancels any pending trailing timer
- Final complete output is unaffected — it is rendered from the full result returned by `shellExecutionService` after the command exits

## Related Issues

Fixes #25459

## How to Validate

1. Run unit tests: `npx vitest run packages/core/src/tools/shell.test.ts` — all 82 tests pass (4 new regression tests)
2. Run a high-volume shell command from inside the CLI: `for i in $(seq 1 20000); do echo "line $i"; done`
3. Verify the UI stays responsive while the command runs (no freeze, input stays interactive) and the final output is complete and correct
4. Run a PTY-style command (e.g. anything with ANSI progress bars) and verify updates still appear at full rate (no throttle on PTY)

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker