### PR TITLE
fix(cli): prevent ghost text wrapping stall

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -5334,6 +5334,35 @@ describe('InputPrompt', () => {
   });
 
   describe('terminal buffer rendering', () => {
+    it('continues rendering ghost text when inputWidth is narrower than the next code point', async () => {
+      props.inputWidth = 1;
+      props.suggestionsWidth = 1;
+      mockBuffer.text = 'a';
+      mockBuffer.lines = ['a'];
+      mockBuffer.allVisualLines = ['a'];
+      mockBuffer.viewportVisualLines = ['a'];
+      mockBuffer.cursor = [0, 1];
+      mockBuffer.visualCursor = [0, 1];
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        promptCompletion: {
+          ...mockCommandCompletion.promptCompletion,
+          text: 'a🙂b',
+          isActive: true,
+        },
+      });
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} />,
+        { uiActions },
+      );
+
+      await waitFor(() => {
+        expect(clean(lastFrame())).toContain('🙂');
+      });
+      unmount();
+    });
+
     it('does not clip the last char of a visual line whose width equals inputWidth', async () => {
       const fullLine = '1234567890'; // 10 chars, exactly props.inputWidth
       props.inputWidth = 10;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1503,6 +1503,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 partWidth += charWidth;
                 splitIndex = i + 1;
               }
+              if (splitIndex === 0) {
+                part = wordCP[0] ?? '';
+                splitIndex = 1;
+              }
               additionalLines.push(part);
               wordToProcess = cpSlice(wordToProcess, splitIndex);
             }


### PR DESCRIPTION
Fixes #19985

## Root cause

`InputPrompt` wraps ghost completion text by repeatedly splitting long words to fit `inputWidth`. If the next code point is wider than `inputWidth`, the split loop leaves `splitIndex` at `0`, appends an empty line, and slices the word from the same offset again. That can stall rendering indefinitely in narrow terminal states or with wide characters.

## Change

When no code point fits in the current width, consume one code point anyway before continuing. This preserves forward progress and keeps the wrapping behavior localized to ghost text rendering.

Added a regression test that renders ghost text with `inputWidth = 1` and a wide emoji code point.

## Validation

- `npm install`
- `npm run build --workspace @google/gemini-cli-core`
- `git diff --check`
- `npx vitest run packages/cli/src/ui/components/InputPrompt.test.tsx -t "continues rendering ghost text"`

Note: I also ran the full `InputPrompt.test.tsx` file. It reached the new regression test and that test passed, but the full file failed on existing snapshot/timing/environment-sensitive tests unrelated to this patch.