### PR TITLE
fix(acp/auth): prevent conflicting credentials on enterprise gateways and support optional API keys natively

### DIFF
--- a/packages/cli/src/acp/acpSessionManager.ts
+++ b/packages/cli/src/acp/acpSessionManager.ts
@@ -69,7 +69,10 @@ export class AcpSessionManager {
     );
 
     const authType =
-      loadedSettings.merged.security.auth.selectedType || AuthType.USE_GEMINI;
+      loadedSettings.merged.security.auth.selectedType ||
+      (authDetails.baseUrl || process.env['GOOGLE_GEMINI_BASE_URL']
+        ? AuthType.GATEWAY
+        : AuthType.USE_GEMINI);
 
     let isAuthenticated = false;
     let authErrorMessage = '';
@@ -231,7 +234,12 @@ export class AcpSessionManager {
     mcpServers: acp.McpServer[],
     authDetails: AuthDetails,
   ): Promise<Config> {
-    const selectedAuthType = this.settings.merged.security.auth.selectedType;
+    const selectedAuthType =
+      this.settings.merged.security.auth.selectedType ||
+      (authDetails.baseUrl || process.env['GOOGLE_GEMINI_BASE_URL']
+        ? AuthType.GATEWAY
+        : undefined);
+
     if (!selectedAuthType) {
       throw acp.RequestError.authRequired();
     }

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -9,6 +9,7 @@ import {
   createContentGenerator,
   AuthType,
   createContentGeneratorConfig,
+  getAuthTypeFromEnv,
   type ContentGenerator,
 } from './contentGenerator.js';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
@@ -34,6 +35,45 @@ const mockConfig = {
   getUsageStatisticsEnabled: vi.fn().mockReturnValue(true),
   getClientName: vi.fn().mockReturnValue(undefined),
 } as unknown as Config;
+
+describe('getAuthTypeFromEnv', () => {
+  beforeEach(() => {
+    vi.stubEnv('GEMINI_API_KEY', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should detect LOGIN_WITH_GOOGLE when GOOGLE_GENAI_USE_GCA is true', () => {
+    vi.stubEnv('GOOGLE_GENAI_USE_GCA', 'true');
+    expect(getAuthTypeFromEnv()).toBe(AuthType.LOGIN_WITH_GOOGLE);
+  });
+
+  it('should detect USE_VERTEX_AI when GOOGLE_GENAI_USE_VERTEXAI is true', () => {
+    vi.stubEnv('GOOGLE_GENAI_USE_VERTEXAI', 'true');
+    expect(getAuthTypeFromEnv()).toBe(AuthType.USE_VERTEX_AI);
+  });
+
+  it('should detect GATEWAY when GOOGLE_GEMINI_BASE_URL is present', () => {
+    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', 'https://gateway.example.com');
+    expect(getAuthTypeFromEnv()).toBe(AuthType.GATEWAY);
+  });
+
+  it('should detect USE_GEMINI when GEMINI_API_KEY is present', () => {
+    vi.stubEnv('GEMINI_API_KEY', 'fake-key');
+    expect(getAuthTypeFromEnv()).toBe(AuthType.USE_GEMINI);
+  });
+
+  it('should detect COMPUTE_ADC when CLOUD_SHELL is true', () => {
+    vi.stubEnv('CLOUD_SHELL', 'true');
+    expect(getAuthTypeFromEnv()).toBe(AuthType.COMPUTE_ADC);
+  });
+
+  it('should return undefined when no matching env variables are set', () => {
+    expect(getAuthTypeFromEnv()).toBeUndefined();
+  });
+});
 
 describe('createContentGenerator', () => {
   beforeEach(() => {
@@ -851,6 +891,40 @@ describe('createContentGenerator', () => {
       ),
     ).rejects.toThrow('Invalid custom base URL: not-a-url');
   });
+
+  it('should set empty x-goog-api-key header for GATEWAY auth when apiKey is empty string', async () => {
+    const mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+
+    await createContentGenerator(
+      {
+        apiKey: '',
+        authType: AuthType.GATEWAY,
+        baseUrl: 'https://gateway.test.local',
+      },
+      mockConfig,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: '',
+        httpOptions: expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-goog-api-key': '',
+          }),
+        }),
+      }),
+    );
+  });
 });
 
 describe('createContentGeneratorConfig', () => {
@@ -955,24 +1029,33 @@ describe('createContentGeneratorConfig', () => {
     expect(config.apiKey).toBeUndefined();
     expect(config.vertexai).toBeUndefined();
   });
-  it('should configure for GATEWAY using dummy placeholder if GEMINI_API_KEY is set', async () => {
-    vi.stubEnv('GEMINI_API_KEY', 'env-gemini-key');
+  it('should configure for GATEWAY using provided apiKey if available', async () => {
     const config = await createContentGeneratorConfig(
       mockConfig,
       AuthType.GATEWAY,
+      'custom-gateway-key',
     );
-    expect(config.apiKey).toBe('gateway-placeholder-key');
+    expect(config.apiKey).toBe('custom-gateway-key');
     expect(config.vertexai).toBe(false);
   });
 
-  it('should configure for GATEWAY using dummy placeholder if GEMINI_API_KEY is not set', async () => {
-    vi.stubEnv('GEMINI_API_KEY', '');
-    vi.mocked(loadApiKey).mockResolvedValue(null);
+  it('should configure for GATEWAY using GEMINI_API_KEY from environment if set', async () => {
+    vi.stubEnv('GEMINI_API_KEY', 'env-gateway-key');
     const config = await createContentGeneratorConfig(
       mockConfig,
       AuthType.GATEWAY,
     );
-    expect(config.apiKey).toBe('gateway-placeholder-key');
+    expect(config.apiKey).toBe('env-gateway-key');
+    expect(config.vertexai).toBe(false);
+  });
+
+  it('should configure for GATEWAY using empty string if no apiKey is provided', async () => {
+    vi.stubEnv('GEMINI_API_KEY', '');
+    const config = await createContentGeneratorConfig(
+      mockConfig,
+      AuthType.GATEWAY,
+    );
+    expect(config.apiKey).toBe('');
     expect(config.vertexai).toBe(false);
   });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -80,6 +80,9 @@ export function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env['GOOGLE_GENAI_USE_VERTEXAI'] === 'true') {
     return AuthType.USE_VERTEX_AI;
   }
+  if (process.env['GOOGLE_GEMINI_BASE_URL']) {
+    return AuthType.GATEWAY;
+  }
   if (process.env['GEMINI_API_KEY']) {
     return AuthType.USE_GEMINI;
   }
@@ -178,7 +181,8 @@ export async function createContentGeneratorConfig(
   }
 
   if (authType === AuthType.GATEWAY) {
-    contentGeneratorConfig.apiKey = apiKey || 'gateway-placeholder-key';
+    contentGeneratorConfig.apiKey =
+      apiKey || process.env['GEMINI_API_KEY'] || '';
     contentGeneratorConfig.vertexai = false;
 
     return contentGeneratorConfig;
@@ -313,6 +317,9 @@ export async function createContentGenerator(
           'x-gemini-api-privileged-user-id': `${installationId}`,
         };
       }
+      if (config.authType === AuthType.GATEWAY && config.apiKey === '') {
+        headers['x-goog-api-key'] = '';
+      }
       let baseUrl = config.baseUrl;
       if (!baseUrl) {
         const envBaseUrl =
@@ -337,7 +344,12 @@ export async function createContentGenerator(
       }
 
       const googleGenAI = new GoogleGenAI({
-        apiKey: config.apiKey === '' ? undefined : config.apiKey,
+        apiKey:
+          config.authType === AuthType.GATEWAY
+            ? config.apiKey
+            : config.apiKey === ''
+              ? undefined
+              : config.apiKey,
         vertexai: config.vertexai ?? config.authType === AuthType.USE_VERTEX_AI,
         httpOptions,
         ...(apiVersionEnv && { apiVersion: apiVersionEnv }),


### PR DESCRIPTION
## Summary

Configures the `GATEWAY` authentication mode to supply an empty string for `apiKey` instead of injecting a dummy placeholder, avoiding client instantiation errors while natively suppressing conflicting `x-goog-api-key` headers. Additionally, updates ACP session initialization to infer `GATEWAY` auth when custom proxy URLs are active, allowing sidecar agents to connect without needing placeholder environment variables.

## Details

Why this happened:
Previously, initializing a session with the `GATEWAY` auth method without specifying an API key caused the underlying `@google/genai` SDK to throw a constructor initialization error. 

To circumvent this, a placeholder key (`'gateway-placeholder-key'`) was automatically injected. However, the SDK's internal `WebAuth` module unconditionally appended this placeholder as an `x-goog-api-key` header to outgoing network requests. 

When enterprise AI API Gateways received both an OIDC authentication header (e.g., `Authorization: Bearer <token>`) and the invalid placeholder key, they prioritized validating the API key and rejected the requests. Furthermore, partner IDE sidecars initializing sessions via ACP were forced to provide dummy `GEMINI_API_KEY` environment variables to bypass the agent's default startup assertions.

Solution Implemented:
1. Pristine SDK Configuration: Configured `createContentGeneratorConfig` to supply an empty string (`apiKey ?? ''`) when `GATEWAY` auth is used without an explicit key. This fulfills the SDK constructor's null check while preventing unwanted key injection.
2. Network Header Suppression: Updated `createContentGenerator` to pre-clear the `x-goog-api-key` base header (`headers['x-goog-api-key'] = ''`) whenever `GATEWAY` auth runs with an empty string key. This triggers an early return inside the SDK's `WebAuth` interceptor, guaranteeing that outgoing requests heading to enterprise Gateways remain pristine.
3. Robust ACP Handshake: Refined `acpSessionManager.ts` to natively infer `AuthType.GATEWAY` if the environment configures a custom gateway URL (`GOOGLE_GEMINI_BASE_URL`). This cleanly bypasses default `USE_GEMINI` startup validations, eliminating the need for partner IDEs to inject dummy environment keys.


## Related Issues

Fixes google-gemini/maintainers-gemini-cli#1663


## How to Validate

No regressions in unit tests and get Partner IDEs to help validate. 

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [NA] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [NA] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
