### PR TITLE
fix(core): enable env var redaction by default in getSecureSanitizationConfig

### DIFF
--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -233,6 +233,6 @@ export function getSecureSanitizationConfig(
     enableEnvironmentVariableRedaction:
       requestedConfig.enableEnvironmentVariableRedaction ??
       baseConfig?.enableEnvironmentVariableRedaction ??
-      false,
+      true,
   };
 }


### PR DESCRIPTION
## Problem

`getSecureSanitizationConfig()` defaulted `enableEnvironmentVariableRedaction` to `false`. Callers that did not explicitly set this flag (e.g. `NoopSandboxManager`) silently skipped all environment variable redaction, potentially leaking secrets such as API keys, tokens, and passwords into spawned shell commands.

The function is named "secure" but behaved insecurely by default — a classic footgun.

## Root Cause

In `environmentSanitization.ts`, the final fallback in the returned config:

```ts
enableEnvironmentVariableRedaction:
  requestedConfig.enableEnvironmentVariableRedaction ??
  baseConfig?.enableEnvironmentVariableRedaction ??
  false,  // <-- BUG: should be true
```

## Fix

Change the fallback default from `false` to `true` (1 line change). This ensures the function named `getSecureSanitizationConfig` is actually secure by default.

## Impact

- `NoopSandboxManager` (default sandbox when none is configured) now redacts env vars correctly
- `gitService.ts` already sets `enableEnvironmentVariableRedaction: true` — no change needed
- `MacOsSandboxManager` already overwrites `sanitizationConfig.enableEnvironmentVariableRedaction = true` after the call — no change needed
- Callers that intentionally want no redaction must now opt out explicitly

## Testing

Existing tests in `environmentSanitization.test.ts` cover the redaction logic. The change only affects the default value returned by `getSecureSanitizationConfig` when neither caller nor base config specifies a preference.