### PR TITLE
feat(cli): cycle Shift+Tab through Full Access and add ⏵⏵ auto mode label

### DIFF
--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -512,6 +512,7 @@ const baseMockUiState = {
   terminalBackgroundColor: 'black' as const,
   cleanUiDetailsVisible: false,
   allowPlanMode: true,
+  allowYoloMode: true,
   activePtyId: undefined,
   backgroundTasks: new Map(),
   backgroundTaskHeight: 0,

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -3647,6 +3647,36 @@ describe('AppContainer State Management', () => {
     });
   });
 
+  describe('Auto Mode (YOLO) Availability', () => {
+    it('should allow auto mode when YOLO is not disabled by settings', async () => {
+      vi.spyOn(mockConfig, 'isYoloModeDisabled').mockReturnValue(false);
+      mockedUseGeminiStream.mockReturnValue({
+        ...DEFAULT_GEMINI_STREAM_MOCK,
+        pendingHistoryItems: [],
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      expect(capturedUIState).toBeTruthy();
+      expect(capturedUIState.allowYoloMode).toBe(true);
+      unmount();
+    });
+
+    it('should NOT allow auto mode when YOLO is disabled', async () => {
+      vi.spyOn(mockConfig, 'isYoloModeDisabled').mockReturnValue(true);
+      mockedUseGeminiStream.mockReturnValue({
+        ...DEFAULT_GEMINI_STREAM_MOCK,
+        pendingHistoryItems: [],
+      });
+
+      const { unmount } = await act(async () => renderAppContainer());
+
+      expect(capturedUIState).toBeTruthy();
+      expect(capturedUIState.allowYoloMode).toBe(false);
+      unmount();
+    });
+  });
+
   describe('Compression Queuing', () => {
     beforeEach(async () => {
       const { checkPermissions } = await import(

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2296,6 +2296,8 @@ Logging in with Google... Restarting Gemini CLI to continue.
     streamingState === StreamingState.Idle &&
     !hasPendingActionRequired;
 
+  const allowYoloMode = !config.isYoloModeDisabled();
+
   const showApprovalModeIndicator = useApprovalModeIndicator({
     config,
     addItem: historyManager.addItem,
@@ -2520,6 +2522,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       queueErrorMessage,
       showApprovalModeIndicator,
       allowPlanMode,
+      allowYoloMode,
       currentModel,
       contextFileNames,
       errorCount,
@@ -2633,6 +2636,7 @@ Logging in with Google... Restarting Gemini CLI to continue.
       queueErrorMessage,
       showApprovalModeIndicator,
       allowPlanMode,
+      allowYoloMode,
       contextFileNames,
       errorCount,
       availableTerminalHeight,

--- a/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeIndicator.tsx
@@ -14,36 +14,43 @@ import { Command } from '../key/keyBindings.js';
 interface ApprovalModeIndicatorProps {
   approvalMode: ApprovalMode;
   allowPlanMode?: boolean;
+  allowYoloMode?: boolean;
 }
+
+const AUTO_GLYPH = '⏵⏵';
 
 export const ApprovalModeIndicator: React.FC<ApprovalModeIndicatorProps> = ({
   approvalMode,
-  allowPlanMode,
+  allowPlanMode = false,
+  allowYoloMode = true,
 }) => {
+  const cycleHint = formatCommand(Command.CYCLE_APPROVAL_MODE);
+
   let textColor = '';
   let textContent = '';
   let subText = '';
 
-  const cycleHint = formatCommand(Command.CYCLE_APPROVAL_MODE);
-  const yoloHint = formatCommand(Command.TOGGLE_YOLO);
-
   switch (approvalMode) {
     case ApprovalMode.AUTO_EDIT:
       textColor = theme.status.warning;
-      textContent = 'auto-accept edits';
+      textContent = `${AUTO_GLYPH} accept edits on`;
       subText = allowPlanMode
         ? `${cycleHint} to plan`
-        : `${cycleHint} to manual`;
+        : allowYoloMode
+          ? `${cycleHint} to auto mode`
+          : `${cycleHint} to manual`;
       break;
     case ApprovalMode.PLAN:
       textColor = theme.status.success;
-      textContent = 'plan';
-      subText = `${cycleHint} to manual`;
+      textContent = 'plan mode on';
+      subText = allowYoloMode
+        ? `${cycleHint} to auto mode`
+        : `${cycleHint} to manual`;
       break;
     case ApprovalMode.YOLO:
       textColor = theme.status.error;
-      textContent = 'YOLO';
-      subText = yoloHint;
+      textContent = `${AUTO_GLYPH} auto mode on`;
+      subText = `${cycleHint} to manual`;
       break;
     case ApprovalMode.DEFAULT:
     default:

--- a/packages/cli/src/ui/components/StatusRow.test.tsx
+++ b/packages/cli/src/ui/components/StatusRow.test.tsx
@@ -34,6 +34,7 @@ describe('<StatusRow />', () => {
     contextFileNames: [],
     showApprovalModeIndicator: ApprovalMode.DEFAULT,
     allowPlanMode: false,
+    allowYoloMode: true,
     renderMarkdown: true,
     currentModel: 'gemini-3',
   };

--- a/packages/cli/src/ui/components/StatusRow.tsx
+++ b/packages/cli/src/ui/components/StatusRow.tsx
@@ -399,6 +399,7 @@ export const StatusRow: React.FC<StatusRowProps> = ({
                     <ApprovalModeIndicator
                       approvalMode={uiState.showApprovalModeIndicator}
                       allowPlanMode={uiState.allowPlanMode}
+                      allowYoloMode={uiState.allowYoloMode}
                     />
                   )}
                 {inputState.shellModeActive && (

--- a/packages/cli/src/ui/components/__snapshots__/ApprovalModeIndicator.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/ApprovalModeIndicator.test.tsx.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ApprovalModeIndicator > renders correctly for AUTO_EDIT mode 1`] = `
-"auto-accept edits Shift+Tab to manual
+"⏵⏵ accept edits on Shift+Tab to auto mode
 "
 `;
 
 exports[`ApprovalModeIndicator > renders correctly for AUTO_EDIT mode with plan enabled 1`] = `
-"auto-accept edits Shift+Tab to plan
+"⏵⏵ accept edits on Shift+Tab to plan
 "
 `;
 
@@ -21,11 +21,11 @@ exports[`ApprovalModeIndicator > renders correctly for DEFAULT mode with plan en
 `;
 
 exports[`ApprovalModeIndicator > renders correctly for PLAN mode 1`] = `
-"plan Shift+Tab to manual
+"plan mode on Shift+Tab to auto mode
 "
 `;
 
 exports[`ApprovalModeIndicator > renders correctly for YOLO mode 1`] = `
-"YOLO Ctrl+Y
+"⏵⏵ auto mode on Shift+Tab to manual
 "
 `;

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -161,6 +161,7 @@ export interface UIState {
   queueErrorMessage: string | null;
   showApprovalModeIndicator: ApprovalMode;
   allowPlanMode: boolean;
+  allowYoloMode: boolean;
   currentModel: string;
   contextFileNames: string[];
   errorCount: number;

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.test.ts
@@ -196,6 +196,32 @@ describe('useApprovalModeIndicator', () => {
     );
     expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
 
+    // From AUTO_EDIT, without plan mode, Shift+Tab advances to YOLO
+    // (the Claude Code style linear cycle).
+    act(() => {
+      capturedUseKeypressHandler({
+        name: 'tab',
+        shift: true,
+      } as Key);
+    });
+    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.YOLO,
+    );
+    expect(result.current).toBe(ApprovalMode.YOLO);
+
+    // Shift+Tab from YOLO returns to DEFAULT (linear cycle end)
+    act(() => {
+      capturedUseKeypressHandler({
+        name: 'tab',
+        shift: true,
+      } as Key);
+    });
+    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.DEFAULT,
+    );
+    expect(result.current).toBe(ApprovalMode.DEFAULT);
+
+    // Ctrl+Y still works as a fast toggle to YOLO
     act(() => {
       capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
     });
@@ -204,38 +230,70 @@ describe('useApprovalModeIndicator', () => {
     );
     expect(result.current).toBe(ApprovalMode.YOLO);
 
-    // Shift+Tab cycles back to AUTO_EDIT (from YOLO)
-    act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: true,
-      } as Key);
-    });
-    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.AUTO_EDIT,
-    );
-    expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
-
-    // Ctrl+Y toggles YOLO
+    // Ctrl+Y toggles back to DEFAULT
     act(() => {
       capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
     });
     expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.YOLO,
+      ApprovalMode.DEFAULT,
     );
+    expect(result.current).toBe(ApprovalMode.DEFAULT);
+  });
+
+  it('should follow full linear cycle DEFAULT → AUTO_EDIT → PLAN → YOLO → DEFAULT when plan mode is allowed', async () => {
+    mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
+    const { result } = await renderHook(() =>
+      useApprovalModeIndicator({
+        config: mockConfigInstance as unknown as ActualConfigType,
+        addItem: vi.fn(),
+        allowPlanMode: true,
+      }),
+    );
+
+    const press = () =>
+      act(() => {
+        capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      });
+
+    press();
+    expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
+
+    press();
+    expect(result.current).toBe(ApprovalMode.PLAN);
+
+    press();
     expect(result.current).toBe(ApprovalMode.YOLO);
 
-    // Shift+Tab from YOLO jumps to AUTO_EDIT
-    act(() => {
-      capturedUseKeypressHandler({
-        name: 'tab',
-        shift: true,
-      } as Key);
-    });
-    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
-      ApprovalMode.AUTO_EDIT,
+    press();
+    expect(result.current).toBe(ApprovalMode.DEFAULT);
+  });
+
+  it('should skip YOLO in the cycle when YOLO is disabled by settings', async () => {
+    mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
+    mockConfigInstance.isYoloModeDisabled.mockReturnValue(true);
+
+    const { result } = await renderHook(() =>
+      useApprovalModeIndicator({
+        config: mockConfigInstance as unknown as ActualConfigType,
+        addItem: vi.fn(),
+        allowPlanMode: true,
+      }),
     );
+
+    const press = () =>
+      act(() => {
+        capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+      });
+
+    press();
     expect(result.current).toBe(ApprovalMode.AUTO_EDIT);
+
+    press();
+    expect(result.current).toBe(ApprovalMode.PLAN);
+
+    // PLAN should skip YOLO and go straight back to DEFAULT
+    press();
+    expect(result.current).toBe(ApprovalMode.DEFAULT);
   });
 
   it('should not toggle if only one key or other keys combinations are pressed', async () => {
@@ -324,15 +382,13 @@ describe('useApprovalModeIndicator', () => {
   describe('in untrusted folders', () => {
     beforeEach(() => {
       mockConfigInstance.isTrustedFolder.mockReturnValue(false);
+      // Match the real Config.isYoloModeDisabled() behavior: untrusted folders
+      // implicitly disable YOLO, so the cycle skips it.
+      mockConfigInstance.isYoloModeDisabled.mockReturnValue(true);
     });
 
     it('should not enable YOLO mode when Ctrl+Y is pressed', async () => {
       mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
-      mockConfigInstance.setApprovalMode.mockImplementation(() => {
-        throw new Error(
-          'Cannot enable privileged approval modes in an untrusted folder.',
-        );
-      });
       const mockAddItem = vi.fn();
       const { result } = await renderHook(() =>
         useApprovalModeIndicator({
@@ -347,12 +403,11 @@ describe('useApprovalModeIndicator', () => {
         capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
       });
 
-      // We expect setApprovalMode to be called, and the error to be caught.
-      expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
-        ApprovalMode.YOLO,
-      );
+      // Ctrl+Y short-circuits when YOLO is disabled (untrusted folder is one
+      // such case): setApprovalMode is never called, but the user gets a
+      // warning message explaining why.
+      expect(mockConfigInstance.setApprovalMode).not.toHaveBeenCalled();
       expect(mockAddItem).toHaveBeenCalled();
-      // Verify the underlying config value was not changed
       expect(mockConfigInstance.getApprovalMode()).toBe(ApprovalMode.DEFAULT);
     });
 
@@ -435,7 +490,7 @@ describe('useApprovalModeIndicator', () => {
     });
 
     it('should show a warning when trying to enable privileged modes', async () => {
-      // Mock the error thrown by setApprovalMode
+      // Mock the error thrown by setApprovalMode (Shift+Tab path).
       const errorMessage =
         'Cannot enable privileged approval modes in an untrusted folder.';
       mockConfigInstance.setApprovalMode.mockImplementation(() => {
@@ -450,20 +505,20 @@ describe('useApprovalModeIndicator', () => {
         }),
       );
 
-      // Try to enable YOLO mode
+      // Ctrl+Y short-circuits to a WARNING message (YOLO is disabled).
       act(() => {
         capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
       });
 
       expect(mockAddItem).toHaveBeenCalledWith(
         {
-          type: MessageType.INFO,
-          text: errorMessage,
+          type: MessageType.WARNING,
+          text: expect.stringMatching(/Full Access mode/),
         },
         expect.any(Number),
       );
 
-      // Try to enable AUTO_EDIT mode
+      // Shift+Tab still triggers the setApprovalMode error path → INFO message.
       act(() => {
         capturedUseKeypressHandler({
           name: 'tab',
@@ -491,7 +546,7 @@ describe('useApprovalModeIndicator', () => {
       }
     });
 
-    it('should not enable YOLO mode when Ctrl+Y is pressed and add an info message', async () => {
+    it('should not enable Full Access mode when Ctrl+Y is pressed and add an info message', async () => {
       mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
       mockConfigInstance.getRemoteAdminSettings.mockReturnValue({
         strictModeDisabled: true,
@@ -516,7 +571,7 @@ describe('useApprovalModeIndicator', () => {
       expect(mockAddItem).toHaveBeenCalledWith(
         {
           type: MessageType.WARNING,
-          text: 'You cannot enter YOLO mode since it is disabled in your settings.',
+          text: 'You cannot enter Full Access mode since it is disabled in your settings.',
         },
         expect.any(Number),
       );
@@ -524,7 +579,7 @@ describe('useApprovalModeIndicator', () => {
       expect(result.current).toBe(ApprovalMode.DEFAULT);
     });
 
-    it('should show admin error message when YOLO mode is disabled by admin', async () => {
+    it('should show admin error message when Full Access mode is disabled by admin', async () => {
       mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.DEFAULT);
       mockConfigInstance.getRemoteAdminSettings.mockReturnValue({
         mcpEnabled: true,
@@ -545,7 +600,7 @@ describe('useApprovalModeIndicator', () => {
       expect(mockAddItem).toHaveBeenCalledWith(
         {
           type: MessageType.WARNING,
-          text: '[Mock] YOLO mode is disabled',
+          text: '[Mock] Full Access mode is disabled',
         },
         expect.any(Number),
       );
@@ -570,7 +625,7 @@ describe('useApprovalModeIndicator', () => {
       expect(mockAddItem).toHaveBeenCalledWith(
         {
           type: MessageType.WARNING,
-          text: 'You cannot enter YOLO mode since it is disabled in your settings.',
+          text: 'You cannot enter Full Access mode since it is disabled in your settings.',
         },
         expect.any(Number),
       );
@@ -681,7 +736,7 @@ describe('useApprovalModeIndicator', () => {
       capturedUseKeypressHandler({ name: 'y', ctrl: true } as Key);
     });
 
-    // Switch to AUTO_EDIT
+    // Linear cycle: YOLO -> DEFAULT
     act(() => {
       capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
     });
@@ -693,7 +748,7 @@ describe('useApprovalModeIndicator', () => {
     );
     expect(mockOnApprovalModeChange).toHaveBeenNthCalledWith(
       2,
-      ApprovalMode.AUTO_EDIT,
+      ApprovalMode.DEFAULT,
     );
   });
 
@@ -717,7 +772,7 @@ describe('useApprovalModeIndicator', () => {
     );
   });
 
-  it('should cycle to DEFAULT when allowPlanMode is false', async () => {
+  it('should cycle from AUTO_EDIT to YOLO when allowPlanMode is false and YOLO is allowed', async () => {
     mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.AUTO_EDIT);
 
     await renderHook(() =>
@@ -728,7 +783,27 @@ describe('useApprovalModeIndicator', () => {
       }),
     );
 
-    // AUTO_EDIT -> DEFAULT
+    // AUTO_EDIT -> YOLO (plan is skipped, YOLO is the next in the linear cycle)
+    act(() => {
+      capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
+    });
+    expect(mockConfigInstance.setApprovalMode).toHaveBeenCalledWith(
+      ApprovalMode.YOLO,
+    );
+  });
+
+  it('should cycle from AUTO_EDIT directly to DEFAULT when both PLAN and YOLO are disabled', async () => {
+    mockConfigInstance.getApprovalMode.mockReturnValue(ApprovalMode.AUTO_EDIT);
+    mockConfigInstance.isYoloModeDisabled.mockReturnValue(true);
+
+    await renderHook(() =>
+      useApprovalModeIndicator({
+        config: mockConfigInstance as unknown as ActualConfigType,
+        addItem: vi.fn(),
+        allowPlanMode: false,
+      }),
+    );
+
     act(() => {
       capturedUseKeypressHandler({ name: 'tab', shift: true } as Key);
     });

--- a/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
+++ b/packages/cli/src/ui/hooks/useApprovalModeIndicator.ts
@@ -49,12 +49,12 @@ export function useApprovalModeIndicator({
         ) {
           if (addItem) {
             let text =
-              'You cannot enter YOLO mode since it is disabled in your settings.';
+              'You cannot enter Full Access mode since it is disabled in your settings.';
             const adminSettings = config.getRemoteAdminSettings();
             const hasSettings =
               adminSettings && Object.keys(adminSettings).length > 0;
             if (hasSettings && !adminSettings.strictModeDisabled) {
-              text = getAdminErrorMessage('YOLO mode', config);
+              text = getAdminErrorMessage('Full Access mode', config);
             }
 
             addItem(
@@ -72,7 +72,12 @@ export function useApprovalModeIndicator({
             ? ApprovalMode.DEFAULT
             : ApprovalMode.YOLO;
       } else if (keyMatchers[Command.CYCLE_APPROVAL_MODE](key)) {
+        // Linear cycle (Claude Code style):
+        //   DEFAULT → AUTO_EDIT → PLAN? → YOLO? → DEFAULT
+        // PLAN is skipped if !allowPlanMode; YOLO is skipped when it is
+        // disabled by admin/security settings or by untrusted folder.
         const currentMode = config.getApprovalMode();
+        const yoloAvailable = !config.isYoloModeDisabled();
         switch (currentMode) {
           case ApprovalMode.DEFAULT:
             nextApprovalMode = ApprovalMode.AUTO_EDIT;
@@ -80,13 +85,17 @@ export function useApprovalModeIndicator({
           case ApprovalMode.AUTO_EDIT:
             nextApprovalMode = allowPlanMode
               ? ApprovalMode.PLAN
-              : ApprovalMode.DEFAULT;
+              : yoloAvailable
+                ? ApprovalMode.YOLO
+                : ApprovalMode.DEFAULT;
             break;
           case ApprovalMode.PLAN:
-            nextApprovalMode = ApprovalMode.DEFAULT;
+            nextApprovalMode = yoloAvailable
+              ? ApprovalMode.YOLO
+              : ApprovalMode.DEFAULT;
             break;
           case ApprovalMode.YOLO:
-            nextApprovalMode = ApprovalMode.AUTO_EDIT;
+            nextApprovalMode = ApprovalMode.DEFAULT;
             break;
           default:
         }


### PR DESCRIPTION
## Summary

Adds **Full Access** (the existing `--yolo`/`ApprovalMode.YOLO` mode) to the in-session `Shift+Tab` cycle and renders a clear `⏵⏵ auto mode on` indicator. Closes the UX gap where Full Access is reachable only via CLI flag or `Ctrl+Y`, with no visible cue in the footer that it exists.

## Details

- **`Shift+Tab` cycle** is now linear and includes Full Access: `DEFAULT → AUTO_EDIT → PLAN? → YOLO? → DEFAULT`.
  - `PLAN` is skipped when `!allowPlanMode`.
  - `YOLO` is skipped when `config.isYoloModeDisabled()` (i.e. `security.disableYoloMode`, `admin.secureModeEnabled`, or untrusted folder).
  - `Ctrl+Y` still works as the direct manual ↔ auto toggle.
- **Indicator labels** match Claude Code's visual language (extracted from the public `claude` binary v2.1.143):
  - `⏵⏵ accept edits on` (was `auto-accept edits`, warning color)
  - `plan mode on` (was `plan`, success color)
  - `⏵⏵ auto mode on` (was `YOLO`, error color)
  - Subtext shows the next destination: `Shift+Tab to plan` / `Shift+Tab to auto mode` / `Shift+Tab to manual`.
- **`allowYoloMode` prop** added to `UIState` and plumbed through `AppContainer` → `StatusRow` → `ApprovalModeIndicator`, mirroring how `allowPlanMode` is already wired.
- Existing guards (`disableYoloMode`, `secureModeEnabled`, untrusted folders) all remain authoritative — the cycle just respects them.

## Scope

UX/UI only. No changes to:

- Settings schema or `settings.json` parsing (a follow-up PR will let users persist `defaultApprovalMode: "full_access"` once the alias work in #27026 lands).
- Policy engine.
- Shell execution.
- The `ApprovalMode` enum, `--yolo` flag, or any existing CLI path.

## Related Issues

Closes #27035

Related to (platform-specific variants of the broken Shift+Tab cycle):
- #20929 — Windows: Shift+Tab does not cycle approval mode in PowerShell / Command Prompt
- #22738 — [Windows/WezTerm] Shift+Tab and fallback F10 fail to cycle approval mode

## How to Validate

1. `gemini` → footer shows `Shift+Tab to accept edits` (unchanged default).
2. Press `Shift+Tab` once: footer shows `⏵⏵ accept edits on   Shift+Tab to plan` (or `to auto mode` if plan is disabled).
3. Continue pressing `Shift+Tab` and watch it cycle through `plan mode on` → `⏵⏵ auto mode on` → default.
4. From any state, `Ctrl+Y` toggles directly to/from `⏵⏵ auto mode on`.
5. With `~/.gemini/settings.json` containing `{ "security": { "disableYoloMode": true } }`, `Shift+Tab` skips YOLO in the cycle (cycle: `default → ⏵⏵ accept edits on → plan mode on → default`).

## Pre-Merge Checklist

- [x] Tests added/updated (`useApprovalModeIndicator.test.ts`, `ApprovalModeIndicator.test.tsx` + regenerated snapshot, `StatusRow.test.tsx`, `AppContainer.test.tsx`)
- [x] No breaking changes — `ApprovalMode.YOLO`, `--yolo`, `Ctrl+Y`, and the `auto_edit`/`plan` cycle entries all behave the same way externally
- [x] Validated on Linux (Ubuntu 24.04, Node 24.15.0)

