### PR TITLE
fix(cli): show Seatbelt profile in footer

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -4,12 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { renderWithProviders } from '../../test-utils/render.js';
-import { createMockSettings } from '../../test-utils/settings.js';
 import { Footer } from './Footer.js';
-import { tildeifyPath, ToolCallDecision } from '@google/gemini-cli-core';
-import type { SessionStatsState } from '../contexts/SessionContext.js';
+import { createMockSettings } from '../../test-utils/settings.js';
+import {
+  type Config,
+  UserAccountManager,
+  AuthType,
+} from '@google/gemini-cli-core';
+import path from 'node:path';
+
+// Normalize paths to POSIX slashes for stable cross-platform snapshots.
+const normalizeFrame = (frame: string | undefined) => {
+  if (!frame) return frame;
+  return frame.replace(/\\/g, '/');
+};
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    isDevelopment: false,
+  },
+}));
+
+vi.mock('../../utils/installationInfo.js', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../utils/installationInfo.js')>();
+  return {
+    ...original,
+    get isDevelopment() {
+      return mocks.isDevelopment;
+    },
+  };
+});
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
@@ -27,19 +54,51 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
 
 const defaultProps = {
   model: 'gemini-pro',
-  targetDir:
-    '/Users/test/project/foo/bar/and/some/more/directories/to/make/it/long',
+  targetDir: path.join(
+    path.parse(process.cwd()).root,
+    'Users',
+    'test',
+    'project',
+    'foo',
+    'bar',
+    'and',
+    'some',
+    'more',
+    'directories',
+    'to',
+    'make',
+    'it',
+    'long',
+  ),
   branchName: 'main',
 };
 
-const mockSessionStats: SessionStatsState = {
-  sessionId: 'test-session',
+const mockConfigPlain = {
+  getTargetDir: () => defaultProps.targetDir,
+  getDebugMode: () => false,
+  getModel: () => defaultProps.model,
+  getIdeMode: () => false,
+  isTrustedFolder: () => true,
+  getExtensionRegistryURI: () => undefined,
+  getContentGeneratorConfig: () => ({ authType: undefined }),
+  getSandboxEnabled: () => false,
+  getSessionId: () => 'test-session-id',
+};
+
+const mockConfig = mockConfigPlain as unknown as Config;
+
+const mockSessionStats = {
+  sessionId: 'test-session-id',
   sessionStartTime: new Date(),
-  lastPromptTokenCount: 0,
   promptCount: 0,
+  lastPromptTokenCount: 150000,
   metrics: {
-    models: {},
+    files: {
+      totalLinesAdded: 12,
+      totalLinesRemoved: 4,
+    },
     tools: {
+      count: 0,
       totalCalls: 0,
       totalSuccess: 0,
       totalFail: 0,
@@ -48,262 +107,314 @@ const mockSessionStats: SessionStatsState = {
         accept: 0,
         reject: 0,
         modify: 0,
-        [ToolCallDecision.AUTO_ACCEPT]: 0,
+        auto_accept: 0,
       },
       byName: {},
+      latency: { avg: 0, max: 0, min: 0 },
     },
-    files: {
-      totalLinesAdded: 0,
-      totalLinesRemoved: 0,
+    models: {
+      'gemini-pro': {
+        api: {
+          totalRequests: 0,
+          totalErrors: 0,
+          totalLatencyMs: 0,
+        },
+        tokens: {
+          input: 0,
+          prompt: 0,
+          candidates: 0,
+          total: 1500,
+          cached: 0,
+          thoughts: 0,
+          tool: 0,
+        },
+        roles: {},
+      },
     },
   },
 };
 
 describe('<Footer />', () => {
+  beforeEach(() => {
+    const root = path.parse(process.cwd()).root;
+    vi.stubEnv('GEMINI_CLI_HOME', path.join(root, 'Users', 'test'));
+    vi.stubEnv('SANDBOX', '');
+    vi.stubEnv('SEATBELT_PROFILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders the component', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: {
-          branchName: defaultProps.branchName,
-          sessionStats: mockSessionStats,
-        },
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        branchName: defaultProps.branchName,
+        sessionStats: mockSessionStats,
       },
-    );
-    await waitUntilReady();
+    });
     expect(lastFrame()).toBeDefined();
     unmount();
   });
 
   describe('path display', () => {
     it('should display a shortened path on a narrow terminal', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 79,
-          uiState: { sessionStats: mockSessionStats },
-        },
-      );
-      await waitUntilReady();
-      const tildePath = tildeifyPath(defaultProps.targetDir);
-      const pathLength = Math.max(20, Math.floor(79 * 0.25));
-      const expectedPath =
-        '...' + tildePath.slice(tildePath.length - pathLength + 3);
-      expect(lastFrame()).toContain(expectedPath);
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 79,
+        uiState: { sessionStats: mockSessionStats },
+      });
+      const output = lastFrame();
+      expect(output).toBeDefined();
+      // Should contain some part of the path, likely shortened
+      expect(output).toContain(path.join('make', 'it'));
       unmount();
     });
 
     it('should use wide layout at 80 columns', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 80,
-          uiState: { sessionStats: mockSessionStats },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 80,
+        uiState: { sessionStats: mockSessionStats },
+      });
+      const output = lastFrame();
+      expect(output).toBeDefined();
+      expect(output).toContain(path.join('make', 'it'));
+      unmount();
+    });
+
+    it('should not truncate high-priority items on narrow terminals (regression)', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 60,
+        uiState: {
+          sessionStats: mockSessionStats,
         },
-      );
-      await waitUntilReady();
-      const tildePath = tildeifyPath(defaultProps.targetDir);
-      const expectedPath =
-        '...' + tildePath.slice(tildePath.length - 80 * 0.25 + 3);
-      expect(lastFrame()).toContain(expectedPath);
+        settings: createMockSettings({
+          general: {
+            vimMode: true,
+          },
+          ui: {
+            footer: {
+              showLabels: true,
+              items: ['workspace', 'model-name'],
+            },
+          },
+        }),
+      });
+      const output = lastFrame();
+      // [INSERT] is high priority and should be fully visible
+      // (Note: VimModeProvider defaults to 'INSERT' mode when enabled)
+      expect(output).toContain('[INSERT]');
+      // Other items should be present but might be shortened
+      expect(output).toContain('gemini-pro');
       unmount();
     });
   });
 
   it('displays the branch name when provided', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: {
-          branchName: defaultProps.branchName,
-          sessionStats: mockSessionStats,
-        },
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        branchName: defaultProps.branchName,
+        sessionStats: mockSessionStats,
       },
