### PR TITLE
fix(hooks): make AfterAgent prompt_response match the streamed answer

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -3304,6 +3304,159 @@ ${JSON.stringify(
         );
       });
 
+      it('should build AfterAgent prompt_response from streamed content events', async () => {
+        const promptId = 'test-prompt-hook-streamed-response';
+        const request = { text: 'Hi' };
+        const signal = new AbortController().signal;
+
+        mockTurnRunFn.mockImplementation(async function* (
+          this: MockTurnContext,
+        ) {
+          this.getResponseText.mockReturnValue(
+            'Hello! I am ready Hello! I am ready to help',
+          );
+          yield { type: GeminiEventType.Content, value: 'Hello! I am ready' };
+          yield { type: GeminiEventType.Content, value: ' to help' };
+        });
+
+        const stream = client.sendMessageStream(request, signal, promptId);
+        while (!(await stream.next()).done);
+
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
+          'Hello! I am ready to help',
+          false,
+        );
+      });
+
+      it('should preserve turn boundaries when building AfterAgent prompt_response from recursive streamed content', async () => {
+        const { checkNextSpeaker } = await import(
+          '../utils/nextSpeakerChecker.js'
+        );
+        vi.mocked(checkNextSpeaker)
+          .mockResolvedValueOnce({ next_speaker: 'model', reasoning: 'more' })
+          .mockResolvedValueOnce(null);
+
+        const promptId = 'test-prompt-hook-recursive-streamed-response';
+        const request = { text: 'Continue twice' };
+        const signal = new AbortController().signal;
+
+        let callCount = 0;
+        mockTurnRunFn.mockImplementation(async function* (
+          this: MockTurnContext,
+        ) {
+          callCount++;
+          const response = `Response ${callCount}`;
+          this.getResponseText.mockReturnValue(`${response} ${response}`);
+          yield { type: GeminiEventType.Content, value: response };
+        });
+
+        const stream = client.sendMessageStream(request, signal, promptId);
+        while (!(await stream.next()).done);
+
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
+          'Response 1\nResponse 2',
+          false,
+        );
+      });
+
+      it('should fall back to turn response text when no content events are streamed', async () => {
+        const promptId = 'test-prompt-hook-response-fallback';
+        const request = { text: 'Hi' };
+        const signal = new AbortController().signal;
+
+        mockTurnRunFn.mockImplementation(async function* (
+          this: MockTurnContext,
+        ) {
+          this.getResponseText.mockReturnValue('Fallback response');
+          yield { type: GeminiEventType.Finished, value: {} };
+        });
+
+        const stream = client.sendMessageStream(request, signal, promptId);
+        while (!(await stream.next()).done);
+
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
+          'Fallback response',
+          false,
+        );
+      });
+
+      it('should match AfterAgent prompt_response to yielded content across mixed stream events', async () => {
+        const promptId = 'test-prompt-hook-mixed-stream-response';
+        const request = { text: 'Show formatted output' };
+        const signal = new AbortController().signal;
+
+        mockTurnRunFn.mockImplementation(async function* (
+          this: MockTurnContext,
+        ) {
+          this.getResponseText.mockReturnValue(
+            'First line First line Second line',
+          );
+          yield { type: GeminiEventType.ModelInfo, value: 'gemini-test' };
+          yield { type: GeminiEventType.Content, value: 'First line\n' };
+          yield {
+            type: GeminiEventType.Citation,
+            value: 'Citations:\n(Source) https://example.com/source',
+          };
+          yield { type: GeminiEventType.Content, value: '  Second line' };
+          yield { type: GeminiEventType.Finished, value: {} };
+        });
+
+        const events = await fromAsync(
+          client.sendMessageStream(request, signal, promptId),
+        );
+        const yieldedText = events
+          .filter((event) => event.type === GeminiEventType.Content)
+          .map((event) => event.value)
+          .join('');
+
+        expect(yieldedText).toBe('First line\n  Second line');
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
+          yieldedText,
+          false,
+        );
+      });
+
+      it('should keep streamed and fallback response sources isolated across recursive turns', async () => {
+        const { checkNextSpeaker } = await import(
+          '../utils/nextSpeakerChecker.js'
+        );
+        vi.mocked(checkNextSpeaker)
+          .mockResolvedValueOnce({ next_speaker: 'model', reasoning: 'more' })
+          .mockResolvedValueOnce(null);
+
+        const promptId = 'test-prompt-hook-mixed-recursive-sources';
+        const request = { text: 'Continue with fallback' };
+        const signal = new AbortController().signal;
+
+        let callCount = 0;
+        mockTurnRunFn.mockImplementation(async function* (
+          this: MockTurnContext,
+        ) {
+          callCount++;
+          if (callCount === 1) {
+            this.getResponseText.mockReturnValue('First turn First turn');
+            yield { type: GeminiEventType.Content, value: 'First turn' };
+            return;
+          }
+
+          this.getResponseText.mockReturnValue('Second turn fallback');
+          yield { type: GeminiEventType.Finished, value: {} };
+        });
+
+        const stream = client.sendMessageStream(request, signal, promptId);
+        while (!(await stream.next()).done);
+
+        expect(mockHookSystem.fireAfterAgentEvent).toHaveBeenCalledWith(
+          partToString(request),
+          'First turn\nSecond turn fallback',
+          false,
+        );
+      });
+
       it('should cleanup state when prompt_id changes', async () => {
         const signal = new AbortController().signal;
         mockTurnRunFn.mockImplementation(async function* (

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -791,6 +791,7 @@ export class GeminiClient {
       displayContent,
     );
     let isError = false;
+    let streamedResponseText = '';
 
     let loopDetectedAbort = false;
     let loopRecoverResult: { detail?: string } | undefined;
@@ -808,6 +809,9 @@ export class GeminiClient {
         }
         loopRecoverResult = loopResult;
         break;
+      }
+      if (event.type === GeminiEventType.Content) {
+        streamedResponseText += event.value;
       }
       yield event;
 
@@ -847,7 +851,7 @@ export class GeminiClient {
     // We do this immediately after the stream finishes for THIS turn.
     const hooksEnabled = this.config.getEnableHooks();
     if (hooksEnabled) {
-      const responseText = turn.getResponseText() || '';
+      const responseText = streamedResponseText || turn.getResponseText() || '';
       const hookState = this.hookStateMap.get(prompt_id);
       if (hookState && responseText) {
         // Append with newline if not empty


### PR DESCRIPTION
## Summary

Fixes `AfterAgent` hook `prompt_response` construction so it mirrors the text that was actually streamed to the user instead of rebuilding the payload from the turn debug response buffer.

## Motivation

Issue #27030 reports that `prompt_response` can contain duplicated/corrupted text even though the session transcript is correct. The mismatch makes hooks harder to trust for logging, automation, and post-agent processing because the hook receives a response that the user did not actually see.

The root cause is that `AfterAgent` was using `turn.getResponseText()`, which reconstructs text from stored streamed responses. If those response chunks overlap, the rebuilt string can duplicate text. The streamed `Content` events already represent the user-visible answer, so the hook payload should prefer that source.

## Changes

- Track `GeminiEventType.Content` values while each turn is streamed.
- Use the streamed content as the source for `AfterAgent.prompt_response`.
- Keep the existing `turn.getResponseText()` fallback for turns that do not emit content events.
- Add regression coverage for:
  - duplicated buffered response text
  - recursive model turns
  - fallback behavior when no content events are streamed
  - mixed event streams with citations/model info/finished events
  - mixed streamed/fallback response sources across recursive turns

## Test Plan

- `npm run test --workspace @google/gemini-cli-core -- src/core/client.test.ts src/core/turn.test.ts src/core/geminiChat.test.ts src/hooks/hookEventHandler.test.ts src/hooks/hookSystem.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run lint --workspace @google/gemini-cli-core -- src/core/client.ts src/core/client.test.ts`
- `npx prettier --check packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `git diff --check`

## Risk

Low. This changes only the source used for the `AfterAgent` hook response payload. The streamed response itself is not changed, and the previous response-text reconstruction remains as a fallback when no content events are available.

## Related Issue

Fixes #27030
