### PR TITLE
Avoid duplicate home slash commands

### DIFF
--- a/packages/cli/src/services/FileCommandLoader.test.ts
+++ b/packages/cli/src/services/FileCommandLoader.test.ts
@@ -348,6 +348,32 @@ describe('FileCommandLoader', () => {
     expect(commands.every((c) => c.kind === CommandKind.USER_FILE)).toBe(true);
   });
 
+  it('does not duplicate commands when command directories resolve to the same path', async () => {
+    const userCommandsDir = Storage.getUserCommandsDir();
+    mock({
+      [userCommandsDir]: {
+        'test.toml': 'prompt = "User prompt"',
+      },
+    });
+
+    const mockConfig = {
+      getProjectRoot: vi.fn(() => homedir()),
+      getExtensions: vi.fn(() => []),
+      getFolderTrust: vi.fn(() => false),
+      isTrustedFolder: vi.fn(() => false),
+      storage: {
+        isWorkspaceHomeDir: vi.fn(() => false),
+        getProjectCommandsDir: vi.fn(() => userCommandsDir),
+      },
+    } as unknown as Config;
+    const loader = new FileCommandLoader(mockConfig);
+    const commands = await loader.loadCommands(signal);
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0].name).toBe('test');
+    expect(commands[0].kind).toBe(CommandKind.USER_FILE);
+  });
+
   it('ignores files with TOML syntax errors', async () => {
     const userCommandsDir = Storage.getUserCommandsDir();
     mock({

--- a/packages/cli/src/services/FileCommandLoader.ts
+++ b/packages/cli/src/services/FileCommandLoader.ts
@@ -9,7 +9,13 @@ import path from 'node:path';
 import toml from '@iarna/toml';
 import { glob } from 'glob';
 import { z } from 'zod';
-import { Storage, coreEvents, type Config } from '@google/gemini-cli-core';
+import {
+  Storage,
+  coreEvents,
+  normalizePath,
+  resolveToRealPath,
+  type Config,
+} from '@google/gemini-cli-core';
 import type { ICommandLoader } from './types.js';
 import type {
   CommandContext,
@@ -46,6 +52,17 @@ export interface CommandFileGroup {
   path: string;
   files: string[];
   error?: string;
+}
+
+function areSameCommandDirectory(left: string, right: string): boolean {
+  try {
+    return (
+      normalizePath(resolveToRealPath(left)) ===
+      normalizePath(resolveToRealPath(right))
+    );
+  } catch {
+    return normalizePath(left) === normalizePath(right);
+  }
 }
 
 /**
@@ -220,9 +237,13 @@ export class FileCommandLoader implements ICommandLoader {
 
     // 2. Project commands (skip if same directory as user commands, e.g. when
     //    cwd is the user's home directory, to avoid false conflict warnings)
-    if (!storage.isWorkspaceHomeDir()) {
+    const projectCommandsDir = storage.getProjectCommandsDir();
+    if (
+      !storage.isWorkspaceHomeDir() &&
+      !areSameCommandDirectory(userCommandsDir, projectCommandsDir)
+    ) {
       dirs.push({
-        path: storage.getProjectCommandsDir(),
+        path: projectCommandsDir,
         kind: CommandKind.WORKSPACE_FILE,
       });
     }


### PR DESCRIPTION
## Summary

Fixes a duplicate slash-command loading edge case when the user command directory and project command directory resolve to the same location.

The loader already skips project commands when the workspace is detected as the home directory. This adds a second, directory-level check so duplicate user/workspace commands are also avoided if path normalization or platform-specific path representation makes the home-directory check miss the overlap.

Fixes #27075

## Testing

- `npm run build --workspace @google/gemini-cli-core`
- `npm run test --workspace @google/gemini-cli -- FileCommandLoader.test.ts`
- `npx prettier --check packages/cli/src/services/FileCommandLoader.ts packages/cli/src/services/FileCommandLoader.test.ts`
- `npx eslint packages/cli/src/services/FileCommandLoader.ts packages/cli/src/services/FileCommandLoader.test.ts`
- `npm run typecheck --workspace @google/gemini-cli`