### PR TITLE
fix(ide/process-utils): spawn powershell.exe with -NoProfile -NonInteractive

### DIFF
--- a/packages/core/src/ide/process-utils.test.ts
+++ b/packages/core/src/ide/process-utils.test.ts
@@ -71,9 +71,15 @@ describe('getIdeProcessInfo', () => {
         command: 'C:\\Program Files\\VSCode\\Code.exe',
       });
       expect(mockedExec).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine',
-        ),
+        'powershell.exe',
+        expect.arrayContaining([
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          expect.stringContaining(
+            'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine',
+          ),
+        ]),
         expect.anything(),
       );
     });
@@ -142,9 +148,37 @@ describe('getIdeProcessInfo', () => {
       const result = await getIdeProcessInfo();
       expect(result).toEqual({ pid: 900, command: 'powershell.exe' });
       expect(mockedExec).toHaveBeenCalledWith(
-        expect.stringContaining('Get-CimInstance Win32_Process'),
+        'powershell.exe',
+        expect.arrayContaining([
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          expect.stringContaining('Get-CimInstance Win32_Process'),
+        ]),
         expect.anything(),
       );
+    });
+
+    it('should invoke powershell.exe with -NoProfile -NonInteractive flags', async () => {
+      (os.platform as Mock).mockReturnValue('win32');
+      const processes = [
+        {
+          ProcessId: 1000,
+          ParentProcessId: 0,
+          Name: 'node.exe',
+          CommandLine: 'node.exe',
+        },
+      ];
+      mockedExec.mockResolvedValueOnce({ stdout: JSON.stringify(processes) });
+
+      await getIdeProcessInfo();
+
+      expect(mockedExec).toHaveBeenCalledTimes(1);
+      const [program, args] = mockedExec.mock.calls[0];
+      expect(program).toBe('powershell.exe');
+      expect(args).toContain('-NoProfile');
+      expect(args).toContain('-NonInteractive');
+      expect(args).toContain('-Command');
     });
 
     it('should handle short process chains', async () => {

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import os from 'node:os';
 import path from 'node:path';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const MAX_TRAVERSAL_DEPTH = 32;
 
@@ -37,9 +38,13 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
     const powershellCommand =
       'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress';
     // Increase maxBuffer to handle large process lists (default is 1MB)
-    const { stdout } = await execAsync(`powershell "${powershellCommand}"`, {
-      maxBuffer: 10 * 1024 * 1024,
-    });
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', powershellCommand],
+      {
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
 
     if (!stdout.trim()) {
       return processMap;


### PR DESCRIPTION
## Summary

Spawns `powershell.exe` via `execFile` with `-NoProfile -NonInteractive`
flags in the Windows IDE process probe (`getProcessTableWindows`). This
was the only PowerShell call site in the repo invoked without
`-NoProfile` — every other site (`security.ts`, `clipboardUtils.ts`,
`secure-browser-launcher.ts`, `parsePowerShellCommandDetails`,
`gemma/platform.ts`) already uses this pattern.

## Why this matters

Removes a profile-load side effect and speeds up startup.

1. Every other powershell call site in gemini-cli already uses
   `-NoProfile`. Users and agents don't expect a persistent PowerShell
   session across spawns — this probe was the lone exception.

2. A user's `$PROFILE` can contain anything. In some setups it mutates
   the shared conhost via `chcp` or `[Console]::OutputEncoding`. That
   leaks into gemini-cli's encoding behavior and gets stuck for the rest
   of the session — the `chcp` snapshot is cached process-wide in
   `getCachedEncodingForBuffer` (`packages/core/src/utils/systemEncoding.ts`)
   and is reused for every shell-output `TextDecoder` in
   `shellExecutionService.ts` (cpSpawn path and PTY path).

## Change

- Replace `execAsync(\"powershell \\\"...\\\"\", opts)` with `execFileAsync(\"powershell.exe\", [\"-NoProfile\", \"-NonInteractive\", \"-Command\", powershellCommand], opts)`.
- `execFile` (vs. `exec`) drops the unnecessary `cmd.exe` hop and the shell-string interpolation surface.
- `maxBuffer` and JSON parsing unchanged.

## Tests

Existing `process-utils.test.ts` assertions updated to the new
`(program, argsArray)` mock signature. Added one explicit test that
verifies `-NoProfile`, `-NonInteractive`, and `-Command` are present in
the args.

## Context

Found while investigating the broader Windows encoding issues tracked in
#20968. This change is independent of that — it removes a side-effect
that complicates the encoding picture without itself fixing the
underlying decoder behavior.