### PR TITLE
fix(core): buffer chat compression telemetry

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -187,6 +187,24 @@ describe('loggers', () => {
         { tokens_before: 9001, tokens_after: 9000 },
       );
     });
+
+    it('buffers the chat compression OTEL event and metrics', () => {
+      vi.spyOn(sdk, 'bufferTelemetryEvent').mockImplementation(() => {});
+      const mockConfig = makeFakeConfig();
+      const event = makeChatCompressionEvent({
+        tokens_before: 9001,
+        tokens_after: 9000,
+      });
+
+      logChatCompression(mockConfig, event);
+
+      expect(sdk.bufferTelemetryEvent).toHaveBeenCalledOnce();
+      expect(mockLogger.emit).not.toHaveBeenCalled();
+      expect(metrics.recordChatCompressionMetrics).not.toHaveBeenCalled();
+      expect(
+        ClearcutLogger.prototype.logChatCompressionEvent,
+      ).toHaveBeenCalledWith(event);
+    });
   });
 
   describe('logCliConfiguration', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -442,16 +442,18 @@ export function logChatCompression(
 ): void {
   ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  recordChatCompressionMetrics(config, {
-    tokens_before: event.tokens_before,
-    tokens_after: event.tokens_after,
+    recordChatCompressionMetrics(config, {
+      tokens_before: event.tokens_before,
+      tokens_after: event.tokens_after,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- wrap chat compression OTel logging in bufferTelemetryEvent
- buffer the associated chat compression metrics call with the OTel event
- keep Clearcut chat compression logging immediate

Fixes #23445.

## Validation
- npx vitest run packages/core/src/telemetry/loggers.test.ts
- npx eslint packages/core/src/telemetry/loggers.ts packages/core/src/telemetry/loggers.test.ts --max-warnings 0
- npx prettier --check packages/core/src/telemetry/loggers.ts packages/core/src/telemetry/loggers.test.ts
- git diff --check origin/main...HEAD
- git merge-tree origin/main fix-telemetry-buffer-23445-forksafe