### PR TITLE
fix(cli): support Volta auto updates

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -56,6 +56,7 @@ describe('getInstallationInfo', () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    vi.unstubAllEnvs();
   });
 
   it('should detect running as a standalone binary', () => {
@@ -263,6 +264,42 @@ describe('getInstallationInfo', () => {
     // isAutoUpdateEnabled = false -> "Please run..."
     const infoDisabled = getInstallationInfo(projectRoot, false);
     expect(infoDisabled.updateMessage).toContain('Please run bun add');
+  });
+
+  it('should detect Volta installation from VOLTA_HOME', () => {
+    vi.stubEnv('VOLTA_HOME', 'C:\\Users\\test\\AppData\\Local\\Volta');
+    const voltaPath = 'C:\\Users\\test\\AppData\\Local\\Volta\\bin\\gemini.cmd';
+    process.argv[1] = voltaPath;
+    mockedRealPathSync.mockReturnValue(voltaPath);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    const info = getInstallationInfo(projectRoot, true);
+
+    expect(info.packageManager).toBe(PackageManager.VOLTA);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateCommand).toBe('volta install @google/gemini-cli@latest');
+    expect(info.updateMessage).toContain('Attempting to automatically update');
+
+    const infoDisabled = getInstallationInfo(projectRoot, false);
+    expect(infoDisabled.updateMessage).toContain('Please run volta install');
+  });
+
+  it('should detect Volta installation from standard tool paths', () => {
+    const voltaPath =
+      '/Users/test/.volta/tools/image/packages/@google/gemini-cli/0.40.1/bin/gemini';
+    process.argv[1] = voltaPath;
+    mockedRealPathSync.mockReturnValue(voltaPath);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    const info = getInstallationInfo(projectRoot, true);
+
+    expect(info.packageManager).toBe(PackageManager.VOLTA);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateCommand).toBe('volta install @google/gemini-cli@latest');
   });
 
   it('should detect local installation and identify yarn from lockfile', () => {

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -19,6 +19,7 @@ export enum PackageManager {
   PNPX = 'pnpx',
   BUN = 'bun',
   BUNX = 'bunx',
+  VOLTA = 'volta',
   HOMEBREW = 'homebrew',
   NPX = 'npx',
   BINARY = 'binary',
@@ -30,6 +31,27 @@ export interface InstallationInfo {
   isGlobal: boolean;
   updateCommand?: string;
   updateMessage?: string;
+}
+
+function normalizePathForMatching(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function isVoltaPath(realPath: string): boolean {
+  const voltaHome = process.env['VOLTA_HOME'];
+  if (voltaHome) {
+    const normalizedVoltaHome = normalizePathForMatching(voltaHome);
+    if (realPath.toLowerCase().startsWith(normalizedVoltaHome.toLowerCase())) {
+      return true;
+    }
+  }
+
+  const lowerRealPath = realPath.toLowerCase();
+  return (
+    lowerRealPath.includes('/.volta/') ||
+    lowerRealPath.includes('/volta/bin/') ||
+    lowerRealPath.includes('/volta/tools/')
+  );
 }
 
 export function getInstallationInfo(
@@ -53,8 +75,10 @@ export function getInstallationInfo(
     }
 
     // Normalize path separators to forward slashes for consistent matching.
-    const realPath = fs.realpathSync(cliPath).replace(/\\/g, '/');
-    const normalizedProjectRoot = projectRoot?.replace(/\\/g, '/');
+    const realPath = normalizePathForMatching(fs.realpathSync(cliPath));
+    const normalizedProjectRoot = projectRoot
+      ? normalizePathForMatching(projectRoot)
+      : undefined;
     const isGit = isGitRepository(process.cwd());
 
     // Check for local git clone first
@@ -161,6 +185,20 @@ export function getInstallationInfo(
         updateCommand,
         updateMessage: isAutoUpdateEnabled
           ? 'Installed with bun. Attempting to automatically update now...'
+          : `Please run ${updateCommand} to update`,
+      };
+    }
+
+    // Check for Volta before falling back to npm. Volta shims stay pinned
+    // unless the package is updated through Volta itself.
+    if (isVoltaPath(realPath)) {
+      const updateCommand = 'volta install @google/gemini-cli@latest';
+      return {
+        packageManager: PackageManager.VOLTA,
+        isGlobal: true,
+        updateCommand,
+        updateMessage: isAutoUpdateEnabled
+          ? 'Installed with Volta. Attempting to automatically update now...'
           : `Please run ${updateCommand} to update`,
       };
     }


### PR DESCRIPTION
## Summary

Fixes the auto-updater loop for Gemini CLI installations managed by Volta by detecting Volta-managed executable paths and using Volta's install command instead of falling back to npm.

## Details

- Adds `PackageManager.VOLTA` to installation detection.
- Detects Volta from `VOLTA_HOME` as well as common `.volta`, `volta/bin`, and `volta/tools` paths.
- Returns `volta install @google/gemini-cli@latest` for global Volta installs.
- Keeps standalone binary detection ahead of path-based package manager detection.

## Related Issues

Fixes #26573

## How to Validate

- `npm run test --workspace packages/cli -- installationInfo.test.ts`
  - Expected: `src/utils/installationInfo.test.ts` passes 20/20 tests and the package `posttest` build completes.
- `git diff --check origin/main...HEAD`

Note: an initial attempt with `--runInBand` was rejected because Vitest does not support that Jest flag; the command above is the successful validation run.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

Windows validation is covered by the `VOLTA_HOME` Windows-path unit test; Linux/macOS-style validation is covered by the `.volta/tools` path unit test.