-    );
-    await waitUntilReady();
-    expect(lastFrame()).toContain(`(${defaultProps.branchName}*)`);
+    });
+    expect(lastFrame()).toContain(defaultProps.branchName);
     unmount();
   });
 
   it('does not display the branch name when not provided', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: { branchName: undefined, sessionStats: mockSessionStats },
-      },
-    );
-    await waitUntilReady();
-    expect(lastFrame()).not.toContain(`(${defaultProps.branchName}*)`);
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: { branchName: undefined, sessionStats: mockSessionStats },
+    });
+    expect(lastFrame()).not.toContain('Branch');
     unmount();
   });
 
   it('displays the model name and context percentage', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: { sessionStats: mockSessionStats },
-        settings: createMockSettings({
-          ui: {
-            footer: {
-              hideContextPercentage: false,
-            },
-          },
-        }),
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        currentModel: defaultProps.model,
+        sessionStats: {
+          ...mockSessionStats,
+          lastPromptTokenCount: 1000,
+        },
       },
-    );
-    await waitUntilReady();
+      settings: createMockSettings({
+        ui: {
+          footer: {
+            hideContextPercentage: false,
+          },
+        },
+      }),
+    });
     expect(lastFrame()).toContain(defaultProps.model);
-    expect(lastFrame()).toMatch(/\d+% context left/);
+    expect(lastFrame()).toMatch(/\d+% used/);
     unmount();
   });
 
   it('displays the usage indicator when usage is low', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: {
-          sessionStats: mockSessionStats,
-          quota: {
-            userTier: undefined,
-            stats: {
-              remaining: 15,
-              limit: 100,
-              resetTime: undefined,
-            },
-            proQuotaRequest: null,
-            validationRequest: null,
-          },
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        sessionStats: mockSessionStats,
+      },
+      quotaState: {
+        stats: {
+          remaining: 15,
+          limit: 100,
+          resetTime: undefined,
         },
       },
-    );
-    await waitUntilReady();
-    expect(lastFrame()).toContain('15%');
-    expect(lastFrame()).toMatchSnapshot();
+    });
+    expect(lastFrame()).toContain('85% used');
+    expect(normalizeFrame(lastFrame())).toMatchSnapshot();
     unmount();
   });
 
   it('hides the usage indicator when usage is not near limit', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: {
-          sessionStats: mockSessionStats,
-          quota: {
-            userTier: undefined,
-            stats: {
-              remaining: 85,
-              limit: 100,
-              resetTime: undefined,
-            },
-            proQuotaRequest: null,
-            validationRequest: null,
-          },
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        sessionStats: mockSessionStats,
+      },
+      quotaState: {
+        stats: {
+          remaining: 85,
+          limit: 100,
+          resetTime: undefined,
         },
       },
-    );
-    await waitUntilReady();
-    expect(lastFrame()).not.toContain('Usage remaining');
-    expect(lastFrame()).toMatchSnapshot();
+    });
+    expect(normalizeFrame(lastFrame())).toContain('15% used');
+    expect(normalizeFrame(lastFrame())).toMatchSnapshot();
     unmount();
   });
 
   it('displays "Limit reached" message when remaining is 0', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 120,
-        uiState: {
-          sessionStats: mockSessionStats,
-          quota: {
-            userTier: undefined,
-            stats: {
-              remaining: 0,
-              limit: 100,
-              resetTime: undefined,
-            },
-            proQuotaRequest: null,
-            validationRequest: null,
-          },
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 120,
+      uiState: {
+        sessionStats: mockSessionStats,
+      },
+      quotaState: {
+        stats: {
+          remaining: 0,
+          limit: 100,
+          resetTime: undefined,
         },
       },
-    );
-    await waitUntilReady();
-    expect(lastFrame()).toContain('Limit reached');
-    expect(lastFrame()).toMatchSnapshot();
+    });
+    expect(lastFrame()?.toLowerCase()).toContain('limit reached');
+    expect(normalizeFrame(lastFrame())).toMatchSnapshot();
     unmount();
   });
 
-  it('displays the model name and abbreviated context percentage', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
-        width: 99,
-        uiState: { sessionStats: mockSessionStats },
-        settings: createMockSettings({
-          ui: {
-            footer: {
-              hideContextPercentage: false,
-            },
+  it('displays the model name and abbreviated context used label on narrow terminals', async () => {
+    const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+      config: mockConfig,
+      width: 99,
+      uiState: { sessionStats: mockSessionStats },
+      settings: createMockSettings({
+        ui: {
+          footer: {
+            hideContextPercentage: false,
           },
-        }),
-      },
-    );
-    await waitUntilReady();
+        },
+      }),
+    });
     expect(lastFrame()).toContain(defaultProps.model);
     expect(lastFrame()).toMatch(/\d+%/);
+    expect(lastFrame()).not.toContain('context used');
     unmount();
   });
 
   describe('sandbox and trust info', () => {
     it('should display untrusted when isTrustedFolder is false', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { isTrustedFolder: false, sessionStats: mockSessionStats },
-        },
-      );
-      await waitUntilReady();
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: false, sessionStats: mockSessionStats },
+      });
       expect(lastFrame()).toContain('untrusted');
       unmount();
     });
 
-    it('should display custom sandbox info when SANDBOX env is set', async () => {
+    it('should display "current process" for custom sandbox when SANDBOX env is set', async () => {
       vi.stubEnv('SANDBOX', 'gemini-cli-test-sandbox');
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: {
-            isTrustedFolder: undefined,
-            sessionStats: mockSessionStats,
-          },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          isTrustedFolder: undefined,
+          sessionStats: mockSessionStats,
         },
-      );
-      await waitUntilReady();
-      expect(lastFrame()).toContain('test');
+      });
+      expect(lastFrame()).toContain('current process');
       vi.unstubAllEnvs();
       unmount();
     });
 
