### PR TITLE
fix(ui): preserve new line at the end of edit window

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -511,6 +511,42 @@ function doIt() {
       expect(result.newContent).toBe(expectedContent);
     });
 
+    it('should preserve trailing newlines in flexible replacement (regression)', async () => {
+      const content = '  line1\n  line2\n  line3\n';
+      const result = await calculateReplacement(mockConfig, {
+        params: {
+          file_path: 'test.txt',
+          old_string: 'line1\nline2',
+          new_string: 'line1-replaced\nline2-replaced',
+        },
+        currentContent: content,
+        abortSignal,
+      });
+
+      expect(result.newContent).toBe(
+        '  line1-replaced\n  line2-replaced\n  line3\n',
+      );
+    });
+
+    it('should correctly increment loop index in flexible replacement when allow_multiple is true (regression)', async () => {
+      const content = '  match1\n  match2\n  match1\n  match2\n';
+      const result = await calculateReplacement(mockConfig, {
+        params: {
+          file_path: 'test.txt',
+          old_string: 'match1\nmatch2',
+          new_string: 'replaced1\nreplaced2\nreplaced3',
+          allow_multiple: true,
+        },
+        currentContent: content,
+        abortSignal,
+      });
+
+      expect(result.occurrences).toBe(2);
+      expect(result.newContent).toBe(
+        '  replaced1\n  replaced2\n  replaced3\n  replaced1\n  replaced2\n  replaced3\n',
+      );
+    });
+
     it('should correctly rebase indentation in flexible replacement without double-indenting', async () => {
       const content = '    if (a) {\n        foo();\n    }\n';
       // old_string and new_string are unindented. They should be rebased to 4-space.

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -204,15 +204,17 @@ async function calculateFlexibleReplacement(
       const newBlockWithIndent = applyIndentation(replaceLines, indentation);
 
       let replacementText = newBlockWithIndent.join('\n');
-      if (window[window.length - 1].endsWith('\n')) {
+      if (
+        new_string !== '' &&
+        window[window.length - 1].endsWith('\n') &&
+        !replacementText.endsWith('\n')
+      ) {
         replacementText += '\n';
       }
 
       sourceLines.splice(i, searchLinesStripped.length, replacementText);
-      i += 1;
-    } else {
-      i++;
     }
+    i++;
   }
 
   if (flexibleOccurrences > 0) {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -202,12 +202,14 @@ async function calculateFlexibleReplacement(
       const indentationMatch = firstLineInMatch.match(/^([ \t]*)/);
       const indentation = indentationMatch ? indentationMatch[1] : '';
       const newBlockWithIndent = applyIndentation(replaceLines, indentation);
-      sourceLines.splice(
-        i,
-        searchLinesStripped.length,
-        newBlockWithIndent.join('\n'),
-      );
-      i += replaceLines.length;
+
+      let replacementText = newBlockWithIndent.join('\n');
+      if (window[window.length - 1].endsWith('\n')) {
+        replacementText += '\n';
+      }
+
+      sourceLines.splice(i, searchLinesStripped.length, replacementText);
+      i += 1;
     } else {
       i++;
     }


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Preserve new line at the end of edit window.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
* **Trailing Newline Preservation**: Updated the flexible replacement logic to ensure that trailing newlines are preserved when replacing code blocks.
* **Loop Index Correction**: Adjusted the loop increment logic during multi-occurrence replacements to prevent skipping or miscalculating subsequent matches.
* **Regression Testing**: Added new test cases to verify that trailing newlines are maintained and that multiple replacements are handled correctly.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #21127

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Make sure that lines are never merged when any code is getting edited. I added test cases to test this.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
