### PR TITLE
feat(mcp): add sampling request handler (1/3 for #10704)

### DIFF
--- a/packages/core/src/tools/mcp-sampling.test.ts
+++ b/packages/core/src/tools/mcp-sampling.test.ts
@@ -1,0 +1,358 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from '@google/genai';
+import { FinishReason } from '@google/genai';
+import type { CreateMessageRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { Config } from '../config/config.js';
+import type { ContentGenerator } from '../core/contentGenerator.js';
+import { handleSamplingRequest } from './mcp-sampling.js';
+
+const MODEL = 'gemini-test-model';
+
+function buildResponse(
+  text: string,
+  finishReason: FinishReason = FinishReason.STOP,
+): GenerateContentResponse {
+  return {
+    candidates: [
+      {
+        content: { role: 'model', parts: [{ text }] },
+        finishReason,
+        index: 0,
+      },
+    ],
+  } as unknown as GenerateContentResponse;
+}
+
+function buildRequest(
+  params: Partial<CreateMessageRequest['params']>,
+): CreateMessageRequest {
+  return {
+    method: 'sampling/createMessage',
+    params: {
+      messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }],
+      maxTokens: 100,
+      ...params,
+    },
+  };
+}
+
+interface Harness {
+  config: Config;
+  generateContent: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(
+  response: GenerateContentResponse = buildResponse('hello back'),
+): Harness {
+  const generateContent = vi.fn().mockResolvedValue(response);
+  const generator: Pick<ContentGenerator, 'generateContent'> = {
+    generateContent,
+  };
+  const config = {
+    getModel: () => MODEL,
+    getContentGenerator: () => generator as ContentGenerator,
+  } as unknown as Config;
+  return { config, generateContent };
+}
+
+describe('handleSamplingRequest', () => {
+  let signal: AbortSignal;
+
+  beforeEach(() => {
+    signal = new AbortController().signal;
+  });
+
+  it('returns an MCP-shaped result for a simple text request', async () => {
+    const { config, generateContent } = makeHarness(
+      buildResponse('hello back'),
+    );
+    const result = await handleSamplingRequest(
+      buildRequest({
+        messages: [{ role: 'user', content: { type: 'text', text: 'say hi' } }],
+      }),
+      config,
+      signal,
+    );
+
+    expect(result).toEqual({
+      role: 'assistant',
+      content: { type: 'text', text: 'hello back' },
+      model: MODEL,
+      stopReason: 'endTurn',
+    });
+    expect(generateContent).toHaveBeenCalledTimes(1);
+    const [call] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+      string,
+    ];
+    expect(call.model).toBe(MODEL);
+    expect(call.contents).toEqual([
+      { role: 'user', parts: [{ text: 'say hi' }] },
+    ]);
+  });
+
+  it('maps the assistant role to "model" and preserves conversation order', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(
+      buildRequest({
+        messages: [
+          { role: 'user', content: { type: 'text', text: 'q1' } },
+          { role: 'assistant', content: { type: 'text', text: 'a1' } },
+          { role: 'user', content: { type: 'text', text: 'q2' } },
+        ],
+      }),
+      config,
+      signal,
+    );
+
+    const [{ contents }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(contents).toEqual([
+      { role: 'user', parts: [{ text: 'q1' }] },
+      { role: 'model', parts: [{ text: 'a1' }] },
+      { role: 'user', parts: [{ text: 'q2' }] },
+    ]);
+  });
+
+  it('converts image content to an inlineData Gemini part', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(
+      buildRequest({
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'image',
+              data: 'BASE64DATA',
+              mimeType: 'image/png',
+            },
+          },
+        ],
+      }),
+      config,
+      signal,
+    );
+
+    const [{ contents }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(contents).toEqual([
+      {
+        role: 'user',
+        parts: [{ inlineData: { mimeType: 'image/png', data: 'BASE64DATA' } }],
+      },
+    ]);
+  });
+
+  it('accepts an array of content blocks in a single message (forward compat)', async () => {
+    // Newer MCP spec revisions allow `content` to be an array of blocks; the
+    // installed SDK types model it as a single block, so we cast to exercise
+    // the runtime path without coupling the test to a specific SDK version.
+    const { config, generateContent } = makeHarness();
+    const request = {
+      method: 'sampling/createMessage',
+      params: {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'caption this:' },
+              { type: 'image', data: 'AAAA', mimeType: 'image/jpeg' },
+            ],
+          },
+        ],
+        maxTokens: 100,
+      },
+    } as unknown as CreateMessageRequest;
+    await handleSamplingRequest(request, config, signal);
+
+    const [{ contents }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(contents).toEqual([
+      {
+        role: 'user',
+        parts: [
+          { text: 'caption this:' },
+          { inlineData: { mimeType: 'image/jpeg', data: 'AAAA' } },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects audio content with a clear error', async () => {
+    const { config } = makeHarness();
+    await expect(
+      handleSamplingRequest(
+        buildRequest({
+          messages: [
+            {
+              role: 'user',
+              content: {
+                type: 'audio',
+                data: 'AAAA',
+                mimeType: 'audio/wav',
+              },
+            },
+          ],
+        }),
+        config,
+        signal,
+      ),
+    ).rejects.toThrow(/audio content is not supported/);
+  });
+
+  it('rejects unsupported content types (forward-compat, e.g. tool_use)', async () => {
+    // The installed SDK types only allow text/image/audio. Newer revisions
+    // add tool_use / tool_result; we cast to exercise the rejection path.
+    const { config } = makeHarness();
+    const request = {
+      method: 'sampling/createMessage',
+      params: {
+        messages: [
+          {
+            role: 'user',
+            content: { type: 'tool_use', id: 't1', name: 'foo', input: {} },
+          },
+        ],
+        maxTokens: 100,
+      },
+    } as unknown as CreateMessageRequest;
+    await expect(
+      handleSamplingRequest(request, config, signal),
+    ).rejects.toThrow(/unsupported content type "tool_use"/);
+  });
+
+  it('passes systemPrompt, temperature, maxTokens and stopSequences through to the generator', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(
+      buildRequest({
+        systemPrompt: 'You are concise.',
+        maxTokens: 256,
+        temperature: 0.3,
+        stopSequences: ['STOP'],
+      }),
+      config,
+      signal,
+    );
+
+    const [{ config: genConfig }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(genConfig).toMatchObject({
+      systemInstruction: 'You are concise.',
+      maxOutputTokens: 256,
+      temperature: 0.3,
+      stopSequences: ['STOP'],
+    });
+    expect(genConfig?.abortSignal).toBe(signal);
+  });
+
+  it('omits generation params when the request does not set them', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(
+      // maxTokens is required by the MCP schema; everything else omitted.
+      buildRequest({ maxTokens: 50 }),
+      config,
+      signal,
+    );
+
+    const [{ config: genConfig }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(genConfig).toEqual({
+      abortSignal: signal,
+      maxOutputTokens: 50,
+    });
+  });
+
+  it('ignores modelPreferences from the request and uses the configured model', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(
+      buildRequest({
+        modelPreferences: {
+          hints: [{ name: 'claude-3-sonnet' }],
+          costPriority: 0.9,
+        },
+      }),
+      config,
+      signal,
+    );
+
+    const [{ model }] = generateContent.mock.calls[0] as [
+      GenerateContentParameters,
+    ];
+    expect(model).toBe(MODEL);
+  });
+
+  it('maps MAX_TOKENS finish reason to "maxTokens" stopReason', async () => {
+    const { config } = makeHarness(
+      buildResponse('partial', FinishReason.MAX_TOKENS),
+    );
+    const result = await handleSamplingRequest(
+      buildRequest({}),
+      config,
+      signal,
+    );
+    expect(result.stopReason).toBe('maxTokens');
+  });
+
+  it('maps STOP finish reason (and others) to "endTurn"', async () => {
+    const { config } = makeHarness(buildResponse('done', FinishReason.SAFETY));
+    const result = await handleSamplingRequest(
+      buildRequest({}),
+      config,
+      signal,
+    );
+    expect(result.stopReason).toBe('endTurn');
+  });
+
+  it('throws when the response has no candidates', async () => {
+    const empty = { candidates: [] } as unknown as GenerateContentResponse;
+    const { config } = makeHarness(empty);
+    await expect(
+      handleSamplingRequest(buildRequest({}), config, signal),
+    ).rejects.toThrow(/no text content/);
+  });
+
+  it('throws when the candidate has no text parts', async () => {
+    const noText = {
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [{ inlineData: { mimeType: 'image/png', data: 'XX' } }],
+          },
+          finishReason: FinishReason.STOP,
+          index: 0,
+        },
+      ],
+    } as unknown as GenerateContentResponse;
+    const { config } = makeHarness(noText);
+    await expect(
+      handleSamplingRequest(buildRequest({}), config, signal),
+    ).rejects.toThrow(/no text content/);
+  });
+
+  it('uses a unique prompt id per call', async () => {
+    const { config, generateContent } = makeHarness();
+    await handleSamplingRequest(buildRequest({}), config, signal);
+    await handleSamplingRequest(buildRequest({}), config, signal);
+
+    const id1 = generateContent.mock.calls[0]?.[1] as string;
+    const id2 = generateContent.mock.calls[1]?.[1] as string;
+    expect(id1).toMatch(/^mcp-sampling-/);
+    expect(id2).toMatch(/^mcp-sampling-/);
+    expect(id1).not.toBe(id2);
+  });
+});

