### PR TITLE
fix(core): ensure stable admin settings comparison across IPC to prevent restart loop

### DIFF
--- a/packages/core/src/code_assist/admin/admin_controls.ts
+++ b/packages/core/src/code_assist/admin/admin_controls.ts
@@ -87,7 +87,9 @@ export function sanitizeAdminSettings(
     mcpSetting: {
       mcpEnabled: sanitized.mcpSetting?.mcpEnabled ?? false,
       mcpConfig: mcpConfig ?? {},
-      requiredMcpConfig: mcpConfig?.requiredMcpServers,
+      ...(mcpConfig?.requiredMcpServers && {
+        requiredMcpConfig: mcpConfig.requiredMcpServers,
+      }),
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes a persistent restart loop issue where users are repeatedly prompted to restart to apply admin settings.

## Details

The issue was caused by inconsistent handling of optional keys (specifically `requiredMcpConfig`) in the `AdminControlsSettings` object. When settings are transferred between processes via IPC, `undefined` keys are removed during JSON serialization. However, `sanitizeAdminSettings` was explicitly including these keys as `undefined`. This led to a mismatch during polling comparison (`isDeepStrictEqual`), triggering a false-positive change detection. The fix ensures that optional keys are only included if they have a non-undefined value.

## Related Issues

Internal bug reported for restart loop.

## How to Validate

1. Run the core package tests: `npm test -w @google/gemini-cli-core -- src/code_assist/admin/admin_controls.test.ts`
2. Manually verify that the sanitized settings object no longer contains `requiredMcpConfig` if the value is missing from the server response.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
