### PR TITLE
fix(cli): restore non-interactive stdin raw mode on exit

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -15,6 +15,7 @@ import type { LoadedSettings } from './config/settings.js';
 import {
   convertSessionToClientHistory,
   GeminiEventType,
+  FatalCancellationError,
   FatalInputError,
   promptIdContext,
   OutputFormat,
@@ -33,7 +34,6 @@ import {
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
-import readline from 'node:readline';
 import stripAnsi from 'strip-ansi';
 
 import { handleSlashCommand } from './nonInteractiveCliCommands.js';
@@ -42,11 +42,11 @@ import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import {
   handleError,
   handleToolError,
-  handleCancellationError,
   handleMaxTurnsExceededError,
 } from './utils/errors.js';
 import { TextOutput } from './ui/utils/textOutput.js';
 import { runNonInteractive as runNonInteractiveAgentSession } from './nonInteractiveCliAgentSession.js';
+import { setupStdinCancellation } from './utils/stdinCancellation.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -115,86 +115,7 @@ export async function runNonInteractive(
         : null;
 
     const abortController = new AbortController();
-
-    // Track cancellation state
-    let isAborting = false;
-    let cancelMessageTimer: NodeJS.Timeout | null = null;
-
-    // Setup stdin listener for Ctrl+C detection
-    let stdinWasRaw = false;
-    let rl: readline.Interface | null = null;
-
-    const setupStdinCancellation = () => {
-      // Only setup if stdin is a TTY (user can interact)
-      if (!process.stdin.isTTY) {
-        return;
-      }
-
-      // Save original raw mode state
-      stdinWasRaw = process.stdin.isRaw || false;
-
-      // Enable raw mode to capture individual keypresses
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-
-      // Setup readline to emit keypress events
-      rl = readline.createInterface({
-        input: process.stdin,
-        escapeCodeTimeout: 0,
-      });
-      readline.emitKeypressEvents(process.stdin, rl);
-
-      // Listen for Ctrl+C
-      const keypressHandler = (
-        str: string,
-        key: { name?: string; ctrl?: boolean },
-      ) => {
-        // Detect Ctrl+C: either ctrl+c key combo or raw character code 3
-        if ((key && key.ctrl && key.name === 'c') || str === '\u0003') {
-          // Only handle once
-          if (isAborting) {
-            return;
-          }
-
-          isAborting = true;
-
-          // Only show message if cancellation takes longer than 200ms
-          // This reduces verbosity for fast cancellations
-          cancelMessageTimer = setTimeout(() => {
-            process.stderr.write('\nCancelling...\n');
-          }, 200);
-
-          abortController.abort();
-          // Note: Don't exit here - let the abort flow through the system
-          // and trigger handleCancellationError() which will exit with proper code
-        }
-      };
-
-      process.stdin.on('keypress', keypressHandler);
-    };
-
-    const cleanupStdinCancellation = () => {
-      // Clear any pending cancel message timer
-      if (cancelMessageTimer) {
-        clearTimeout(cancelMessageTimer);
-        cancelMessageTimer = null;
-      }
-
-      // Cleanup readline and stdin listeners
-      if (rl) {
-        rl.close();
-        rl = null;
-      }
-
-      // Remove keypress listener
-      process.stdin.removeAllListeners('keypress');
-
-      // Restore stdin to original state
-      if (process.stdin.isTTY) {
-        process.stdin.setRawMode(stdinWasRaw);
-        process.stdin.pause();
-      }
-    };
+    let cleanupStdinCancellation = () => {};
 
     let errorToHandle: unknown | undefined;
     let scheduler: Scheduler | undefined;
@@ -212,7 +133,7 @@ export async function runNonInteractive(
       }
 
       // Setup stdin cancellation listener
-      setupStdinCancellation();
+      cleanupStdinCancellation = setupStdinCancellation({ abortController });
 
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
       coreEvents.drainBacklogs();
@@ -328,7 +249,7 @@ export async function runNonInteractive(
         let responseText = '';
         for await (const event of responseStream) {
           if (abortController.signal.aborted) {
-            handleCancellationError(config);
+            throw new FatalCancellationError('Operation cancelled.');
           }
 
           if (event.type === GeminiEventType.Content) {

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -42,7 +42,6 @@ import {
 } from '@google/gemini-cli-core';
 
 import type { Part } from '@google/genai';
-import readline from 'node:readline';
 import stripAnsi from 'strip-ansi';
 
 import { handleSlashCommand } from './nonInteractiveCliCommands.js';
@@ -50,6 +49,7 @@ import { ConsolePatcher } from './ui/utils/ConsolePatcher.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import { handleError, handleToolError } from './utils/errors.js';
 import { TextOutput } from './ui/utils/textOutput.js';
+import { setupStdinCancellation } from './utils/stdinCancellation.js';
 
 interface RunNonInteractiveParams {
   config: Config;
@@ -112,84 +112,7 @@ export async function runNonInteractive({
         : null;
 
     const abortController = new AbortController();
-
-    // Track cancellation state
-    let isAborting = false;
-    let cancelMessageTimer: NodeJS.Timeout | null = null;
-
-    // Setup stdin listener for Ctrl+C detection
-    let stdinWasRaw = false;
-    let rl: readline.Interface | null = null;
-
-    const setupStdinCancellation = () => {
-      // Only setup if stdin is a TTY (user can interact)
-      if (!process.stdin.isTTY) {
-        return;
-      }
-
-      // Save original raw mode state
-      stdinWasRaw = process.stdin.isRaw || false;
-
-      // Enable raw mode to capture individual keypresses
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-
-      // Setup readline to emit keypress events
-      rl = readline.createInterface({
-        input: process.stdin,
-        escapeCodeTimeout: 0,
-      });
-      readline.emitKeypressEvents(process.stdin, rl);
-
-      // Listen for Ctrl+C
-      const keypressHandler = (
-        str: string,
-        key: { name?: string; ctrl?: boolean },
-      ) => {
-        // Detect Ctrl+C: either ctrl+c key combo or raw character code 3
-        if ((key && key.ctrl && key.name === 'c') || str === '\u0003') {
-          // Only handle once
-          if (isAborting) {
-            return;
-          }
-
-          isAborting = true;
-
-          // Only show message if cancellation takes longer than 200ms
-          // This reduces verbosity for fast cancellations
-          cancelMessageTimer = setTimeout(() => {
-            process.stderr.write('\nCancelling...\n');
-          }, 200);
-
-          abortController.abort();
-        }
-      };
-
-      process.stdin.on('keypress', keypressHandler);
-    };
-
-    const cleanupStdinCancellation = () => {
-      // Clear any pending cancel message timer
-      if (cancelMessageTimer) {
-        clearTimeout(cancelMessageTimer);
-        cancelMessageTimer = null;
-      }
-
-      // Cleanup readline and stdin listeners
-      if (rl) {
-        rl.close();
-        rl = null;
-      }
-
-      // Remove keypress listener
-      process.stdin.removeAllListeners('keypress');
-
-      // Restore stdin to original state
-      if (process.stdin.isTTY) {
-        process.stdin.setRawMode(stdinWasRaw);
-        process.stdin.pause();
-      }
-    };
+    let cleanupStdinCancellation = () => {};
 
     let errorToHandle: unknown | undefined;
     let scheduler: Scheduler | undefined;
@@ -208,7 +131,7 @@ export async function runNonInteractive({
       }
 
       // Setup stdin cancellation listener
-      setupStdinCancellation();
+      cleanupStdinCancellation = setupStdinCancellation({ abortController });
 
       coreEvents.on(CoreEvent.UserFeedback, handleUserFeedback);
       coreEvents.drainBacklogs();

--- a/packages/cli/src/utils/stdinCancellation.test.ts
+++ b/packages/cli/src/utils/stdinCancellation.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+import { setupStdinCancellation } from './stdinCancellation.js';
+
+type StdinWithRawMode = typeof process.stdin & {
+  setRawMode?: (mode: boolean) => boolean;
+};
+
+type KeypressHandler = (
+  str: string,
+  key: { name?: string; ctrl?: boolean },
+) => void;
+
+type ProcessHandler = (...args: unknown[]) => void;
+
+let originalIsTTY: boolean | undefined;
+let originalSetRawMode: StdinWithRawMode['setRawMode'];
+let setRawModeSpy: MockInstance;
+let stdinOnSpy: MockInstance;
+
+function captureProcessHandlers() {
+  const handlers = new Map<string | symbol, ProcessHandler>();
+  vi.spyOn(process, 'on').mockImplementation((event, listener) => {
+    handlers.set(event, listener as ProcessHandler);
+    return process;
+  });
+  vi.spyOn(process, 'off').mockImplementation(() => process);
+  return handlers;
+}
+
+describe('setupStdinCancellation', () => {
+  beforeEach(() => {
+    const stdin = process.stdin as StdinWithRawMode;
+    originalIsTTY = process.stdin.isTTY;
+    originalSetRawMode = stdin.setRawMode;
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    if (!originalSetRawMode) {
+      stdin.setRawMode = vi.fn();
+    }
+
+    setRawModeSpy = vi
+      .spyOn(
+        stdin as typeof stdin & { setRawMode: (mode: boolean) => boolean },
+        'setRawMode',
+      )
+      .mockImplementation(() => true);
+    stdinOnSpy = vi
+      .spyOn(process.stdin, 'on')
+      .mockImplementation(() => process.stdin);
+    vi.spyOn(process.stdin, 'resume').mockImplementation(() => process.stdin);
+    vi.spyOn(process.stdin, 'pause').mockImplementation(() => process.stdin);
+    vi.spyOn(process.stdin, 'removeListener').mockImplementation(
+      () => process.stdin,
+    );
+  });
+
+  afterEach(() => {
+    const stdin = process.stdin as StdinWithRawMode;
+
+    vi.restoreAllMocks();
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    if (originalSetRawMode) {
+      stdin.setRawMode = originalSetRawMode;
+    } else {
+      Reflect.deleteProperty(stdin, 'setRawMode');
+    }
+  });
+
+  it('restores stdin raw mode from the process exit handler', () => {
+    const handlers = captureProcessHandlers();
+    const cleanup = setupStdinCancellation({
+      abortController: new AbortController(),
+    });
+
+    handlers.get('exit')?.();
+
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(process.off).toHaveBeenCalledWith('exit', cleanup);
+  });
+
+  it('does not install cleanup signal handlers when stdin is not a TTY', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+    const handlers = captureProcessHandlers();
+
+    setupStdinCancellation({ abortController: new AbortController() });
+
+    expect([...handlers.keys()]).toEqual(['exit']);
+    expect(setRawModeSpy).not.toHaveBeenCalled();
+  });
+
+  it('aborts and restores stdin from cleanup signals without exiting', () => {
+    const abortController = new AbortController();
+    const handlers = captureProcessHandlers();
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code}) called`);
+    });
+
+    setupStdinCancellation({ abortController });
+
+    expect([...handlers.keys()]).toEqual(
+      expect.arrayContaining([
+        'SIGINT',
+        'SIGTERM',
+        'SIGHUP',
+        'SIGBREAK',
+        'SIGQUIT',
+      ]),
+    );
+
+    handlers.get('SIGTERM')?.();
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(process.off).toHaveBeenCalledWith(
+      'SIGTERM',
+      handlers.get('SIGTERM'),
+    );
+  });
+
+  it('aborts on the first Ctrl+C and force exits on a second Ctrl+C', () => {
+    const abortController = new AbortController();
+    let keypressHandler: KeypressHandler | undefined;
+    captureProcessHandlers();
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code}) called`);
+    });
+    stdinOnSpy.mockImplementation((event, listener) => {
+      if (String(event) === 'keypress') {
+        keypressHandler = listener as KeypressHandler;
+      }
+      return process.stdin;
+    });
+
+    setupStdinCancellation({ abortController });
+    keypressHandler?.('\u0003', { ctrl: true, name: 'c' });
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(() =>
+      keypressHandler?.('\u0003', { ctrl: true, name: 'c' }),
+    ).toThrow('process.exit(130) called');
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(process.exit).toHaveBeenCalledWith(130);
+  });
+});

--- a/packages/cli/src/utils/stdinCancellation.ts
+++ b/packages/cli/src/utils/stdinCancellation.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import readline from 'node:readline';
+
+const stdinCleanupSignals = [
+  'SIGINT',
+  'SIGTERM',
+  'SIGHUP',
+  'SIGBREAK',
+  'SIGQUIT',
+] as const;
+const SIGINT_EXIT_CODE = 130;
+
+type StdinCleanupSignal = (typeof stdinCleanupSignals)[number];
+
+type KeypressHandler = (
+  str: string,
+  key: { name?: string; ctrl?: boolean },
+) => void;
+
+interface SetupStdinCancellationOptions {
+  abortController: AbortController;
+}
+
+export function setupStdinCancellation({
+  abortController,
+}: SetupStdinCancellationOptions): () => void {
+  let isAborting = false;
+  let cancelMessageTimer: NodeJS.Timeout | null = null;
+  let stdinWasRaw = false;
+  let rl: readline.Interface | null = null;
+  let stdinCancellationSetup = false;
+  let keypressHandler: KeypressHandler | null = null;
+  const signalHandlers = new Map<StdinCleanupSignal, () => void>();
+
+  const cleanupStdinSignalHandlers = () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+    signalHandlers.clear();
+  };
+
+  const cleanupStdinCancellation = () => {
+    process.off('exit', cleanupStdinCancellation);
+    cleanupStdinSignalHandlers();
+
+    if (cancelMessageTimer) {
+      clearTimeout(cancelMessageTimer);
+      cancelMessageTimer = null;
+    }
+
+    if (rl) {
+      rl.close();
+      rl = null;
+    }
+
+    if (keypressHandler) {
+      process.stdin.removeListener('keypress', keypressHandler);
+      keypressHandler = null;
+    }
+
+    if (stdinCancellationSetup && process.stdin.isTTY) {
+      process.stdin.setRawMode(stdinWasRaw);
+      process.stdin.pause();
+    }
+    stdinCancellationSetup = false;
+  };
+
+  const abort = () => {
+    if (isAborting) {
+      return;
+    }
+
+    isAborting = true;
+
+    cancelMessageTimer = setTimeout(() => {
+      process.stderr.write('\nCancelling...\n');
+    }, 200);
+
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+
+  const handleStdinCleanupSignal = () => {
+    abort();
+    cleanupStdinCancellation();
+  };
+
+  process.on('exit', cleanupStdinCancellation);
+
+  if (!process.stdin.isTTY) {
+    return cleanupStdinCancellation;
+  }
+
+  try {
+    for (const signal of stdinCleanupSignals) {
+      const handler = () => handleStdinCleanupSignal();
+      signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+
+    stdinWasRaw = process.stdin.isRaw || false;
+
+    process.stdin.setRawMode(true);
+    stdinCancellationSetup = true;
+    process.stdin.resume();
+
+    rl = readline.createInterface({
+      input: process.stdin,
+      escapeCodeTimeout: 0,
+    });
+    readline.emitKeypressEvents(process.stdin, rl);
+
+    keypressHandler = (str, key) => {
+      if ((key && key.ctrl && key.name === 'c') || str === '\u0003') {
+        if (isAborting) {
+          cleanupStdinCancellation();
+          process.exit(SIGINT_EXIT_CODE);
+        }
+        abort();
+      }
+    };
+
+    process.stdin.on('keypress', keypressHandler);
+  } catch (error) {
+    cleanupStdinCancellation();
+    throw error;
+  }
+
+  return cleanupStdinCancellation;
+}


### PR DESCRIPTION
## Summary

This PR makes the non-interactive Ctrl+C cancellation path safer by restoring stdin raw mode during process exit, not only during the normal `finally` cleanup path.

Today, non-interactive mode enables raw mode when `process.stdin.isTTY` is true so it can catch Ctrl+C. If the process exits after raw mode is enabled but before the normal cleanup path runs, the user’s terminal can be left in a bad state until they run `reset` or `stty sane`.

## Details

The fix updates both non-interactive implementations:

- `packages/cli/src/nonInteractiveCli.ts`
- `packages/cli/src/nonInteractiveCliAgentSession.ts`

Changes made:

- Register `cleanupStdinCancellation` with `process.on('exit', ...)`.
- Make stdin cancellation cleanup idempotent.
- Track whether raw mode was actually enabled before trying to restore it.
- Remove only the keypress listener registered by this path instead of clearing all stdin `keypress` listeners.

One small caveat: Node cannot handle literal `SIGKILL`, so no process-level cleanup can protect against `kill -9`. This still improves the normal abrupt-exit path where Node emits `exit`.

## Related Issues

Fixes #27290

## How to Validate

From the repo root:

```bash
npm run build --workspace=@google/gemini-cli-core
```
Then run the targeted regression tests:

```bash
cd packages/cli
../../node_modules/.bin/vitest run src/nonInteractiveCli.test.ts src/nonInteractiveCliAgentSession.test.ts
```

### Expected result:

```bash
✓ src/nonInteractiveCli.test.ts
✓ src/nonInteractiveCliAgentSession.test.ts

Test Files  2 passed
Tests       115 passed
```

Also validated from the repo root:
```bash
npm run typecheck --workspace=@google/gemini-cli
npm run lint --workspace=@google/gemini-cli -- --max-warnings=0
Expected result: both commands pass.
```

## Regression coverage added:

- Verifies that non-interactive mode registers a process.on('exit', ...) cleanup handler.
- Verifies that invoking the exit handler restores the previous stdin raw-mode state.
- Verifies that the exit handler unregisters itself afterward.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [ ] Validated on required platforms/methods:
- [x] MacOS
- [x] npm run
- [ ] npx
- [ ] Docker
- [ ] Podman
- [ ] Seatbelt
- [ ] Windows
- [ ] Linux