--- a/packages/core/src/tools/mcp-sampling.ts
+++ b/packages/core/src/tools/mcp-sampling.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  Content,
+  GenerateContentConfig,
+  GenerateContentResponse,
+  Part,
+} from '@google/genai';
+import { FinishReason } from '@google/genai';
+import type {
+  CreateMessageRequest,
+  CreateMessageResult,
+  SamplingMessage,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Config } from '../config/config.js';
+
+type StopReason = NonNullable<CreateMessageResult['stopReason']>;
+
+type SamplingContentBlock = SamplingMessage['content'] extends infer C
+  ? C extends readonly unknown[]
+    ? C[number]
+    : C
+  : never;
+
+/**
+ * Handles an MCP `sampling/createMessage` request: converts the MCP request to
+ * a Gemini `generateContent` call and converts the response back to an MCP
+ * result.
+ *
+ * This function is the pure core of MCP sampling support. It does not handle
+ * user consent, capability advertisement, or transport wiring — callers are
+ * expected to register it as a request handler on an MCP client and to gate
+ * invocation with whatever approval policy is appropriate.
+ *
+ * Only `text` and `image` content blocks are supported in v1. `audio`,
+ * `tool_use`, and `tool_result` are rejected.
+ */
+export async function handleSamplingRequest(
+  request: CreateMessageRequest,
+  config: Config,
+  abortSignal: AbortSignal,
+): Promise<CreateMessageResult> {
+  const params = request.params;
+  const contents: Content[] = params.messages.map(toGeminiContent);
+
+  const generationConfig: GenerateContentConfig = { abortSignal };
+  if (params.systemPrompt !== undefined) {
+    generationConfig.systemInstruction = params.systemPrompt;
+  }
+  if (params.maxTokens !== undefined) {
+    generationConfig.maxOutputTokens = params.maxTokens;
+  }
+  if (params.temperature !== undefined) {
+    generationConfig.temperature = params.temperature;
+  }
+  if (params.stopSequences !== undefined) {
+    generationConfig.stopSequences = params.stopSequences;
+  }
+
+  const model = config.getModel();
+  const generator = config.getContentGenerator();
+  const response = await generator.generateContent(
+    { model, contents, config: generationConfig },
+    `mcp-sampling-${randomUUID()}`,
+  );
+
+  return toMcpResult(response, model);
+}
+
+function toGeminiContent(message: SamplingMessage): Content {
+  const blocks: readonly SamplingContentBlock[] = Array.isArray(message.content)
+    ? message.content
+    : [message.content];
+  const parts: Part[] = blocks.map(toGeminiPart);
+  return {
+    role: message.role === 'assistant' ? 'model' : 'user',
+    parts,
+  };
+}
+
+function toGeminiPart(block: SamplingContentBlock): Part {
+  switch (block.type) {
+    case 'text':
+      return { text: block.text };
+    case 'image':
+      return {
+        inlineData: { mimeType: block.mimeType, data: block.data },
+      };
+    case 'audio':
+      throw new Error(
+        'MCP sampling: audio content is not supported in this version.',
+      );
+    default:
+      throw new Error(
+        `MCP sampling: unsupported content type "${(block as { type: string }).type}".`,
+      );
+  }
+}
+
+function toMcpResult(
+  response: GenerateContentResponse,
+  model: string,
+): CreateMessageResult {
+  const candidate = response.candidates?.[0];
+  const parts = candidate?.content?.parts ?? [];
+  const text = parts
+    .map((part) => part.text)
+    .filter((t): t is string => typeof t === 'string')
+    .join('');
+  if (!text) {
+    throw new Error('MCP sampling: model returned no text content.');
+  }
+  return {
+    role: 'assistant',
+    content: { type: 'text', text },
+    model,
+    stopReason: mapFinishReason(candidate?.finishReason),
+  };
+}
+
+function mapFinishReason(reason: FinishReason | undefined): StopReason {
+  if (reason === FinishReason.MAX_TOKENS) {
+    return 'maxTokens';
+  }
+  return 'endTurn';
+}


