### PR TITLE
fix(cli): ignore unmapped vim normal keys

### DIFF
--- a/packages/cli/src/ui/hooks/vim-passthrough.test.tsx
+++ b/packages/cli/src/ui/hooks/vim-passthrough.test.tsx
@@ -81,4 +81,24 @@ describe('useVim passthrough', () => {
 
     expect(handled).toBe(false);
   });
+
+  it.each(['H', 'M', 'Q', 'm'])(
+    'should ignore unmapped printable key %s in NORMAL mode',
+    async (sequence) => {
+      mockVimContext.vimMode = 'NORMAL';
+      const { result } = await renderHook(() =>
+        useVim(mockBuffer as TextBuffer),
+      );
+
+      let handled = false;
+      act(() => {
+        handled = result.current.handleInput(
+          createKey({ name: sequence, sequence, insertable: true }),
+        );
+      });
+
+      expect(handled).toBe(true);
+      expect(mockBuffer.handleInput).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -1486,8 +1486,14 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
             // Unknown command, clear count and pending states
             dispatch({ type: 'CLEAR_PENDING_STATES' });
 
-            // Ignore any Insertable key in Normal Mode
-            if (normalizedKey.insertable) {
+            // Ignore unmapped Insertable keys in Normal Mode, but let
+            // modifier-key chords (ctrl/alt/cmd) fall through to other handlers.
+            if (
+              normalizedKey.insertable &&
+              !normalizedKey.ctrl &&
+              !normalizedKey.alt &&
+              !normalizedKey.cmd
+            ) {
               return true;
             }
 


### PR DESCRIPTION
Fixes #21686.

## Summary
- Swallow unmapped printable keys in Vim NORMAL mode so they do not fall through to prompt insertion.
- Preserve passthrough behavior for non-printable shortcuts such as function keys and Ctrl combinations.
- Add regression coverage for the reported unmapped printable keys.

## Test
- `npm run test --workspace @google/gemini-cli -- src/ui/hooks/vim-passthrough.test.tsx`