### PR TITLE
feat(plan): opt-in trust for MCP readOnlyHint via general.plan.trustReadOnlyHint

### DIFF
--- a/packages/cli/src/config/policy.ts
+++ b/packages/cli/src/config/policy.ts
@@ -67,6 +67,7 @@ export async function createPolicyEngineConfig(
     disableAlwaysAllow:
       settings.security?.disableAlwaysAllow ||
       settings.admin?.secureModeEnabled,
+    trustReadOnlyHintInPlanMode: settings.general?.plan?.trustReadOnlyHint,
   };
 
   return createCorePolicyEngineConfig(

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -339,6 +339,16 @@ const SETTINGS_SCHEMA = {
               'Automatically switch between Pro and Flash models based on Plan Mode status. Uses Pro for the planning phase and Flash for the implementation phase.',
             showInDialog: true,
           },
+          trustReadOnlyHint: {
+            type: 'boolean',
+            label: 'Trust MCP readOnlyHint in Plan Mode',
+            category: 'General',
+            requiresRestart: true,
+            default: false,
+            description:
+              'When true, MCP tools declared with `readOnlyHint: true` are allowed silently in Plan Mode instead of prompting on every call. Disabled by default — Plan Mode follows secure-by-default and prompts for tools whose read-only nature is asserted only by external metadata. Enable only for MCP servers you fully trust.',
+            showInDialog: true,
+          },
         },
       },
       retryFetchErrors: {

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -779,6 +779,51 @@ modes = ["plan"]
 
     feedbackSpy.mockRestore();
   });
+
+  describe('trustReadOnlyHintInPlanMode setting', () => {
+    it('should NOT inject the trust-readOnlyHint rule when setting is unset', async () => {
+      const config = await createPolicyEngineConfig(
+        {},
+        ApprovalMode.PLAN,
+        MOCK_DEFAULT_DIR,
+      );
+      const trustRule = config.rules?.find(
+        (r) => r.source === 'Settings (general.plan.trustReadOnlyHint)',
+      );
+      expect(trustRule).toBeUndefined();
+    });
+
+    it('should NOT inject the rule when setting is explicitly false', async () => {
+      const config = await createPolicyEngineConfig(
+        { trustReadOnlyHintInPlanMode: false },
+        ApprovalMode.PLAN,
+        MOCK_DEFAULT_DIR,
+      );
+      const trustRule = config.rules?.find(
+        (r) => r.source === 'Settings (general.plan.trustReadOnlyHint)',
+      );
+      expect(trustRule).toBeUndefined();
+    });
+
+    it('should inject a high-priority ALLOW rule when setting is true', async () => {
+      const config = await createPolicyEngineConfig(
+        { trustReadOnlyHintInPlanMode: true },
+        ApprovalMode.PLAN,
+        MOCK_DEFAULT_DIR,
+      );
+      const trustRule = config.rules?.find(
+        (r) => r.source === 'Settings (general.plan.trustReadOnlyHint)',
+      );
+      expect(trustRule).toBeDefined();
+      expect(trustRule!.decision).toBe(PolicyDecision.ALLOW);
+      expect(trustRule!.modes).toEqual([ApprovalMode.PLAN]);
+      expect(trustRule!.toolAnnotations).toEqual({ readOnlyHint: true });
+      expect(trustRule!.mcpName).toBe('*');
+      // Priority 4.5 — user tier, above the 1.05 ASK_USER rule from plan.toml,
+      // below MCP_EXCLUDED_PRIORITY (4.9) so admin/security blocks still win.
+      expect(trustRule!.priority).toBeCloseTo(4.5, 5);
+    });
+  });
 });
 
 describe('getPolicyDirectories', () => {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -73,6 +73,7 @@ export const ADMIN_POLICY_TIER = 5;
 // Specific priority offsets and derived priorities for dynamic/settings rules.
 
 export const MCP_EXCLUDED_PRIORITY = USER_POLICY_TIER + 0.9;
+export const TRUST_READ_ONLY_HINT_PRIORITY = USER_POLICY_TIER + 0.5;
 export const EXCLUDE_TOOLS_FLAG_PRIORITY = USER_POLICY_TIER + 0.4;
 export const CONFIRMATION_REQUIRED_PRIORITY = USER_POLICY_TIER + 0.35;
 export const ALLOWED_TOOLS_FLAG_PRIORITY = USER_POLICY_TIER + 0.3;
@@ -434,6 +435,29 @@ export async function createPolicyEngineConfig(
         source: 'Settings (Tools Excluded)',
       });
     }
+  }
+
+  // Opt-in: trust MCP-declared `readOnlyHint = true` in Plan Mode.
+  // Off by default — Plan Mode follows secure-by-default and prompts on
+  // every MCP read so the user can verify the call. When the user enables
+  // `general.plan.trustReadOnlyHint`, this dynamic rule (priority
+  // TRUST_READ_ONLY_HINT_PRIORITY = 4.5, comfortably above plan.toml's
+  // priority-1.05 ASK_USER rule and below MCP_EXCLUDED_PRIORITY)
+  // overrides ASK_USER → ALLOW for the readOnlyHint annotation.
+  //
+  // Built-in read tools (read_file, glob, grep_search, list_directory,
+  // ...) already run silently in Plan Mode via the explicit allow-list
+  // in read-only.toml and are not affected by this setting.
+  if (settings.trustReadOnlyHintInPlanMode) {
+    rules.push({
+      toolName: '*',
+      mcpName: '*',
+      toolAnnotations: { readOnlyHint: true },
+      decision: PolicyDecision.ALLOW,
+      priority: TRUST_READ_ONLY_HINT_PRIORITY,
+      modes: [ApprovalMode.PLAN],
+      source: 'Settings (general.plan.trustReadOnlyHint)',
+    });
   }
 
   const nonPlanModes = [

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -347,6 +347,10 @@ export interface PolicySettings {
   adminPolicyPaths?: string[];
   workspacePoliciesDir?: string;
   disableAlwaysAllow?: boolean;
+  // When true, MCP tools annotated `readOnlyHint = true` are allowed silently
+  // in Plan Mode (overrides plan.toml's default ASK_USER). Maps to
+  // `general.plan.trustReadOnlyHint` in user settings.
+  trustReadOnlyHintInPlanMode?: boolean;
 }
 
 export interface CheckResult {


### PR DESCRIPTION
## Summary

Adds an opt-in setting (`general.plan.trustReadOnlyHint`, default `false`) that lets users allow MCP tools declared with `readOnlyHint = true` to run silently in Plan Mode, instead of prompting on every call.

**Default behavior is unchanged** — Plan Mode keeps the secure-by-default `ASK_USER` for MCP read-only-annotated tools. The user opts in only for MCP servers they fully trust.

## Why this revision

The first revision of this PR ([initial commit](https://github.com/google-gemini/gemini-cli/pull/27156/commits/50ee0e2aa24f54fa7e2c1fb6e5691f29892d039b)) flipped the `plan.toml` rule unconditionally from `ASK_USER` to `ALLOW`. @gemini-code-assist[bot] correctly flagged this as a security bypass: a malicious MCP server could declare `readOnlyHint: true` on a write-tool and silently execute in Plan Mode.

This revision keeps `plan.toml` unchanged and gives users explicit, per-installation control via a setting. The setting is documented as "Enable only for MCP servers you fully trust" so the trust decision is informed.

## How it works

When `general.plan.trustReadOnlyHint = true`, a dynamic rule is injected at policy-engine construction time with priority `TRUST_READ_ONLY_HINT_PRIORITY = USER_POLICY_TIER + 0.5 = 4.5`. That priority:

- **above** `plan.toml`'s `1.05` `ASK_USER` rule → overrides it to `ALLOW`
- **below** `MCP_EXCLUDED_PRIORITY` (`4.9`) → admin/security server-blocks still win
- **above** the lower flag priorities (`EXCLUDE_TOOLS_FLAG_PRIORITY = 4.4`, `ALLOWED_TOOLS_FLAG_PRIORITY = 4.3`, `TRUSTED_MCP_SERVER_PRIORITY = 4.2`, `ALLOWED_MCP_SERVER_PRIORITY = 4.1`) → explicit user opt-in is ordered above the exclude/allow/trusted flag tier

Priorities used (see `packages/core/src/policy/config.ts`):

```
MCP_EXCLUDED_PRIORITY            4.9
TRUST_READ_ONLY_HINT_PRIORITY    4.5   ← new
EXCLUDE_TOOLS_FLAG_PRIORITY      4.4
ALLOWED_TOOLS_FLAG_PRIORITY      4.3
TRUSTED_MCP_SERVER_PRIORITY      4.2
ALLOWED_MCP_SERVER_PRIORITY      4.1
```

So `MCP_EXCLUDED_PRIORITY` (admin/security excluding an MCP server) beats this setting — which is the correct ordering for fail-closed security.

Built-in read tools (`read_file`, `glob`, `grep_search`, `list_directory`, ...) already run silently in Plan Mode via the explicit allow-list in `read-only.toml` and are unaffected.

## Files

- `packages/cli/src/config/settingsSchema.ts` — new `general.plan.trustReadOnlyHint` boolean, default `false`
- `packages/cli/src/config/policy.ts` — pipes the setting through to `PolicySettings`
- `packages/core/src/policy/types.ts` — adds `trustReadOnlyHintInPlanMode?: boolean` to `PolicySettings`
- `packages/core/src/policy/config.ts` — new priority constant + conditional rule injection in `createPolicyEngineConfig`
- `packages/core/src/policy/config.test.ts` — 3 test cases (setting unset, false, true)

## Related Issues

Closes #27163

Part of #25406 (Epic: Plan Mode Post-Launch Work).

## How to Validate

1. Default (setting unset): `gemini --approval-mode=plan`. Prompt the agent to call an MCP tool annotated `readOnlyHint: true` — approval dialog appears (unchanged from current behavior).
2. Enabled: `~/.gemini/settings.json` → `{ "general": { "plan": { "trustReadOnlyHint": true } } }`. Restart and repeat — runs silently.
3. With both `trustReadOnlyHint: true` AND `mcp.excluded: ["my-trusted-server"]` — server-block wins (server is denied entirely).
4. Built-in `read_file` / `glob` / `grep_search` in Plan Mode — silent regardless of the setting (governed by `read-only.toml`).

## Pre-Merge Checklist

- [x] Tests added in `config.test.ts` (3 cases covering the new setting)
- [x] No breaking changes — default is the existing `ASK_USER` behavior
- [x] Setting documented with clear "trust" framing in `settingsSchema.ts`
- [x] Priority placement keeps `MCP_EXCLUDED_PRIORITY` (security-critical) above the new opt-in
- [x] Validated on Linux (Ubuntu 24.04, Node 24.15.0)



