### PR TITLE
fix(core): upgrade pty dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,13 +77,13 @@
       },
       "optionalDependencies": {
         "@github/keytar": "^7.10.6",
-        "@lydell/node-pty": "1.1.0",
-        "@lydell/node-pty-darwin-arm64": "1.1.0",
-        "@lydell/node-pty-darwin-x64": "1.1.0",
-        "@lydell/node-pty-linux-x64": "1.1.0",
-        "@lydell/node-pty-win32-arm64": "1.1.0",
-        "@lydell/node-pty-win32-x64": "1.1.0",
-        "node-pty": "^1.0.0"
+        "@lydell/node-pty": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
+        "node-pty": "1.2.0-beta.12"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -1992,23 +1992,23 @@
       "license": "MIT"
     },
     "node_modules/@lydell/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
       "license": "MIT",
       "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.1.0",
-        "@lydell/node-pty-darwin-x64": "1.1.0",
-        "@lydell/node-pty-linux-arm64": "1.1.0",
-        "@lydell/node-pty-linux-x64": "1.1.0",
-        "@lydell/node-pty-win32-arm64": "1.1.0",
-        "@lydell/node-pty-win32-x64": "1.1.0"
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12"
       }
     },
     "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2019,9 +2019,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==",
       "cpu": [
         "x64"
       ],
@@ -2032,9 +2032,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.1.0.tgz",
-      "integrity": "sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==",
       "cpu": [
         "arm64"
       ],
@@ -2045,9 +2045,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==",
       "cpu": [
         "x64"
       ],
@@ -2058,9 +2058,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.1.0.tgz",
-      "integrity": "sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==",
       "cpu": [
         "arm64"
       ],
@@ -2071,9 +2071,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.1.0.tgz",
-      "integrity": "sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==",
       "cpu": [
         "x64"
       ],
@@ -12170,13 +12170,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nano-spawn": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
@@ -12232,6 +12225,13 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -12313,14 +12313,14 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
-      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nan": "^2.17.0"
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/node-sarif-builder": {
@@ -18490,13 +18490,13 @@
       },
       "optionalDependencies": {
         "@github/keytar": "^7.10.6",
-        "@lydell/node-pty": "1.1.0",
-        "@lydell/node-pty-darwin-arm64": "1.1.0",
-        "@lydell/node-pty-darwin-x64": "1.1.0",
-        "@lydell/node-pty-linux-x64": "1.1.0",
-        "@lydell/node-pty-win32-arm64": "1.1.0",
-        "@lydell/node-pty-win32-x64": "1.1.0",
-        "node-pty": "^1.0.0"
+        "@lydell/node-pty": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
+        "node-pty": "1.2.0-beta.12"
       }
     },
     "packages/core/node_modules/@a2a-js/sdk": {
@@ -18731,7 +18731,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
-        "@lydell/node-pty": "1.1.0",
+        "@lydell/node-pty": "1.2.0-beta.12",
         "asciichart": "^1.5.25",
         "strip-ansi": "^7.1.2",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -152,13 +152,13 @@
   },
   "optionalDependencies": {
     "@github/keytar": "^7.10.6",
-    "@lydell/node-pty": "1.1.0",
-    "@lydell/node-pty-darwin-arm64": "1.1.0",
-    "@lydell/node-pty-darwin-x64": "1.1.0",
-    "@lydell/node-pty-linux-x64": "1.1.0",
-    "@lydell/node-pty-win32-arm64": "1.1.0",
-    "@lydell/node-pty-win32-x64": "1.1.0",
-    "node-pty": "^1.0.0"
+    "@lydell/node-pty": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
+    "node-pty": "1.2.0-beta.12"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,13 +96,13 @@
   },
   "optionalDependencies": {
     "@github/keytar": "^7.10.6",
-    "@lydell/node-pty": "1.1.0",
-    "@lydell/node-pty-darwin-arm64": "1.1.0",
-    "@lydell/node-pty-darwin-x64": "1.1.0",
-    "@lydell/node-pty-linux-x64": "1.1.0",
-    "@lydell/node-pty-win32-arm64": "1.1.0",
-    "@lydell/node-pty-win32-x64": "1.1.0",
-    "node-pty": "^1.0.0"
+    "@lydell/node-pty": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
+    "node-pty": "1.2.0-beta.12"
   },
   "devDependencies": {
     "@google/gemini-cli-test-utils": "file:../test-utils",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@google/gemini-cli-core": "file:../core",
-    "@lydell/node-pty": "1.1.0",
+    "@lydell/node-pty": "1.2.0-beta.12",
     "asciichart": "^1.5.25",
     "strip-ansi": "^7.1.2",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary

Upgrades the PTY dependencies used by Gemini CLI to pick up the upstream macOS `/dev/ptmx` leak fix from microsoft/node-pty#882.

This updates:

- `@lydell/node-pty`
- `@lydell/node-pty-*` platform optional packages
- fallback `node-pty`

to `1.2.0-beta.12`.

## Details

Gemini CLI resolves PTY support through `packages/core/src/utils/getPty.ts`, which tries `@lydell/node-pty` first and falls back to `node-pty`.

Because the leak is in the PTY implementation layer, this PR updates both paths so the fallback does not remain on the older affected package line.

`packages/test-utils` is also updated so the test rig uses the same PTY package version.

This is intentionally dependency-only. It does not change shell execution behavior or PTY lifecycle logic.

## Related Issues

Related to #26327.

Upstream fix: microsoft/node-pty#882.

## How to Validate

Validated locally with Node `v20.19.0` and npm `10.8.2`:

```bash
fnm exec --using 20.19.0 npm run preflight
```

Also verified directly that `@lydell/node-pty` loads successfully and resolves to `1.2.0-beta.12` with the `darwin-arm64` platform package.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed): not needed, dependency-only change
- [x] Added/updated tests (if needed): not needed, covered by existing shell execution/preflight tests
- [x] Noted breaking changes (if any): none
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
