### PR TITLE
fix(core): avoid duplicate home workspace commands

### DIFF
--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -16,10 +16,16 @@ import * as fs from 'node:fs';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
+  const realpathSync = vi.fn(
+    actual.realpathSync,
+  ) as unknown as typeof actual.realpathSync;
+  realpathSync.native = vi.fn(
+    actual.realpathSync.native,
+  ) as unknown as typeof actual.realpathSync.native;
   return {
     ...actual,
     mkdirSync: vi.fn(),
-    realpathSync: vi.fn(actual.realpathSync),
+    realpathSync,
   };
 });
 
@@ -125,6 +131,35 @@ describe('Storage – additional helpers', () => {
   it('getProjectCommandsDir returns project/.gemini/commands', () => {
     const expected = path.join(projectRoot, GEMINI_DIR, 'commands');
     expect(storage.getProjectCommandsDir()).toBe(expected);
+  });
+
+  it('recognizes home when native and generic realpath use different Windows spellings', () => {
+    const originalHomeDir = os.homedir();
+    vi.mocked(homedir).mockReturnValue('C:\\Users\\TestUser');
+    vi.mocked(fs.realpathSync).mockImplementation((pathLike) => {
+      const pathStr = String(pathLike);
+      if (pathStr.endsWith('C:\\Users\\TESTUS~1')) {
+        return 'C:\\Users\\TESTUS~1';
+      }
+      return pathStr;
+    });
+    vi.mocked(fs.realpathSync.native).mockImplementation((pathLike) => {
+      const pathStr = String(pathLike);
+      if (pathStr.endsWith('C:\\Users\\TESTUS~1')) {
+        return 'C:\\Users\\TestUser';
+      }
+      return pathStr;
+    });
+
+    try {
+      expect(new Storage('C:\\Users\\TESTUS~1').isWorkspaceHomeDir()).toBe(
+        true,
+      );
+    } finally {
+      vi.mocked(homedir).mockReturnValue(originalHomeDir);
+      vi.mocked(fs.realpathSync).mockRestore();
+      vi.mocked(fs.realpathSync.native).mockRestore();
+    }
   });
 
   it('getUserSkillsDir returns ~/.gemini/skills', () => {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -28,6 +28,10 @@ const AGENTS_DIR_NAME = '.agents';
 export const AUTO_SAVED_POLICY_FILENAME = 'auto-saved.toml';
 
 export class Storage {
+  private static homePathComparisonCache:
+    | { homeDir: string; candidates: Set<string> }
+    | undefined;
+
   private readonly targetDir: string;
   private sessionId: string | undefined;
   private projectIdentifier: string | undefined;
@@ -168,10 +172,45 @@ export class Storage {
    * This handles symlinks and platform-specific path normalization.
    */
   isWorkspaceHomeDir(): boolean {
-    return (
-      normalizePath(resolveToRealPath(this.targetDir)) ===
-      normalizePath(resolveToRealPath(homedir()))
+    const homeDir = homedir();
+    if (!homeDir) {
+      return false;
+    }
+
+    const targetCandidates = Storage.getPathComparisonCandidates(
+      this.targetDir,
     );
+    const homeCandidates = Storage.getHomePathComparisonCandidates(homeDir);
+
+    for (const candidate of targetCandidates) {
+      if (homeCandidates.has(candidate)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static getHomePathComparisonCandidates(homeDir: string): Set<string> {
+    if (Storage.homePathComparisonCache?.homeDir !== homeDir) {
+      Storage.homePathComparisonCache = {
+        homeDir,
+        candidates: Storage.getPathComparisonCandidates(homeDir),
+      };
+    }
+
+    return Storage.homePathComparisonCache.candidates;
+  }
+
+  private static getPathComparisonCandidates(pathStr: string): Set<string> {
+    const candidates = [pathStr, resolveToRealPath(pathStr)];
+
+    try {
+      candidates.push(fs.realpathSync.native(path.resolve(pathStr)));
+    } catch {
+      // Fall back to the existing path and robust realpath candidates.
+    }
+
+    return new Set(candidates.map((candidate) => normalizePath(candidate)));
   }
 
   getAgentsDir(): string {


### PR DESCRIPTION
## Summary
- compare multiple canonical path spellings when deciding whether the workspace is the user home directory
- include the native realpath spelling so Windows short-name paths still skip duplicate workspace command loading
- add a regression test for differing Windows path spellings

Fixes #27075

## Tests
- `npx vitest run packages/core/src/config/storage.test.ts --root packages/core`
- `npx vitest run packages/cli/src/services/FileCommandLoader.test.ts --root packages/cli`
- `npx prettier --check packages/core/src/config/storage.ts packages/core/src/config/storage.test.ts`

Note: `npm test --workspace @google/gemini-cli-core -- storage.test.ts` ran the matching tests successfully, then failed in the posttest build on an existing `src/services/gitService.ts` TypeScript error: `allowUnsafeAlias` is not a known property.
