### PR TITLE
fix(core): exclude .gemini/tmp/ from agent search tools by default to prevent recursive session log growth

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1237,11 +1237,23 @@ const SETTINGS_SCHEMA = {
     type: 'object',
     label: 'Agents',
     category: 'Advanced',
-    requiresRestart: true,
+    requiresRestart: false,
     default: {},
-    description: 'Settings for subagents.',
+    description: 'Agent behavior settings.',
     showInDialog: false,
     properties: {
+      // Governs whether search tools (grep, glob) are permitted to recurse into internal
+      // session storage, which is blocked by default to prevent self-scraping feedback loops.
+      searchSessionDirs: {
+        type: 'boolean',
+        label: 'Search Session Directories',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Whether to allow agent search tools (grep, glob) to scan internal CLI session directories like .gemini/tmp/.',
+        showInDialog: true,
+      },
       overrides: {
         type: 'object',
         label: 'Agent Overrides',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -294,6 +294,7 @@ export interface AgentOverride {
 export interface AgentSettings {
   overrides?: Record<string, AgentOverride>;
   browser?: BrowserAgentCustomConfig;
+  searchSessionDirs?: boolean;
 }
 
 export interface CustomTheme {

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -162,6 +162,21 @@ class GlobToolInvocation extends BaseToolInvocation<
         searchDirectories = workspaceDirectories;
       }
 
+      // Intercept attempts to glob internal session directories.
+      // Recursive loops (finding own output in .jsonl files) cause exponential growth.
+      if (
+        !this.config.getAgentsSettings()?.searchSessionDirs &&
+        ((this.params.dir_path &&
+          this.params.dir_path.includes('.gemini/tmp')) ||
+          this.params.pattern.includes('.gemini/tmp'))
+      ) {
+        return {
+          llmContent:
+            "Access to .gemini/tmp/ is disabled by default to prevent recursive search loops. To search internal session directories, enable 'agents.searchSessionDirs' in settings.",
+          returnDisplay: 'Access to session directories disabled.',
+        };
+      }
+
       // Get centralized file discovery service
       const fileDiscovery = this.config.getFileService();
 

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -197,6 +197,20 @@ class GrepToolInvocation extends BaseToolInvocation<
         }
       }
 
+      // Check if the agent is attempting to search internal session directories.
+      // This is blocked by default to prevent recursive feedback loops (reading own logs).
+      if (
+        !this.config.getAgentsSettings()?.searchSessionDirs &&
+        ((searchDirAbs && searchDirAbs.includes('.gemini/tmp')) ||
+          this.params.pattern.includes('.gemini/tmp'))
+      ) {
+        return {
+          llmContent:
+            "Access to .gemini/tmp/ is disabled by default to prevent recursive search loops. To search internal session directories, enable 'agents.searchSessionDirs' in settings.",
+          returnDisplay: 'Access to session directories disabled.',
+        };
+      }
+
       const searchDirDisplay = pathParam || '.';
 
       // Determine which directories to search
@@ -434,7 +448,13 @@ class GrepToolInvocation extends BaseToolInvocation<
         if (max_matches_per_file) {
           gitArgs.push('--max-count', max_matches_per_file.toString());
         }
-        if (include_pattern) {
+
+        if (!this.config.getAgentsSettings()?.searchSessionDirs) {
+          gitArgs.push('--', ':(exclude)**/.gemini/tmp/**');
+          if (include_pattern) {
+            gitArgs.push(include_pattern);
+          }
+        } else if (include_pattern) {
           gitArgs.push('--', include_pattern);
         }
 

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -225,6 +225,19 @@ class GrepToolInvocation extends BaseToolInvocation<
 
       const searchDirDisplay = pathParam;
 
+      // Protection against recursive search loops where the agent reads its own session state.
+      if (
+        !this.config.getAgentsSettings()?.searchSessionDirs &&
+        ((searchDirAbs && searchDirAbs.includes('.gemini/tmp')) ||
+          this.params.pattern.includes('.gemini/tmp'))
+      ) {
+        return {
+          llmContent:
+            "Access to .gemini/tmp/ is disabled by default to prevent recursive search loops. To search internal session directories, enable 'agents.searchSessionDirs' in settings.",
+          returnDisplay: 'Access to session directories disabled.',
+        };
+      }
+
       const totalMaxMatches =
         this.params.total_max_matches ?? DEFAULT_TOTAL_MAX_MATCHES;
       if (this.config.getDebugMode()) {

--- a/packages/core/src/utils/ignorePatterns.test.ts
+++ b/packages/core/src/utils/ignorePatterns.test.ts
@@ -149,6 +149,7 @@ describe('FileExclusions', () => {
     it('should use config custom excludes when available', () => {
       const mockConfig = {
         getCustomExcludes: vi.fn(() => ['**/config-exclude/**']),
+        getAgentsSettings: vi.fn(() => ({})),
       } as unknown as Config;
 
       const excluder = new FileExclusions(mockConfig);
@@ -159,7 +160,9 @@ describe('FileExclusions', () => {
     });
 
     it('should handle config without getCustomExcludes method', () => {
-      const mockConfig = {} as Config;
+      const mockConfig = {
+        getAgentsSettings: vi.fn(() => ({})),
+      } as unknown as Config;
 
       const excluder = new FileExclusions(mockConfig);
       const patterns = excluder.getDefaultExcludePatterns();
@@ -172,6 +175,7 @@ describe('FileExclusions', () => {
     it('should include config custom excludes in glob patterns', () => {
       const mockConfig = {
         getCustomExcludes: vi.fn(() => ['**/config-glob/**']),
+        getAgentsSettings: vi.fn(() => ({})),
       } as unknown as Config;
 
       const excluder = new FileExclusions(mockConfig);
@@ -180,6 +184,31 @@ describe('FileExclusions', () => {
       expect(patterns).toContain('**/node_modules/**');
       expect(patterns).toContain('**/.git/**');
       expect(patterns).toContain('**/config-glob/**');
+    });
+
+    it('should respect agents.searchSessionDirs setting', () => {
+      const mockConfigDisabled = {
+        getAgentsSettings: vi.fn(() => ({ searchSessionDirs: false })),
+      } as unknown as Config;
+      const mockConfigEnabled = {
+        getAgentsSettings: vi.fn(() => ({ searchSessionDirs: true })),
+      } as unknown as Config;
+
+      const excluderDisabled = new FileExclusions(mockConfigDisabled);
+      expect(excluderDisabled.getCoreIgnorePatterns()).toContain(
+        '**/.gemini/tmp/**',
+      );
+      expect(excluderDisabled.getDefaultExcludePatterns()).toContain(
+        '**/.gemini/tmp/**',
+      );
+
+      const excluderEnabled = new FileExclusions(mockConfigEnabled);
+      expect(excluderEnabled.getCoreIgnorePatterns()).not.toContain(
+        '**/.gemini/tmp/**',
+      );
+      expect(excluderEnabled.getDefaultExcludePatterns()).not.toContain(
+        '**/.gemini/tmp/**',
+      );
     });
   });
 

--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -138,7 +138,13 @@ export class FileExclusions {
    * These are the minimal essential patterns that should almost always be excluded.
    */
   getCoreIgnorePatterns(): string[] {
-    return [...COMMON_IGNORE_PATTERNS];
+    const patterns = [...COMMON_IGNORE_PATTERNS];
+    // Prevent the agent from recursively searching its own session/temp files,
+    // which can lead to exponential log growth and memory spikes.
+    if (this.config && !this.config.getAgentsSettings()?.searchSessionDirs) {
+      patterns.push('**/.gemini/tmp/**');
+    }
+    return patterns;
   }
 
   /**
@@ -163,6 +169,11 @@ export class FileExclusions {
     // Add dynamic patterns (like current Gemini MD filename)
     if (includeDynamicPatterns) {
       patterns.push(`**/${getCurrentGeminiMdFilename()}`);
+    }
+
+    // Standard protection against recursive search loops by excluding internal session state.
+    if (this.config && !this.config.getAgentsSettings()?.searchSessionDirs) {
+      patterns.push('**/.gemini/tmp/**');
     }
 
     // Add custom patterns from configuration


### PR DESCRIPTION
## Summary

Agent search tools (`grep_search`, `glob`, `ripgrep`) had no default exclusion for `.gemini/tmp/`, allowing the agent to recursively scan its own active session `.jsonl` files. This is most likely to occur when the agent operates from or near the user's home directory, where `.gemini/tmp/` is a direct subdirectory. Each tool call that finds and includes session output compounds the previous one, causing exponential log growth, memory spikes, token quota exhaustion, and in the worst case, complete disk fill with no warning to the user.

## Details

Three layers of protection added:

1. **Explicit path intercept** — if the agent directly targets `.gemini/tmp/` in `grep`, `glob`, or `ripgrep`, an early return informs the LLM that access is blocked and explains how to enable it via `agents.searchSessionDirs`.

2. **Passive exclusion** — `.gemini/tmp/**` added to `FileExclusions.getCoreIgnorePatterns()` and `getDefaultExcludePatterns()`, and `:(exclude)**/.gemini/tmp/**` injected into git grep args. This silently prevents incidental hits during broad searches.

3. **User opt-out** — `agents.searchSessionDirs` boolean added to settings schema and `AgentSettings` interface. Defaults to `false`. Users who explicitly need to search session state can enable it via Settings > Search Session Directories.

## Related Issues

Fixes #27164
Related to #26836 (may be a contributing factor)
Related to #26751 (may be a contributing factor)
Related to #26842 (may be a contributing factor)

## How to Validate

1. Start a session and use `grep_search` or `glob` targeting `.gemini/tmp/` — should return the disabled message
2. Enable `agents.searchSessionDirs: true` in settings and repeat — should search normally
3. Run a broad search from the project root — confirm `.gemini/tmp/` is silently excluded from results by default
4. Run `npm test --workspace=packages/core -- ignorePatterns` — all tests pass

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (ignorePatterns.test.ts updated with searchSessionDirs toggle coverage)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker