### PR TITLE
fix(scripts): scrub CI env vars in dev to keep interactive mode

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -70,7 +70,9 @@ const keepCiEnv =
   process.env.GEMINI_KEEP_CI_ENV === '1' ||
   process.env.GEMINI_KEEP_CI_ENV === 'true';
 if (!keepCiEnv) {
-  const ciKeys = ['CI', 'CONTINUOUS_INTEGRATION'].filter((k) => k in env);
+  const ciKeys = ['CI', 'CONTINUOUS_INTEGRATION', 'GITHUB_ACTIONS'].filter(
+    (k) => k in env,
+  );
   if (ciKeys.length > 0) {
     ciKeys.forEach((k) => delete env[k]);
     process.stderr.write(

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -66,6 +66,19 @@ const env = {
   DEV: 'true',
 };
 
+const keepCiEnv =
+  process.env.GEMINI_KEEP_CI_ENV === '1' ||
+  process.env.GEMINI_KEEP_CI_ENV === 'true';
+if (!keepCiEnv) {
+  const ciKeys = ['CI', 'CONTINUOUS_INTEGRATION'].filter((k) => k in env);
+  if (ciKeys.length > 0) {
+    ciKeys.forEach((k) => delete env[k]);
+    process.stderr.write(
+      `[gemini] Removed CI env vars to keep interactive mode working in dev: ${ciKeys.join(', ')}. Set GEMINI_KEEP_CI_ENV=1 to disable.\n`,
+    );
+  }
+}
+
 if (isInDebugMode) {
   // If this is not set, the debugger will pause on the outer process rather
   // than the relaunched process making it harder to debug.


### PR DESCRIPTION
## Summary
- `npm run start` was inheriting `CI` / `CONTINUOUS_INTEGRATION` from the parent shell, which forced the CLI into non-interactive mode during local development.
- `scripts/start.js` now deletes those keys from the spawned child env and prints a one-line stderr notice so the behavior is discoverable.
- Set `GEMINI_KEEP_CI_ENV=1` (or `true`) to opt out and keep the original behavior.

Fixes #22452

## Test plan
- [x] `CI=1 npm run start` — interactive mode works, notice printed to stderr.
- [x] `GEMINI_KEEP_CI_ENV=1 CI=1 npm run start` — CI behavior preserved, no notice.
- [x] Pre-commit lint/prettier hooks pass.

## Notes
- Scoped intentionally to `CI` and `CONTINUOUS_INTEGRATION` (the keys the rest of the codebase checks). Happy to extend to `GITHUB_ACTIONS`, `BUILDKITE`, etc. if reviewers prefer.