### PR TITLE
fix(cli): bundle ink worker-entry.js

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -107,6 +107,24 @@ const cliConfig = {
   metafile: true,
 };
 
+const workerConfig = {
+  ...baseConfig,
+  entryPoints: {
+    'worker/worker-entry': path.join(
+      path.dirname(require.resolve('ink')),
+      'worker/worker-entry.js',
+    ),
+  },
+  outdir: 'bundle',
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || 'production',
+    ),
+  },
+  plugins: createWasmPlugins(),
+  alias: commonAliases,
+};
+
 const a2aServerConfig = {
   ...baseConfig,
   banner: {
@@ -133,11 +151,16 @@ Promise.allSettled([
       writeFileSync('./bundle/esbuild.json', JSON.stringify(metafile, null, 2));
     }
   }),
+  esbuild.build(workerConfig),
   esbuild.build(a2aServerConfig),
 ]).then((results) => {
-  const [cliResult, a2aResult] = results;
+  const [cliResult, workerResult, a2aResult] = results;
   if (cliResult.status === 'rejected') {
     console.error('gemini.js build failed:', cliResult.reason);
+    process.exit(1);
+  }
+  if (workerResult.status === 'rejected') {
+    console.error('worker-entry.js build failed:', workerResult.reason);
     process.exit(1);
   }
   // error in a2a-server bundling will not stop gemini.js bundling process


### PR DESCRIPTION
## Summary

This PR fixes the 'Unable to launch render process' error by ensuring that the ink worker entry point is correctly bundled.

## Details

- Added `workerConfig` to `esbuild.config.js` to bundle `node_modules/ink/build/worker/worker-entry.js` into `bundle/worker/worker-entry.js`.
- Used `require.resolve` for robust path resolution of the worker entry point.
- Ensured consistency in `workerConfig` by adding `plugins` and `alias`.
- Updated the bundling promise to include the new worker build and verify its success.

## Related Issues

None.

## Validation

- Ran `npm run bundle` and verified `bundle/worker/worker-entry.js` exists.
- Verified `node bundle/gemini.js --version` works correctly.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md) document.
- [x] I have signed the Google CLA.
- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) standard.
- [x] My changes follow the existing code style and conventions.
- [x] I have added tests to cover my changes (N/A for build/bundle fix).
- [x] All new and existing tests passed.
- [x] I have updated documentation where necessary.
