### PR TITLE
Fix /tasks/metadata double response — fixes #21729

### DIFF
--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -322,7 +322,7 @@ export async function createApp() {
     expressApp.get('/tasks/metadata', async (req, res) => {
       // This endpoint is only meaningful if the task store is in-memory.
       if (!(taskStoreForExecutor instanceof InMemoryTaskStore)) {
-        res.status(501).send({
+        return res.status(501).send({
           error:
             'Listing all task metadata is only supported when using InMemoryTaskStore.',
         });


### PR DESCRIPTION
Return after sending 501 in /tasks/metadata to prevent ERR_HTTP_HEADERS_SENT when task store is not InMemoryTaskStore.

Fixes #21729.