### PR TITLE
fix(cli): show Seatbelt profile in footer

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -366,7 +366,7 @@ describe('<Footer />', () => {
       unmount();
     });
 
-    it('should display "current process" for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
+    it('should display the profile for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
       vi.stubEnv('SANDBOX', 'sandbox-exec');
       vi.stubEnv('SEATBELT_PROFILE', 'test-profile');
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
@@ -374,7 +374,47 @@ describe('<Footer />', () => {
         width: 120,
         uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
       });
-      expect(lastFrame()).toContain('current process');
+      expect(lastFrame()).toContain('sandbox-exec (test-profile)');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should display unknown when macOS Seatbelt profile is not set', async () => {
+      vi.stubEnv('SANDBOX', 'sandbox-exec');
+      vi.stubEnv('SEATBELT_PROFILE', '');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
+      expect(lastFrame()).toContain('sandbox-exec (unknown)');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should account for Seatbelt profile width when filtering narrow footer columns', async () => {
+      vi.stubEnv('SANDBOX', 'sandbox-exec');
+      vi.stubEnv('SEATBELT_PROFILE', 'strict-open');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 59,
+        uiState: {
+          isTrustedFolder: true,
+          sessionStats: mockSessionStats,
+        },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['workspace', 'sandbox', 'model-name'],
+              showLabels: true,
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      expect(output).toContain('sandbox-exec (strict-open)');
+      expect(output).not.toContain('/model');
       vi.unstubAllEnvs();
       unmount();
     });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -69,25 +69,35 @@ interface SandboxIndicatorProps {
   isTrustedFolder: boolean | undefined;
 }
 
-const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
-  isTrustedFolder,
-}) => {
-  const config = useConfig();
-  const sandboxEnabled = config.getSandboxEnabled();
+function getSandboxLabel(
+  isTrustedFolder: boolean | undefined,
+  sandboxEnabled: boolean,
+): string {
   if (isTrustedFolder === false) {
-    return <Text color={theme.status.warning}>untrusted</Text>;
+    return 'untrusted';
   }
 
   const sandbox = process.env['SANDBOX'];
   if (sandbox) {
-    return <Text color={theme.status.warning}>current process</Text>;
+    return sandbox === 'sandbox-exec'
+      ? `${sandbox} (${process.env['SEATBELT_PROFILE'] || 'unknown'})`
+      : 'current process';
   }
 
-  if (sandboxEnabled) {
-    return <Text color={theme.status.warning}>all tools</Text>;
-  }
+  return sandboxEnabled ? 'all tools' : 'no sandbox';
+}
 
-  return <Text color={theme.status.error}>no sandbox</Text>;
+const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
+  isTrustedFolder,
+}) => {
+  const config = useConfig();
+  const sandboxLabel = getSandboxLabel(
+    isTrustedFolder,
+    config.getSandboxEnabled(),
+  );
+  const color =
+    sandboxLabel === 'no sandbox' ? theme.status.error : theme.status.warning;
+  return <Text color={color}>{sandboxLabel}</Text>;
 };
 
 const CorgiIndicator: React.FC = () => (
@@ -308,17 +318,16 @@ export const Footer: React.FC = () => {
         break;
       }
       case 'sandbox': {
-        let str = 'no sandbox';
-        const sandbox = process.env['SANDBOX'];
-        if (isTrustedFolder === false) str = 'untrusted';
-        else if (sandbox) str = 'current process';
-        else if (config.getSandboxEnabled()) str = 'all tools';
+        const sandboxLabel = getSandboxLabel(
+          isTrustedFolder,
+          config.getSandboxEnabled(),
+        );
 
         addCol(
           id,
           header,
           () => <SandboxIndicator isTrustedFolder={isTrustedFolder} />,
-          str.length,
+          sandboxLabel.length,
         );
         break;
       }


### PR DESCRIPTION
## Summary

Show the active macOS Seatbelt profile in the footer sandbox indicator instead of the generic `current process` label.

## Details

When the CLI is running under `sandbox-exec`, the footer now renders `sandbox-exec (<profile>)`, matching the sandbox format already shown in `/about`. If `SEATBELT_PROFILE` is missing, the footer falls back to `sandbox-exec (unknown)`.

The sandbox footer width calculation now uses the actual rendered label so narrow footer filtering still works when the Seatbelt profile makes the sandbox column longer.

## Related Issues

Fixes #26697

## How to Validate

- `git diff --cached --check`
- `npx prettier --check packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx`
- `npx eslint packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx --max-warnings 0`
- `npm run typecheck --workspace @google/gemini-cli`
- `npm test --workspace @google/gemini-cli -- src/ui/components/Footer.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