### PR DESCRIPTION
## Summary

First of three PRs implementing MCP client sampling support per issue #10704. This PR adds **only** the pure core handler — no UI, no client wiring, no policy integration, no capability advertised to servers yet.

## Background

The prior consolidated PR #12801 was closed in favor of a 3-PR breakdown agreed with @jackwotherspoon ([comment](https://github.com/google-gemini/gemini-cli/issues/10704#issuecomment-3491168878)), starting with the explicit ask to *"extract the sampling logic into its own named function so we don't bloat `connectToMcpServer`."*

Planned follow-ups (separate PRs):

- **PR 2**: `McpSamplingDialog` + consent UI + `CoreEvent.McpSamplingRequest` event, with an isolated example harness (modeled on the ask-user dialog from #17344)
- **PR 3**: Register the handler in `connectToMcpServer`, advertise `sampling: {}` capability, wrap with policy/approval, add the integration test

The transport memory-leak fix that originally rode along in #12801 has already shipped separately in #18054.

## What's in this PR

`packages/core/src/tools/mcp-sampling.ts` — a single exported async function:

```ts
export async function handleSamplingRequest(
  request: CreateMessageRequest,
  config: Config,
  abortSignal: AbortSignal,
): Promise<CreateMessageResult>
```

What it does:

- Converts MCP `SamplingMessage[]` → Gemini `Content[]`
  - `text` → `{ text }` parts
  - `image` → `{ inlineData: { mimeType, data } }` parts
  - `audio` → rejected with a clear error (deferred)
  - Unknown content types (e.g. `tool_use` from newer SDK revisions) → rejected
  - `role: assistant` → `model`
- Passes through optional generation params:
  - `systemPrompt` → `systemInstruction`
  - `maxTokens` → `maxOutputTokens`
  - `temperature` → `temperature`
  - `stopSequences` → `stopSequences`
- Calls `config.getContentGenerator()` directly (intentionally bypasses `GeminiClient` so the agent's core system prompt does NOT leak into server-driven sampling)
- Uses `config.getModel()`; `modelPreferences` hints from the request are ignored (per the RFC v1 — client retains model authority)
- Maps `FinishReason.MAX_TOKENS` → MCP `maxTokens`; everything else → `endTurn`
- Generates a fresh `mcp-sampling-<uuid>` prompt id per call

`packages/core/src/tools/mcp-sampling.test.ts` — 14 unit tests covering text + image, audio/unknown-type rejection, role mapping, conversation order, param pass-through, param omission, `modelPreferences` ignored, finish-reason mapping, empty/no-text candidate errors, and prompt-id uniqueness.

**No changes to `mcp-client.ts` or anywhere else.** The handler isn't reachable yet — wiring lives in PR 3.

## Test plan

- [x] `npm run typecheck -w @google/gemini-cli-core`
- [x] `npx eslint packages/core/src/tools/mcp-sampling.ts packages/core/src/tools/mcp-sampling.test.ts`
- [x] `npx vitest run packages/core/src/tools/mcp-sampling.test.ts` — 14/14 pass
- [x] `npx vitest run packages/core/src/tools/` — 533 pass, 2 pre-existing skipped, no regressions
- [ ] End-to-end manual verification — N/A in this PR; handler is not wired

---

_This PR was generated with the help of AI, and reviewed by a Human_