### PR TITLE
fix(a2a-server): use deep merge for user and workspace settings

### DIFF
--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -124,7 +124,7 @@ describe('loadSettings', () => {
     expect(result.experimental?.enableAgents).toBe(true);
   });
 
-  it('should overwrite top-level settings from workspace (shallow merge)', () => {
+  it('should deep merge nested settings from user and workspace', () => {
     const userSettings = {
       showMemoryUsage: false,
       fileFiltering: {
@@ -150,8 +150,125 @@ describe('loadSettings', () => {
     // Primitive value overwritten
     expect(result.showMemoryUsage).toBe(true);
 
-    // Object value completely replaced (shallow merge behavior)
+    // Nested object deep merged: workspace overrides respectGitIgnore,
+    // but user's enableRecursiveFileSearch is preserved
     expect(result.fileFiltering?.respectGitIgnore).toBe(false);
-    expect(result.fileFiltering?.enableRecursiveFileSearch).toBeUndefined();
+    expect(result.fileFiltering?.enableRecursiveFileSearch).toBe(true);
+  });
+
+  it('should preserve unrelated user nested keys not present in workspace', () => {
+    const userSettings = {
+      fileFiltering: {
+        respectGitIgnore: true,
+        enableRecursiveFileSearch: true,
+        customIgnoreFilePaths: ['path1'],
+      },
+      telemetry: { enabled: true },
+    };
+    fs.writeFileSync(USER_SETTINGS_PATH, JSON.stringify(userSettings));
+
+    const workspaceSettings = {
+      fileFiltering: {
+        respectGitIgnore: false,
+      },
+    };
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, JSON.stringify(workspaceSettings));
+
+    const result = loadSettings(mockWorkspaceDir);
+
+    expect(result.fileFiltering).toEqual({
+      respectGitIgnore: false,
+      enableRecursiveFileSearch: true,
+      customIgnoreFilePaths: ['path1'],
+    });
+
+    // Unrelated top-level keys from user are preserved
+    expect(result.telemetry).toEqual({ enabled: true });
+  });
+
+  it('should deep merge tools settings from user and workspace', () => {
+    const userSettings = {
+      tools: {
+        allowed: ['tool-a', 'tool-b'],
+        exclude: ['tool-c'],
+      },
+    };
+    fs.writeFileSync(USER_SETTINGS_PATH, JSON.stringify(userSettings));
+
+    const workspaceSettings = {
+      tools: {
+        exclude: ['tool-d'],
+      },
+    };
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, JSON.stringify(workspaceSettings));
+
+    const result = loadSettings(mockWorkspaceDir);
+
+    // Arrays are replaced (not concatenated), but unrelated keys are preserved
+    expect(result.tools).toEqual({
+      allowed: ['tool-a', 'tool-b'],
+      exclude: ['tool-d'],
+    });
+  });
+
+  it('should deep merge experimental settings from user and workspace', () => {
+    const userSettings = {
+      experimental: {
+        enableAgents: true,
+      },
+    };
+    fs.writeFileSync(USER_SETTINGS_PATH, JSON.stringify(userSettings));
+
+    const workspaceSettings = {
+      experimental: {
+        enableAgents: false,
+      },
+    };
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, JSON.stringify(workspaceSettings));
+
+    const result = loadSettings(mockWorkspaceDir);
+
+    expect(result.experimental).toEqual({
+      enableAgents: false,
+    });
+  });
+
+  it('should handle workspace adding new nested keys not in user', () => {
+    const userSettings = {
+      fileFiltering: {
+        respectGitIgnore: true,
+      },
+    };
+    fs.writeFileSync(USER_SETTINGS_PATH, JSON.stringify(userSettings));
+
+    const workspaceSettings = {
+      fileFiltering: {
+        enableRecursiveFileSearch: true,
+      },
+    };
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, JSON.stringify(workspaceSettings));
+
+    const result = loadSettings(mockWorkspaceDir);
+
+    expect(result.fileFiltering).toEqual({
+      respectGitIgnore: true,
+      enableRecursiveFileSearch: true,
+    });
   });
 });

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -63,6 +63,52 @@ export interface CheckpointingSettings {
 }
 
 /**
+ * Recursively merges `source` into `target`.
+ *
+ * For each key present in `source`:
+ * - If both `target[key]` and `source[key]` are plain objects, they are merged recursively.
+ * - Otherwise, `source[key]` replaces `target[key]` (workspace overrides user).
+ *
+ * This avoids the shallow-spread bug where nested objects in workspace settings
+ * would entirely replace the corresponding user settings object, silently dropping
+ * unrelated keys.
+ */
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+   
+): Record<string, unknown> {
+  const result = { ...target } as Record<string, unknown>;
+
+  for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+
+    const targetValue = result[key];
+    const sourceValue = source[key];
+
+    if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+      result[key] = deepMerge(
+         
+        targetValue,
+         
+        sourceValue,
+      );
+    } else {
+      result[key] = sourceValue;
+    }
+  }
+
+   
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
  * Loads settings from user and workspace directories.
  * Project settings override user settings.
  *
