### PR TITLE
fix(core): update chat compression model aliases to avoid 404 errors

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -768,7 +768,7 @@ their corresponding top-level category object in your `settings.json` file.
       },
       "chat-compression-default": {
         "modelConfig": {
-          "model": "gemini-3-pro-preview"
+          "model": "gemini-3.1-flash-lite-preview"
         }
       },
       "agent-history-provider-summarizer": {

--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -284,7 +284,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     },
     'chat-compression-default': {
       modelConfig: {
-        model: 'gemini-3-pro-preview',
+        model: 'gemini-3.1-flash-lite-preview',
       },
     },
     'agent-history-provider-summarizer': {

--- a/packages/core/src/context/chatCompressionService.test.ts
+++ b/packages/core/src/context/chatCompressionService.test.ts
@@ -130,6 +130,25 @@ describe('modelStringToModelConfigAlias', () => {
       'chat-compression-2.5-flash-lite',
     );
   });
+
+  it('should handle auto aliases and other convenient aliases', () => {
+    expect(modelStringToModelConfigAlias('auto')).toBe(
+      'chat-compression-3-pro',
+    );
+    expect(modelStringToModelConfigAlias('auto-gemini-3')).toBe(
+      'chat-compression-3-pro',
+    );
+    expect(modelStringToModelConfigAlias('pro')).toBe('chat-compression-3-pro');
+    expect(modelStringToModelConfigAlias('flash')).toBe(
+      'chat-compression-3-flash',
+    );
+    expect(modelStringToModelConfigAlias('flash-lite')).toBe(
+      'chat-compression-3.1-flash-lite',
+    );
+    expect(modelStringToModelConfigAlias('auto-gemini-2.5')).toBe(
+      'chat-compression-2.5-pro',
+    );
+  });
 });
 
 describe('ChatCompressionService', () => {

--- a/packages/core/src/context/chatCompressionService.ts
+++ b/packages/core/src/context/chatCompressionService.ts
@@ -31,6 +31,12 @@ import {
   PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL,
+  PREVIEW_GEMINI_MODEL_AUTO,
+  DEFAULT_GEMINI_MODEL_AUTO,
+  GEMINI_MODEL_ALIAS_AUTO,
+  GEMINI_MODEL_ALIAS_PRO,
+  GEMINI_MODEL_ALIAS_FLASH,
+  GEMINI_MODEL_ALIAS_FLASH_LITE,
 } from '../config/models.js';
 import { PreCompressTrigger } from '../hooks/types.js';
 
@@ -103,12 +109,18 @@ export function modelStringToModelConfigAlias(model: string): string {
   switch (model) {
     case PREVIEW_GEMINI_MODEL:
     case PREVIEW_GEMINI_3_1_MODEL:
+    case PREVIEW_GEMINI_MODEL_AUTO:
+    case GEMINI_MODEL_ALIAS_AUTO:
+    case GEMINI_MODEL_ALIAS_PRO:
       return 'chat-compression-3-pro';
     case PREVIEW_GEMINI_FLASH_MODEL:
+    case GEMINI_MODEL_ALIAS_FLASH:
       return 'chat-compression-3-flash';
     case PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL:
+    case GEMINI_MODEL_ALIAS_FLASH_LITE:
       return 'chat-compression-3.1-flash-lite';
     case DEFAULT_GEMINI_MODEL:
+    case DEFAULT_GEMINI_MODEL_AUTO:
       return 'chat-compression-2.5-pro';
     case DEFAULT_GEMINI_FLASH_MODEL:
       return 'chat-compression-2.5-flash';

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -990,7 +990,7 @@
           },
           "chat-compression-default": {
             "modelConfig": {
-              "model": "gemini-3-pro-preview"
+              "model": "gemini-3.1-flash-lite-preview"
             }
           },
           "agent-history-provider-summarizer": {


### PR DESCRIPTION
## Summary

This PR fixes a 404 error occurring during background chat history compression. The error was triggered when using "Auto" model aliases, which caused the `ChatCompressionService` to fall back to model (`gemini-2.5-pro`) when preview access was missing.

## Details

- Updated `modelStringToModelConfigAlias` in `packages/core/src/context/chatCompressionService.ts` to explicitly handle `auto`, `pro`, `flash`, and `flash-lite` aliases. This ensures they map to the correct compression profiles (e.g., `chat-compression-3-pro`) instead of falling through to the default.
- Changed the default compression model in `packages/core/src/config/defaultModelConfigs.ts` from `gemini-3-pro-preview` (which falls back to `2.5-pro` in certain contexts) to `gemini-3.1-flash-lite-preview`.
- Updated `schemas/settings.schema.json` and `docs/reference/configuration.md` to reflect the new default.
- Added comprehensive unit tests in `packages/core/src/context/chatCompressionService.test.ts` to verify the alias mapping logic.

## Related Issues

Reported by user in chat.

## How to Validate

1. Use an "Auto" model (e.g., `npm start -- --model auto-gemini-3`).
2. Engage in a long conversation that exceeds the compression threshold (or force compression).
3. Observe that background compression no longer fails with a 404 error.
4. Run tests: `npm test -w @google/gemini-cli-core -- src/context/chatCompressionService.test.ts`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] Linux
    - [x] npm run
