### PR TITLE
fix(cli): preserve proxy-agent named exports in ESM bundle

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -102,6 +102,14 @@ const cliConfig = {
   plugins: createWasmPlugins(),
   alias: {
     'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
+    'https-proxy-agent': path.resolve(
+      __dirname,
+      'packages/cli/src/patches/https-proxy-agent.ts',
+    ),
+    'http-proxy-agent': path.resolve(
+      __dirname,
+      'packages/cli/src/patches/http-proxy-agent.ts',
+    ),
     ...commonAliases,
   },
   metafile: true,

--- a/packages/cli/src/patches/http-proxy-agent.ts
+++ b/packages/cli/src/patches/http-proxy-agent.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line import/no-relative-packages
+export { HttpProxyAgent } from '../../../../node_modules/http-proxy-agent/dist/index.js';

--- a/packages/cli/src/patches/https-proxy-agent.ts
+++ b/packages/cli/src/patches/https-proxy-agent.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// eslint-disable-next-line import/no-relative-packages
+export { HttpsProxyAgent } from '../../../../node_modules/https-proxy-agent/dist/index.js';

--- a/scripts/tests/proxy-agent-bundle.test.ts
+++ b/scripts/tests/proxy-agent-bundle.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+vi.unmock('fs');
+vi.unmock('node:fs');
+import * as esbuild from 'esbuild';
+import path from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../');
+
+describe('proxy-agent bundle shape', () => {
+  it('preserves named constructors after ESM splitting', async () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'gemini-proxy-test-'));
+    const entryFile = path.join(tmpDir, 'entry.ts');
+
+    // Create a minimal entry file that dynamically imports the proxy agents
+    writeFileSync(
+      entryFile,
+      `
+      export async function getAgents() {
+        const httpsMod = await import('https-proxy-agent');
+        const httpMod = await import('http-proxy-agent');
+        return {
+          https: httpsMod,
+          http: httpMod,
+        };
+      }
+      `,
+    );
+
+    // Bundle with the exact same splitting config and aliases as cliConfig
+    await esbuild.build({
+      entryPoints: { gemini: entryFile },
+      outdir: path.join(tmpDir, 'bundle'),
+      bundle: true,
+      splitting: true,
+      format: 'esm',
+      platform: 'node',
+      outExtension: { '.js': '.mjs' },
+      alias: {
+        'https-proxy-agent': path.resolve(
+          projectRoot,
+          'packages/cli/src/patches/https-proxy-agent.ts',
+        ),
+        'http-proxy-agent': path.resolve(
+          projectRoot,
+          'packages/cli/src/patches/http-proxy-agent.ts',
+        ),
+      },
+    });
+
+    // Import the bundled chunk
+    const bundledEntryUrl = pathToFileURL(
+      path.join(tmpDir, 'bundle/gemini.mjs'),
+    ).href;
+    const { getAgents } = await import(bundledEntryUrl);
+
+    const { https, http } = await getAgents();
+
+    // Verify named exports exist
+    expect(typeof https.HttpsProxyAgent).toBe('function');
+    expect(typeof http.HttpProxyAgent).toBe('function');
+
+    // Verify they are constructable
+    expect(() => new https.HttpsProxyAgent('http://127.0.0.1:9')).not.toThrow();
+    expect(() => new http.HttpProxyAgent('http://127.0.0.1:9')).not.toThrow();
+
+    // Cleanup
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a remaining bundled proxy fallback path where `gaxios` can receive `undefined` from a lazy `import('https-proxy-agent')` and throw `TypeError: HttpsProxyAgent3 is not a constructor`.

PR #26361 avoids this for the main `GoogleGenAI` auth path by passing an explicit proxy agent. This PR fixes the underlying CLI bundle shape so fallback proxy-agent imports still expose constructable named exports.

## Details

The CLI bundle uses esbuild with ESM splitting. For the CommonJS proxy-agent packages, the generated split chunk can expose constructors under `default.HttpsProxyAgent` / `default.HttpProxyAgent`, while bundled `gaxios` reads the named exports directly.

This adds CLI-only esbuild aliases for `https-proxy-agent` and `http-proxy-agent` to small ESM patch modules that re-export stable named constructors. The packages remain bundled, so this does not add runtime externalization or bundle asset-copying.

A new script-level regression test bundles a minimal dynamic-import entry with the same alias shape and verifies that both named constructors remain available and constructable from the generated ESM output. The test imports the generated temp bundle via a file URL so it is portable on Windows.

I considered externalizing the proxy-agent packages, but that adds runtime packaging complexity for published CLI / SEA builds. I also considered adding more explicit agent injection at individual call sites, but that only bypasses selected paths. The alias-shim approach keeps the packages bundled and fixes the shared fallback module shape.

## Related Issues

Fixes #27143
Related to #24471
Related to #26361

## How to Validate

```sh
npm run test:scripts -- proxy-agent-bundle
```

Also useful for manual bundle validation:

```sh
npm run bundle
node scripts/proxy-bundle-probe.mjs
```

Expected: generated proxy-agent bundle chunks expose constructable named `HttpsProxyAgent` / `HttpProxyAgent` exports.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