@@ -123,12 +169,20 @@ export function loadSettings(workspaceDir: string): Settings {
     }
   }
 
-  // If there are overlapping keys, the values of workspaceSettings will
-  // override values from userSettings
-  return {
-    ...userSettings,
-    ...workspaceSettings,
-  };
+  // Deep merge user and workspace settings so that nested objects (e.g.
+  // fileFiltering, tools, telemetry) are merged recursively rather than
+  // replaced wholesale. Workspace values still override user values for
+  // explicitly provided keys.
+  return (
+     
+    deepMerge(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      userSettings as Record<string, unknown>,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      workspaceSettings as Record<string, unknown>,
+       
+    ) as Settings
+  );
 }
 
 function resolveEnvVarsInString(value: string): string {


### PR DESCRIPTION
## Summary

Fixes #25747

The A2A server was using a shallow object spread (`{...userSettings, ...workspaceSettings}`) to merge user and workspace settings. This caused nested objects like `fileFiltering`, `tools`, `telemetry`, and `experimental` to be entirely replaced by workspace settings, silently dropping unrelated user configuration keys.

## Changes

- **Replaced shallow spread with recursive `deepMerge` function** in `packages/a2a-server/src/config/settings.ts`
  - Recursively merges plain objects (preserving unrelated nested keys from user settings)
  - Replaces non-object values (workspace still overrides user for primitives/arrays)
  - Guards against prototype pollution (`__proto__`, `constructor`, `prototype`)

- **Updated existing test** that encoded shallow merge behavior to expect deep merge
- **Added 5 new tests** covering:
  - `fileFiltering` deep merge with partial workspace override
  - Preservation of unrelated user nested keys
  - `tools` settings deep merge
  - `experimental` settings deep merge
  - Workspace adding new nested keys not present in user

## Concrete example (from issue)

**Before (shallow merge):**
```json
// User: { "fileFiltering": { "respectGitIgnore": true, "enableRecursiveFileSearch": true } }
// Workspace: { "fileFiltering": { "respectGitIgnore": false } }
// Result: { "fileFiltering": { "respectGitIgnore": false } }  // enableRecursiveFileSearch LOST!
```

**After (deep merge):**
```json
// Result: { "fileFiltering": { "respectGitIgnore": false, "enableRecursiveFileSearch": true } }
```

## Alignment with main CLI

This aligns the A2A server's merge behavior with the main CLI, which already uses `customDeepMerge` for the same purpose (`packages/cli/src/utils/deepMerge.ts`).

## Testing

```
134 tests passed (14 test files) in packages/a2a-server
Pre-commit hooks passed (prettier + eslint)
```

## Acceptance Criteria

- [x] User and workspace settings merge correctly for nested objects
- [x] Partial workspace overrides preserve unspecified user values
- [x] Test coverage exists for `fileFiltering` and other nested settings objects
- [x] No regressions in existing A2A settings loading behavior outside the merge semantics