### PR TITLE
Feat/a2a expose usage metadata

### DIFF
--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -294,6 +294,66 @@ describe('Task', () => {
       ]);
     });
 
+    it('should capture usageMetadata on Finished event and include it in final status update', async () => {
+      const mockConfig = createMockConfig();
+      const mockEventBus: ExecutionEventBus = {
+        publish: vi.fn(),
+        on: vi.fn(),
+        off: vi.fn(),
+        once: vi.fn(),
+        removeAllListeners: vi.fn(),
+        finished: vi.fn(),
+      };
+
+      // @ts-expect-error - Calling private constructor for test purposes.
+      const task = new Task(
+        'task-id',
+        'context-id',
+        mockConfig as Config,
+        mockEventBus,
+      );
+
+      const finishedEvent = {
+        type: GeminiEventType.Finished,
+        value: {
+          reason: 'STOP',
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 50,
+            totalTokenCount: 150,
+          },
+        },
+      };
+
+      await task.acceptAgentMessage(finishedEvent);
+      expect(task.usageMetadata).toEqual({
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        totalTokenCount: 150,
+      });
+
+      task.setTaskStateAndPublishUpdate(
+        'input-required',
+        { kind: CoderAgentEvent.StateChangeEvent },
+        undefined,
+        undefined,
+        true, // final
+      );
+
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          final: true,
+          metadata: expect.objectContaining({
+            usageMetadata: {
+              promptTokenCount: 100,
+              candidatesTokenCount: 50,
+              totalTokenCount: 150,
+            },
+          }),
+        }),
+      );
+    });
+
     it('should update modelInfo and reflect it in metadata and status updates', async () => {
       const mockConfig = createMockConfig();
       const mockEventBus: ExecutionEventBus = {

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -93,6 +93,7 @@ export class Task {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
     totalTokenCount?: number;
+    cachedContentTokenCount?: number;
   };
   private get isYoloMatch(): boolean {
     return (
@@ -279,7 +280,7 @@ export class Task {
       userTier?: UserTierId;
       error?: string;
       traceId?: string;
-      usageMetadata?: unknown;
+      usageMetadata?: Task['usageMetadata'];
     } = {
       coderAgent: coderAgentMessage,
       model: this.modelInfo || this.config.getModel(),
@@ -878,6 +879,7 @@ export class Task {
         }
         break;
       case GeminiEventType.ModelInfo:
+        this.usageMetadata = undefined;
         this.modelInfo = event.value;
         break;
       case GeminiEventType.Retry:

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -89,6 +89,11 @@ export class Task {
   currentAgentMessageId = uuidv4();
   promptCount = 0;
   autoExecute: boolean;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
   private get isYoloMatch(): boolean {
     return (
       this.autoExecute || this.config.getApprovalMode() === ApprovalMode.YOLO
@@ -274,6 +279,7 @@ export class Task {
       userTier?: UserTierId;
       error?: string;
       traceId?: string;
+      usageMetadata?: unknown;
     } = {
       coderAgent: coderAgentMessage,
       model: this.modelInfo || this.config.getModel(),
@@ -286,6 +292,10 @@ export class Task {
 
     if (traceId) {
       metadata.traceId = traceId;
+    }
+
+    if (final && this.usageMetadata) {
+      metadata.usageMetadata = this.usageMetadata;
     }
 
     return {
@@ -857,6 +867,15 @@ export class Task {
         break;
       case GeminiEventType.Finished:
         logger.info(`[Task ${this.id}] Agent finished its turn.`);
+        // Capture the usage metadata when the stream finishes
+        if (
+          event.value &&
+          typeof event.value === 'object' &&
+          'usageMetadata' in event.value
+        ) {
+          this.usageMetadata = event.value
+            .usageMetadata as typeof this.usageMetadata;
+        }
         break;
       case GeminiEventType.ModelInfo:
         this.modelInfo = event.value;


### PR DESCRIPTION
## Summary

This PR introduces the functionality to expose `usageMetadata` from the Gemini API's streaming responses within the `a2a-server` in agent mode.

## Details

**Changes:**

-   Modified stream handling in `a2a-server` to extract `usageMetadata`.
-   Includes the `usageMetadata` object in the final event sent to the client.
-   Added comprehensive unit tests to validate the new logic.

**Reasoning:**

This change is required to enable token usage tracking and display in Gemini Code Assist, providing users with insights into context window utilization.

## Related Issues

Fixes b/436499242 # Internal contribution for GCA feature

## How to Validate

  1.  Run unit tests for the A2A server:
    ```bash
    npm test -w @google/gemini-cli-a2a-server
    ```
 2. Verify that all 131 tests pass, confirming that both default policy loading and YOLO mode overrides are correctly handled.

## Pre-Merge Checklist

- [ x] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ x] Linux
    - [ x] npm run
    - [ ] npx
    - [ ] Docker
