### PR TITLE
fix(core): ensure Vertex AI sets hasAccessToPreviewModels and remove aggressive 404 fallback revocation

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1627,7 +1627,10 @@ export class Config implements McpContext, AgentLoopContext {
     this.baseLlmClient = new BaseLlmClient(this.contentGenerator, this);
 
     const authType = this.contentGeneratorConfig.authType;
-    if (authType === AuthType.USE_GEMINI) {
+    if (
+      authType === AuthType.USE_GEMINI ||
+      authType === AuthType.USE_VERTEX_AI
+    ) {
       this.setHasAccessToPreviewModel(true);
     }
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -20,8 +20,6 @@ import {
   applyAvailabilityTransition,
 } from '../availability/policyHelpers.js';
 
-import { isPreviewModel } from '../config/models.js';
-
 export const UPGRADE_URL_PAGE = 'https://goo.gle/set-up-gemini-code-assist';
 
 export async function handleFallback(
@@ -31,11 +29,6 @@ export async function handleFallback(
   error?: unknown,
 ): Promise<string | boolean | null> {
   const failureKind = classifyFailureKind(error);
-
-  // If a preview model is not found, record that the user lacks preview access.
-  if (failureKind === 'not_found' && isPreviewModel(failedModel, config)) {
-    config.setHasAccessToPreviewModel?.(false);
-  }
 
   const chain = resolvePolicyChain(config);
   const { failedPolicy, candidates } = buildFallbackPolicyContext(


### PR DESCRIPTION
## Summary

Fixes a bug where the `handleFallback` logic aggressively revoked access to all preview models when a `not_found` (404) error occurred. It also ensures that `hasAccessToPreviewModel` is set to `true` for users authenticating via Vertex AI (`AuthType.USE_VERTEX_AI`), matching the API Key (`AuthType.USE_GEMINI`) behavior.

## Details

- When a preview model (like `gemini-3.1-pro-preview`) hit a rate limit, the fallback routing chain attempted a fallback model (e.g. `gemini-3-flash-preview`).
- If Google AI Studio returned a 404 for that fallback model, the fallback handler incorrectly revoked access to all preview models for the session by setting `config.hasAccessToPreviewModel = false`.
- This PR removes the brittle revocation logic from `packages/core/src/fallback/handler.ts` to prevent false negatives.
- It also ensures the configuration properly allows preview models for Vertex AI users out-of-the-box in `packages/core/src/config/config.ts`.
- Extensive unit tests were updated/added in `packages/core/src/fallback/handler.test.ts` to verify the fix.

## Related Issues

N/A

## How to Validate

- Run the unit tests: `npm test -w @google/gemini-cli-core -- src/fallback/handler.test.ts`
- Alternatively, launch the CLI using an API Key or Vertex AI, use `gemini-3.1-pro`, and hit a transient/quota error. The fallback should gracefully handle it without permanently revoking access to `gemini-3.1` models.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