-    it('should display macOS Seatbelt info when SANDBOX is sandbox-exec', async () => {
+    it('should display the profile for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
       vi.stubEnv('SANDBOX', 'sandbox-exec');
       vi.stubEnv('SEATBELT_PROFILE', 'test-profile');
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
+      expect(lastFrame()).toContain('sandbox-exec (test-profile)');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should display unknown when macOS Seatbelt profile is not set', async () => {
+      vi.stubEnv('SANDBOX', 'sandbox-exec');
+      vi.stubEnv('SEATBELT_PROFILE', '');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
+      expect(lastFrame()).toContain('sandbox-exec (unknown)');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should account for Seatbelt profile width when filtering narrow footer columns', async () => {
+      vi.stubEnv('SANDBOX', 'sandbox-exec');
+      vi.stubEnv('SEATBELT_PROFILE', 'strict-open');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 59,
+        uiState: {
+          isTrustedFolder: true,
+          sessionStats: mockSessionStats,
         },
-      );
-      await waitUntilReady();
-      expect(lastFrame()).toMatch(/macOS Seatbelt.*\(test-profile\)/s);
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['workspace', 'sandbox', 'model-name'],
+              showLabels: true,
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      expect(output).toContain('sandbox-exec (strict-open)');
+      expect(output).not.toContain('/model');
       vi.unstubAllEnvs();
       unmount();
     });
@@ -311,29 +422,41 @@ describe('<Footer />', () => {
     it('should display "no sandbox" when SANDBOX is not set and folder is trusted', async () => {
       // Clear any SANDBOX env var that might be set.
       vi.stubEnv('SANDBOX', '');
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
-        },
-      );
-      await waitUntilReady();
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
       expect(lastFrame()).toContain('no sandbox');
+      vi.unstubAllEnvs();
+      unmount();
+    });
+
+    it('should display "all tools" when tool sandboxing is enabled and agent is local', async () => {
+      vi.stubEnv('SANDBOX', '');
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: Object.assign(
+          Object.create(Object.getPrototypeOf(mockConfig)),
+          mockConfig,
+          {
+            getSandboxEnabled: () => true,
+          },
+        ),
+        width: 120,
+        uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
+      });
+      expect(lastFrame()).toContain('all tools');
       vi.unstubAllEnvs();
       unmount();
     });
 
     it('should prioritize untrusted message over sandbox info', async () => {
       vi.stubEnv('SANDBOX', 'gemini-cli-test-sandbox');
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { isTrustedFolder: false, sessionStats: mockSessionStats },
-        },
-      );
-      await waitUntilReady();
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { isTrustedFolder: false, sessionStats: mockSessionStats },
+      });
       expect(lastFrame()).toContain('untrusted');
       expect(lastFrame()).not.toMatch(/test-sandbox/s);
       vi.unstubAllEnvs();
@@ -342,197 +465,473 @@ describe('<Footer />', () => {
   });
 
   describe('footer configuration filtering (golden snapshots)', () => {
-    beforeEach(() => {
-      vi.stubEnv('SANDBOX', '');
-      vi.stubEnv('SEATBELT_PROFILE', '');
-    });
-
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
-
     it('renders complete footer with all sections visible (baseline)', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideContextPercentage: false,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
             },
-          }),
-        },
+          },
+        }),
+      });
+      expect(normalizeFrame(lastFrame())).toMatchSnapshot(
+        'complete-footer-wide',
       );
-      await waitUntilReady();
-      expect(lastFrame()).toMatchSnapshot('complete-footer-wide');
       unmount();
     });
 
     it('renders footer with all optional sections hidden (minimal footer)', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideCWD: true,
-                hideSandboxStatus: true,
-                hideModelInfo: true,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideCWD: true,
+              hideSandboxStatus: true,
+              hideModelInfo: true,
             },
-          }),
-        },
+          },
+        }),
+      });
+      // Wait for Ink to render
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(normalizeFrame(lastFrame({ allowEmpty: true }))).toMatchSnapshot(
+        'footer-minimal',
       );
-      await waitUntilReady();
-      expect(lastFrame({ allowEmpty: true })).toMatchSnapshot('footer-minimal');
       unmount();
     });
 
     it('renders footer with only model info hidden (partial filtering)', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideCWD: false,
-                hideSandboxStatus: false,
-                hideModelInfo: true,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideCWD: false,
+              hideSandboxStatus: false,
+              hideModelInfo: true,
             },
-          }),
-        },
-      );
-      await waitUntilReady();
-      expect(lastFrame()).toMatchSnapshot('footer-no-model');
+          },
+        }),
+      });
+      expect(normalizeFrame(lastFrame())).toMatchSnapshot('footer-no-model');
       unmount();
     });
 
     it('renders footer with CWD and model info hidden to test alignment (only sandbox visible)', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideCWD: true,
-                hideSandboxStatus: false,
-                hideModelInfo: true,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideCWD: true,
+              hideSandboxStatus: false,
+              hideModelInfo: true,
             },
-          }),
-        },
+          },
+        }),
+      });
+      expect(normalizeFrame(lastFrame())).toMatchSnapshot(
+        'footer-only-sandbox',
       );
-      await waitUntilReady();
-      expect(lastFrame()).toMatchSnapshot('footer-only-sandbox');
       unmount();
     });
 
     it('hides the context percentage when hideContextPercentage is true', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideContextPercentage: true,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: true,
             },
-          }),
-        },
-      );
-      await waitUntilReady();
+          },
+        }),
+      });
       expect(lastFrame()).toContain(defaultProps.model);
-      expect(lastFrame()).not.toMatch(/\d+% context left/);
+      expect(lastFrame()).not.toMatch(/\d+% used/);
       unmount();
     });
     it('shows the context percentage when hideContextPercentage is false', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 120,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideContextPercentage: false,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
             },
-          }),
-        },
-      );
-      await waitUntilReady();
+          },
+        }),
+      });
       expect(lastFrame()).toContain(defaultProps.model);
