### PR TITLE
fix(cli): make --skip-trust actually load workspace settings

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -306,7 +306,10 @@ export async function parseArguments(
         })
         .option('skip-trust', {
           type: 'boolean',
-          description: 'Trust the current workspace for this session.',
+          description:
+            'Trust the current workspace for this session. Also lets workspace ' +
+            '`.gemini/settings.json` (including hooks/extensions) and project ' +
+            '`.env` files take effect.',
           default: false,
         })
         .option('worktree', {
@@ -512,6 +515,11 @@ export async function parseArguments(
       throw new Error('Failed to parse arguments');
     }
     result = parsed;
+    // applySkipTrustFromArgv() in gemini.tsx already sets this earlier, before
+    // loadSettings() runs (which is where the workspace-trust gate lives).
+    // This second set is kept as a backstop for code paths that bypass main()
+    // (e.g., direct callers of parseArguments in tests) and is intentionally
+    // idempotent.
     if (result['skip-trust']) {
       process.env['GEMINI_CLI_TRUST_WORKSPACE'] = 'true';
     }

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -2033,6 +2033,63 @@ describe('Settings Loading and Merging', () => {
       expect(settings.merged.tools?.sandbox).toBe(false); // User setting
       expect(settings.merged.context?.fileName).toBe('USER.md'); // User setting
     });
+
+    it('should merge workspace settings (incl. hooks) when GEMINI_CLI_TRUST_WORKSPACE=true even if folder is otherwise untrusted (regression for --skip-trust)', () => {
+      // Simulate the real checkPathTrust behavior: env var grants trust
+      // regardless of the trusted_folders.json file or IDE state.
+      const originalEnv = process.env['GEMINI_CLI_TRUST_WORKSPACE'];
+      process.env['GEMINI_CLI_TRUST_WORKSPACE'] = 'true';
+      try {
+        vi.spyOn(trustedFolders, 'isWorkspaceTrusted').mockImplementation(
+          () => ({
+            isTrusted:
+              process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'true'
+                ? true
+                : false,
+            source: 'env',
+          }),
+        );
+        (mockFsExistsSync as Mock).mockReturnValue(true);
+        const userSettingsContent = {
+          ui: { theme: 'dark' },
+        };
+        const workspaceSettingsContent = {
+          hooks: {
+            BeforeAgent: [
+              {
+                hooks: [{ type: 'command', command: 'touch /tmp/sentinel' }],
+              },
+            ],
+          },
+        };
+
+        (fs.readFileSync as Mock).mockImplementation(
+          (p: fs.PathOrFileDescriptor) => {
+            if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
+              return JSON.stringify(userSettingsContent);
+            if (
+              normalizePath(p) === normalizePath(MOCK_WORKSPACE_SETTINGS_PATH)
+            )
+              return JSON.stringify(workspaceSettingsContent);
+            return '{}';
+          },
+        );
+
+        const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+        // The bug: workspace hooks would be silently dropped when isTrusted
+        // is false at merge time. With GEMINI_CLI_TRUST_WORKSPACE=true (which
+        // is what applySkipTrustFromArgv sets), the merge must include them.
+        expect(settings.merged.hooks?.BeforeAgent).toBeDefined();
+        expect(settings.merged.hooks?.BeforeAgent).toHaveLength(1);
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env['GEMINI_CLI_TRUST_WORKSPACE'];
+        } else {
+          process.env['GEMINI_CLI_TRUST_WORKSPACE'] = originalEnv;
+        }
+      }
+    });
   });
 
   describe('loadEnvironment', () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -21,6 +21,7 @@ import {
   startInteractiveUI,
   getNodeMemoryArgs,
   resolveSessionId,
+  applySkipTrustFromArgv,
 } from './gemini.js';
 import {
   loadCliConfig,
@@ -1509,6 +1510,64 @@ describe('validateDnsResolutionOrder', () => {
     expect(debugLoggerWarnSpy).toHaveBeenCalledExactlyOnceWith(
       'Invalid value for dnsResolutionOrder in settings: "invalid-value". Using default "ipv4first".',
     );
+  });
+});
+
+describe('applySkipTrustFromArgv', () => {
+  beforeEach(() => {
+    delete process.env['GEMINI_CLI_TRUST_WORKSPACE'];
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env['GEMINI_CLI_TRUST_WORKSPACE'];
+  });
+
+  it('sets GEMINI_CLI_TRUST_WORKSPACE when --skip-trust is present', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--skip-trust', '-p', 'hi']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBe('true');
+  });
+
+  it('leaves the env var untouched when --skip-trust is absent', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '-p', 'hi']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBeUndefined();
+  });
+
+  it('does not falsely match similar-looking flags', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--skip-trust-something']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBeUndefined();
+  });
+
+  it('does not match --skip-trust after the -- positional boundary', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--', '--skip-trust']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBeUndefined();
+  });
+
+  it('still matches flags before the -- boundary', () => {
+    applySkipTrustFromArgv([
+      'node',
+      'gemini',
+      '--skip-trust',
+      '--',
+      'rest',
+      'args',
+    ]);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBe('true');
+  });
+
+  it('matches --skip-trust=true (yargs explicit boolean form)', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--skip-trust=true']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBe('true');
+  });
+
+  it('does NOT match --skip-trust=false', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--skip-trust=false']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBeUndefined();
+  });
+
+  it('does NOT match --no-skip-trust (yargs negation form)', () => {
+    applySkipTrustFromArgv(['node', 'gemini', '--no-skip-trust']);
+    expect(process.env['GEMINI_CLI_TRUST_WORKSPACE']).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -40,6 +40,8 @@ import {
   type MessageRecord,
 } from '@google/gemini-cli-core';
 
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { loadCliConfig, parseArguments } from './config/config.js';
 import * as cliConfig from './config/config.js';
 import { readStdin } from './utils/readStdin.js';
@@ -347,6 +349,31 @@ export async function startInteractiveUI(
   );
 }
 
+/**
+ * Sets the GEMINI_CLI_TRUST_WORKSPACE env var early if --skip-trust is
+ * truthy in argv. The CLI flag itself is handled inside parseArguments,
+ * but that runs *after* loadSettings, so without an early hint the
+ * workspace-trust gate inside the settings merge drops workspace settings
+ * (including hooks and extensions). Exported for testing.
+ *
+ * Uses yargs to pre-parse, so all the yargs-supported forms behave
+ * identically to the main parse: `--skip-trust`, `--skip-trust=true`,
+ * `--skip-trust=false`, `--no-skip-trust`, `--` positional boundary, and
+ * SEA/pkg argv layouts (via hideBin).
+ */
+export function applySkipTrustFromArgv(argv: string[]): void {
+  const result = yargs(hideBin(argv))
+    .help(false)
+    .version(false)
+    .option('skip-trust', { type: 'boolean', default: false })
+    .strict(false)
+    .exitProcess(false)
+    .parseSync();
+  if (result['skip-trust'] === true) {
+    process.env['GEMINI_CLI_TRUST_WORKSPACE'] = 'true';
+  }
+}
+
 export async function main() {
   let config: Config | undefined;
   const cliStartupHandle = startupProfiler.start('cli_startup');
@@ -372,6 +399,14 @@ export async function main() {
   const slashCommandConflictHandler = new SlashCommandConflictHandler();
   slashCommandConflictHandler.start();
   registerCleanup(() => slashCommandConflictHandler.stop());
+
+  // Pre-detect --skip-trust before loadSettings. parseArguments would set
+  // this env var, but it runs *after* loadSettings — and the workspace-trust
+  // gate (which drops workspace settings, including hooks, on untrusted
+  // folders) happens during the merge inside loadSettings. Without this
+  // pre-detect, the documented --skip-trust flag silently fails to load
+  // workspace hooks/extensions.
+  applySkipTrustFromArgv(process.argv);
 
   const loadSettingsHandle = startupProfiler.start('load_settings');
   const settings = loadSettings();


### PR DESCRIPTION
## Summary

The `--skip-trust` flag is documented to "trust the current workspace for this session", but in practice it has no effect on workspace settings. Hooks, extensions, MCP servers, and similar configuration placed in `.gemini/settings.json` are silently dropped even when the flag is set, because the trust signal arrives too late in startup. This PR makes the flag work as documented.

## Details

### Root cause

The startup order is:

1. `main()` in `packages/cli/src/gemini.tsx` calls `loadSettings()`.
2. Inside `loadSettings()`, `mergeSettings()` (`packages/cli/src/config/settings.ts`) computes `isTrusted` via `isWorkspaceTrusted()` → `checkPathTrust()` (`packages/core/src/utils/trust.ts`).
3. When `isTrusted` is `false`, `mergeSettings()` drops the workspace settings (`safeWorkspace = isTrusted ? workspace : ({} as Settings)`).
4. `main()` then calls `parseArguments()`, which is where `--skip-trust` is finally observed and `process.env.GEMINI_CLI_TRUST_WORKSPACE='true'` is set.

Steps 1–3 finish before step 4, so the env var that `checkPathTrust()` consults is unset at merge time. The 10-second settings cache means the env var being set later does not retroactively fix the merged state for the current run. Net effect: workspace settings never reach `settings.merged` and downstream consumers (hook registry, extension loader, MCP server enablement) silently see nothing.

### Fix

Pre-detect `--skip-trust` at the very top of `main()` — before `loadSettings()` runs — and set `GEMINI_CLI_TRUST_WORKSPACE='true'` immediately if present. The detection is factored into a small exported helper, `applySkipTrustFromArgv`, that uses yargs (with `hideBin`) so it behaves exactly like the main parser: it honors all yargs-supported forms of the flag (`--skip-trust`, `--skip-trust=true`, `--skip-trust=false`, `--no-skip-trust`), respects the `--` positional boundary, and works under SEA/pkg argv layouts. The existing env-var set inside `parseArguments` is kept as an idempotent backstop with a comment explaining the relationship.

### Side effect worth flagging

`loadEnvironment()` also gates project `.env` reading on `isTrusted`. With this fix, `--skip-trust` now causes project `.env` files to be loaded in addition to workspace `settings.json`. This is consistent with the documented scope ("trust the current workspace for this session"), but is a meaningful expansion of behavior, so the `--skip-trust` help text has been updated to mention hooks, extensions, and `.env`.

### Backward compatibility

Untrusted, non-opted-in folders are unaffected. Without `--skip-trust` (and without `GEMINI_CLI_TRUST_WORKSPACE=true` or a `trusted_folders.json` entry), workspace settings remain dropped at merge time exactly as before, and the "Gemini CLI is not running in a trusted directory" message still fires.

## Related Issues

Fixes #13155
Fixes #14932
Fixes #15063
Fixes #16315
Related to #16697

## How to Validate

Reproducer that fails on `main` and passes with this PR:

\`\`\`bash
mkdir -p /tmp/hook-repro/.gemini
cat > /tmp/hook-repro/.gemini/settings.json <<'JSON'
{
  \"hooks\": {
    \"BeforeAgent\": [
      {
        \"hooks\": [{ \"type\": \"command\", \"command\": \"touch /tmp/sentinel\" }]
      }
    ]
  }
}
JSON
rm -f /tmp/sentinel
cd /tmp/hook-repro
gemini --skip-trust -p \"Reply with 'OK'.\"
ls /tmp/sentinel   # expected: file exists. Pre-fix: \"No such file or directory\".
\`\`\`

Also runs cleanly:

\`\`\`bash
npm run build
npm run typecheck
npm run test:ci
npm run lint
\`\`\`

New tests:

- \`packages/cli/src/gemini.test.tsx\` — 8 unit tests for \`applySkipTrustFromArgv\` (flag present/absent, fuzzy-match guard, \`--\` boundary in both positions, \`--skip-trust=true\`, \`--skip-trust=false\`, \`--no-skip-trust\`).
- \`packages/cli/src/config/settings.test.ts\` — 1 regression test that runs the real \`loadSettings\` merge pipeline with \`GEMINI_CLI_TRUST_WORKSPACE=true\` and asserts workspace \`hooks.BeforeAgent\` surfaces in \`settings.merged.hooks\`. The existing \`'project hooks loading based on trust'\` suite mocks \`loadSettings\` itself and so could not catch this regression.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — \`--skip-trust\` help text expanded
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none; behavior change only when the user explicitly opts in via \`--skip-trust\`
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker