### PR TITLE
feat(core): non-interactive env and PTY skip for Full Access shell exec

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2193,11 +2193,18 @@ describe('ShellExecutionService environment variables', () => {
     vi.unstubAllEnvs();
   });
 
-  it('should inject non-interactive env vars in Full Access (YOLO) mode', async () => {
+  it('should inject Full Access (YOLO) env vars on top of the !isInteractive block', async () => {
+    // Real production flow: shell.ts forces shouldUseNodePty=false when
+    // approvalMode === YOLO, so execute() runs the child_process path with
+    // isInteractive=false. Both env blocks compose: `!isInteractive`
+    // contributes GIT_TERMINAL_PROMPT / GH_PROMPT_DISABLED / GCM_INTERACTIVE
+    // (and GIT_CONFIG_* shaping); the YOLO block contributes the
+    // package-manager / installer vars on top.
     vi.resetModules();
     vi.stubEnv('CI', undefined);
     vi.stubEnv('npm_config_yes', undefined);
     vi.stubEnv('DEBIAN_FRONTEND', undefined);
+    vi.stubEnv('GIT_CONFIG_COUNT', undefined);
 
     const { ShellExecutionService } = await import(
       './shellExecutionService.js'
@@ -2210,12 +2217,13 @@ describe('ShellExecutionService environment variables', () => {
       '/',
       vi.fn(),
       new AbortController().signal,
-      true, // interactive UI session — YOLO is the new gate
+      false, // YOLO real flow: PTY skipped → isInteractive=false
       { ...shellExecutionConfig, approvalMode: ApprovalMode.YOLO },
     );
 
     expect(mockCpSpawn).toHaveBeenCalled();
     const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+    // From the YOLO block (this PR):
     expect(cpEnv).toHaveProperty('CI', '1');
     expect(cpEnv).toHaveProperty('npm_config_yes', 'true');
     expect(cpEnv).toHaveProperty('npm_config_fund', 'false');
@@ -2223,10 +2231,12 @@ describe('ShellExecutionService environment variables', () => {
     expect(cpEnv).toHaveProperty('YARN_ENABLE_INTERACTIVE', 'false');
     expect(cpEnv).toHaveProperty('DEBIAN_FRONTEND', 'noninteractive');
     expect(cpEnv).toHaveProperty('NEEDRESTART_MODE', 'a');
+    expect(cpEnv).toHaveProperty('PIP_DISABLE_PIP_VERSION_CHECK', '1');
+    // From the pre-existing !isInteractive block — included here so a
+    // regression that decouples the two blocks gets caught:
     expect(cpEnv).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
     expect(cpEnv).toHaveProperty('GH_PROMPT_DISABLED', '1');
     expect(cpEnv).toHaveProperty('GCM_INTERACTIVE', 'never');
-    expect(cpEnv).toHaveProperty('PIP_DISABLE_PIP_VERSION_CHECK', '1');
 
     mockChildProcess.emit('exit', 0, null);
     mockChildProcess.emit('close', 0, null);

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2192,4 +2192,121 @@ describe('ShellExecutionService environment variables', () => {
 
     vi.unstubAllEnvs();
   });
+
+  it('should inject non-interactive env vars in Full Access (YOLO) mode', async () => {
+    vi.resetModules();
+    vi.stubEnv('CI', undefined);
+    vi.stubEnv('npm_config_yes', undefined);
+    vi.stubEnv('DEBIAN_FRONTEND', undefined);
+
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
+    const { ApprovalMode } = await import('../policy/types.js');
+
+    mockGetPty.mockResolvedValue(null); // child_process fallback
+    await ShellExecutionService.execute(
+      'test-cp-yolo-env',
+      '/',
+      vi.fn(),
+      new AbortController().signal,
+      true, // interactive UI session — YOLO is the new gate
+      { ...shellExecutionConfig, approvalMode: ApprovalMode.YOLO },
+    );
+
+    expect(mockCpSpawn).toHaveBeenCalled();
+    const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+    expect(cpEnv).toHaveProperty('CI', '1');
+    expect(cpEnv).toHaveProperty('npm_config_yes', 'true');
+    expect(cpEnv).toHaveProperty('npm_config_fund', 'false');
+    expect(cpEnv).toHaveProperty('npm_config_audit', 'false');
+    expect(cpEnv).toHaveProperty('YARN_ENABLE_INTERACTIVE', 'false');
+    expect(cpEnv).toHaveProperty('DEBIAN_FRONTEND', 'noninteractive');
+    expect(cpEnv).toHaveProperty('NEEDRESTART_MODE', 'a');
+    expect(cpEnv).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
+    expect(cpEnv).toHaveProperty('GH_PROMPT_DISABLED', '1');
+    expect(cpEnv).toHaveProperty('GCM_INTERACTIVE', 'never');
+    expect(cpEnv).toHaveProperty('PIP_DISABLE_PIP_VERSION_CHECK', '1');
+
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await new Promise(process.nextTick);
+    vi.unstubAllEnvs();
+  });
+
+  it('should NOT inject Full Access env vars when approvalMode is DEFAULT', async () => {
+    vi.resetModules();
+    vi.stubEnv('CI', undefined);
+    vi.stubEnv('npm_config_yes', undefined);
+    vi.stubEnv('DEBIAN_FRONTEND', undefined);
+
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
+    const { ApprovalMode } = await import('../policy/types.js');
+
+    mockGetPty.mockResolvedValue(null);
+    await ShellExecutionService.execute(
+      'test-cp-default-env',
+      '/',
+      vi.fn(),
+      new AbortController().signal,
+      true, // interactive
+      { ...shellExecutionConfig, approvalMode: ApprovalMode.DEFAULT },
+    );
+
+    expect(mockCpSpawn).toHaveBeenCalled();
+    const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+    expect(cpEnv).not.toHaveProperty('CI');
+    expect(cpEnv).not.toHaveProperty('npm_config_yes');
+    expect(cpEnv).not.toHaveProperty('DEBIAN_FRONTEND');
+    expect(cpEnv).not.toHaveProperty('NEEDRESTART_MODE');
+
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await new Promise(process.nextTick);
+    vi.unstubAllEnvs();
+  });
+
+  it('should preserve pre-existing user env values in Full Access mode (?? coalesce)', async () => {
+    vi.resetModules();
+    vi.stubEnv('CI', '0');
+    vi.stubEnv('DEBIAN_FRONTEND', 'dialog');
+
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
+    const { ApprovalMode } = await import('../policy/types.js');
+
+    mockGetPty.mockResolvedValue(null);
+    await ShellExecutionService.execute(
+      'test-cp-yolo-preserve',
+      '/',
+      vi.fn(),
+      new AbortController().signal,
+      true,
+      {
+        ...shellExecutionConfig,
+        approvalMode: ApprovalMode.YOLO,
+        sanitizationConfig: {
+          ...shellExecutionConfig.sanitizationConfig,
+          allowedEnvironmentVariables: ['CI', 'DEBIAN_FRONTEND'],
+        },
+      },
+    );
+
+    expect(mockCpSpawn).toHaveBeenCalled();
+    const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+    // User-set values take precedence over the YOLO defaults
+    expect(cpEnv).toHaveProperty('CI', '0');
+    expect(cpEnv).toHaveProperty('DEBIAN_FRONTEND', 'dialog');
+    // The non-conflicting Full Access defaults still get injected
+    expect(cpEnv).toHaveProperty('npm_config_yes', 'true');
+    expect(cpEnv).toHaveProperty('NEEDRESTART_MODE', 'a');
+
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await new Promise(process.nextTick);
+    vi.unstubAllEnvs();
+  });
 });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -487,13 +487,21 @@ export class ShellExecutionService {
     }
 
     // Full Access mode opts the user into "auto-everything". Make common
-    // installers / package managers / VCS clients run non-interactively so
-    // they don't hang on prompts like `npx`'s "Ok to proceed? [y]" or
-    // `apt`'s "Do you want to continue?". Pre-existing user values pass
-    // through (?? coalesce). Codex CLI does this unconditionally at exec
-    // (codex-rs `UNIFIED_EXEC_ENV`); Claude Code propagates these vars from
-    // the user's env. We gate on YOLO because outside Full Access the user
-    // has not opted in to skipping prompts.
+    // installers / package managers run non-interactively so they don't hang
+    // on prompts like `npx`'s "Ok to proceed? [y]" or `apt`'s "Do you want
+    // to continue?". Pre-existing user values pass through (?? coalesce).
+    //
+    // GIT_TERMINAL_PROMPT, GH_PROMPT_DISABLED, GCM_INTERACTIVE are NOT set
+    // here: the `!isInteractive` block above already does (in YOLO we force
+    // shouldUseNodePty=false in shell.ts → isInteractive=false → that block
+    // runs and overwrites them unconditionally). Listing them here would be
+    // redundant and the `??` would be misleading — user values for those
+    // three are not preserved by either path.
+    //
+    // Codex CLI does the always-on equivalent at exec (codex-rs
+    // `UNIFIED_EXEC_ENV`); Claude Code propagates these vars from the user's
+    // env. We gate on YOLO because outside Full Access the user has not
+    // opted in to skipping prompts.
     if (shellExecutionConfig.approvalMode === ApprovalMode.YOLO) {
       Object.assign(baseEnv, {
         CI: baseEnv['CI'] ?? '1',
@@ -503,9 +511,6 @@ export class ShellExecutionService {
         YARN_ENABLE_INTERACTIVE: baseEnv['YARN_ENABLE_INTERACTIVE'] ?? 'false',
         DEBIAN_FRONTEND: baseEnv['DEBIAN_FRONTEND'] ?? 'noninteractive',
         NEEDRESTART_MODE: baseEnv['NEEDRESTART_MODE'] ?? 'a',
-        GIT_TERMINAL_PROMPT: baseEnv['GIT_TERMINAL_PROMPT'] ?? '0',
-        GH_PROMPT_DISABLED: baseEnv['GH_PROMPT_DISABLED'] ?? '1',
-        GCM_INTERACTIVE: baseEnv['GCM_INTERACTIVE'] ?? 'never',
         PIP_DISABLE_PIP_VERSION_CHECK:
           baseEnv['PIP_DISABLE_PIP_VERSION_CHECK'] ?? '1',
       });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -37,6 +37,7 @@ import {
   type SandboxPermissions,
 } from './sandboxManager.js';
 import type { SandboxConfig } from '../config/config.js';
+import { ApprovalMode } from '../policy/types.js';
 import { killProcessGroup } from '../utils/process-utils.js';
 import {
   ExecutionLifecycleService,
@@ -105,6 +106,10 @@ export interface ShellExecutionConfig {
   backgroundCompletionBehavior?: 'inject' | 'notify' | 'silent';
   originalCommand?: string;
   sessionId?: string;
+  // When set to YOLO, prepareExecution injects non-interactive env vars
+  // (CI=1, npm_config_yes=true, DEBIAN_FRONTEND=noninteractive, etc.) so
+  // package managers and installers auto-confirm instead of hanging on stdin.
+  approvalMode?: ApprovalMode;
 }
 
 /**
@@ -478,6 +483,31 @@ export class ShellExecutionService {
         GIT_CONFIG_COUNT: (gitConfigCount + 1).toString(),
         [newKey]: 'credential.helper',
         [newValue]: '',
+      });
+    }
+
+    // Full Access mode opts the user into "auto-everything". Make common
+    // installers / package managers / VCS clients run non-interactively so
+    // they don't hang on prompts like `npx`'s "Ok to proceed? [y]" or
+    // `apt`'s "Do you want to continue?". Pre-existing user values pass
+    // through (?? coalesce). Codex CLI does this unconditionally at exec
+    // (codex-rs `UNIFIED_EXEC_ENV`); Claude Code propagates these vars from
+    // the user's env. We gate on YOLO because outside Full Access the user
+    // has not opted in to skipping prompts.
+    if (shellExecutionConfig.approvalMode === ApprovalMode.YOLO) {
+      Object.assign(baseEnv, {
+        CI: baseEnv['CI'] ?? '1',
+        npm_config_yes: baseEnv['npm_config_yes'] ?? 'true',
+        npm_config_fund: baseEnv['npm_config_fund'] ?? 'false',
+        npm_config_audit: baseEnv['npm_config_audit'] ?? 'false',
+        YARN_ENABLE_INTERACTIVE: baseEnv['YARN_ENABLE_INTERACTIVE'] ?? 'false',
+        DEBIAN_FRONTEND: baseEnv['DEBIAN_FRONTEND'] ?? 'noninteractive',
+        NEEDRESTART_MODE: baseEnv['NEEDRESTART_MODE'] ?? 'a',
+        GIT_TERMINAL_PROMPT: baseEnv['GIT_TERMINAL_PROMPT'] ?? '0',
+        GH_PROMPT_DISABLED: baseEnv['GH_PROMPT_DISABLED'] ?? '1',
+        GCM_INTERACTIVE: baseEnv['GCM_INTERACTIVE'] ?? 'never',
+        PIP_DISABLE_PIP_VERSION_CHECK:
+          baseEnv['PIP_DISABLE_PIP_VERSION_CHECK'] ?? '1',
       });
     }
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -52,6 +52,7 @@ import {
 } from './shell.js';
 import { debugLogger } from '../index.js';
 import { type Config } from '../config/config.js';
+import { ApprovalMode } from '../policy/types.js';
 import { NoopSandboxManager } from '../services/sandboxManager.js';
 import {
   type ShellExecutionResult,
@@ -896,6 +897,58 @@ EOF`;
         );
 
         await promise;
+      });
+    });
+
+    describe('PTY routing vs Full Access (YOLO)', () => {
+      it('should enable PTY when interactive shell is on and approvalMode is not YOLO', async () => {
+        vi.mocked(mockConfig.getEnableInteractiveShell).mockReturnValue(true);
+        vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
+          ApprovalMode.DEFAULT,
+        );
+
+        const invocation = shellTool.build({ command: 'echo hi' });
+        const promise = invocation.execute({ abortSignal: mockAbortSignal });
+        resolveShellExecution();
+        await promise;
+
+        const call = mockShellExecutionService.mock.calls.at(-1);
+        // 5th positional arg (index 4) is shouldUseNodePty.
+        expect(call?.[4]).toBe(true);
+      });
+
+      it('should skip PTY in Full Access (YOLO) so sudo cannot prompt for a password', async () => {
+        // PTY would give sudo a real TTY and let it hang forever waiting for
+        // a password. The child_process fallback uses stdio:['ignore', ...]
+        // so sudo fails fast with "a password is required" (matches Codex's
+        // Stdio::null() in codex-rs/utils/pty/src/pipe.rs:144).
+        vi.mocked(mockConfig.getEnableInteractiveShell).mockReturnValue(true);
+        vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
+          ApprovalMode.YOLO,
+        );
+
+        const invocation = shellTool.build({ command: 'sudo apt update' });
+        const promise = invocation.execute({ abortSignal: mockAbortSignal });
+        resolveShellExecution();
+        await promise;
+
+        const call = mockShellExecutionService.mock.calls.at(-1);
+        expect(call?.[4]).toBe(false);
+      });
+
+      it('should still skip PTY when interactive shell is disabled, regardless of approvalMode', async () => {
+        vi.mocked(mockConfig.getEnableInteractiveShell).mockReturnValue(false);
+        vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
+          ApprovalMode.DEFAULT,
+        );
+
+        const invocation = shellTool.build({ command: 'echo hi' });
+        const promise = invocation.execute({ abortSignal: mockAbortSignal });
+        resolveShellExecution();
+        await promise;
+
+        const call = mockShellExecutionService.mock.calls.at(-1);
+        expect(call?.[4]).toBe(false);
       });
     });
   });

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -651,11 +651,18 @@ export class ShellToolInvocation extends BaseToolInvocation<
             }
           },
           combinedController.signal,
-          this.context.config.getEnableInteractiveShell(),
+          // In Full Access (YOLO) skip the PTY: a real TTY lets `sudo` and
+          // similar prompt for a password indefinitely. The child_process
+          // fallback uses stdio:['ignore', ...] so sudo fails fast with
+          // "a password is required" (matches Codex's Stdio::null() in
+          // codex-rs/utils/pty/src/pipe.rs:144).
+          this.context.config.getEnableInteractiveShell() &&
+            this.context.config.getApprovalMode() !== ApprovalMode.YOLO,
           {
             ...shellExecutionConfig,
             sessionId: this.context.config?.getSessionId?.() ?? 'default',
             pager: 'cat',
+            approvalMode: this.context.config.getApprovalMode(),
             sanitizationConfig:
               shellExecutionConfig?.sanitizationConfig ??
               this.context.config.sanitizationConfig,


### PR DESCRIPTION
## Summary

Two related fixes for Full Access mode (`--full-access` / `--approval-mode=full_access`) so shell commands don't hang on interactive sub-prompts:

1. **Inject non-interactive env vars** so `npm`, `npx`, `apt`, `pip`, `yarn`, `git` auto-confirm instead of waiting at `Ok to proceed? [y]`.
2. **Route child processes through the stdin-closed `child_process` path** (skip the PTY) so `sudo` fails fast (`a password is required`) instead of waiting forever on a PTY password prompt.

Both gated strictly on `approvalMode === YOLO` — non-Full-Access flows are unchanged.

## Details

**Env vars (`packages/core/src/services/shellExecutionService.ts`)** — extends the existing non-interactive env block (which only fires in `!isInteractive`) with a second branch firing on `approvalMode === YOLO`, regardless of interactive UI. Pre-existing user values pass through via `?? 'default'` coalesce. Vars injected:

```
CI=1
npm_config_yes=true
npm_config_fund=false
npm_config_audit=false
YARN_ENABLE_INTERACTIVE=false
DEBIAN_FRONTEND=noninteractive
NEEDRESTART_MODE=a
GIT_TERMINAL_PROMPT=0
GH_PROMPT_DISABLED=1
GCM_INTERACTIVE=never
PIP_DISABLE_PIP_VERSION_CHECK=1
```

**PTY skip (`packages/core/src/tools/shell.ts`)** — passes `shouldUseNodePty = getEnableInteractiveShell() && approvalMode !== YOLO` to `ShellExecutionService.execute`. In Full Access the child_process fallback runs with `stdio: ['ignore', 'pipe', 'pipe']`, so `sudo` reads EOF on stdin and exits with `sudo: a password is required` within a second instead of hanging on the TTY password prompt.

Trade-off accepted: TUI tools like `vim`, `htop`, interactive REPLs no longer work *inside Full Access*. That matches the intent — Full Access is for fire-and-forget execution; interactive TUI sessions don't belong in it. The user can toggle out via `Ctrl+Y` if they need them.

## Prior art

- **Codex CLI** — `codex-rs/core/src/unified_exec/process_manager.rs:60-71` injects a fixed 10-var env block at every exec (`NO_COLOR=1`, `TERM=dumb`, `LANG=C.UTF-8`, `PAGER=cat`, `CODEX_CI=1`, ...). Always on. Codex also calls `command.stdin(Stdio::null())` at `codex-rs/utils/pty/src/pipe.rs:144` via `spawn_process_no_stdin_with_inherited_fds()`, which is the same mechanism that makes `sudo` fail fast.
- **Claude Code** (binary v2.1.143) — propagates an allow-list including `CI`, `DEBIAN_FRONTEND`, `GIT_TERMINAL_PROMPT`, `NO_COLOR`, `TERM`, `COLORTERM`, `LANG`, `LC_ALL` (from the user's environment to the child process). Also surfaces a detection message when a shell hangs: *"The command is likely blocked on an interactive prompt. Kill this task and re-run with piped input (e.g., `echo y \| command`) or a non-interactive flag if one exists."*

This PR is the hybrid: opinionated like Codex (auto-injects, doesn't just propagate), but gated like a user-opt-in feature (only on YOLO).

## Related Issues

Closes #24707

Related to (variants of the same hang-on-stdin symptom):
- #25782 — `npx op packup` never exits; Shift+Tab can't recover
- #25914 — gemini-cli yolo mode still always prompts for manual PowerShell execution
- #22465 — Gemini CLI gets stuck at interactive prompt creating vite app
- #22452 — `CI_*` env var scrub not applied in dev mode (interactive prompt loop)
- #21052 — Sub-agents hang indefinitely on interactive terminal prompts

## How to Validate

Run `gemini --full-access` in a fresh terminal, then:

1. `gemini --full-access -p "execute: env | sort | grep -E '^(CI|npm_config|DEBIAN_FRONTEND|NEEDRESTART|GIT_TERMINAL_PROMPT)='"` → output includes `CI=1`, `npm_config_yes=true`, `DEBIAN_FRONTEND=noninteractive`, `NEEDRESTART_MODE=a`, `GIT_TERMINAL_PROMPT=0`.
2. `gemini --full-access -p "execute: cd /tmp && rm -rf vite-x && npx create-vite@latest vite-x -- --template react"` → completes; previously hung at `Ok to proceed? [y]`.
3. `gemini --full-access -p "execute: sudo -n true"` → exits within ~1s with `sudo: a password is required`; previously hung indefinitely on the password prompt.
4. With `CI=0` already exported in the user's shell, run (1) again → output shows `CI=0` (the `?? '1'` coalesce respects pre-existing user values).
5. Without `--full-access` (default mode): the env vars in (1) are NOT present; PTY is used as before.

## Pre-Merge Checklist

- [x] Tests added in `shellExecutionService.test.ts`: YOLO injects env / DEFAULT does not / user-set `CI=0` and `DEBIAN_FRONTEND=dialog` preserved
- [x] Tests added in `shell.test.ts`: PTY enabled when interactive + non-YOLO / PTY skipped in YOLO / PTY skipped when interactiveShell disabled regardless of mode
- [x] No breaking changes for non-YOLO flows
- [x] Validated on Linux (Ubuntu 24.04, Node 24.15.0)

