### PR TITLE
fix(core): Added date field for the GCal MCP

### DIFF
--- a/evals/calendar-all-day.eval.ts
+++ b/evals/calendar-all-day.eval.ts
@@ -21,7 +21,7 @@ evalTest('USUALLY_PASSES', {
 
     expect(createEventCall).toBeDefined();
 
-    const args = JSON.parse(createEventCall?.toolRequest.args);
+    const args = JSON.parse(createEventCall!.toolRequest.args);
 
     expect(args?.start).toHaveProperty('date');
     expect(args?.start).not.toHaveProperty('dateTime');

--- a/evals/calendar-all-day.eval.ts
+++ b/evals/calendar-all-day.eval.ts
@@ -1,0 +1,33 @@
+import { evalTest } from './test-helper.js';
+import { expect } from 'vitest';
+
+evalTest('USUALLY_PASSES', {
+  suiteName: 'default',
+  suiteType: 'behavioral',
+  name: 'should create an all-day event using the optional date field',
+  prompt:
+    'Create an all-day event for 2026-05-20 titled "Company Retreat". Do not use a specific time.',
+  setup: async (rig) => {
+    rig.addTestMcpServer('workspace-server', 'google-workspace');
+  },
+  assert: async (rig) => {
+    const toolLogs = rig.readToolLogs();
+    console.log('TOOL LOGS:', JSON.stringify(toolLogs, null, 2));
+
+    const createEventCall = toolLogs.find(
+      (log) =>
+        log.toolRequest.name === 'mcp_workspace-server_calendar.createEvent',
+    );
+
+    expect(createEventCall).toBeDefined();
+
+    const args = JSON.parse(createEventCall?.toolRequest.args);
+
+    expect(args?.start).toHaveProperty('date');
+    expect(args?.start).not.toHaveProperty('dateTime');
+    expect(args?.start?.date).toBe('2026-05-20');
+
+    expect(args?.end).toHaveProperty('date');
+    expect(args?.end).not.toHaveProperty('dateTime');
+  },
+});

--- a/packages/test-utils/assets/test-servers/google-workspace.json
+++ b/packages/test-utils/assets/test-servers/google-workspace.json
@@ -905,7 +905,8 @@
                 "type": "string",
                 "description": "The new date, in the format \"yyyy-mm-dd\", for an all-day event."
               }
-            }
+            },
+            "anyOf": [{ "required": ["dateTime"] }, { "required": ["date"] }]
           },
           "attendees": {
             "description": "The new list of attendees for the event.",

--- a/packages/test-utils/assets/test-servers/google-workspace.json
+++ b/packages/test-utils/assets/test-servers/google-workspace.json
@@ -684,9 +684,12 @@
               "dateTime": {
                 "type": "string",
                 "description": "The start time in strict ISO 8601 format with seconds and timezone (e.g., 2024-01-15T10:30:00Z or 2024-01-15T10:30:00-05:00)."
+              },
+              "date": {
+                "type": "string",
+                "description": "The date, in the format \"yyyy-mm-dd\", for an all-day event."
               }
-            },
-            "required": ["dateTime"]
+            }
           },
           "end": {
             "type": "object",
@@ -694,9 +697,12 @@
               "dateTime": {
                 "type": "string",
                 "description": "The end time in strict ISO 8601 format with seconds and timezone (e.g., 2024-01-15T11:30:00Z or 2024-01-15T11:30:00-05:00)."
+              },
+              "date": {
+                "type": "string",
+                "description": "The date, in the format \"yyyy-mm-dd\", for an all-day event."
               }
-            },
-            "required": ["dateTime"]
+            }
           },
           "attendees": {
             "description": "The email addresses of the attendees.",
@@ -881,9 +887,12 @@
               "dateTime": {
                 "type": "string",
                 "description": "The new start time in strict ISO 8601 format with seconds and timezone (e.g., 2024-01-15T10:30:00Z or 2024-01-15T10:30:00-05:00)."
+              },
+              "date": {
+                "type": "string",
+                "description": "The new date, in the format \"yyyy-mm-dd\", for an all-day event."
               }
-            },
-            "required": ["dateTime"]
+            }
           },
           "end": {
             "type": "object",
@@ -891,9 +900,12 @@
               "dateTime": {
                 "type": "string",
                 "description": "The new end time in strict ISO 8601 format with seconds and timezone (e.g., 2024-01-15T11:30:00Z or 2024-01-15T11:30:00-05:00)."
+              },
+              "date": {
+                "type": "string",
+                "description": "The new date, in the format \"yyyy-mm-dd\", for an all-day event."
               }
-            },
-            "required": ["dateTime"]
+            }
           },
           "attendees": {
             "description": "The new list of attendees for the event.",


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->
Added date field for the GCal MCP and made the dateTime field optional. This allows users to create all-day events.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #23486

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Run the new eval test added using `npm run test:all_evals -- evals/calendar-all-day.eval.ts`. It should pass.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