-      expect(lastFrame()).toMatch(/\d+% context left/);
+      expect(lastFrame()).toMatch(/\d+% used/);
       unmount();
     });
     it('renders complete footer in narrow terminal (baseline narrow)', async () => {
-      const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-        <Footer />,
-        {
-          width: 79,
-          uiState: { sessionStats: mockSessionStats },
-          settings: createMockSettings({
-            ui: {
-              footer: {
-                hideContextPercentage: false,
-              },
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 79,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              hideContextPercentage: false,
             },
-          }),
-        },
+          },
+        }),
+      });
+      expect(normalizeFrame(lastFrame())).toMatchSnapshot(
+        'complete-footer-narrow',
       );
-      await waitUntilReady();
-      expect(lastFrame()).toMatchSnapshot('complete-footer-narrow');
       unmount();
     });
   });
-});
 
-describe('fallback mode display', () => {
-  it('should display Flash model when in fallback mode, not the configured Pro model', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
+  describe('Footer Token Formatting', () => {
+    const renderWithTokens = async (tokens: number) => {
+      const result = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: {
+            ...mockSessionStats,
+            metrics: {
+              ...mockSessionStats.metrics,
+              models: {
+                'gemini-pro': {
+                  api: {
+                    totalRequests: 0,
+                    totalErrors: 0,
+                    totalLatencyMs: 0,
+                  },
+                  tokens: {
+                    input: 0,
+                    prompt: 0,
+                    candidates: 0,
+                    total: tokens,
+                    cached: 0,
+                    thoughts: 0,
+                    tool: 0,
+                  },
+                  roles: {},
+                },
+              },
+            },
+          },
+        },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['token-count'],
+            },
+          },
+        }),
+      });
+      await result.waitUntilReady();
+      return result;
+    };
+
+    it('formats thousands with k', async () => {
+      const { lastFrame, unmount } = await renderWithTokens(1500);
+      expect(lastFrame()).toContain('1.5k tokens');
+      unmount();
+    });
+
+    it('formats millions with m', async () => {
+      const { lastFrame, unmount } = await renderWithTokens(1500000);
+      expect(lastFrame()).toContain('1.5m tokens');
+      unmount();
+    });
+
+    it('formats billions with b', async () => {
+      const { lastFrame, unmount } = await renderWithTokens(1500000000);
+      expect(lastFrame()).toContain('1.5b tokens');
+      unmount();
+    });
+
+    it('formats small numbers without suffix', async () => {
+      const { lastFrame, unmount } = await renderWithTokens(500);
+      expect(lastFrame()).toContain('500 tokens');
+      unmount();
+    });
+  });
+
+  describe('error summary visibility', () => {
+    beforeEach(() => {
+      mocks.isDevelopment = false;
+    });
+
+    afterEach(() => {
+      mocks.isDevelopment = false;
+    });
+
+    it('hides error summary in low verbosity mode out of dev mode', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: mockSessionStats,
+          errorCount: 2,
+          showErrorDetails: false,
+        },
+        settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
+      });
+      expect(lastFrame()).not.toContain('F12 for details');
+      unmount();
+    });
+
+    it('shows error summary in low verbosity mode in dev mode', async () => {
+      mocks.isDevelopment = true;
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: mockSessionStats,
+          errorCount: 2,
+          showErrorDetails: false,
+        },
+        settings: createMockSettings({ ui: { errorVerbosity: 'low' } }),
+      });
+      expect(lastFrame()).toContain('F12 for details');
+      expect(lastFrame()).toContain('2 errors');
+      unmount();
+    });
+
+    it('shows error summary in full verbosity mode', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: mockSessionStats,
+          errorCount: 2,
+          showErrorDetails: false,
+        },
+        settings: createMockSettings({ ui: { errorVerbosity: 'full' } }),
+      });
+      expect(lastFrame()).toContain('F12 for details');
+      expect(lastFrame()).toContain('2 errors');
+      unmount();
+    });
+  });
+
+  describe('Footer Custom Items', () => {
+    it('renders auth item with email', async () => {
+      const authConfig = {
+        ...mockConfigPlain,
+        getContentGeneratorConfig: () => ({
+          authType: AuthType.LOGIN_WITH_GOOGLE,
+        }),
+      } as unknown as Config;
+      const getCachedAccountSpy = vi
+        .spyOn(UserAccountManager.prototype, 'getCachedGoogleAccount')
+        .mockReturnValue('test@example.com');
+
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: authConfig,
+        width: 120,
+        uiState: {
+          currentModel: 'gemini-pro',
+          sessionStats: mockSessionStats,
+        },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['auth'],
+            },
+          },
+        }),
+      });
+
+      expect(lastFrame()).toContain('auth');
+      expect(lastFrame()).toContain('test@example.com');
+      unmount();
+      getCachedAccountSpy.mockRestore();
+    });
+
+    it('does NOT render auth item when showUserIdentity is false', async () => {
+      const authConfig = {
+        ...mockConfigPlain,
+        getContentGeneratorConfig: () => ({
+          authType: AuthType.LOGIN_WITH_GOOGLE,
+        }),
+      } as unknown as Config;
+      const getCachedAccountSpy = vi
+        .spyOn(UserAccountManager.prototype, 'getCachedGoogleAccount')
+        .mockReturnValue('test@example.com');
+
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: authConfig,
+        width: 120,
+        uiState: {
+          currentModel: 'gemini-pro',
+          sessionStats: mockSessionStats,
+        },
+        settings: createMockSettings({
+          ui: {
+            showUserIdentity: false,
+            footer: {
+              items: ['workspace', 'auth'],
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      expect(output).toContain('workspace');
+      expect(output).not.toContain('auth');
+      expect(output).not.toContain('test@example.com');
+      unmount();
+      getCachedAccountSpy.mockRestore();
+    });
+
+    it('renders items in the specified order', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          currentModel: 'gemini-pro',
+          sessionStats: mockSessionStats,
+        },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['model-name', 'workspace'],
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      const modelIdx = output.indexOf('/model');
+      const cwdIdx = output.indexOf('workspace (/directory)');
+      expect(modelIdx).toBeLessThan(cwdIdx);
+      unmount();
+    });
+
+    it('renders multiple items with proper alignment', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: mockSessionStats,
+          branchName: 'main',
+        },
+        settings: createMockSettings({
+          vimMode: {
+            vimMode: true,
+          },
+          ui: {
+            footer: {
+              items: ['workspace', 'git-branch', 'sandbox', 'model-name'],
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      expect(output).toBeDefined();
+      // Headers should be present
+      expect(output).toContain('workspace (/directory)');
+      expect(output).toContain('branch');
+      expect(output).toContain('sandbox');
+      expect(output).toContain('/model');
+      // Data should be present
+      expect(output).toContain('main');
+      expect(output).toContain('gemini-pro');
+      unmount();
+    });
+
+    it('handles empty items array', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: { sessionStats: mockSessionStats },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: [],
+            },
+          },
+        }),
+      });
+      // Wait for Ink to render
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const output = lastFrame({ allowEmpty: true });
+      expect(output).toBeDefined();
+      expect(output.trim()).toBe('');
+      unmount();
+    });
+
+    it('does not render items that are conditionally hidden', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
+        width: 120,
+        uiState: {
+          sessionStats: mockSessionStats,
+          branchName: undefined, // No branch
+        },
+        settings: createMockSettings({
+          ui: {
+            footer: {
+              items: ['workspace', 'git-branch', 'model-name'],
+            },
+          },
+        }),
+      });
+
+      const output = lastFrame();
+      expect(output).toBeDefined();
+      expect(output).not.toContain('branch');
+      expect(output).toContain('workspace (/directory)');
+      expect(output).toContain('/model');
+      unmount();
+    });
+  });
+
+  describe('fallback mode display', () => {
+    it('should display Flash model when in fallback mode, not the configured Pro model', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
         width: 120,
         uiState: {
           sessionStats: mockSessionStats,
           currentModel: 'gemini-2.5-flash', // Fallback active, showing Flash
         },
-      },
-    );
-    await waitUntilReady();
+      });
 
