### PR TITLE
fix(cli): explicitly clear entrypoint when spawning sandbox container

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -336,7 +336,14 @@ describe('sandbox', () => {
       await expect(promise).resolves.toBe(0);
       expect(spawn).toHaveBeenCalledWith(
         'docker',
-        expect.arrayContaining(['run', '-i', '--rm', '--init']),
+        expect.arrayContaining([
+          'run',
+          '-i',
+          '--rm',
+          '--init',
+          '--entrypoint',
+          '',
+        ]),
         expect.objectContaining({ stdio: 'inherit' }),
       );
 

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -314,6 +314,10 @@ export async function start_sandbox(
     // run init binary inside container to forward signals & reap zombies
     const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
 
+    // explicitly clear the entrypoint to prevent the container's default
+    // entrypoint from interfering with the CLI's spawn command.
+    args.push('--entrypoint', '');
+
     // add runsc runtime if using runsc
     if (config.command === 'runsc') {
       args.push('--runtime=runsc');
@@ -716,6 +720,8 @@ export async function start_sandbox(
         'run',
         '--rm',
         '--init',
+        '--entrypoint',
+        '',
         ...(userFlag ? userFlag.split(' ') : []),
         '--name',
         SANDBOX_PROXY_NAME,


### PR DESCRIPTION
## Summary

This PR explicitly clears the `ENTRYPOINT` when spawning the Docker, Podman, or runsc sandbox container by adding the `--entrypoint ""` flag to the container run arguments. This prevents conflicts where the default image entrypoint (introduced in newer CLI sandbox images) interferes with the dynamically constructed execution command generated by `gemini-cli`.

## Details

In `v0.42.0`, the CLI sandbox image was updated to include a default `ENTRYPOINT` (e.g., `ENTRYPOINT ["gemini"]`). Because the CLI uses `docker run` and passes the intended execution command (like `bash -c "..."`) directly as arguments, the container engine was appending our arguments to the entrypoint. This resulted in the execution of `gemini bash -c "..."` instead of `bash -c "..."`, causing an immediate `Unknown argument: c` failure during sandbox initialization. 

By passing `--entrypoint=""`, we ensure the container executes our exact arguments, maintaining backward compatibility and restoring expected behavior across Docker, Podman, and runsc engines. Test assertions have been updated to enforce this parameter's presence.

## Related Issues

Fixes #26964

## How to Validate

1. Checkout this branch and run `npm install`.
2. Ensure you have Docker or Podman installed.
3. Build the CLI with `npm run build` and `npm run bundle`.
4. Run the sandbox locally: `GEMINI_SANDBOX=docker node bundle/gemini.js --sandbox /about`.
5. Verify the sandbox starts successfully without throwing the `Unknown argument: c` error.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [x] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
