### PR TITLE
fix(core): prevent dropping valid model turns with empty text parts

### DIFF
--- a/packages/core/src/core/geminiChat.edge.test.ts
+++ b/packages/core/src/core/geminiChat.edge.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { GeminiChat } from './geminiChat.js';
+import type { Config } from '../config/config.js';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
+
+describe('GeminiChat Edge Case', () => {
+  it('should not drop model turns with empty text and functionCall when getHistory(true) is called', () => {
+    const mockConfig = {
+      isContextManagementEnabled: () => false,
+      getProjectRoot: () => '/fake/root',
+      getSessionId: () => 'fake-session',
+      getContextManagementConfig: () => ({ enabled: false }),
+    } as unknown as Config;
+
+    const mockContext = {
+      config: mockConfig,
+      promptId: 'fake-prompt-id',
+      messageBus: {
+        emit: () => {},
+      },
+    } as unknown as AgentLoopContext;
+
+    const chat = new GeminiChat(mockContext);
+    chat['chatRecordingService'].updateMessagesFromHistory = () => {};
+
+    chat.setHistory([
+      { role: 'user', parts: [{ text: 'Do something' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: '' }, // empty text!
+          { functionCall: { name: 'myTool', args: {} } },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: { name: 'myTool', response: { result: 'done' } },
+          },
+        ],
+      },
+    ]);
+
+    const curatedHistory = chat.getHistory(true);
+
+    // The model turn should NOT be dropped now!
+    expect(curatedHistory.length).toBe(3);
+    expect(curatedHistory[0].role).toBe('user');
+    expect(curatedHistory[1].role).toBe('model');
+    expect(curatedHistory[2].role).toBe('user');
+  });
+});

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -142,15 +142,35 @@ function isValidContent(content: Content): boolean {
   if (content.parts === undefined || content.parts.length === 0) {
     return false;
   }
+
+  // A content turn is valid if it contains at least one meaningful part.
+  // Empty text parts (e.g. { text: "" }) are ignored but do not invalidate the entire turn
+  // if other valid parts (like functionCall) are present.
+  let hasValidData = false;
+
   for (const part of content.parts) {
+    // Skip empty part objects rather than invalidating the entire turn.
+    // A single empty {} among otherwise valid parts should not cause the
+    // whole model turn to be dropped, which would create orphaned function responses.
     if (part === undefined || Object.keys(part).length === 0) {
-      return false;
+      continue;
     }
-    if (!part.thought && part.text !== undefined && part.text === '') {
-      return false;
+
+    if (
+      (part.text !== undefined && part.text !== '') ||
+      part.functionCall ||
+      part.functionResponse ||
+      part.thought ||
+      part.inlineData ||
+      part.fileData ||
+      part.executableCode ||
+      part.codeExecutionResult
+    ) {
+      hasValidData = true;
     }
   }
-  return true;
+
+  return hasValidData;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes an API 400 error ("function call turn comes immediately after a user turn") caused by overly aggressive content filtering. When a model returns a `functionCall` alongside an empty `{ text: "" }` part, the CLI incorrectly drops the entire model turn from the curated history. This orphans the subsequent `functionResponse`, violating the Gemini API's strict alternating turn rules.

## Details

- **Fixed `isValidContent` in `geminiChat.ts`:** Empty objects or `{ text: "" }` artifacts no longer immediately invalidate the turn if other meaningful data (like a `functionCall`, `functionResponse`, or `thought`) is present.
- **Added tradeoff documentation:** Clarified the intent behind skipping empty part objects rather than dropping the whole turn.
- **Regression Test:** Added `geminiChat.edge.test.ts` to guarantee that model turns containing both empty text and a `functionCall` are preserved in the curated history when `getHistory(true)` is called.

## Related Issues

Closes #26956

## How to Validate

1. Run the new regression test: `npm test -w @google/gemini-cli-core -- src/core/geminiChat.edge.test.ts` to ensure the edge case is successfully handled.
2. Run the full validation suite: `npm run test` across the monorepo to verify no existing history management tests are broken.
3. (Optional) Engage in a multi-turn chat using tools with a model version prone to returning empty text parts alongside function calls. Verify that no 400 sequence errors occur.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker