### PR TITLE
fix(cli)#25369: correct Thai and Lao SARA AM display width

### DIFF
--- a/packages/cli/src/interactiveCli.tsx
+++ b/packages/cli/src/interactiveCli.tsx
@@ -50,8 +50,11 @@ import { TerminalProvider } from './ui/contexts/TerminalContext.js';
 import { OverflowProvider } from './ui/contexts/OverflowContext.js';
 import { profiler } from './ui/components/DebugProfiler.js';
 import { initializeConsoleStore } from './ui/hooks/useConsoleMessages.js';
+import { configureInkStringWidth } from './ui/utils/configureInkStringWidth.js';
 
 const SLOW_RENDER_MS = 200;
+
+configureInkStringWidth();
 
 export async function startInteractiveUI(
   config: Config,

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -52,8 +52,11 @@ import { themeManager, DEFAULT_THEME } from '../ui/themes/theme-manager.js';
 import { DefaultLight } from '../ui/themes/builtin/light/default-light.js';
 import { pickDefaultThemeName } from '../ui/themes/theme.js';
 import { generateSvgForTerminal } from './svg.js';
+import { configureInkStringWidth } from '../ui/utils/configureInkStringWidth.js';
 
 export const persistentStateMock = new FakePersistentState();
+
+configureInkStringWidth();
 
 if (process.env['NODE_ENV'] === 'test') {
   // We mock NODE_ENV to development during tests that use render.tsx

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -40,7 +40,7 @@ import {
   cpIndexToOffset,
 } from '../utils/textUtils.js';
 import chalk from 'chalk';
-import stringWidth from 'string-width';
+import { getTerminalStringWidth as stringWidth } from '../utils/terminalStringWidth.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -38,9 +38,9 @@ import {
   cpLen,
   toCodePoints,
   cpIndexToOffset,
+  getCachedStringWidth as stringWidth,
 } from '../utils/textUtils.js';
 import chalk from 'chalk';
-import { getTerminalStringWidth as stringWidth } from '../utils/terminalStringWidth.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import {

--- a/packages/cli/src/ui/utils/configureInkStringWidth.ts
+++ b/packages/cli/src/ui/utils/configureInkStringWidth.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { setStringWidthFunction } from 'ink';
+import { getTerminalStringWidth } from './terminalStringWidth.js';
+
+let inkStringWidthConfigured = false;
+
+export function configureInkStringWidth(): void {
+  if (inkStringWidthConfigured) {
+    return;
+  }
+
+  setStringWidthFunction(getTerminalStringWidth);
+  inkStringWidthConfigured = true;
+}

--- a/packages/cli/src/ui/utils/terminalStringWidth.test.ts
+++ b/packages/cli/src/ui/utils/terminalStringWidth.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  clearStringWidthCache,
+  styledCharsWidth,
+  toStyledCharacters,
+} from 'ink';
+import { describe, expect, it } from 'vitest';
+import { configureInkStringWidth } from './configureInkStringWidth.js';
+import { getTerminalStringWidth } from './terminalStringWidth.js';
+
+describe('getTerminalStringWidth', () => {
+  it.each([
+    ['กำ', 2],
+    ['ทำ', 2],
+    ['แนะนำ', 5],
+    ['ນຳ', 2],
+    ['ำ', 1],
+    ['👩🏽‍💻', 2],
+    ['क्ष', 1],
+  ])('measures %s as %d columns', (input, expectedWidth) => {
+    expect(getTerminalStringWidth(input)).toBe(expectedWidth);
+  });
+});
+
+describe('configureInkStringWidth', () => {
+  it('keeps Ink aligned with terminal width for Thai and Lao SARA AM', () => {
+    configureInkStringWidth();
+    clearStringWidthCache();
+
+    expect(styledCharsWidth(toStyledCharacters('กำ'))).toBe(2);
+    expect(styledCharsWidth(toStyledCharacters('ນຳ'))).toBe(2);
+    expect(styledCharsWidth(toStyledCharacters('👩🏽‍💻'))).toBe(2);
+  });
+});

