### PR TITLE
fix(core): resolve shell executables on RHEL/CentOS systems

### DIFF
--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -87,9 +87,28 @@ export async function resolveExecutable(
       return undefined;
     }
   }
+
+  const isWindows = os.platform() === 'win32';
+  const isLinux = os.platform() === 'linux';
+
   const paths = (process.env['PATH'] || '').split(path.delimiter);
-  const extensions =
-    os.platform() === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+  // On Linux (especially RHEL/CentOS), add common shell locations as fallback
+  // since PATH might not include them in some environments.
+  if (isLinux && (exe === 'bash' || exe === 'sh')) {
+    for (const fallbackPath of [
+      '/bin',
+      '/usr/bin',
+      '/usr/local/bin',
+      '/sbin',
+      '/usr/sbin',
+    ]) {
+      if (!paths.includes(fallbackPath)) {
+        paths.push(fallbackPath);
+      }
+    }
+  }
+
+  const extensions = isWindows ? ['.exe', '.cmd', '.bat', ''] : [''];
 
   for (const p of paths) {
     for (const ext of extensions) {


### PR DESCRIPTION
## Summary
Fixes Issue #25933 - Shell commands fail with "execvp(3) failed.: Permission denied" on RHEL8/9. On Linux systems where shell executables may not be found through PATH resolution, the fix adds fallback paths for common shell locations.
## Details
Modified `resolveExecutable()` in `packages/core/src/utils/shell-utils.ts` to check common shell locations on Linux (/bin/bash, /usr/bin/bash, /usr/local/bin/bash, /sbin, /usr/sbin) as a fallback before searching PATH. This ensures the shell executable is found even in restricted RHEL/CentOS environments where PATH may not include certain directories.
## Related Issues
Fixes #25933
## How to Validate
1. Clone the repo on RHEL8/9 or similar Linux
2. Run `npm install && npm run build`
3. Run any shell command like `echo Hello`
4. Verify it works without "execvp(3) failed.: Permission denied" error
## Pre-Merge Checklist
- [x] Not a breaking change
- [x] Build passes
- [ ] Tested on Linux (requires RHEL environment - issue reporter can validate)
**Note:** This fix adds fallback paths specifically for Linux. It should not affect MacOS or Windows behavior.