-    // Footer should show the effective model (Flash), not the config model (Pro)
-    expect(lastFrame()).toContain('gemini-2.5-flash');
-    expect(lastFrame()).not.toContain('gemini-2.5-pro');
-    unmount();
-  });
+      // Footer should show the effective model (Flash), not the config model (Pro)
+      expect(lastFrame()).toContain('gemini-2.5-flash');
+      expect(lastFrame()).not.toContain('gemini-2.5-pro');
+      unmount();
+    });
 
-  it('should display Pro model when NOT in fallback mode', async () => {
-    const { lastFrame, waitUntilReady, unmount } = renderWithProviders(
-      <Footer />,
-      {
+    it('should display Pro model when NOT in fallback mode', async () => {
+      const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
+        config: mockConfig,
         width: 120,
         uiState: {
           sessionStats: mockSessionStats,
           currentModel: 'gemini-2.5-pro', // Normal mode, showing Pro
         },
-      },
-    );
-    await waitUntilReady();
+      });
 
-    expect(lastFrame()).toContain('gemini-2.5-pro');
-    unmount();
+      expect(lastFrame()).toContain('gemini-2.5-pro');
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -5,30 +5,206 @@
  */
 
 import type React from 'react';
+import { useState, useEffect } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import {
   shortenPath,
   tildeifyPath,
   getDisplayString,
+  checkExhaustive,
+  AuthType,
+  UserAccountManager,
 } from '@google/gemini-cli-core';
 import { ConsoleSummaryDisplay } from './ConsoleSummaryDisplay.js';
 import process from 'node:process';
+import os from 'node:os';
 import { MemoryUsageDisplay } from './MemoryUsageDisplay.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { QuotaDisplay } from './QuotaDisplay.js';
 import { DebugProfiler } from './DebugProfiler.js';
-import { isDevelopment } from '../../utils/installationInfo.js';
 import { useUIState } from '../contexts/UIStateContext.js';
+import { useQuotaState } from '../contexts/QuotaContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
+import { useInputState } from '../contexts/InputContext.js';
+import {
+  ALL_ITEMS,
+  type FooterItemId,
+  deriveItemsFromLegacySettings,
+} from '../../config/footerItems.js';
+import { isDevelopment } from '../../utils/installationInfo.js';
+
+const HOSTNAME = os.hostname();
+
+interface CwdIndicatorProps {
+  targetDir: string;
+  maxWidth: number;
+  debugMode?: boolean;
+  debugMessage?: string;
+  color?: string;
+}
+
+const CwdIndicator: React.FC<CwdIndicatorProps> = ({
+  targetDir,
+  maxWidth,
+  debugMode,
+  debugMessage,
+  color = theme.text.primary,
+}) => {
+  const debugSuffix = debugMode ? ' ' + (debugMessage || '--debug') : '';
+  const availableForPath = Math.max(10, maxWidth - debugSuffix.length);
+  const displayPath = shortenPath(tildeifyPath(targetDir), availableForPath);
+
+  return (
+    <Text color={color}>
+      {displayPath}
+      {debugMode && <Text color={theme.status.error}>{debugSuffix}</Text>}
+    </Text>
+  );
+};
+
+interface SandboxIndicatorProps {
+  isTrustedFolder: boolean | undefined;
+}
+
+function getSandboxLabel(
+  isTrustedFolder: boolean | undefined,
+  sandboxEnabled: boolean,
+): string {
+  if (isTrustedFolder === false) {
+    return 'untrusted';
+  }
+
+  const sandbox = process.env['SANDBOX'];
+  if (sandbox) {
+    return sandbox === 'sandbox-exec'
+      ? `${sandbox} (${process.env['SEATBELT_PROFILE'] || 'unknown'})`
+      : 'current process';
+  }
+
+  return sandboxEnabled ? 'all tools' : 'no sandbox';
+}
+
+const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
+  isTrustedFolder,
+}) => {
+  const config = useConfig();
+  const sandboxLabel = getSandboxLabel(
+    isTrustedFolder,
+    config.getSandboxEnabled(),
+  );
+  const color =
+    sandboxLabel === 'no sandbox' ? theme.status.error : theme.status.warning;
+  return <Text color={color}>{sandboxLabel}</Text>;
+};
+
+const CorgiIndicator: React.FC = () => (
+  <Text>
+    <Text color={theme.status.error}>▼</Text>
+    <Text color={theme.text.primary}>(´</Text>
+    <Text color={theme.status.error}>ᴥ</Text>
+    <Text color={theme.text.primary}>`)</Text>
+    <Text color={theme.status.error}>▼</Text>
+  </Text>
+);
+
+export interface FooterRowItem {
+  key: string;
+  header: string;
+  element: React.ReactNode;
+  flexGrow?: number;
+  flexShrink?: number;
+  isFocused?: boolean;
+  alignItems?: 'flex-start' | 'center' | 'flex-end';
+}
+
+const COLUMN_GAP = 3;
+
+export const FooterRow: React.FC<{
+  items: FooterRowItem[];
+  showLabels: boolean;
+}> = ({ items, showLabels }) => {
+  const elements: React.ReactNode[] = [];
+
+  items.forEach((item, idx) => {
+    if (idx > 0) {
+      elements.push(
+        <Box
+          key={`sep-${item.key}`}
+          flexGrow={1}
+          flexShrink={1}
+          minWidth={showLabels ? COLUMN_GAP : 3}
+          justifyContent="center"
+          alignItems="center"
+        >
+          {!showLabels && <Text color={theme.ui.comment}> · </Text>}
+        </Box>,
+      );
+    }
+
+    elements.push(
+      <Box
+        key={item.key}
+        flexDirection="column"
+        flexGrow={item.flexGrow ?? 0}
+        flexShrink={item.flexShrink ?? 1}
+        alignItems={item.alignItems}
+        backgroundColor={item.isFocused ? theme.background.focus : undefined}
+      >
+        {showLabels && (
+          <Box height={1}>
+            <Text
+              color={item.isFocused ? theme.text.primary : theme.ui.comment}
+            >
+              {item.header}
+            </Text>
+          </Box>
+        )}
+        <Box height={1}>{item.element}</Box>
+      </Box>,
+    );
+  });
+
+  return (
+    <Box flexDirection="row" flexWrap="nowrap" width="100%">
+      {elements}
+    </Box>
+  );
+};
+
+function isFooterItemId(id: string): id is FooterItemId {
+  return ALL_ITEMS.some((i) => i.id === id);
+}
+
+interface FooterColumn {
+  id: string;
+  header: string;
+  element: (maxWidth: number) => React.ReactNode;
+  width: number;
+  isHighPriority: boolean;
+}
 
 export const Footer: React.FC = () => {
   const uiState = useUIState();
+  const quotaState = useQuotaState();
+  const { copyModeEnabled } = useInputState();
   const config = useConfig();
   const settings = useSettings();
   const { vimEnabled, vimMode } = useVimMode();
+
+  const authType = config.getContentGeneratorConfig()?.authType;
+  const [email, setEmail] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (authType) {
+      const userAccountManager = new UserAccountManager();
+      setEmail(userAccountManager.getCachedGoogleAccount() ?? undefined);
+    } else {
+      setEmail(undefined);
+    }
+  }, [authType]);
 
   const {
     model,
@@ -42,7 +218,6 @@ export const Footer: React.FC = () => {
     promptTokenCount,
     isTrustedFolder,
     terminalWidth,
-    quotaStats,
   } = {
     model: uiState.currentModel,
     targetDir: config.getTargetDir(),
@@ -55,140 +230,323 @@ export const Footer: React.FC = () => {
     promptTokenCount: uiState.sessionStats.lastPromptTokenCount,
     isTrustedFolder: uiState.isTrustedFolder,
     terminalWidth: uiState.terminalWidth,
-    quotaStats: uiState.quota.stats,
   };
 
-  const showMemoryUsage =
-    config.getDebugMode() || settings.merged.ui.showMemoryUsage;
-  const hideCWD = settings.merged.ui.footer.hideCWD;
-  const hideSandboxStatus = settings.merged.ui.footer.hideSandboxStatus;
-  const hideModelInfo = settings.merged.ui.footer.hideModelInfo;
-  const hideContextPercentage = settings.merged.ui.footer.hideContextPercentage;
+  const quotaStats = quotaState.stats;
 
-  const pathLength = Math.max(20, Math.floor(terminalWidth * 0.25));
-  const displayPath = shortenPath(tildeifyPath(targetDir), pathLength);
-
-  const justifyContent = hideCWD && hideModelInfo ? 'center' : 'space-between';
+  const isFullErrorVerbosity = settings.merged.ui.errorVerbosity === 'full';
+  const showErrorSummary =
+    !showErrorDetails &&
+    errorCount > 0 &&
+    (isFullErrorVerbosity || debugMode || isDevelopment);
   const displayVimMode = vimEnabled ? vimMode : undefined;
 
-  const showDebugProfiler = debugMode || isDevelopment;
+  const items =
+    settings.merged.ui.footer.items ??
+    deriveItemsFromLegacySettings(settings.merged);
+  const showLabels = settings.merged.ui.footer.showLabels !== false;
+  const itemColor = showLabels ? theme.text.primary : theme.ui.comment;
+
+  const potentialColumns: FooterColumn[] = [];
+
+  const addCol = (
+    id: string,
+    header: string,
+    element: (maxWidth: number) => React.ReactNode,
+    dataWidth: number,
+    isHighPriority = false,
+  ) => {
+    potentialColumns.push({
+      id,
+      header: showLabels ? header : '',
+      element,
+      width: Math.max(dataWidth, showLabels ? header.length : 0),
+      isHighPriority,
+    });
+  };
+
+  // 1. System Indicators (Far Left, high priority)
+  if (uiState.showDebugProfiler) {
+    addCol('debug', '', () => <DebugProfiler />, 45, true);
+  }
+  if (displayVimMode) {
+    const vimStr = `[${displayVimMode}]`;
+    addCol(
+      'vim',
+      '',
+      () => <Text color={theme.text.accent}>{vimStr}</Text>,
+      vimStr.length,
+      true,
+    );
+  }
+
+  // 2. Main Configurable Items
+  for (const id of items) {
+    if (!isFooterItemId(id)) continue;
+    const itemConfig = ALL_ITEMS.find((i) => i.id === id);
+    const header = itemConfig?.header ?? id;
+
+    switch (id) {
+      case 'workspace': {
+        const fullPath = tildeifyPath(targetDir);
+        const debugSuffix = debugMode ? ' ' + (debugMessage || '--debug') : '';
+        addCol(
+          id,
+          header,
+          (maxWidth) => (
+            <CwdIndicator
+              targetDir={targetDir}
+              maxWidth={maxWidth}
+              debugMode={debugMode}
+              debugMessage={debugMessage}
+              color={itemColor}
+            />
+          ),
+          fullPath.length + debugSuffix.length,
+        );
+        break;
+      }
+      case 'git-branch': {
+        if (branchName) {
+          addCol(
+            id,
+            header,
+            () => <Text color={itemColor}>{branchName}</Text>,
+            branchName.length,
+          );
+        }
+        break;
+      }
+      case 'sandbox': {
+        const sandboxLabel = getSandboxLabel(
+          isTrustedFolder,
+          config.getSandboxEnabled(),
+        );
+
+        addCol(
+          id,
+          header,
+          () => <SandboxIndicator isTrustedFolder={isTrustedFolder} />,
+          sandboxLabel.length,
+        );
+        break;
+      }
+      case 'model-name': {
+        const str = getDisplayString(model);
+        addCol(
+          id,
+          header,
+          () => <Text color={itemColor}>{str}</Text>,
+          str.length,
+        );
+        break;
+      }
+      case 'context-used': {
+        addCol(
+          id,
+          header,
+          () => (
+            <ContextUsageDisplay
+              promptTokenCount={promptTokenCount}
+              model={model}
+              terminalWidth={terminalWidth}
+            />
+          ),
+          10, // "100% used" is 9 chars
+        );
+        break;
+      }
+      case 'quota': {
+        if (quotaStats?.remaining !== undefined && quotaStats.limit) {
+          addCol(
+            id,
+            header,
+            () => (
+              <QuotaDisplay
+                remaining={quotaStats.remaining}
+                limit={quotaStats.limit}
+                forceShow={true}
+                lowercase={true}
+              />
+            ),
+            9, // "100% used" is 9 chars
+          );
+        }
+        break;
+      }
+      case 'memory-usage': {
+        addCol(
+          id,
+          header,
+          () => (
+            <MemoryUsageDisplay color={itemColor} isActive={!copyModeEnabled} />
+          ),
+          10,
+        );
+        break;
+      }
+      case 'session-id': {
+        addCol(
+          id,
+          header,
+          () => (
+            <Text color={itemColor}>
+              {uiState.sessionStats.sessionId.slice(0, 8)}
+            </Text>
+          ),
+          8,
+        );
+        break;
+      }
+      case 'hostname': {
+        addCol(
+          id,
+          header,
+          () => <Text color={itemColor}>{HOSTNAME}</Text>,
+          HOSTNAME.length,
+        );
+        break;
+      }
+      case 'auth': {
+        if (!settings.merged.ui.showUserIdentity) break;
+        if (!authType) break;
+        const displayStr =
+          authType === AuthType.LOGIN_WITH_GOOGLE
+            ? (email ?? 'google')
+            : authType;
+        addCol(
+          id,
+          header,
+          () => (
+            <Text color={itemColor} wrap="truncate-end">
+              {displayStr}
+            </Text>
+          ),
+          displayStr.length,
+        );
+        break;
+      }
+      case 'code-changes': {
+        const added = uiState.sessionStats.metrics.files.totalLinesAdded;
+        const removed = uiState.sessionStats.metrics.files.totalLinesRemoved;
+        if (added > 0 || removed > 0) {
+          const str = `+${added} -${removed}`;
+          addCol(
+            id,
+            header,
+            () => (
+              <Text>
+                <Text color={theme.status.success}>+{added}</Text>{' '}
+                <Text color={theme.status.error}>-{removed}</Text>
+              </Text>
+            ),
+            str.length,
+          );
+        }
+        break;
+      }
+      case 'token-count': {
+        let total = 0;
+        for (const m of Object.values(uiState.sessionStats.metrics.models))
+          total += m.tokens.total;
+        if (total > 0) {
+          const formatter = new Intl.NumberFormat('en-US', {
+            notation: 'compact',
+            maximumFractionDigits: 1,
+          });
+          const formatted = formatter.format(total).toLowerCase();
+          addCol(
+            id,
+            header,
+            () => <Text color={itemColor}>{formatted} tokens</Text>,
+            formatted.length + 7,
+          );
+        }
+        break;
+      }
+      default:
+        checkExhaustive(id);
+        break;
+    }
+  }
+
+  // 3. Transients
+  if (corgiMode) addCol('corgi', '', () => <CorgiIndicator />, 5);
+  if (showErrorSummary) {
+    addCol(
+      'error-count',
+      '',
+      () => <ConsoleSummaryDisplay errorCount={errorCount} />,
+      12,
+      true,
+    );
+  }
+
+  // --- Width Fitting Logic ---
+  const columnsToRender: FooterColumn[] = [];
+  let droppedAny = false;
+  let currentUsedWidth = 2; // Initial padding
+
+  for (const col of potentialColumns) {
+    const gap = columnsToRender.length > 0 ? (showLabels ? COLUMN_GAP : 3) : 0;
+    const budgetWidth = col.id === 'workspace' ? 20 : col.width;
+
+    if (
+      col.isHighPriority ||
+      currentUsedWidth + gap + budgetWidth <= terminalWidth - 2
+    ) {
+      columnsToRender.push(col);
+      currentUsedWidth += gap + budgetWidth;
+    } else {
+      droppedAny = true;
+    }
+  }
+
+  const rowItems: FooterRowItem[] = columnsToRender.map((col, index) => {
+    const isWorkspace = col.id === 'workspace';
+    const isLast = index === columnsToRender.length - 1;
+
+    // Calculate exact space available for growth to prevent over-estimation truncation
+    const otherItemsWidth = columnsToRender
+      .filter((c) => c.id !== 'workspace')
+      .reduce((sum, c) => sum + c.width, 0);
+    const numItems = columnsToRender.length + (droppedAny ? 1 : 0);
+    const numGaps = numItems > 1 ? numItems - 1 : 0;
+    const gapsWidth = numGaps * (showLabels ? COLUMN_GAP : 3);
+    const ellipsisWidth = droppedAny ? 1 : 0;
+
+    const availableForWorkspace = Math.max(
+      20,
+      terminalWidth - 2 - gapsWidth - otherItemsWidth - ellipsisWidth,
+    );
+
+    const estimatedWidth = isWorkspace ? availableForWorkspace : col.width;
+
+    return {
+      key: col.id,
+      header: col.header,
+      element: col.element(estimatedWidth),
+      flexGrow: 0,
+      flexShrink: isWorkspace ? 1 : 0,
+      alignItems:
+        isLast && !droppedAny && index > 0 ? 'flex-end' : 'flex-start',
+    };
+  });
+
+  if (droppedAny) {
+    rowItems.push({
+      key: 'ellipsis',
+      header: '',
+      element: <Text color={theme.ui.comment}>…</Text>,
+      flexGrow: 0,
+      flexShrink: 0,
+      alignItems: 'flex-end',
+    });
+  }
 
   return (
-    <Box
-      justifyContent={justifyContent}
-      width={terminalWidth}
-      flexDirection="row"
-      alignItems="center"
-      paddingX={1}
-    >
-      {(showDebugProfiler || displayVimMode || !hideCWD) && (
-        <Box>
-          {showDebugProfiler && <DebugProfiler />}
-          {displayVimMode && (
-            <Text color={theme.text.secondary}>[{displayVimMode}] </Text>
-          )}
-          {!hideCWD && (
-            <Text color={theme.text.primary}>
-              {displayPath}
-              {branchName && (
-                <Text color={theme.text.secondary}> ({branchName}*)</Text>
-              )}
-            </Text>
-          )}
-          {debugMode && (
-            <Text color={theme.status.error}>
-              {' ' + (debugMessage || '--debug')}
-            </Text>
-          )}
-        </Box>
-      )}
-
-      {/* Middle Section: Centered Trust/Sandbox Info */}
-      {!hideSandboxStatus && (
-        <Box
-          flexGrow={1}
-          alignItems="center"
-          justifyContent="center"
-          display="flex"
-        >
-          {isTrustedFolder === false ? (
-            <Text color={theme.status.warning}>untrusted</Text>
-          ) : process.env['SANDBOX'] &&
-            process.env['SANDBOX'] !== 'sandbox-exec' ? (
-            <Text color="green">
-              {process.env['SANDBOX'].replace(/^gemini-(?:cli-)?/, '')}
-            </Text>
-          ) : process.env['SANDBOX'] === 'sandbox-exec' ? (
-            <Text color={theme.status.warning}>
-              macOS Seatbelt{' '}
-              <Text color={theme.text.secondary}>
-                ({process.env['SEATBELT_PROFILE']})
-              </Text>
-            </Text>
-          ) : (
-            <Text color={theme.status.error}>
-              no sandbox
-              {terminalWidth >= 100 && (
-                <Text color={theme.text.secondary}> (see /docs)</Text>
-              )}
-            </Text>
-          )}
-        </Box>
-      )}
-
-      {/* Right Section: Gemini Label and Console Summary */}
-      {!hideModelInfo && (
-        <Box alignItems="center" justifyContent="flex-end">
-          <Box alignItems="center">
-            <Text color={theme.text.primary}>
-              <Text color={theme.text.secondary}>/model </Text>
-              {getDisplayString(model)}
-              {!hideContextPercentage && (
-                <>
-                  {' '}
-                  <ContextUsageDisplay
-                    promptTokenCount={promptTokenCount}
-                    model={model}
-                    terminalWidth={terminalWidth}
-                  />
-                </>
-              )}
-              {quotaStats && (
-                <>
-                  {' '}
-                  <QuotaDisplay
-                    remaining={quotaStats.remaining}
-                    limit={quotaStats.limit}
-                    resetTime={quotaStats.resetTime}
-                    terse={true}
-                  />
-                </>
-              )}
-            </Text>
-            {showMemoryUsage && <MemoryUsageDisplay />}
-          </Box>
-          <Box alignItems="center">
-            {corgiMode && (
-              <Box paddingLeft={1} flexDirection="row">
-                <Text>
-                  <Text color={theme.ui.symbol}>| </Text>
-                  <Text color={theme.status.error}>▼</Text>
-                  <Text color={theme.text.primary}>(´</Text>
-                  <Text color={theme.status.error}>ᴥ</Text>
-                  <Text color={theme.text.primary}>`)</Text>
-                  <Text color={theme.status.error}>▼</Text>
-                </Text>
-              </Box>
-            )}
-            {!showErrorDetails && errorCount > 0 && (
-              <Box paddingLeft={1} flexDirection="row">
-                <Text color={theme.ui.comment}>| </Text>
-                <ConsoleSummaryDisplay errorCount={errorCount} />
-              </Box>
-            )}
-          </Box>
-        </Box>
-      )}
+    <Box width={terminalWidth} paddingX={1} overflow="hidden" flexWrap="nowrap">
+      <FooterRow items={rowItems} showLabels={showLabels} />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Show the active macOS Seatbelt profile in the footer sandbox indicator instead of the generic `current process` label.

## Details

When the CLI is running under `sandbox-exec`, the footer now renders `sandbox-exec (<profile>)`, matching the sandbox format already shown in `/about`. If `SEATBELT_PROFILE` is missing, the footer falls back to `sandbox-exec (unknown)`.

The sandbox footer width calculation now uses the actual rendered label so narrow footer filtering still works when the Seatbelt profile makes the sandbox column longer.

## Related Issues

Fixes #26697

## How to Validate

- `git diff --cached --check`
- `npx prettier --check packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx`
- `npx eslint packages/cli/src/ui/components/Footer.tsx packages/cli/src/ui/components/Footer.test.tsx --max-warnings 0`
- `npm run typecheck --workspace @google/gemini-cli`
- `npm test --workspace @google/gemini-cli -- src/ui/components/Footer.test.tsx`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker