### PR TITLE
perf(sessions): sub-second /chat loading for large session histories

### DIFF
--- a/packages/cli/src/ui/components/SessionBrowser/utils.ts
+++ b/packages/cli/src/ui/components/SessionBrowser/utils.ts
@@ -24,10 +24,15 @@ export const sortSessions = (
 ): SessionInfo[] => {
   const sorted = [...sessions].sort((a, b) => {
     switch (sortBy) {
-      case 'date':
+      case 'date': {
+        const diff =
+          new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
+        if (diff !== 0) return diff;
+        // Stable secondary sort by startTime
         return (
-          new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()
+          new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
         );
+      }
       case 'messages':
         return b.messageCount - a.messageCount;
       case 'name':

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -13,6 +13,7 @@ import {
   type ConversationRecord,
   type MessageRecord,
   loadConversationRecord,
+  resolveToRealPath,
 } from '@google/gemini-cli-core';
 import * as fsPromises from 'node:fs/promises';
 import * as fs from 'node:fs';
@@ -286,9 +287,13 @@ export const getAllSessionFiles = async (
             });
             const lines = stdout.trim().split('\n');
             for (const line of lines) {
-              const parts = line.trim().split(/\s+/);
-              if (parts.length >= 2 && parts[1] !== 'total') {
-                lineCounts.set(path.basename(parts[1]), parseInt(parts[0], 10));
+              const match = line.trim().match(/^(\d+)\s+(.+)$/);
+              if (match && match[2] !== 'total') {
+                const resolvedPath = resolveToRealPath(match[2]);
+                lineCounts.set(
+                  path.basename(resolvedPath),
+                  parseInt(match[1], 10),
+                );
               }
             }
           }

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -360,10 +360,7 @@ export const getAllSessionFiles = async (
             const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
             const startTime = content.startTime || fallbackTimestamp;
 
-            const lastUpdated =
-              !options.includeFullContent && fileTimestamp
-                ? fileTimestamp
-                : content.lastUpdated || fallbackTimestamp;
+            const lastUpdated = content.lastUpdated || fallbackTimestamp;
 
             if (!content.hasUserOrAssistantMessage) {
               return { fileName: file, sessionInfo: null };

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -311,8 +311,9 @@ export const getAllSessionFiles = async (
                 const buffer = Buffer.isBuffer(chunk)
                   ? chunk
                   : Buffer.from(chunk);
-                for (let i = 0; i < buffer.length; i++) {
-                  if (buffer[i] === 10) lines++;
+                let pos = -1;
+                while ((pos = buffer.indexOf(10, pos + 1)) !== -1) {
+                  lines++;
                 }
               });
               stream.on('end', () => resolve(lines));

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -320,7 +320,7 @@ export const getAllSessionFiles = async (
           }
         } catch {
           // Fallback to individual counting if bulk fails
-          const CONCURRENT_LIMIT = 100;
+          const CONCURRENT_LIMIT = 20;
           for (let i = 0; i < sessionFiles.length; i += CONCURRENT_LIMIT) {
             const batch = sessionFiles.slice(i, i + CONCURRENT_LIMIT);
             const batchPromises = batch.map((f) =>

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -264,6 +264,7 @@ export const getAllSessionFiles = async (
         try {
           const content = await loadConversationRecord(filePath, {
             metadataOnly: !options.includeFullContent,
+            fastPreview: !options.includeFullContent,
           });
           if (!content) {
             return { fileName: file, sessionInfo: null };
@@ -275,17 +276,16 @@ export const getAllSessionFiles = async (
             return { fileName: file, sessionInfo: null };
           }
 
-          const fileTimestamp =
-            !content.startTime || !content.lastUpdated
-              ? (
-                  await fs.stat(filePath).catch(() => undefined)
-                )?.mtime.toISOString()
-              : undefined;
+          const fileStat = await fs.stat(filePath).catch(() => undefined);
+          const fileTimestamp = fileStat?.mtime.toISOString();
           const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
-          const startTime =
-            content.startTime || content.lastUpdated || fallbackTimestamp;
+          const startTime = content.startTime || fallbackTimestamp;
+
+          // Use mtime as the authoritative last updated time when fastPreview is true
           const lastUpdated =
-            content.lastUpdated || content.startTime || fallbackTimestamp;
+            !options.includeFullContent && fileTimestamp
+              ? fileTimestamp
+              : content.lastUpdated || fallbackTimestamp;
 
           // Skip sessions that only contain system messages (info, error, warning)
           if (!content.hasUserOrAssistantMessage) {

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -258,98 +258,136 @@ export const getAllSessionFiles = async (
       )
       .sort(); // Sort by filename, which includes timestamp
 
-    const sessionPromises = sessionFiles.map(
-      async (file): Promise<SessionFileEntry> => {
-        const filePath = path.join(chatsDir, file);
+    if (sessionFiles.length === 0) {
+      return [];
+    }
+
+    const getBulkLineCounts = async (): Promise<Map<string, number>> => {
+      const lineCounts = new Map<string, number>();
+      if (!options.includeFullContent && process.platform !== 'win32') {
         try {
-          const content = await loadConversationRecord(filePath, {
-            metadataOnly: !options.includeFullContent,
-            fastPreview: !options.includeFullContent,
-          });
-          if (!content) {
-            return { fileName: file, sessionInfo: null };
+          const { execFile } = await import('node:child_process');
+          const { promisify } = await import('node:util');
+          const execFileAsync = promisify(execFile);
+          const filePaths = sessionFiles.map((f) => path.join(chatsDir, f));
+
+          const CMD_BATCH_SIZE = 100;
+          for (let i = 0; i < filePaths.length; i += CMD_BATCH_SIZE) {
+            const batch = filePaths.slice(i, i + CMD_BATCH_SIZE);
+            const { stdout } = await execFileAsync('wc', ['-l', ...batch], {
+              encoding: 'utf8',
+              maxBuffer: 10 * 1024 * 1024,
+            });
+            const lines = stdout.trim().split('\n');
+            for (const line of lines) {
+              const parts = line.trim().split(/\s+/);
+              if (parts.length >= 2 && parts[1] !== 'total') {
+                lineCounts.set(path.basename(parts[1]), parseInt(parts[0], 10));
+              }
+            }
           }
-
-          // Validate required fields
-          if (!content.sessionId) {
-            // Missing required fields - treat as corrupted
-            return { fileName: file, sessionInfo: null };
-          }
-
-          const fileStat = await fs.stat(filePath).catch(() => undefined);
-          const fileTimestamp = fileStat?.mtime.toISOString();
-          const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
-          const startTime = content.startTime || fallbackTimestamp;
-
-          // Use mtime as the authoritative last updated time when fastPreview is true
-          const lastUpdated =
-            !options.includeFullContent && fileTimestamp
-              ? fileTimestamp
-              : content.lastUpdated || fallbackTimestamp;
-
-          // Skip sessions that only contain system messages (info, error, warning)
-          if (!content.hasUserOrAssistantMessage) {
-            return { fileName: file, sessionInfo: null };
-          }
-
-          // Skip subagent sessions - these are implementation details of a tool call
-          // and shouldn't be surfaced for resumption in the main agent history.
-          if (content.kind === 'subagent') {
-            return { fileName: file, sessionInfo: null };
-          }
-
-          const firstUserMessage = content.firstUserMessage
-            ? cleanMessage(content.firstUserMessage)
-            : extractFirstUserMessage(content.messages);
-          const isCurrentSession = currentSessionId
-            ? file.includes(currentSessionId.slice(0, 8))
-            : false;
-
-          let fullContent: string | undefined;
-          let messages:
-            | Array<{ role: 'user' | 'assistant'; content: string }>
-            | undefined;
-
-          if (options.includeFullContent) {
-            fullContent = content.messages
-              .map((msg) => partListUnionToString(msg.content))
-              .join(' ');
-            messages = content.messages.map((msg) => ({
-              role:
-                msg.type === 'user'
-                  ? ('user' as const)
-                  : ('assistant' as const),
-              content: partListUnionToString(msg.content),
-            }));
-          }
-
-          const sessionInfo: SessionInfo = {
-            id: content.sessionId,
-            file: file.replace(/\.jsonl?$/, ''),
-            fileName: file,
-            startTime,
-            lastUpdated,
-            messageCount: content.messageCount ?? content.messages.length,
-            displayName: content.summary
-              ? stripUnsafeCharacters(content.summary)
-              : firstUserMessage,
-            firstUserMessage,
-            isCurrentSession,
-            index: 0, // Will be set after sorting valid sessions
-            summary: content.summary,
-            fullContent,
-            messages,
-          };
-
-          return { fileName: file, sessionInfo };
         } catch {
-          // File is corrupted (can't read or parse JSON)
-          return { fileName: file, sessionInfo: null };
+          // Fallback handled by individual loadConversationRecord if needed
         }
-      },
-    );
+      }
+      return lineCounts;
+    };
 
-    return await Promise.all(sessionPromises);
+    const [lineCounts, results] = await Promise.all([
+      getBulkLineCounts(),
+      Promise.all(
+        sessionFiles.map(async (file): Promise<SessionFileEntry> => {
+          const filePath = path.join(chatsDir, file);
+          try {
+            const content = await loadConversationRecord(filePath, {
+              metadataOnly: !options.includeFullContent,
+              fastPreview: !options.includeFullContent,
+            });
+            if (!content) {
+              return { fileName: file, sessionInfo: null };
+            }
+
+            if (!content.sessionId) {
+              return { fileName: file, sessionInfo: null };
+            }
+
+            const fileStat = await fs.stat(filePath).catch(() => undefined);
+            const fileTimestamp = fileStat?.mtime.toISOString();
+            const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
+            const startTime = content.startTime || fallbackTimestamp;
+
+            const lastUpdated =
+              !options.includeFullContent && fileTimestamp
+                ? fileTimestamp
+                : content.lastUpdated || fallbackTimestamp;
+
+            if (!content.hasUserOrAssistantMessage) {
+              return { fileName: file, sessionInfo: null };
+            }
+
+            if (content.kind === 'subagent') {
+              return { fileName: file, sessionInfo: null };
+            }
+
+            const firstUserMessage = content.firstUserMessage
+              ? cleanMessage(content.firstUserMessage)
+              : extractFirstUserMessage(content.messages);
+            const isCurrentSession = currentSessionId
+              ? file.includes(currentSessionId.slice(0, 8))
+              : false;
+
+            let fullContent: string | undefined;
+            let messages:
+              | Array<{ role: 'user' | 'assistant'; content: string }>
+              | undefined;
+
+            if (options.includeFullContent) {
+              fullContent = content.messages
+                .map((msg) => partListUnionToString(msg.content))
+                .join(' ');
+              messages = content.messages.map((msg) => ({
+                role:
+                  msg.type === 'user'
+                    ? ('user' as const)
+                    : ('assistant' as const),
+                content: partListUnionToString(msg.content),
+              }));
+            }
+
+            const sessionInfo: SessionInfo = {
+              id: content.sessionId,
+              file: file.replace(/\.jsonl?$/, ''),
+              fileName: file,
+              startTime,
+              lastUpdated,
+              messageCount: 0, // Placeholder
+              displayName: content.summary
+                ? stripUnsafeCharacters(content.summary)
+                : firstUserMessage,
+              firstUserMessage,
+              isCurrentSession,
+              index: 0,
+              summary: content.summary,
+              fullContent,
+              messages,
+            };
+
+            return { fileName: file, sessionInfo };
+          } catch {
+            return { fileName: file, sessionInfo: null };
+          }
+        }),
+      ),
+    ]);
+
+    // Patch message counts
+    for (const entry of results) {
+      if (entry.sessionInfo) {
+        entry.sessionInfo.messageCount = lineCounts.get(entry.fileName) ?? 0;
+      }
+    }
+
+    return results;
   } catch (error) {
     // It's expected that the directory might not exist, which is not an error.
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -270,6 +270,27 @@ export const getAllSessionFiles = async (
         return lineCounts;
       }
 
+      const countLines = (filePath: string): Promise<number> =>
+        new Promise((resolve) => {
+          try {
+            let lines = 0;
+            const stream = fs.createReadStream(filePath);
+            stream.on('data', (chunk: Buffer | string) => {
+              const buffer = Buffer.isBuffer(chunk)
+                ? chunk
+                : Buffer.from(chunk);
+              let pos = -1;
+              while ((pos = buffer.indexOf(10, pos + 1)) !== -1) {
+                lines++;
+              }
+            });
+            stream.on('end', () => resolve(lines));
+            stream.on('error', () => resolve(0));
+          } catch {
+            resolve(0);
+          }
+        });
+
       if (process.platform !== 'win32') {
         // POSIX FAST PATH: Use native wc -l for maximum speed
         try {
@@ -298,53 +319,44 @@ export const getAllSessionFiles = async (
             }
           }
         } catch {
-          /* Fallback to individual counting if bulk fails */
+          // Fallback to individual counting if bulk fails
+          const CONCURRENT_LIMIT = 100;
+          for (let i = 0; i < sessionFiles.length; i += CONCURRENT_LIMIT) {
+            const batch = sessionFiles.slice(i, i + CONCURRENT_LIMIT);
+            const batchPromises = batch.map((f) =>
+              countLines(path.join(chatsDir, f)),
+            );
+            const batchCounts = await Promise.all(batchPromises);
+            batchCounts.forEach((count, j) => {
+              lineCounts.set(batch[j], count);
+            });
+          }
         }
       } else {
         // WINDOWS FALLBACK: Batch-limited Node.js buffer scanning to avoid FD exhaustion
-        const countLines = (filePath: string): Promise<number> =>
-          new Promise((resolve) => {
-            try {
-              let lines = 0;
-              const stream = fs.createReadStream(filePath);
-              stream.on('data', (chunk: Buffer | string) => {
-                const buffer = Buffer.isBuffer(chunk)
-                  ? chunk
-                  : Buffer.from(chunk);
-                let pos = -1;
-                while ((pos = buffer.indexOf(10, pos + 1)) !== -1) {
-                  lines++;
-                }
-              });
-              stream.on('end', () => resolve(lines));
-              stream.on('error', () => resolve(0));
-            } catch {
-              resolve(0);
-            }
-          });
-
         const CONCURRENT_LIMIT = 20;
-        const counts: number[] = sessionFiles.map(() => 0);
-
         for (let i = 0; i < sessionFiles.length; i += CONCURRENT_LIMIT) {
           const batch = sessionFiles.slice(i, i + CONCURRENT_LIMIT);
-          const batchPromises: Array<Promise<number>> = batch.map((f) =>
+          const batchPromises = batch.map((f) =>
             countLines(path.join(chatsDir, f)),
           );
-          const batchCounts: number[] = await Promise.all(batchPromises);
+          const batchCounts = await Promise.all(batchPromises);
           batchCounts.forEach((count, j) => {
-            counts[i + j] = count;
+            lineCounts.set(batch[j], count);
           });
         }
-        sessionFiles.forEach((f, i) => lineCounts.set(f, counts[i]));
       }
       return lineCounts;
     };
 
-    const [lineCounts, results] = await Promise.all([
-      getBulkLineCounts(),
-      Promise.all(
-        sessionFiles.map(async (file): Promise<SessionFileEntry> => {
+    const lineCountsPromise = getBulkLineCounts();
+    const results: SessionFileEntry[] = [];
+    const SESSION_BATCH_SIZE = 100;
+
+    for (let i = 0; i < sessionFiles.length; i += SESSION_BATCH_SIZE) {
+      const batch = sessionFiles.slice(i, i + SESSION_BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map(async (file): Promise<SessionFileEntry> => {
           const filePath = path.join(chatsDir, file);
           try {
             const content = await loadConversationRecord(filePath, {
@@ -359,14 +371,8 @@ export const getAllSessionFiles = async (
               return { fileName: file, sessionInfo: null };
             }
 
-            const fileStat = await fsPromises
-              .stat(filePath)
-              .catch(() => undefined);
-            const fileTimestamp = fileStat?.mtime.toISOString();
-            const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
-            const startTime = content.startTime || fallbackTimestamp;
-
-            const lastUpdated = content.lastUpdated || fallbackTimestamp;
+            const startTime = content.startTime;
+            const lastUpdated = content.lastUpdated;
 
             if (!content.hasUserOrAssistantMessage) {
               return { fileName: file, sessionInfo: null };
@@ -424,8 +430,11 @@ export const getAllSessionFiles = async (
             return { fileName: file, sessionInfo: null };
           }
         }),
-      ),
-    ]);
+      );
+      results.push(...batchResults);
+    }
+
+    const lineCounts = await lineCountsPromise;
 
     // Patch message counts
     for (const entry of results) {

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -296,8 +296,9 @@ export const getAllSessionFiles = async (
           /* Fallback to individual counting if bulk fails */
         }
       } else {
-        // WINDOWS FALLBACK: Parallelized Node.js buffer scanning
-        const countLines = async (filePath: string): Promise<number> => new Promise((resolve) => {
+        // WINDOWS FALLBACK: Batch-limited Node.js buffer scanning to avoid FD exhaustion
+        const countLines = (filePath: string): Promise<number> =>
+          new Promise((resolve) => {
             try {
               let lines = 0;
               const stream = fs.createReadStream(filePath);
@@ -316,9 +317,19 @@ export const getAllSessionFiles = async (
             }
           });
 
-        const counts = await Promise.all(
-          sessionFiles.map((f) => countLines(path.join(chatsDir, f))),
-        );
+        const CONCURRENT_LIMIT = 20;
+        const counts: number[] = sessionFiles.map(() => 0);
+
+        for (let i = 0; i < sessionFiles.length; i += CONCURRENT_LIMIT) {
+          const batch = sessionFiles.slice(i, i + CONCURRENT_LIMIT);
+          const batchPromises: Array<Promise<number>> = batch.map((f) =>
+            countLines(path.join(chatsDir, f)),
+          );
+          const batchCounts: number[] = await Promise.all(batchPromises);
+          batchCounts.forEach((count, j) => {
+            counts[i + j] = count;
+          });
+        }
         sessionFiles.forEach((f, i) => lineCounts.set(f, counts[i]));
       }
       return lineCounts;

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -14,7 +14,8 @@ import {
   type MessageRecord,
   loadConversationRecord,
 } from '@google/gemini-cli-core';
-import * as fs from 'node:fs/promises';
+import * as fsPromises from 'node:fs/promises';
+import * as fs from 'node:fs';
 import path from 'node:path';
 import { stripUnsafeCharacters } from '../ui/utils/textUtils.js';
 import { MessageType, type HistoryItemWithoutId } from '../ui/types.js';
@@ -249,7 +250,7 @@ export const getAllSessionFiles = async (
   options: GetSessionOptions = {},
 ): Promise<SessionFileEntry[]> => {
   try {
-    const files = await fs.readdir(chatsDir);
+    const files = await fsPromises.readdir(chatsDir);
     const sessionFiles = files
       .filter(
         (f) =>
@@ -264,7 +265,12 @@ export const getAllSessionFiles = async (
 
     const getBulkLineCounts = async (): Promise<Map<string, number>> => {
       const lineCounts = new Map<string, number>();
-      if (!options.includeFullContent && process.platform !== 'win32') {
+      if (options.includeFullContent || sessionFiles.length === 0) {
+        return lineCounts;
+      }
+
+      if (process.platform !== 'win32') {
+        // POSIX FAST PATH: Use native wc -l for maximum speed
         try {
           const { execFile } = await import('node:child_process');
           const { promisify } = await import('node:util');
@@ -287,8 +293,33 @@ export const getAllSessionFiles = async (
             }
           }
         } catch {
-          // Fallback handled by individual loadConversationRecord if needed
+          /* Fallback to individual counting if bulk fails */
         }
+      } else {
+        // WINDOWS FALLBACK: Parallelized Node.js buffer scanning
+        const countLines = async (filePath: string): Promise<number> => new Promise((resolve) => {
+            try {
+              let lines = 0;
+              const stream = fs.createReadStream(filePath);
+              stream.on('data', (chunk: Buffer | string) => {
+                const buffer = Buffer.isBuffer(chunk)
+                  ? chunk
+                  : Buffer.from(chunk);
+                for (let i = 0; i < buffer.length; i++) {
+                  if (buffer[i] === 10) lines++;
+                }
+              });
+              stream.on('end', () => resolve(lines));
+              stream.on('error', () => resolve(0));
+            } catch {
+              resolve(0);
+            }
+          });
+
+        const counts = await Promise.all(
+          sessionFiles.map((f) => countLines(path.join(chatsDir, f))),
+        );
+        sessionFiles.forEach((f, i) => lineCounts.set(f, counts[i]));
       }
       return lineCounts;
     };
@@ -311,7 +342,9 @@ export const getAllSessionFiles = async (
               return { fileName: file, sessionInfo: null };
             }
 
-            const fileStat = await fs.stat(filePath).catch(() => undefined);
+            const fileStat = await fsPromises
+              .stat(filePath)
+              .catch(() => undefined);
             const fileTimestamp = fileStat?.mtime.toISOString();
             const fallbackTimestamp = fileTimestamp ?? new Date().toISOString();
             const startTime = content.startTime || fallbackTimestamp;
@@ -360,7 +393,7 @@ export const getAllSessionFiles = async (
               fileName: file,
               startTime,
               lastUpdated,
-              messageCount: 0, // Placeholder
+              messageCount: 0, // Patched below after parallel getBulkLineCounts completes
               displayName: content.summary
                 ? stripUnsafeCharacters(content.summary)
                 : firstUserMessage,
@@ -459,7 +492,7 @@ export class SessionSelector {
    */
   async sessionExists(id: string): Promise<boolean> {
     const chatsDir = path.join(this.storage.getProjectTempDir(), 'chats');
-    const files = await fs.readdir(chatsDir).catch(() => []);
+    const files = await fsPromises.readdir(chatsDir).catch(() => []);
 
     // The filename format is `session-<TIMESTAMP>-<ID_SLICE(0,8)>.jsonl`
     const shortId = id.slice(0, 8);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1255,6 +1255,10 @@ async function parseLegacyRecordFallback(
         userMessageCount:
           legacyRecord.messages?.filter((m) => m.type === 'user').length || 0,
         messageCount: legacyRecord.messages?.length || 0,
+        hasUserOrAssistantMessage:
+          legacyRecord.messages?.some(
+            (m) => m.type === 'user' || m.type === 'gemini',
+          ) || false,
       };
     }
   } catch {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -188,7 +188,11 @@ export async function loadConversationRecord(
         if (userLine) {
           try {
             const record = JSON.parse(userLine) as unknown;
-            if (hasProperty(record, 'content')) {
+            if (
+              hasProperty(record, 'type') &&
+              record.type === 'user' &&
+              hasProperty(record, 'content')
+            ) {
               const content = record.content;
               if (Array.isArray(content)) {
                 firstUserMessage = content

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -121,18 +121,101 @@ export async function loadConversationRecord(
   }
 
   try {
-    const fileOptions: { start?: number; end?: number } = {};
     const MAX_FAST_READ = 64 * 1024; // 64KB
-    let fileSize = 0;
+    const stats = await fs.promises.stat(filePath).catch(() => null);
+    const fileSize = stats ? stats.size : 0;
+    const mtime = stats ? stats.mtime.toISOString() : new Date().toISOString();
 
-    if (options?.fastPreview) {
-      const stats = await fs.promises.stat(filePath).catch(() => null);
-      if (stats) fileSize = stats.size;
-      fileOptions.start = 0;
-      fileOptions.end = MAX_FAST_READ; // Read only first 64KB for metadata/preview
+    if (options?.fastPreview && fileSize > MAX_FAST_READ) {
+      // ULTRA-FAST PATH: Regex extraction from raw buffers
+      const fd = await fs.promises.open(filePath, 'r');
+      try {
+        const headBuffer = Buffer.alloc(MAX_FAST_READ);
+        const { bytesRead: headReadCount } = await fd.read(
+          headBuffer,
+          0,
+          MAX_FAST_READ,
+          0,
+        );
+        const headStr = headBuffer.toString('utf8', 0, headReadCount);
+
+        const TAIL_SIZE = 128 * 1024;
+        let tailStr = '';
+        if (fileSize > MAX_FAST_READ) {
+          const tailReadSize = Math.min(TAIL_SIZE, fileSize - headReadCount);
+          if (tailReadSize > 0) {
+            const tailBuffer = Buffer.alloc(tailReadSize);
+            const { bytesRead: tailReadCount } = await fd.read(
+              tailBuffer,
+              0,
+              tailReadSize,
+              fileSize - tailReadSize,
+            );
+            tailStr = tailBuffer.toString('utf8', 0, tailReadCount);
+          }
+        }
+
+        const getMatch = (str: string, reg: RegExp) => {
+          const m = str.match(reg);
+          return m ? m[1] : undefined;
+        };
+
+        const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
+        const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
+        const startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
+        const lastUpdated =
+          getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
+          getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/);
+        const summary =
+          getMatch(tailStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/) ||
+          getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/);
+        const rawKind = getMatch(headStr, /"kind"\s*:\s*"([^"]+)"/);
+        const kind =
+          rawKind === 'main' || rawKind === 'subagent' ? rawKind : undefined;
+        const hasUserOrAssistantMessage =
+          /"type"\s*:\s*"(user|gemini)"/.test(headStr) ||
+          /"type"\s*:\s*"(user|gemini)"/.test(tailStr);
+
+        let firstUserMessage: string | undefined;
+        const userMsgMatch = headStr.match(
+          /"type"\s*:\s*"user"[^}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")/,
+        );
+        if (userMsgMatch) {
+          try {
+            const content = JSON.parse(userMsgMatch[1]) as unknown;
+            if (Array.isArray(content)) {
+              firstUserMessage = content
+                .map((p: unknown) => (isTextPart(p) ? p.text : ''))
+                .join('');
+            } else if (typeof content === 'string') {
+              firstUserMessage = content;
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+
+        if (sessionId && projectHash) {
+          return {
+            sessionId,
+            projectHash,
+            startTime: startTime || mtime,
+            lastUpdated: lastUpdated || mtime,
+            summary,
+            kind,
+            messages: [],
+            messageCount: options?.precalculatedLineCount ?? 0,
+            hasUserOrAssistantMessage,
+            firstUserMessage,
+            memoryScratchpadIsStale: false,
+          };
+        }
+      } finally {
+        await fd.close();
+      }
     }
 
-    const fileStream = fs.createReadStream(filePath, fileOptions);
+    const fileStream = fs.createReadStream(filePath);
     const rl = readline.createInterface({
       input: fileStream,
       crlfDelay: Infinity,
@@ -177,7 +260,7 @@ export async function loadConversationRecord(
                   const rawContent = record.content;
                   if (Array.isArray(rawContent)) {
                     firstUserMessageStr = rawContent
-                      .map((p: unknown) => (isTextPart(p) ? p['text'] : ''))
+                      .map((p: unknown) => (isTextPart(p) ? p.text : ''))
                       .join('');
                   } else if (typeof rawContent === 'string') {
                     firstUserMessageStr = rawContent;
@@ -288,76 +371,6 @@ export async function loadConversationRecord(
       }
     }
 
-    // Try to get summary from the end of the file if fastPreview skipped it
-    let fastTotalLines = 0;
-    if (options?.fastPreview && fileSize > MAX_FAST_READ) {
-      try {
-        const CHUNK_SIZE = 1024 * 1024; // 1MB chunks
-        const SEARCH_LIMIT = 5 * 1024 * 1024; // Max 5MB backward search
-        const minPosition = Math.max(0, fileSize - SEARCH_LIMIT);
-        const fd = await fs.promises.open(filePath, 'r');
-        let position = fileSize;
-        const buffer = Buffer.alloc(CHUNK_SIZE);
-        let leftover = '';
-        const summaryRegex =
-          /"\$set"\s*:\s*\{[^}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
-
-        while (position > minPosition) {
-          const readSize = Math.min(CHUNK_SIZE, position);
-          position -= readSize;
-
-          await fd.read(buffer, 0, readSize, position);
-          const chunkStr = buffer.toString('utf8', 0, readSize) + leftover;
-
-          if (!metadata.summary) {
-            const matches = [...chunkStr.matchAll(summaryRegex)];
-            if (matches.length > 0) {
-              metadata.summary = matches[matches.length - 1][1];
-            }
-          }
-          leftover = chunkStr.substring(0, 1024);
-          if (metadata.summary) break; // Optimization: stop if we found what we needed
-        }
-        await fd.close();
-      } catch {
-        // Ignore tail read errors
-      }
-
-      // Fast line count for accurate messageCount
-      try {
-        if (process.platform !== 'win32') {
-          const { execFile } = await import('node:child_process');
-          const { promisify } = await import('node:util');
-          const execFileAsync = promisify(execFile);
-          const { stdout } = await execFileAsync('wc', ['-l', filePath], {
-            encoding: 'utf8',
-          });
-          fastTotalLines = parseInt(stdout.trim().split(/\s+/)[0], 10);
-        } else {
-          // Fallback to async buffer counting for Windows
-          const stream = fs.createReadStream(filePath);
-          fastTotalLines = await new Promise<number>((resolve) => {
-            let lines = 0;
-            stream.on('data', (chunk: Buffer | string) => {
-              if (Buffer.isBuffer(chunk)) {
-                for (let i = 0; i < chunk.length; i++) {
-                  if (chunk[i] === 10) lines++;
-                }
-              } else if (typeof chunk === 'string') {
-                for (let i = 0; i < chunk.length; i++) {
-                  if (chunk.charCodeAt(i) === 10) lines++;
-                }
-              }
-            });
-            stream.on('end', () => resolve(lines));
-            stream.on('error', () => resolve(0));
-          });
-        }
-      } catch {
-        // Ignore line counting errors
-      }
-    }
-
     if (!metadata.sessionId || !metadata.projectHash) {
       return await parseLegacyRecordFallback(filePath, options);
     }
@@ -390,17 +403,16 @@ export async function loadConversationRecord(
       : loadedMessages.some((m) => m.type === 'user' || m.type === 'gemini');
 
     const finalMessageCount =
-      fastTotalLines > 0
-        ? fastTotalLines
-        : options?.metadataOnly
-          ? metadataMessages.length || messageIds.length
-          : loadedMessages.length;
+      options?.precalculatedLineCount ??
+      (options?.metadataOnly
+        ? metadataMessages.length || messageIds.length
+        : loadedMessages.length);
 
     return {
       sessionId: metadata.sessionId,
       projectHash: metadata.projectHash,
-      startTime: metadata.startTime || new Date().toISOString(),
-      lastUpdated: metadata.lastUpdated || new Date().toISOString(),
+      startTime: metadata.startTime || mtime,
+      lastUpdated: metadata.lastUpdated || mtime,
       summary: metadata.summary,
       memoryScratchpad: metadata.memoryScratchpad,
       directories: metadata.directories,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -164,7 +164,14 @@ export async function loadConversationRecord(
         };
 
         const getLastMatch = (str: string, reg: RegExp) => {
-          const matches = Array.from(str.matchAll(new RegExp(reg.source, 'g')));
+          const matches = Array.from(
+            str.matchAll(
+              new RegExp(
+                reg.source,
+                reg.flags.includes('g') ? reg.flags : reg.flags + 'g',
+              ),
+            ),
+          );
           return matches.length > 0
             ? matches[matches.length - 1][1]
             : undefined;
@@ -205,7 +212,7 @@ export async function loadConversationRecord(
 
         const lastUpdated =
           getLastMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
-          getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
+          getLastMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
           filenameTimestamp;
 
         const isJsonl = filePath.endsWith('.jsonl');
@@ -216,7 +223,7 @@ export async function loadConversationRecord(
             tailStr,
             /"\$set"\s*:\s*\{.*?"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||
-          getMatch(
+          getLastMatch(
             headStr,
             /"\$set"\s*:\s*\{.*?"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -104,11 +104,7 @@ function isSessionIdRecord(record: unknown): record is { sessionId: string } {
 }
 
 const sanitizeSummary = (s: string) =>
-  s
-    .replace(/\r?\n/g, ' ')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\]/g, '&#93;');
+  s.replace(/\r?\n/g, ' ').replace(/[[]\]/g, ' ');
 
 export async function loadConversationRecord(
   filePath: string,
@@ -174,9 +170,18 @@ export async function loadConversationRecord(
             : undefined;
         };
 
-        const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
-        const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
-        let startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
+        const sessionId = getMatch(
+          headStr,
+          /"sessionId"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+        );
+        const projectHash = getMatch(
+          headStr,
+          /"projectHash"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+        );
+        let startTime = getMatch(
+          headStr,
+          /"startTime"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+        );
         let filenameTimestamp: string | undefined;
 
         // Fallback: Extract startTime from filename if not in header (format: session-YYYY-MM-DDTHH-MM-8CHARS.jsonl)
@@ -358,10 +363,10 @@ export async function loadConversationRecord(
             record = JSON.parse(line) as unknown;
           } else if (line.includes('"sessionId"')) {
             record = JSON.parse(line) as unknown;
-          } else if (line.startsWith('{"id":')) {
+          } else if (line.includes('"id":') && line.includes('"type":')) {
             if (isTrackingMemoryScratchpadFreshness)
               memoryScratchpadIsStale = true;
-            const idMatch = line.match(/^\{"id":"([^"]+)"/);
+            const idMatch = line.match(/"id":"([^"]+)"/);
             if (idMatch) {
               const id = idMatch[1];
               const isUser = /"type"\s*:\s*"user"/.test(line);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -240,6 +240,12 @@ export async function loadConversationRecord(
         const rawKind = getMatch(headStr, /"kind"\s*:\s*"([^"]+)"/);
         const kind =
           rawKind === 'main' || rawKind === 'subagent' ? rawKind : undefined;
+
+        // Note: fastPreview checks only the head (64KB) and tail (128KB) buffers.
+        // We acknowledge the theoretical risk of a message falling in the unread gap for massive files.
+        // However, simpler truncation logic is preferred here because the potential inaccuracy is trivial
+        // compared to the overall buffer sizes. Introducing a full-file or binary search would defeat
+        // the O(1) performance benefits of this fast path.
         const hasUserOrAssistantMessage =
           /"type"\s*:\s*"(user|gemini)"/.test(headStr) ||
           /"type"\s*:\s*"(user|gemini)"/.test(tailStr);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -106,6 +106,18 @@ function isSessionIdRecord(record: unknown): record is { sessionId: string } {
 const sanitizeSummary = (s: string) =>
   s.replace(/\r?\n/g, ' ').replace(/[\x5b\x5d]/g, ' ');
 
+// Unescapes JSON strings extracted via regex (e.g., converting literal \n to actual newlines)
+// Only applied to strings displayed in the UI to avoid unnecessary overhead on structural IDs.
+const decodeJsonString = (s: string | undefined): string | undefined => {
+  if (!s) return undefined;
+  try {
+    const parsed = JSON.parse('"' + s + '"') as unknown;
+    return typeof parsed === 'string' ? parsed : s;
+  } catch {
+    return s;
+  }
+};
+
 export async function loadConversationRecord(
   filePath: string,
   options?: LoadConversationOptions,
@@ -235,7 +247,9 @@ export async function loadConversationRecord(
             ? getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/)
             : undefined);
 
-        const summary = rawSummary ? sanitizeSummary(rawSummary) : undefined;
+        const summary = rawSummary
+          ? sanitizeSummary(decodeJsonString(rawSummary)!)
+          : undefined;
 
         const rawKind = getMatch(headStr, /"kind"\s*:\s*"([^"]+)"/);
         const kind =
@@ -310,7 +324,7 @@ export async function loadConversationRecord(
             ),
           ];
           for (const match of legacyUserMatches) {
-            const msgText = match[1];
+            const msgText = decodeJsonString(match[1]) || match[1];
             if (!fallbackFirstUserMessage) {
               fallbackFirstUserMessage = msgText;
             }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -178,23 +178,25 @@ export async function loadConversationRecord(
 
         let firstUserMessage: string | undefined;
         // FAST PREVIEW: Find the first line that is a 'user' message and extract its content
-        const userMsgMatch =
-          headStr.match(
-            /\{[^{}]*"type"\s*:\s*"user"[^{}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")[^{}]*\}/,
-          ) ||
-          headStr.match(
-            /\{[^{}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")[^{}]*"type"\s*:\s*"user"[^{}]*\}/,
+        const userLine = headStr
+          .split('\n')
+          .find(
+            (line) =>
+              line.includes('"type":"user"') || line.includes('"type": "user"'),
           );
 
-        if (userMsgMatch) {
+        if (userLine) {
           try {
-            const content = JSON.parse(userMsgMatch[1]) as unknown;
-            if (Array.isArray(content)) {
-              firstUserMessage = content
-                .map((p: unknown) => (isTextPart(p) ? p.text : ''))
-                .join('');
-            } else if (typeof content === 'string') {
-              firstUserMessage = content;
+            const record = JSON.parse(userLine) as unknown;
+            if (hasProperty(record, 'content')) {
+              const content = record.content;
+              if (Array.isArray(content)) {
+                firstUserMessage = content
+                  .map((p: unknown) => (isTextPart(p) ? p.text : ''))
+                  .join('');
+              } else if (typeof content === 'string') {
+                firstUserMessage = content;
+              }
             }
           } catch {
             /* ignore */

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -393,12 +393,12 @@ export async function loadConversationRecord(
           } else if (line.includes('"id"') && line.includes('"type"')) {
             if (isTrackingMemoryScratchpadFreshness)
               memoryScratchpadIsStale = true;
-            const idMatch = line.match(/"id"\s*:\s*"([^"]+)"/);
+            const idMatch = line.match(/(?:^|\{|,)\s*"id"\s*:\s*"((?:[^"\\]|\\.)*)"/);
             if (idMatch) {
               const id = idMatch[1];
-              const isUser = /"type"\s*:\s*"user"/.test(line);
-              const isUserOrAssistant =
-                isUser || /"type"\s*:\s*"gemini"/.test(line);
+              const typeMatch = line.match(/(?:^|\{|,)\s*"type"\s*:\s*"(user|gemini)"/);
+              const isUser = typeMatch?.[1] === 'user';
+              const isUserOrAssistant = !!typeMatch;
               messageIds.push(id);
               messageKinds.set(id, { isUser, isUserOrAssistant });
               if (!firstUserMessageStr && isUser) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -162,10 +162,32 @@ export async function loadConversationRecord(
 
         const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
         const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
-        const startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
+        let startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
+        let filenameTimestamp: string | undefined;
+
+        // Fallback: Extract startTime from filename if not in header (format: session-YYYY-MM-DDTHH-MM-8CHARS.jsonl)
+        if (!startTime || !getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/)) {
+          const basename = path.basename(filePath);
+          const timeMatch = basename.match(
+            /session-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})/,
+          );
+          if (timeMatch) {
+            // Convert session-2026-05-10T11-45-... to valid ISO 2026-05-10T11:45:00Z
+            filenameTimestamp =
+              timeMatch[1].replace(/-/g, (m, offset) =>
+                offset > 10 ? ':' : '-',
+              ) + ':00Z';
+          }
+        }
+
+        if (!startTime) {
+          startTime = filenameTimestamp;
+        }
+
         const lastUpdated =
           getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
-          getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/);
+          getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
+          filenameTimestamp;
         const summary =
           getMatch(tailStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/) ||
           getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -163,22 +163,23 @@ export async function loadConversationRecord(
         const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
         const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
         let startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
-        let filenameTimestamp: string | undefined;
-
-        // Fallback: Extract startTime from filename if not in header (format: session-YYYY-MM-DDTHH-MM-8CHARS.jsonl)
-        if (!startTime || !getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/)) {
-          const basename = path.basename(filePath);
-          const timeMatch = basename.match(
-            /session-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})/,
-          );
-          if (timeMatch) {
-            // Convert session-2026-05-10T11-45-... to valid ISO 2026-05-10T11:45:00Z
-            filenameTimestamp =
-              timeMatch[1].replace(/-/g, (m, offset) =>
-                offset > 10 ? ':' : '-',
-              ) + ':00Z';
-          }
-        }
+        const filenameTimestamp = startTime
+          ? undefined
+          : (function () {
+              const basename = path.basename(filePath);
+              const timeMatch = basename.match(
+                /session-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})/,
+              );
+              if (timeMatch) {
+                // Convert session-2026-05-10T11-45-... to valid ISO 2026-05-10T11:45:00Z
+                return (
+                  timeMatch[1].replace(/-/g, (m, offset) =>
+                    offset > 10 ? ':' : '-',
+                  ) + ':00Z'
+                );
+              }
+              return undefined;
+            })();
 
         if (!startTime) {
           startTime = filenameTimestamp;
@@ -188,9 +189,24 @@ export async function loadConversationRecord(
           getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
           getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
           filenameTimestamp;
+
+        const isJsonl = filePath.endsWith('.jsonl');
+
+        // For .jsonl, summary is strictly inside "$set". For legacy .json, it's at the absolute end of the file.
         const summary =
-          getMatch(tailStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/) ||
-          getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\\\]|\\\\.)*)"/);
+          getMatch(
+            tailStr,
+            /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+          ) ||
+          getMatch(
+            headStr,
+            /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+          ) ||
+          getMatch(tailStr, /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\}\s*$/) ||
+          (!isJsonl
+            ? getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/)
+            : undefined);
+
         const rawKind = getMatch(headStr, /"kind"\s*:\s*"([^"]+)"/);
         const kind =
           rawKind === 'main' || rawKind === 'subagent' ? rawKind : undefined;
@@ -199,33 +215,79 @@ export async function loadConversationRecord(
           /"type"\s*:\s*"(user|gemini)"/.test(tailStr);
 
         let firstUserMessage: string | undefined;
-        // FAST PREVIEW: Find the first line that is a 'user' message and extract its content
-        const userLine = headStr
-          .split('\n')
-          .find(
-            (line) =>
-              line.includes('"type":"user"') || line.includes('"type": "user"'),
-          );
+        let fallbackFirstUserMessage: string | undefined;
 
-        if (userLine) {
-          try {
-            const record = JSON.parse(userLine) as unknown;
+        if (isJsonl) {
+          // FAST PREVIEW (.jsonl): Find all potential user message lines
+          const lines = headStr.split('\n');
+          for (const line of lines) {
             if (
-              hasProperty(record, 'type') &&
-              record.type === 'user' &&
-              hasProperty(record, 'content')
+              line.includes('"type":"user"') ||
+              line.includes('"type": "user"')
             ) {
-              const content = record.content;
-              if (Array.isArray(content)) {
-                firstUserMessage = content
-                  .map((p: unknown) => (isTextPart(p) ? p.text : ''))
-                  .join('');
-              } else if (typeof content === 'string') {
-                firstUserMessage = content;
+              try {
+                const record = JSON.parse(line) as unknown;
+                if (
+                  hasProperty(record, 'type') &&
+                  record.type === 'user' &&
+                  hasProperty(record, 'content')
+                ) {
+                  const content = record.content;
+                  let msgText = '';
+                  if (Array.isArray(content)) {
+                    msgText = content
+                      .map((p: unknown) => (isTextPart(p) ? p.text : ''))
+                      .join('');
+                  } else if (typeof content === 'string') {
+                    msgText = content;
+                  }
+
+                  if (msgText) {
+                    if (!fallbackFirstUserMessage) {
+                      fallbackFirstUserMessage = msgText; // Keep the very first one as a fallback
+                    }
+                    // Like extractFirstUserMessage, filter out slash commands
+                    if (
+                      !msgText.startsWith('/') &&
+                      !msgText.startsWith('?') &&
+                      msgText.trim().length > 0
+                    ) {
+                      firstUserMessage = msgText;
+                      break; // Found the true first user message
+                    }
+                  }
+                }
+              } catch {
+                /* ignore */
               }
             }
-          } catch {
-            /* ignore */
+          }
+          if (!firstUserMessage) {
+            firstUserMessage = fallbackFirstUserMessage;
+          }
+        } else {
+          // FAST PREVIEW (legacy .json): Extract first user message text roughly using regex to avoid 1s+ JSON.parse
+          const legacyUserMatches = [
+            ...headStr.matchAll(
+              /"type"\s*:\s*"user"[\s\S]*?"text"\s*:\s*"((?:[^"\\]|\\.)*)"/g,
+            ),
+          ];
+          for (const match of legacyUserMatches) {
+            const msgText = match[1];
+            if (!fallbackFirstUserMessage) {
+              fallbackFirstUserMessage = msgText;
+            }
+            if (
+              !msgText.startsWith('/') &&
+              !msgText.startsWith('?') &&
+              msgText.trim().length > 0
+            ) {
+              firstUserMessage = msgText;
+              break;
+            }
+          }
+          if (!firstUserMessage) {
+            firstUserMessage = fallbackFirstUserMessage;
           }
         }
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -103,6 +103,12 @@ function isSessionIdRecord(record: unknown): record is { sessionId: string } {
   return isStringProperty(record, 'sessionId');
 }
 
+const sanitizeSummary = (s: string) => s
+    .replace(/\r?\n/g, ' ')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\]/g, '&#93;');
+
 export async function loadConversationRecord(
   filePath: string,
   options?: LoadConversationOptions,
@@ -160,6 +166,13 @@ export async function loadConversationRecord(
           return m ? m[1] : undefined;
         };
 
+        const getLastMatch = (str: string, reg: RegExp) => {
+          const matches = Array.from(str.matchAll(new RegExp(reg, 'g')));
+          return matches.length > 0
+            ? matches[matches.length - 1][1]
+            : undefined;
+        };
+
         const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
         const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
         let startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
@@ -185,15 +198,15 @@ export async function loadConversationRecord(
         }
 
         const lastUpdated =
-          getMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
+          getLastMatch(tailStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
           getMatch(headStr, /"lastUpdated"\s*:\s*"([^"]+)"/) ||
           filenameTimestamp;
 
         const isJsonl = filePath.endsWith('.jsonl');
 
         // For .jsonl, summary is strictly inside "$set". For legacy .json, it's at the absolute end of the file.
-        const summary =
-          getMatch(
+        const rawSummary =
+          getLastMatch(
             tailStr,
             /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||
@@ -201,10 +214,15 @@ export async function loadConversationRecord(
             headStr,
             /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||
-          getMatch(tailStr, /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\}\s*$/) ||
+          getLastMatch(
+            tailStr,
+            /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\}\s*$/,
+          ) ||
           (!isJsonl
             ? getMatch(headStr, /"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/)
             : undefined);
+
+        const summary = rawSummary ? sanitizeSummary(rawSummary) : undefined;
 
         const rawKind = getMatch(headStr, /"kind"\s*:\s*"([^"]+)"/);
         const kind =
@@ -339,15 +357,15 @@ export async function loadConversationRecord(
             record = JSON.parse(line) as unknown;
           } else if (line.includes('"sessionId"')) {
             record = JSON.parse(line) as unknown;
-          } else if (line.includes('"id":')) {
+          } else if (line.startsWith('{"id":')) {
             if (isTrackingMemoryScratchpadFreshness)
               memoryScratchpadIsStale = true;
-            const idMatch = line.match(/"id":"([^"]+)"/);
+            const idMatch = line.match(/^\{"id":"([^"]+)"/);
             if (idMatch) {
               const id = idMatch[1];
-              const isUser = line.includes('"type":"user"');
+              const isUser = /"type"\s*:\s*"user"/.test(line);
               const isUserOrAssistant =
-                isUser || line.includes('"type":"gemini"');
+                isUser || /"type"\s*:\s*"gemini"/.test(line);
               messageIds.push(id);
               messageKinds.set(id, { isUser, isUserOrAssistant });
               if (!firstUserMessageStr && isUser) {
@@ -415,7 +433,8 @@ export async function loadConversationRecord(
             hasProperty(record, 'type') &&
             (record.type === 'user' || record.type === 'gemini');
           // Track message count and first user message
-          if (options?.metadataOnly) {
+          // (Already tracked in metadataOnly optimization above if applicable)
+          if (options?.metadataOnly && !messageKinds.has(id)) {
             messageIds.push(id);
             messageKinds.set(id, { isUser, isUserOrAssistant });
           }
@@ -454,12 +473,24 @@ export async function loadConversationRecord(
             memoryScratchpadIsStale = false;
           }
           // Metadata update
+          if (
+            hasProperty(record.$set, 'summary') &&
+            typeof record.$set.summary === 'string'
+          ) {
+            record.$set.summary = sanitizeSummary(record.$set.summary);
+          }
           metadata = {
             ...metadata,
             ...record.$set,
           };
         } else if (isPartialMetadataRecord(record)) {
           // Initial metadata line
+          if (
+            hasProperty(record, 'summary') &&
+            typeof record.summary === 'string'
+          ) {
+            record.summary = sanitizeSummary(record.summary);
+          }
           metadata = { ...metadata, ...record };
         }
       } catch {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -121,7 +121,18 @@ export async function loadConversationRecord(
   }
 
   try {
-    const fileStream = fs.createReadStream(filePath);
+    const fileOptions: { start?: number; end?: number } = {};
+    const MAX_FAST_READ = 64 * 1024; // 64KB
+    let fileSize = 0;
+
+    if (options?.fastPreview) {
+      const stats = await fs.promises.stat(filePath).catch(() => null);
+      if (stats) fileSize = stats.size;
+      fileOptions.start = 0;
+      fileOptions.end = MAX_FAST_READ; // Read only first 64KB for metadata/preview
+    }
+
+    const fileStream = fs.createReadStream(filePath, fileOptions);
     const rl = readline.createInterface({
       input: fileStream,
       crlfDelay: Infinity,
@@ -141,7 +152,49 @@ export async function loadConversationRecord(
     for await (const line of rl) {
       if (!line.trim()) continue;
       try {
-        const record = JSON.parse(line) as unknown;
+        let record: unknown = null;
+        if (options?.metadataOnly) {
+          if (line.includes('"$set"')) {
+            record = JSON.parse(line) as unknown;
+          } else if (line.includes('"$rewindTo"')) {
+            record = JSON.parse(line) as unknown;
+          } else if (line.includes('"sessionId"')) {
+            record = JSON.parse(line) as unknown;
+          } else if (line.includes('"id":')) {
+            if (isTrackingMemoryScratchpadFreshness)
+              memoryScratchpadIsStale = true;
+            const idMatch = line.match(/"id":"([^"]+)"/);
+            if (idMatch) {
+              const id = idMatch[1];
+              const isUser = line.includes('"type":"user"');
+              const isUserOrAssistant =
+                isUser || line.includes('"type":"gemini"');
+              messageIds.push(id);
+              messageKinds.set(id, { isUser, isUserOrAssistant });
+              if (!firstUserMessageStr && isUser) {
+                record = JSON.parse(line) as unknown;
+                if (hasProperty(record, 'content')) {
+                  const rawContent = record.content;
+                  if (Array.isArray(rawContent)) {
+                    firstUserMessageStr = rawContent
+                      .map((p: unknown) => (isTextPart(p) ? p['text'] : ''))
+                      .join('');
+                  } else if (typeof rawContent === 'string') {
+                    firstUserMessageStr = rawContent;
+                  }
+                }
+              }
+            }
+            if (!record) continue;
+          } else {
+            continue;
+          }
+        }
+
+        if (!record) {
+          record = JSON.parse(line) as unknown;
+        }
+
         if (isRewindRecord(record)) {
           if (isTrackingMemoryScratchpadFreshness) {
             memoryScratchpadIsStale = true;
@@ -235,6 +288,76 @@ export async function loadConversationRecord(
       }
     }
 
+    // Try to get summary from the end of the file if fastPreview skipped it
+    let fastTotalLines = 0;
+    if (options?.fastPreview && fileSize > MAX_FAST_READ) {
+      try {
+        const CHUNK_SIZE = 1024 * 1024; // 1MB chunks
+        const SEARCH_LIMIT = 5 * 1024 * 1024; // Max 5MB backward search
+        const minPosition = Math.max(0, fileSize - SEARCH_LIMIT);
+        const fd = await fs.promises.open(filePath, 'r');
+        let position = fileSize;
+        const buffer = Buffer.alloc(CHUNK_SIZE);
+        let leftover = '';
+        const summaryRegex =
+          /"\$set"\s*:\s*\{[^}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+
+        while (position > minPosition) {
+          const readSize = Math.min(CHUNK_SIZE, position);
+          position -= readSize;
+
+          await fd.read(buffer, 0, readSize, position);
+          const chunkStr = buffer.toString('utf8', 0, readSize) + leftover;
+
+          if (!metadata.summary) {
+            const matches = [...chunkStr.matchAll(summaryRegex)];
+            if (matches.length > 0) {
+              metadata.summary = matches[matches.length - 1][1];
+            }
+          }
+          leftover = chunkStr.substring(0, 1024);
+          if (metadata.summary) break; // Optimization: stop if we found what we needed
+        }
+        await fd.close();
+      } catch {
+        // Ignore tail read errors
+      }
+
+      // Fast line count for accurate messageCount
+      try {
+        if (process.platform !== 'win32') {
+          const { execFile } = await import('node:child_process');
+          const { promisify } = await import('node:util');
+          const execFileAsync = promisify(execFile);
+          const { stdout } = await execFileAsync('wc', ['-l', filePath], {
+            encoding: 'utf8',
+          });
+          fastTotalLines = parseInt(stdout.trim().split(/\s+/)[0], 10);
+        } else {
+          // Fallback to async buffer counting for Windows
+          const stream = fs.createReadStream(filePath);
+          fastTotalLines = await new Promise<number>((resolve) => {
+            let lines = 0;
+            stream.on('data', (chunk: Buffer | string) => {
+              if (Buffer.isBuffer(chunk)) {
+                for (let i = 0; i < chunk.length; i++) {
+                  if (chunk[i] === 10) lines++;
+                }
+              } else if (typeof chunk === 'string') {
+                for (let i = 0; i < chunk.length; i++) {
+                  if (chunk.charCodeAt(i) === 10) lines++;
+                }
+              }
+            });
+            stream.on('end', () => resolve(lines));
+            stream.on('error', () => resolve(0));
+          });
+        }
+      } catch {
+        // Ignore line counting errors
+      }
+    }
+
     if (!metadata.sessionId || !metadata.projectHash) {
       return await parseLegacyRecordFallback(filePath, options);
     }
@@ -266,6 +389,13 @@ export async function loadConversationRecord(
       ? Array.from(messageKinds.values()).some((m) => m.isUserOrAssistant)
       : loadedMessages.some((m) => m.type === 'user' || m.type === 'gemini');
 
+    const finalMessageCount =
+      fastTotalLines > 0
+        ? fastTotalLines
+        : options?.metadataOnly
+          ? metadataMessages.length || messageIds.length
+          : loadedMessages.length;
+
     return {
       sessionId: metadata.sessionId,
       projectHash: metadata.projectHash,
@@ -276,9 +406,7 @@ export async function loadConversationRecord(
       directories: metadata.directories,
       kind: metadata.kind,
       messages: options?.metadataOnly ? [] : loadedMessages,
-      messageCount: options?.metadataOnly
-        ? metadataMessages.length || messageIds.length
-        : loadedMessages.length,
+      messageCount: finalMessageCount,
       userMessageCount:
         options?.metadataOnly && metadataMessages.length > 0
           ? metadataMessages.filter((m) => m.type === 'user').length

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -363,10 +363,10 @@ export async function loadConversationRecord(
             record = JSON.parse(line) as unknown;
           } else if (line.includes('"sessionId"')) {
             record = JSON.parse(line) as unknown;
-          } else if (line.includes('"id":') && line.includes('"type":')) {
+          } else if (line.includes('"id"') && line.includes('"type"')) {
             if (isTrackingMemoryScratchpadFreshness)
               memoryScratchpadIsStale = true;
-            const idMatch = line.match(/^\s*\{?"id":"([^"]+)"/);
+            const idMatch = line.match(/"id"\s*:\s*"([^"]+)"/);
             if (idMatch) {
               const id = idMatch[1];
               const isUser = /"type"\s*:\s*"user"/.test(line);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -103,7 +103,8 @@ function isSessionIdRecord(record: unknown): record is { sessionId: string } {
   return isStringProperty(record, 'sessionId');
 }
 
-const sanitizeSummary = (s: string) => s
+const sanitizeSummary = (s: string) =>
+  s
     .replace(/\r?\n/g, ' ')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -167,7 +168,7 @@ export async function loadConversationRecord(
         };
 
         const getLastMatch = (str: string, reg: RegExp) => {
-          const matches = Array.from(str.matchAll(new RegExp(reg, 'g')));
+          const matches = Array.from(str.matchAll(new RegExp(reg.source, 'g')));
           return matches.length > 0
             ? matches[matches.length - 1][1]
             : undefined;

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1208,6 +1208,8 @@ async function parseLegacyRecordFallback(
   | null
 > {
   try {
+    const stats = await fs.promises.stat(filePath).catch(() => null);
+    const mtime = stats ? stats.mtime.toISOString() : new Date().toISOString();
     const fileContent = await fs.promises.readFile(filePath, 'utf8');
     const parsed = JSON.parse(fileContent) as unknown;
 
@@ -1233,6 +1235,8 @@ async function parseLegacyRecordFallback(
         }
         return {
           ...legacyRecord,
+          startTime: legacyRecord.startTime || mtime,
+          lastUpdated: legacyRecord.lastUpdated || mtime,
           messages: [],
           messageCount: legacyRecord.messages?.length || 0,
           userMessageCount:
@@ -1246,12 +1250,11 @@ async function parseLegacyRecordFallback(
       }
       return {
         ...legacyRecord,
+        startTime: legacyRecord.startTime || mtime,
+        lastUpdated: legacyRecord.lastUpdated || mtime,
         userMessageCount:
           legacyRecord.messages?.filter((m) => m.type === 'user').length || 0,
-        hasUserOrAssistantMessage:
-          legacyRecord.messages?.some(
-            (m) => m.type === 'user' || m.type === 'gemini',
-          ) || false,
+        messageCount: legacyRecord.messages?.length || 0,
       };
     }
   } catch {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -163,23 +163,22 @@ export async function loadConversationRecord(
         const sessionId = getMatch(headStr, /"sessionId"\s*:\s*"([^"]+)"/);
         const projectHash = getMatch(headStr, /"projectHash"\s*:\s*"([^"]+)"/);
         let startTime = getMatch(headStr, /"startTime"\s*:\s*"([^"]+)"/);
-        const filenameTimestamp = startTime
-          ? undefined
-          : (function () {
-              const basename = path.basename(filePath);
-              const timeMatch = basename.match(
-                /session-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})/,
-              );
-              if (timeMatch) {
-                // Convert session-2026-05-10T11-45-... to valid ISO 2026-05-10T11:45:00Z
-                return (
-                  timeMatch[1].replace(/-/g, (m, offset) =>
-                    offset > 10 ? ':' : '-',
-                  ) + ':00Z'
-                );
-              }
-              return undefined;
-            })();
+        let filenameTimestamp: string | undefined;
+
+        // Fallback: Extract startTime from filename if not in header (format: session-YYYY-MM-DDTHH-MM-8CHARS.jsonl)
+        if (!startTime) {
+          const basename = path.basename(filePath);
+          const timeMatch = basename.match(
+            /session-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})/,
+          );
+          if (timeMatch) {
+            // Convert session-2026-05-10T11-45-... to valid ISO 2026-05-10T11:45:00Z
+            filenameTimestamp =
+              timeMatch[1].replace(/-/g, (m, offset) =>
+                offset > 10 ? ':' : '-',
+              ) + ':00Z';
+          }
+        }
 
         if (!startTime) {
           startTime = filenameTimestamp;
@@ -267,9 +266,10 @@ export async function loadConversationRecord(
           }
         } else {
           // FAST PREVIEW (legacy .json): Extract first user message text roughly using regex to avoid 1s+ JSON.parse
+          // Bounded cross-line match to prevent bleeding across records
           const legacyUserMatches = [
             ...headStr.matchAll(
-              /"type"\s*:\s*"user"[\s\S]*?"text"\s*:\s*"((?:[^"\\]|\\.)*)"/g,
+              /"type"\s*:\s*"user"[\s\S]{0,500}?"text"\s*:\s*"((?:[^"\\]|\\.)*)"/g,
             ),
           ];
           for (const match of legacyUserMatches) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -209,11 +209,11 @@ export async function loadConversationRecord(
         const rawSummary =
           getLastMatch(
             tailStr,
-            /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+            /"\$set"\s*:\s*\{.*?"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||
           getMatch(
             headStr,
-            /"\$set"\s*:\s*\{[^{}]*"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
+            /"\$set"\s*:\s*\{.*?"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/,
           ) ||
           getLastMatch(
             tailStr,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -177,9 +177,15 @@ export async function loadConversationRecord(
           /"type"\s*:\s*"(user|gemini)"/.test(tailStr);
 
         let firstUserMessage: string | undefined;
-        const userMsgMatch = headStr.match(
-          /"type"\s*:\s*"user"[^}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")/,
-        );
+        // FAST PREVIEW: Find the first line that is a 'user' message and extract its content
+        const userMsgMatch =
+          headStr.match(
+            /\{[^{}]*"type"\s*:\s*"user"[^{}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")[^{}]*\}/,
+          ) ||
+          headStr.match(
+            /\{[^{}]*"content"\s*:\s*(\[[^\]]*\]|"(?:[^"\\\\]|\\\\.)*")[^{}]*"type"\s*:\s*"user"[^{}]*\}/,
+          );
+
         if (userMsgMatch) {
           try {
             const content = JSON.parse(userMsgMatch[1]) as unknown;

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -104,7 +104,7 @@ function isSessionIdRecord(record: unknown): record is { sessionId: string } {
 }
 
 const sanitizeSummary = (s: string) =>
-  s.replace(/\r?\n/g, ' ').replace(/[[]\]/g, ' ');
+  s.replace(/\r?\n/g, ' ').replace(/[\x5b\x5d]/g, ' ');
 
 export async function loadConversationRecord(
   filePath: string,
@@ -366,7 +366,7 @@ export async function loadConversationRecord(
           } else if (line.includes('"id":') && line.includes('"type":')) {
             if (isTrackingMemoryScratchpadFreshness)
               memoryScratchpadIsStale = true;
-            const idMatch = line.match(/"id":"([^"]+)"/);
+            const idMatch = line.match(/^\s*\{?"id":"([^"]+)"/);
             if (idMatch) {
               const id = idMatch[1];
               const isUser = /"type"\s*:\s*"user"/.test(line);

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -118,6 +118,7 @@ export interface ResumedSessionData {
 export interface LoadConversationOptions {
   maxMessages?: number;
   metadataOnly?: boolean;
+  fastPreview?: boolean;
 }
 
 export interface RewindRecord {

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -119,6 +119,7 @@ export interface LoadConversationOptions {
   maxMessages?: number;
   metadataOnly?: boolean;
   fastPreview?: boolean;
+  precalculatedLineCount?: number;
 }
 
 export interface RewindRecord {


### PR DESCRIPTION
## Summary

The `/chat` command took 25+ seconds to load with large session histories. 
This PR reduces load time to 634ms on a real-world benchmark of 59 sessions / 2.3GB of JSONL.

## Details

Three compounding bottlenecks eliminated:

1. `chatRecordingService.ts`: New ultra-fast preview path uses raw `fd.read()` 
   calls (64KB head + 128KB tail). Core metadata is extracted via regex directly 
   on buffers, while the first user message is extracted via line-based JSON parsing 
   to robustly handle nested structures — without streaming the full file.
2. `sessionUtils.ts`: Bulk `wc -l` across all files in a single subprocess call 
   (batched at 100 files) replaces per-file subprocess calls. Windows fallback uses 
   batch-limited (20 concurrent) Node.js buffer scanning to avoid FD exhaustion.

3. `utils.ts`: Stable secondary sort by startTime when lastUpdated ties, fixing 
   inconsistent session ordering. Filename timestamp used as reliable startTime 
   fallback instead of mtime.

Note: The 25.62s benchmark was recorded on a fresh environment. In practice, 
load times frequently exceed 60 seconds on warmed systems with large histories.

## Related Issues

Fixes #27027
Related to #26478

## How to Validate

1. Generate a large session history (30+ sessions with substantial conversation history recommended — the more messages per session, the larger the files and the more pronounced the improvement)
2. Run `/chat` and compare load time against main branch
3. Verify session list ordering is consistent across multiple opens
4. On Linux: load time should be under 1 second for typical histories

Note: Windows fallback path (batch-limited buffer scanning) is implemented 
but not benchmarked on hardware — community validation welcome.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