--- a/packages/cli/src/ui/utils/terminalStringWidth.ts
+++ b/packages/cli/src/ui/utils/terminalStringWidth.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import stringWidth from 'string-width';
+
+const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+const nonPrintingCodePointRegex =
+  /[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]/u;
+
+const thaiOrLaoSaraAmRegex = /[\u0E33\u0EB3]/u;
+
+const THAI_SARA_AM = 0x0e33;
+const LAO_SARA_AM = 0x0eb3;
+
+function isThaiOrLaoSaraAm(codePoint: number | undefined): boolean {
+  return codePoint === THAI_SARA_AM || codePoint === LAO_SARA_AM;
+}
+
+function countSaraAmCodePoints(segment: string): number {
+  let count = 0;
+
+  for (const char of segment) {
+    if (isThaiOrLaoSaraAm(char.codePointAt(0))) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+function getFirstVisibleCodePoint(segment: string): number | undefined {
+  for (const char of segment) {
+    if (!nonPrintingCodePointRegex.test(char)) {
+      return char.codePointAt(0);
+    }
+  }
+
+  return undefined;
+}
+
+function getSaraAmWidthAdjustment(input: string): number {
+  if (!thaiOrLaoSaraAmRegex.test(input)) {
+    return 0;
+  }
+
+  let adjustment = 0;
+
+  for (const { segment } of segmenter.segment(input)) {
+    if (!thaiOrLaoSaraAmRegex.test(segment)) {
+      continue;
+    }
+
+    // string-width treats Thai/Lao SARA AM as zero-width when it is merged
+    // into a grapheme cluster, but terminals still allocate a full cell for it.
+    if (isThaiOrLaoSaraAm(getFirstVisibleCodePoint(segment))) {
+      continue;
+    }
+
+    adjustment += countSaraAmCodePoints(segment);
+  }
+
+  return adjustment;
+}
+
+export function getTerminalStringWidth(input: string): number {
+  return stringWidth(input) + getSaraAmWidthAdjustment(input);
+}

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -7,9 +7,9 @@
 import stripAnsi from 'strip-ansi';
 import ansiRegex from 'ansi-regex';
 import { stripVTControlCharacters } from 'node:util';
-import stringWidth from 'string-width';
 import { LRUCache } from 'mnemonist';
 import { LRU_BUFFER_PERF_CACHE_LIMIT } from '../constants.js';
+import { getTerminalStringWidth as stringWidth } from './terminalStringWidth.js';
 
 /**
  * Calculates the maximum width of a multi-line ASCII art string.


### PR DESCRIPTION
## Summary

Correct terminal width handling for Thai and Lao SARA AM so Ink stays aligned with the real terminal grid in tmux and other wcwidth-based terminals.

## Details

Add a small terminal-aware wrapper around `string-width` that only adjusts grapheme clusters containing Thai `U+0E33` or Lao `U+0EB3` when those code points are merged into a larger cluster. Wire that function into both Gemini CLI width calculations and Ink's global string-width hook, and add regression tests covering Thai, Lao, emoji, and existing complex-script behavior.

## Related Issues

Fixes #25369

## How to Validate

1. Run `GEMINI_CLI_TRUST_WORKSPACE=true npm run test:ci --workspace "@google/gemini-cli"`.
2. Run `NO_COLOR=true npm run test:ci --workspace "@google/gemini-cli-core" --workspace "@google/gemini-cli-a2a-server" --workspace "gemini-cli-vscode-ide-companion" --workspace "@google/gemini-cli-test-utils" --if-present -- --coverage.enabled=false`.
3. Run `npm run test:scripts`.
4. Run `npm run test:sea-launch`.
5. Run `npm run build`.
6. Run `npm run typecheck`.
7. Run `npm run lint:all`.
8. Run `npm run check:lockfile`.
9. Run `npm run predocs:settings`.
10. Run `npm run docs:settings -- --check`.
11. Run `npm run bundle`.
12. Run `node ./bundle/gemini.js --version`.
13. Run `npm pack`, then verify `npx "./<tarball>" --version` works.
14. In `tmux`, start Gemini CLI and type or stream Thai/Lao text containing `กำ`, `ทำ`, `แนะนำ`, or `ນຳ`; confirm the cursor no longer jumps and lines are not duplicated.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
