### PR TITLE
fix(core): dynamic fallback routing for exhausted quota models

### DIFF
--- a/packages/core/src/availability/autoRoutingFallback.integration.test.ts
+++ b/packages/core/src/availability/autoRoutingFallback.integration.test.ts
@@ -386,14 +386,18 @@ describe('Auto Routing Fallback Integration', () => {
     // Simulate start of next turn
     config.getModelAvailabilityService().resetTurn();
 
-    // Turn 2: Pro should be attempted again!
-    // Let's make it succeed this time to verify it works!
+    // Turn 2: Since fallback was 'retry_always', it is permanent. Flash should be used!
     vi.spyOn(fakeGenerator, 'generateContent').mockImplementation(
       async (params) => {
-        if (params.model === PREVIEW_GEMINI_MODEL) {
+        if (params.model === PREVIEW_GEMINI_FLASH_MODEL) {
           return {
             candidates: [
-              { content: { role: 'model', parts: [{ text: 'Pro success' }] } },
+              {
+                content: {
+                  role: 'model',
+                  parts: [{ text: 'Flash Turn 2 success' }],
+                },
+              },
             ],
           } as unknown as GenerateContentResponse;
         }
@@ -411,7 +415,7 @@ describe('Auto Routing Fallback Integration', () => {
 
     const result2 = await promise2;
     expect(result2.candidates?.[0]?.content?.parts?.[0]?.text).toBe(
-      'Pro success',
+      'Flash Turn 2 success',
     );
   });
 });

--- a/packages/core/src/availability/autoRoutingFallback.integration.test.ts
+++ b/packages/core/src/availability/autoRoutingFallback.integration.test.ts
@@ -386,18 +386,14 @@ describe('Auto Routing Fallback Integration', () => {
     // Simulate start of next turn
     config.getModelAvailabilityService().resetTurn();
 
-    // Turn 2: Since fallback was 'retry_always', it is permanent. Flash should be used!
+    // Turn 2: Pro should be attempted again!
+    // Let's make it succeed this time to verify it works!
     vi.spyOn(fakeGenerator, 'generateContent').mockImplementation(
       async (params) => {
-        if (params.model === PREVIEW_GEMINI_FLASH_MODEL) {
+        if (params.model === PREVIEW_GEMINI_MODEL) {
           return {
             candidates: [
-              {
-                content: {
-                  role: 'model',
-                  parts: [{ text: 'Flash Turn 2 success' }],
-                },
-              },
+              { content: { role: 'model', parts: [{ text: 'Pro success' }] } },
             ],
           } as unknown as GenerateContentResponse;
         }
@@ -415,7 +411,7 @@ describe('Auto Routing Fallback Integration', () => {
 
     const result2 = await promise2;
     expect(result2.candidates?.[0]?.content?.parts?.[0]?.text).toBe(
-      'Flash Turn 2 success',
+      'Pro success',
     );
   });
 });

--- a/packages/core/src/availability/testUtils.ts
+++ b/packages/core/src/availability/testUtils.ts
@@ -21,7 +21,7 @@ export function createAvailabilityServiceMock(
     markHealthy: vi.fn(),
     markRetryOncePerTurn: vi.fn(),
     consumeStickyAttempt: vi.fn(),
-    snapshot: vi.fn(),
+    snapshot: vi.fn().mockReturnValue({ available: true }),
     resetTurn: vi.fn(),
     selectFirstAvailable: vi.fn().mockReturnValue(selection),
   };

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -863,6 +863,16 @@ describe('Server Config (config.ts)', () => {
       expect(GeminiClient).toHaveBeenCalledWith(config);
     });
 
+    it('should clear fallback overrides when refreshing auth', async () => {
+      const config = new Config(baseParams);
+      config.activateFallbackMode('fallback-model', 'failed-model');
+      expect(config.getFallbackOverride('failed-model')).toBe('fallback-model');
+
+      await config.refreshAuth(AuthType.USE_GEMINI);
+
+      expect(config.getFallbackOverride('failed-model')).toBeUndefined();
+    });
+
     it('should pass Vertex AI routing settings when refreshing auth', async () => {
       const vertexAiRouting = {
         requestType: 'shared' as const,
@@ -1902,6 +1912,21 @@ describe('Server Config (config.ts)', () => {
     );
   });
 
+  it('clears fallback overrides when session changes', async () => {
+    const config = new Config({
+      ...baseParams,
+      sessionId: 'session-one',
+    });
+    await config.initialize();
+
+    config.activateFallbackMode('fallback-model', 'failed-model');
+    expect(config.getFallbackOverride('failed-model')).toBe('fallback-model');
+
+    config.setSessionId('session-two');
+
+    expect(config.getFallbackOverride('failed-model')).toBeUndefined();
+  });
+
   it('does not throw when changing sessions before the previous plans dir exists', async () => {
     const config = new Config({
       ...baseParams,
@@ -2713,6 +2738,16 @@ describe('Config getHooks', () => {
       expect(config.getModel()).toBe('auto');
       expect(mockCoreEvents.emitModelChanged).toHaveBeenCalledWith('auto');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should clear fallback overrides when setting a model', () => {
+      const config = new Config(baseParams);
+      config.activateFallbackMode('fallback-model', 'failed-model');
+      expect(config.getFallbackOverride('failed-model')).toBe('fallback-model');
+
+      config.setModel('new-model');
+
+      expect(config.getFallbackOverride('failed-model')).toBeUndefined();
     });
 
     it('should allow setting auto model from auto model and reset availability', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2740,14 +2740,14 @@ describe('Config getHooks', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should clear fallback overrides when setting a model', () => {
+    it('should preserve fallback overrides when setting a new model', () => {
       const config = new Config(baseParams);
       config.activateFallbackMode('fallback-model', 'failed-model');
       expect(config.getFallbackOverride('failed-model')).toBe('fallback-model');
 
       config.setModel('new-model');
 
-      expect(config.getFallbackOverride('failed-model')).toBeUndefined();
+      expect(config.getFallbackOverride('failed-model')).toBe('fallback-model');
     });
 
     it('should allow setting auto model from auto model and reset availability', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1929,8 +1929,23 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   activateFallbackMode(model: string, failedModel?: string): void {
-    this.setModel(model, true);
+    if (this.getActiveModel() !== model) {
+      this.setModel(model, true);
+    }
     if (failedModel) {
+      // Chained fallback mitigation: If we already have overrides that point to the model
+      // that just failed, we need to update them to point to the new fallback model.
+      // e.g. A -> B, then B fails and we fallback to C. We must update A to point to C.
+      for (const [source, target] of this.fallbackOverrides.entries()) {
+        if (target === failedModel) {
+          this.fallbackOverrides.set(source, model);
+          this.modelConfigService.registerRuntimeModelOverride({
+            match: { model: source },
+            modelConfig: { model },
+          });
+        }
+      }
+
       this.fallbackOverrides.set(failedModel, model);
       this.modelConfigService.registerRuntimeModelOverride({
         match: { model: failedModel },

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1926,8 +1926,6 @@ export class Config implements McpContext, AgentLoopContext {
       this.onModelChange(newModel);
     }
     this.modelAvailabilityService.reset();
-    this.fallbackOverrides.clear();
-    this.modelConfigService.clearRuntimeOverrides();
   }
 
   activateFallbackMode(model: string, failedModel?: string): void {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -833,6 +833,7 @@ export class Config implements McpContext, AgentLoopContext {
   private ideMode: boolean;
 
   private _activeModel: string;
+  private fallbackOverrides = new Map<string, string>();
   private readonly maxSessionTurns: number;
   private readonly listSessions: boolean;
   private readonly deleteSession: string | undefined;
@@ -1923,12 +1924,23 @@ export class Config implements McpContext, AgentLoopContext {
     this.modelAvailabilityService.reset();
   }
 
-  activateFallbackMode(model: string): void {
+  activateFallbackMode(model: string, failedModel?: string): void {
     this.setModel(model, true);
+    if (failedModel) {
+      this.fallbackOverrides.set(failedModel, model);
+      this.modelConfigService.registerRuntimeModelOverride({
+        match: { model: failedModel },
+        modelConfig: { model },
+      });
+    }
     const authType = this.getContentGeneratorConfig()?.authType;
     if (authType) {
       logFlashFallback(this, new FlashFallbackEvent(authType));
     }
+  }
+
+  getFallbackOverride(model: string): string | undefined {
+    return this.fallbackOverrides.get(model);
   }
 
   getActiveModel(): string {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1568,6 +1568,8 @@ export class Config implements McpContext, AgentLoopContext {
   ) {
     // Reset availability service when switching auth
     this.modelAvailabilityService.reset();
+    this.fallbackOverrides.clear();
+    this.modelConfigService.clearRuntimeOverrides();
 
     // Vertex and Genai have incompatible encryption and sending history with
     // thoughtSignature from Genai to Vertex will fail, we need to strip them
@@ -1829,6 +1831,8 @@ export class Config implements McpContext, AgentLoopContext {
     this._sessionId = sessionId;
     this.storage.setSessionId(sessionId);
     this.trackerService = undefined;
+    this.fallbackOverrides.clear();
+    this.modelConfigService.clearRuntimeOverrides();
     this.approvedPlanPath = undefined;
     this.topicState.reset();
     this.skillManager.reset();
@@ -1922,6 +1926,8 @@ export class Config implements McpContext, AgentLoopContext {
       this.onModelChange(newModel);
     }
     this.modelAvailabilityService.reset();
+    this.fallbackOverrides.clear();
+    this.modelConfigService.clearRuntimeOverrides();
   }
 
   activateFallbackMode(model: string, failedModel?: string): void {

--- a/packages/core/src/config/flashFallback.test.ts
+++ b/packages/core/src/config/flashFallback.test.ts
@@ -73,5 +73,23 @@ describe('Flash Model Fallback Configuration', () => {
         expect.any(FlashFallbackEvent),
       );
     });
+
+    it('should set fallback override when failedModel is provided and register runtime override', () => {
+      config.activateFallbackMode(
+        DEFAULT_GEMINI_FLASH_MODEL,
+        DEFAULT_GEMINI_MODEL,
+      );
+      expect(config.getModel()).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+      expect(config.getFallbackOverride(DEFAULT_GEMINI_MODEL)).toBe(
+        DEFAULT_GEMINI_FLASH_MODEL,
+      );
+
+      // Verify it registers the runtime model override with ModelConfigService
+      expect(
+        config
+          .getModelConfigService()
+          .getResolvedConfig({ model: DEFAULT_GEMINI_MODEL }).model,
+      ).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+    });
   });
 });

--- a/packages/core/src/config/flashFallback.test.ts
+++ b/packages/core/src/config/flashFallback.test.ts
@@ -91,5 +91,40 @@ describe('Flash Model Fallback Configuration', () => {
           .getResolvedConfig({ model: DEFAULT_GEMINI_MODEL }).model,
       ).toBe(DEFAULT_GEMINI_FLASH_MODEL);
     });
+
+    it('should flatten override chains when a model that was previously a target fails', () => {
+      // 1. Initial fallback: A -> B
+      config.activateFallbackMode('model-B', 'model-A');
+      expect(config.getFallbackOverride('model-A')).toBe('model-B');
+      expect(
+        config.getModelConfigService().getResolvedConfig({ model: 'model-A' })
+          .model,
+      ).toBe('model-B');
+
+      // 2. Chained fallback: B fails, fallback to C
+      // This should update A -> C as well.
+      config.activateFallbackMode('model-C', 'model-B');
+
+      expect(config.getFallbackOverride('model-A')).toBe('model-C');
+      expect(config.getFallbackOverride('model-B')).toBe('model-C');
+
+      expect(
+        config.getModelConfigService().getResolvedConfig({ model: 'model-A' })
+          .model,
+      ).toBe('model-C');
+      expect(
+        config.getModelConfigService().getResolvedConfig({ model: 'model-B' })
+          .model,
+      ).toBe('model-C');
+    });
+
+    it('should not reset availability service if model has not changed', () => {
+      const resetSpy = vi.spyOn(config.getModelAvailabilityService(), 'reset');
+      const currentModel = config.getActiveModel();
+
+      config.activateFallbackMode(currentModel);
+
+      expect(resetSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -191,6 +191,7 @@ describe('handleFallback', () => {
         expect(policyConfig.getFallbackModelHandler).not.toHaveBeenCalled();
         expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL,
+          MOCK_PRO_MODEL,
         );
       } finally {
         chainSpy.mockRestore();
@@ -383,6 +384,7 @@ describe('handleFallback', () => {
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
         FALLBACK_MODEL,
+        MOCK_PRO_MODEL,
       );
       // TODO: add logging expect statement
     });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -191,7 +191,7 @@ describe('handleFallback', () => {
         expect(policyConfig.getFallbackModelHandler).not.toHaveBeenCalled();
         expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
           DEFAULT_GEMINI_FLASH_MODEL,
-          MOCK_PRO_MODEL,
+          undefined,
         );
       } finally {
         chainSpy.mockRestore();

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -389,7 +389,7 @@ describe('handleFallback', () => {
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).toHaveBeenCalledWith(
         FALLBACK_MODEL,
-        MOCK_PRO_MODEL,
+        undefined,
       );
       // TODO: add logging expect statement
     });

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -208,6 +208,9 @@ describe('handleFallback', () => {
         selectedModel: MOCK_PRO_MODEL,
         skipped: [],
       });
+      // Mock activeModel to be unavailable so the utility bypass heuristic is skipped
+      vi.mocked(availability.snapshot).mockReturnValue({ available: false });
+
       policyHandler.mockResolvedValue('retry_once');
 
       await handleFallback(
@@ -352,6 +355,8 @@ describe('handleFallback', () => {
       vi.mocked(policyConfig.getModel).mockReturnValue(
         DEFAULT_GEMINI_MODEL_AUTO,
       );
+      // Mock activeModel to be unavailable so the utility bypass heuristic is skipped
+      vi.mocked(availability.snapshot).mockReturnValue({ available: false });
 
       const result = await handleFallback(
         policyConfig,

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -110,7 +110,6 @@ export async function handleFallback(
 
   const handler = config.getFallbackModelHandler();
   if (typeof handler !== 'function') {
-    throw new Error('STOP 2');
     return null;
   }
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -86,7 +86,8 @@ export async function handleFallback(
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
       // For standard auto-routing (silent), we only update the active model, so don't pass failedModel.
       // For utility bypass, we want a hard runtime override, so pass failedModel.
-      const overrideFailedModel = action === 'silent' ? undefined : failedModel;
+      const overrideFailedModel =
+        failedModel !== activeModel ? failedModel : undefined;
       return processIntent(
         config,
         'retry_always',
@@ -109,6 +110,7 @@ export async function handleFallback(
 
   const handler = config.getFallbackModelHandler();
   if (typeof handler !== 'function') {
+    throw new Error('STOP 2');
     return null;
   }
 
@@ -123,7 +125,12 @@ export async function handleFallback(
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
     }
 
-    return await processIntent(config, intent, fallbackModel, failedModel);
+    return await processIntent(
+      config,
+      intent,
+      fallbackModel,
+      failedModel !== activeModel ? failedModel : undefined,
+    );
   } catch (handlerError) {
     debugLogger.error('Fallback handler failed:', handlerError);
     return null;

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -46,10 +46,6 @@ export async function handleFallback(
   let fallbackModel: string;
 
   if (!candidates.length) {
-    if (failedModel !== activeModel) {
-      applyAvailabilityTransition(getAvailabilityContext, failureKind);
-      return processIntent(config, 'retry_always', activeModel, failedModel);
-    }
     fallbackModel = failedModel;
   } else {
     const selection = availability.selectFirstAvailable(
@@ -75,11 +71,21 @@ export async function handleFallback(
 
     // failureKind is already declared and calculated above
     const action = resolvePolicyAction(failureKind, selectedPolicy);
-    const activeModel = config.getActiveModel();
 
-    if (action === 'silent' || fallbackModel === activeModel) {
+    if (
+      action === 'silent' ||
+      (fallbackModel === activeModel && failedModel !== activeModel)
+    ) {
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
-      return processIntent(config, 'retry_always', fallbackModel, failedModel);
+      // For standard auto-routing (silent), we only update the active model, so don't pass failedModel.
+      // For utility bypass, we want a hard runtime override, so pass failedModel.
+      const overrideFailedModel = action === 'silent' ? undefined : failedModel;
+      return processIntent(
+        config,
+        'retry_always',
+        fallbackModel,
+        overrideFailedModel,
+      );
     }
 
     // This will be used in the future when FallbackRecommendation is passed through UI

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -46,6 +46,13 @@ export async function handleFallback(
   let fallbackModel: string;
 
   if (!candidates.length) {
+    if (
+      failedModel !== activeModel &&
+      availability.snapshot(activeModel).available
+    ) {
+      applyAvailabilityTransition(getAvailabilityContext, failureKind);
+      return processIntent(config, 'retry_always', activeModel, failedModel);
+    }
     fallbackModel = failedModel;
   } else {
     const selection = availability.selectFirstAvailable(

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -42,8 +42,14 @@ export async function handleFallback(
     return { service: availability, policy: failedPolicy };
   };
 
+  const activeModel = config.getActiveModel();
   let fallbackModel: string;
+
   if (!candidates.length) {
+    if (failedModel !== activeModel) {
+      applyAvailabilityTransition(getAvailabilityContext, failureKind);
+      return processIntent(config, 'retry_always', activeModel, failedModel);
+    }
     fallbackModel = failedModel;
   } else {
     const selection = availability.selectFirstAvailable(
@@ -69,10 +75,11 @@ export async function handleFallback(
 
     // failureKind is already declared and calculated above
     const action = resolvePolicyAction(failureKind, selectedPolicy);
+    const activeModel = config.getActiveModel();
 
-    if (action === 'silent') {
+    if (action === 'silent' || fallbackModel === activeModel) {
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
-      return processIntent(config, 'retry_always', fallbackModel);
+      return processIntent(config, 'retry_always', fallbackModel, failedModel);
     }
 
     // This will be used in the future when FallbackRecommendation is passed through UI
@@ -103,7 +110,7 @@ export async function handleFallback(
       applyAvailabilityTransition(getAvailabilityContext, failureKind);
     }
 
-    return await processIntent(config, intent, fallbackModel);
+    return await processIntent(config, intent, fallbackModel, failedModel);
   } catch (handlerError) {
     debugLogger.error('Fallback handler failed:', handlerError);
     return null;
@@ -131,12 +138,13 @@ async function processIntent(
   config: Config,
   intent: FallbackIntent | null,
   fallbackModel: string,
+  failedModel?: string,
 ): Promise<boolean> {
   switch (intent) {
     case 'retry_always':
       // TODO(telemetry): Implement generic fallback event logging. Existing
       // logFlashFallback is specific to a single Model.
-      config.activateFallbackMode(fallbackModel);
+      config.activateFallbackMode(fallbackModel, failedModel);
       return true;
 
     case 'retry_once':

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -668,6 +668,31 @@ describe('ModelConfigService', () => {
       // Specificity should win over order
       expect(resolved.generateContentConfig.temperature).toBe(0.1);
     });
+
+    it('should clear runtime overrides', () => {
+      const config: ModelConfigServiceConfig = {
+        aliases: {},
+        overrides: [],
+      };
+      const service = new ModelConfigService(config);
+
+      service.registerRuntimeModelOverride({
+        match: { model: 'gemini-pro' },
+        modelConfig: { generateContentConfig: { temperature: 0.99 } },
+      });
+
+      expect(
+        service.getResolvedConfig({ model: 'gemini-pro' }).generateContentConfig
+          .temperature,
+      ).toBe(0.99);
+
+      service.clearRuntimeOverrides();
+
+      expect(
+        service.getResolvedConfig({ model: 'gemini-pro' }).generateContentConfig
+          .temperature,
+      ).toBeUndefined();
+    });
   });
 
   describe('custom aliases', () => {

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -344,6 +344,10 @@ export class ModelConfigService {
     this.runtimeOverrides.push(override);
   }
 
+  clearRuntimeOverrides(): void {
+    this.runtimeOverrides.length = 0;
+  }
+
   /**
    * Resolves a model configuration by merging settings from aliases and applying overrides.
    *


### PR DESCRIPTION
Fixes #23397

**Description**
This fixes an infinite UI dialog loop caused when hardcoded background utility models (like `llm-edit-fixer`) run out of quota. 

**Root Cause**
Utility models specify hardcoded base configurations (e.g., `gemini-3-flash-preview`) in `defaultModelConfigs.ts`. When the user exhausts quota for that default model, the background task triggers a `TerminalQuotaError` and the system pops the Pro Quota Fallback UI. However, even when the user clicks 'Yes' to switch to an available model (like `gemini-3.1-flash-lite-preview`), the fallback logic was only updating the active chat session state (`getActiveModel`). When the background task subsequently retried, it requested its hardcoded configuration again, hit the quota error again, and popped the dialog again, infinitely.

**The Fix**
1. **Dynamic Rerouting:** `activateFallbackMode` now registers a global runtime override via `ModelConfigService`. When a background utility retries, `ModelConfigService` intercepts the request for the exhausted model and dynamically swaps it with the user's chosen fallback model.
2. **Silent Fallback:** If the fallback model calculation determines the user's *already active* session model is the correct fallback candidate (e.g. they explicitly launched with `-m gemini-3.1-flash-lite-preview`), `handleFallback` now silently registers the override route and retries the background task without ever showing the dialog to the user.