### PR TITLE
fix(core): enforce compile-time exhaustiveness in content-utils

### DIFF
--- a/packages/core/src/agent/content-utils.ts
+++ b/packages/core/src/agent/content-utils.ts
@@ -93,13 +93,16 @@ export function contentPartsToGeminiParts(content: ContentPart[]): Part[] {
         // References are converted to text for the model
         result.push({ text: part.text });
         break;
-      default:
+      default: {
+        const _exhaustiveCheck: never = part;
+        void _exhaustiveCheck;
         debugLogger.warn(
           `Unhandled ContentPart type: ${JSON.stringify(part)} fallback to serialization`,
         );
         // Serialize unknown ContentPart variants instead of dropping them
         result.push({ text: JSON.stringify(part) });
         break;
+      }
     }
   }
   return result;


### PR DESCRIPTION
## Summary

Restores 100% compile-time type safety to `contentPartsToGeminiParts` in `content-utils.ts` while preserving runtime resilience for dynamic/untracked content parts.

## Details

- Added a compile-time-only exhaustiveness check `const _exhaustiveCheck: never = part;` under `default:` in the mapping switch.
- Wrapped the declaration in block scope `{}` to satisfy ESLint scoping rules (`no-case-declarations`).
- Added `void _exhaustiveCheck;` to satisfy TypeScript's `noUnusedLocals` compiler rule.
- The compiler will now fail the build if any developer adds a new type to the `ContentPart` union in `types.ts` but forgets to map it in `content-utils.ts`.
- Verified that the existing unit test `serializes unknown ContentPart variants` passes successfully, confirming that casting/untracked widgets at runtime are safely serialized rather than crashing.
