### PR TITLE
fix(core): handle Windows paths under WSL

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -20,6 +20,9 @@ import {
   toAbsolutePath,
   toPathKey,
   isTrustedSystemPath,
+  isWSL,
+  resetWslCache,
+  translateWindowsPath,
 } from './paths.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -40,6 +43,79 @@ const mockPlatform = (platform: string) => {
     }),
   );
 };
+
+describe('translateWindowsPath', () => {
+  beforeEach(() => {
+    resetWslCache();
+  });
+
+  afterEach(() => {
+    resetWslCache();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('should detect WSL from environment variables and cache the result', () => {
+    mockPlatform('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+
+    expect(isWSL()).toBe(true);
+
+    vi.stubEnv('WSL_DISTRO_NAME', '');
+    expect(isWSL()).toBe(true);
+
+    resetWslCache();
+    mockPlatform('darwin');
+    expect(isWSL()).toBe(false);
+  });
+
+  it('should translate Windows drive paths when running in WSL', () => {
+    mockPlatform('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+
+    expect(translateWindowsPath('C:\\Users\\test\\project')).toBe(
+      '/mnt/c/Users/test/project',
+    );
+    expect(translateWindowsPath('D:/repo/src')).toBe('/mnt/d/repo/src');
+    expect(translateWindowsPath('E:')).toBe('/mnt/e/');
+    expect(translateWindowsPath('Z:\\')).toBe('/mnt/z/');
+  });
+
+  it('should preserve UNC and network paths in WSL', () => {
+    mockPlatform('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+
+    expect(translateWindowsPath('\\\\server\\share\\file.txt')).toBe(
+      '\\\\server\\share\\file.txt',
+    );
+    expect(translateWindowsPath('//server/share/file.txt')).toBe(
+      '//server/share/file.txt',
+    );
+  });
+
+  it('should leave paths unchanged outside WSL', () => {
+    mockPlatform('darwin');
+
+    expect(translateWindowsPath('C:\\Users\\test')).toBe('C:\\Users\\test');
+    expect(translateWindowsPath('/home/user/test')).toBe('/home/user/test');
+  });
+
+  it('should apply WSL drive translation in path helpers', () => {
+    mockPlatform('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+
+    expect(toAbsolutePath('C:\\Users\\test\\project')).toBe(
+      '/mnt/c/Users/test/project',
+    );
+    expect(normalizePath('D:/Repo/Src')).toBe('/mnt/d/Repo/Src');
+    expect(isSubpath('C:\\Users\\test', 'C:\\Users\\test\\project')).toBe(
+      true,
+    );
+    expect(resolveToRealPath('C:\\Users\\test\\missing.txt')).toBe(
+      '/mnt/c/Users/test/missing.txt',
+    );
+  });
+});
 
 describe('escapePath', () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -319,6 +319,64 @@ export function getProjectHash(projectRoot: string): string {
   return crypto.createHash('sha256').update(projectRoot).digest('hex');
 }
 
+let isWslCache: boolean | undefined;
+
+export function resetWslCache(): void {
+  isWslCache = undefined;
+}
+
+export function isWSL(): boolean {
+  if (isWslCache !== undefined) {
+    return isWslCache;
+  }
+
+  if (process.platform !== 'linux') {
+    isWslCache = false;
+    return isWslCache;
+  }
+
+  if (
+    process.env['WSL_DISTRO_NAME'] ||
+    process.env['WSL_INTEROP'] ||
+    process.env['WSLENV']
+  ) {
+    isWslCache = true;
+    return isWslCache;
+  }
+
+  try {
+    const kernelVersion = fs.readFileSync('/proc/version', 'utf8');
+    isWslCache = /microsoft|wsl/i.test(kernelVersion);
+  } catch {
+    isWslCache = false;
+  }
+
+  return isWslCache;
+}
+
+function isWindowsNetworkPath(p: string): boolean {
+  return p.startsWith('\\\\') || p.startsWith('//');
+}
+
+/**
+ * Translates Windows drive paths to WSL mount paths when running under WSL.
+ * UNC/network paths are left untouched because they do not map to /mnt drives.
+ */
+export function translateWindowsPath(p: string): string {
+  if (!p || !isWSL() || isWindowsNetworkPath(p)) {
+    return p;
+  }
+
+  const match = /^([a-zA-Z]):(?:[\\/](.*))?$/.exec(p);
+  if (!match) {
+    return p;
+  }
+
+  const drive = match[1].toLowerCase();
+  const rest = match[2]?.replace(/\\/g, '/') ?? '';
+  return rest ? `/mnt/${drive}/${rest}` : `/mnt/${drive}/`;
+}
+
 /**
  * Resolves a path to an absolute path with forward slashes, preserving the
  * original case of every segment.
@@ -329,9 +387,10 @@ export function getProjectHash(projectRoot: string): string {
  * filesystems use `normalizePath` instead.
  */
 export function toAbsolutePath(p: string): string {
+  const translatedPath = translateWindowsPath(p);
   const isWindows = process.platform === 'win32';
   const pathModule = isWindows ? path.win32 : path;
-  return pathModule.resolve(p).replace(/\\/g, '/');
+  return pathModule.resolve(translatedPath).replace(/\\/g, '/');
 }
 
 /**
@@ -358,6 +417,8 @@ export function normalizePath(p: string): string {
  * @returns True if childPath is a subpath of parentPath, false otherwise.
  */
 export function isSubpath(parentPath: string, childPath: string): boolean {
+  const translatedParentPath = translateWindowsPath(parentPath);
+  const translatedChildPath = translateWindowsPath(childPath);
   const platform = process.platform;
   const isWindows = platform === 'win32';
   const isDarwin = platform === 'darwin';
@@ -365,8 +426,8 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
 
   // Resolve both paths to absolute to ensure consistent comparison,
   // especially when mixing relative and absolute paths or when casing differs.
-  let p = pathModule.resolve(parentPath);
-  let c = pathModule.resolve(childPath);
+  let p = pathModule.resolve(translatedParentPath);
+  let c = pathModule.resolve(translatedChildPath);
 
   // On Windows, path.relative is case-insensitive.
   // On POSIX (including Darwin), path.relative is case-sensitive.
@@ -412,7 +473,7 @@ export function assertValidPathString(p: unknown): asserts p is string {
  */
 export function resolveToRealPath(pathStr: string): string {
   assertValidPathString(pathStr);
-  let resolvedPath = pathStr;
+  let resolvedPath = translateWindowsPath(pathStr);
 
   try {
     if (resolvedPath.startsWith('file://')) {


### PR DESCRIPTION
## Summary
- Translate Windows drive-letter paths to WSL mount paths when running under WSL.
- Preserve existing path resolution behavior for non-WSL and native Windows environments.
- Add focused coverage for WSL path translation and subpath checks.

## Validation
- npm test -w @google/gemini-cli-core -- src/utils/paths.test.ts
- npm run typecheck --workspace @google/gemini-cli-core
- npm run lint --workspace @google/gemini-cli-core
- npm run build --workspace @google/gemini-cli-core
- git diff --check origin/main...HEAD

## Related Issues
Related to #25527
Also related to #25184