### PR TITLE
fix(devtools): bundle devtools package to avoid resolution errors

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -111,7 +111,7 @@ const cliConfig = {
     ),
     '@google/gemini-cli-devtools': path.resolve(
       __dirname,
-      'packages/devtools/dist/src/index.js',
+      'packages/devtools/src/index.ts',
     ),
     ...commonAliases,
   },
@@ -120,6 +120,9 @@ const cliConfig = {
 
 const workerConfig = {
   ...baseConfig,
+  banner: {
+    js: `const require = (await import('node:module')).createRequire(import.meta.url); const __chunk_filename = (await import('node:url')).fileURLToPath(import.meta.url); const __chunk_dirname = (await import('node:path')).dirname(__chunk_filename);`,
+  },
   entryPoints: {
     'worker/worker-entry': path.join(
       path.dirname(require.resolve('ink')),
@@ -128,6 +131,8 @@ const workerConfig = {
   },
   outdir: 'bundle',
   define: {
+    __filename: '__chunk_filename',
+    __dirname: '__chunk_dirname',
     'process.env.NODE_ENV': JSON.stringify(
       process.env.NODE_ENV || 'production',
     ),

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -63,7 +63,6 @@ const external = [
   '@lydell/node-pty-win32-arm64',
   '@lydell/node-pty-win32-x64',
   '@github/keytar',
-  '@google/gemini-cli-devtools',
 ];
 
 const baseConfig = {
@@ -109,6 +108,10 @@ const cliConfig = {
     'http-proxy-agent': path.resolve(
       __dirname,
       'packages/cli/src/patches/http-proxy-agent.ts',
+    ),
+    '@google/gemini-cli-devtools': path.resolve(
+      __dirname,
+      'packages/devtools/dist/src/index.js',
     ),
     ...commonAliases,
   },

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -85,29 +85,7 @@ if (existsSync(builtinSkillsSrc)) {
   console.log('Copied built-in skills to bundle/builtin/');
 }
 
-// 5. Copy DevTools package so the external dynamic import resolves at runtime
-const devtoolsSrc = join(root, 'packages/devtools');
-const devtoolsDest = join(
-  bundleDir,
-  'node_modules',
-  '@google',
-  'gemini-cli-devtools',
-);
-const devtoolsDistSrc = join(devtoolsSrc, 'dist');
-if (existsSync(devtoolsDistSrc)) {
-  mkdirSync(devtoolsDest, { recursive: true });
-  cpSync(devtoolsDistSrc, join(devtoolsDest, 'dist'), {
-    recursive: true,
-    dereference: true,
-  });
-  copyFileSync(
-    join(devtoolsSrc, 'package.json'),
-    join(devtoolsDest, 'package.json'),
-  );
-  console.log('Copied devtools package to bundle/node_modules/');
-}
-
-// 6. Copy bundled chrome-devtools-mcp
+// 5. Copy bundled chrome-devtools-mcp
 const bundleMcpSrc = join(root, 'packages/core/dist/bundled');
 const bundleMcpDest = join(bundleDir, 'bundled');
 if (!existsSync(bundleMcpSrc)) {
@@ -120,7 +98,7 @@ if (!existsSync(bundleMcpSrc)) {
 cpSync(bundleMcpSrc, bundleMcpDest, { recursive: true, dereference: true });
 console.log('Copied bundled chrome-devtools-mcp to bundle/bundled/');
 
-// 7. Copy Extension Examples
+// 6. Copy Extension Examples
 const extensionExamplesSrc = join(
   root,
   'packages/cli/src/commands/extensions/examples',


### PR DESCRIPTION
## Summary

This PR resolves the `ERR_MODULE_NOT_FOUND` error for the DevTools server by transitioning the `@google/gemini-cli-devtools` package from an external dependency to a bundled one.

## Details

Previously, `@google/gemini-cli-devtools` was marked as an external dependency in `esbuild.config.js`. This caused resolution failures in certain environments (e.g., restricted runtimes like `google3`) because the package and its dependencies (like `ws`) were not consistently available in the runtime `node_modules`.

By removing it from `external` and adding an explicit `alias` in `esbuild.config.js`, esbuild now bundles the entire package and its dependencies directly into the CLI's bundled chunks. This makes the bundle self-contained and eliminates the need for runtime package resolution for DevTools.

I have also removed the now-unnecessary manual copying logic from `scripts/copy_bundle_assets.js`.

## Related Issues

Fixes the `ERR_MODULE_NOT_FOUND` error reported during DevTools startup.

## How to Validate

1. Run the bundle process: `npm run bundle`
1. Verify that `@google/gemini-cli-devtools` is no longer in the `external` list in the generated chunks:
   ```bash
   grep -r "@google/gemini-cli-devtools" bundle || echo "SUCCESS"
   ```
1. Start the CLI with devtools enabled and verify it starts correctly:
   ```bash
   node bundle/gemini.js --setting general.devtools=true --help
   ```
1. Run devtools service tests:
   ```bash
   npm test -w @google/gemini-cli -- src/utils/devtoolsService.test.ts
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
