### PR TITLE
ci: block fork PRs from injecting repo/SHA into privileged workflow_run chain

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -68,6 +68,14 @@ jobs:
           name: 'repo_name'
           run-id: '${{ env.RUN_ID }}'
           path: '${{ runner.temp }}/artifacts'
+      - name: 'Verify PR origin is not a fork'
+        run: |
+          REPO=$(cat "${{ runner.temp }}/artifacts/repo_name" 2>/dev/null | tr -d '[:space:]' || echo '')
+          if [[ -n "$REPO" && "$REPO" != "google-gemini/gemini-cli" ]]; then
+            echo "::error::Fork PR detected (origin: $REPO). Blocking secret-privileged execution."
+            exit 1
+          fi
+
       - name: 'Output Repo Name and SHA'
         id: 'output-repo-name'
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v8

--- a/.github/workflows/trigger_e2e.yml
+++ b/.github/workflows/trigger_e2e.yml
@@ -15,7 +15,12 @@ on:
 
 jobs:
   save_repo_name:
-    if: "github.repository == 'google-gemini/gemini-cli'"
+    # Only save repo metadata for internal PRs (same repo) or manual dispatches.
+    # Fork PRs must not inject their repo/SHA into the privileged workflow_run chain.
+    if: >-
+      github.repository == 'google-gemini/gemini-cli' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: 'gemini-cli-ubuntu-16-core'
     steps:
       - name: 'Save Repo name'


### PR DESCRIPTION
## Summary

`trigger_e2e.yml` runs on all `pull_request` events (including from forks) and saves the PR's head repository name and SHA to an artifact. `chained_e2e.yml` is triggered by `workflow_run` (which always runs with repository secrets) and reads that artifact to check out and execute code with `GEMINI_API_KEY` and other secrets available in the environment.

Without a fork origin check, a contributor from a forked repository can submit a PR that causes `chained_e2e.yml` to check out and run the fork's code on self-hosted runners with access to repository secrets.

## Changes

**`trigger_e2e.yml`** (primary fix): Add a fork origin guard so that only PRs from the canonical repository — or manual `workflow_dispatch` invocations — proceed to save metadata to the artifact. Fork PRs skip the `save_repo_name` job entirely, so no attacker-controlled repo/SHA reaches the privileged chain.

**`chained_e2e.yml`** (defense-in-depth): Add an explicit check in `download_repo_name` that fails the job if the artifact's `repo_name` is not `google-gemini/gemini-cli`, providing a second layer of protection independent of the upstream workflow.

## Testing

- Internal PRs: behaviour unchanged — `trigger_e2e.yml` proceeds as before.
- Fork PRs: `save_repo_name` is skipped; `chained_e2e.yml` receives no artifact and falls back to `github.repository` / `github.sha` (the base branch, not fork code).
- Manual `workflow_dispatch`: unaffected.