### PR TITLE
fix(core): skip missing include directories on startup

### DIFF
--- a/packages/core/src/config/config.include-directories.test.ts
+++ b/packages/core/src/config/config.include-directories.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Config, type ConfigParameters } from './config.js';
+import { createTmpDir, cleanupTmpDir } from '@google/gemini-cli-test-utils';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { debugLogger } from '../utils/debugLogger.js';
+
+vi.mock('../core/client.js', () => ({
+  GeminiClient: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    isInitialized: vi.fn().mockReturnValue(true),
+    setTools: vi.fn().mockResolvedValue(undefined),
+    updateSystemInstruction: vi.fn(),
+  })),
+}));
+
+vi.mock('../core/contentGenerator.js');
+vi.mock('../telemetry/index.js');
+vi.mock('../core/tokenLimits.js');
+vi.mock('../services/fileDiscoveryService.js');
+vi.mock('../services/gitService.js');
+vi.mock('../services/trackerService.js');
+
+describe('Config includeDirectories initialization', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir({});
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(tmpDir);
+    vi.clearAllMocks();
+  });
+
+  it('skips missing pending include directories during initialize', async () => {
+    const missingIncludeDir = '.kilocode/rules';
+    const existingIncludeDir = '.cursor/rules';
+    const existingIncludeDirPath = path.join(tmpDir, existingIncludeDir);
+    const missingIncludeDirPath = path.join(tmpDir, missingIncludeDir);
+    await fs.mkdir(existingIncludeDirPath, { recursive: true });
+    const realExistingIncludeDirPath = await fs.realpath(
+      existingIncludeDirPath,
+    );
+    const warnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+    const params: ConfigParameters = {
+      sessionId: 'test-session',
+      targetDir: tmpDir,
+      model: 'test-model',
+      cwd: tmpDir,
+      debugMode: false,
+      checkpointing: false,
+      includeDirectories: [missingIncludeDir, existingIncludeDir],
+    };
+
+    const config = new Config(params);
+    await config.initialize();
+
+    expect(config.getWorkspaceContext().getDirectories()).toEqual([
+      await fs.realpath(tmpDir),
+      realExistingIncludeDirPath,
+    ]);
+    expect(config.sandboxManager.getOptions()?.includeDirectories).toContain(
+      realExistingIncludeDirPath,
+    );
+    expect(
+      config.sandboxManager.getOptions()?.includeDirectories,
+    ).not.toContain(missingIncludeDir);
+    expect(
+      config.sandboxManager.getOptions()?.includeDirectories,
+    ).not.toContain(missingIncludeDirPath);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[WARN] Skipping unreadable directory: ${missingIncludeDir} (Directory does not exist: ${missingIncludeDirPath})`,
+    );
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1028,10 +1028,7 @@ export class Config implements McpContext, AgentLoopContext {
       {
         workspace: this.targetDir,
         forbiddenPaths: this.getSandboxForbiddenPaths.bind(this),
-        includeDirectories: [
-          ...this.pendingIncludeDirectories,
-          Storage.getGlobalTempDir(),
-        ],
+        includeDirectories: this.getSandboxIncludeDirectories(),
         policyManager: this._sandboxPolicyManager,
       },
       initialApprovalMode,
@@ -1443,9 +1440,12 @@ export class Config implements McpContext, AgentLoopContext {
     await this.storage.initialize();
     ragLogger.initialize(this.storage.getProjectTempLogsDir());
 
-    // Add pending directories to workspace context
-    for (const dir of this.pendingIncludeDirectories) {
-      this.workspaceContext.addDirectory(dir);
+    // Add pending optional include directories to workspace context. Missing or
+    // unreadable directories are reported by WorkspaceContext and skipped
+    // instead of aborting startup.
+    this.workspaceContext.addDirectories(this.pendingIncludeDirectories);
+    if (this.pendingIncludeDirectories.length > 0) {
+      this.refreshSandboxManager();
     }
 
     // Add plans directory to workspace context for plan file storage
@@ -1789,15 +1789,24 @@ export class Config implements McpContext, AgentLoopContext {
       {
         workspace: this.targetDir,
         forbiddenPaths: this.getSandboxForbiddenPaths.bind(this),
-        includeDirectories: [
-          ...this.pendingIncludeDirectories,
-          Storage.getGlobalTempDir(),
-        ],
+        includeDirectories: this.getSandboxIncludeDirectories(),
         policyManager: this._sandboxPolicyManager,
       },
       this.getApprovalMode(),
     );
     this.shellExecutionConfig.sandboxManager = this._sandboxManager;
+  }
+
+  private getSandboxIncludeDirectories(): string[] {
+    const initialDirectories = new Set(
+      this.workspaceContext.getInitialDirectories(),
+    );
+    return [
+      ...this.workspaceContext
+        .getDirectories()
+        .filter((directory) => !initialDirectories.has(directory)),
+      Storage.getGlobalTempDir(),
+    ];
   }
 
   get sandboxPolicyManager() {


### PR DESCRIPTION
## Summary

Skip missing or unreadable optional `context.includeDirectories` entries during core startup instead of aborting after logging a warning.

## Details

`Config.initialize()` previously called `WorkspaceContext.addDirectory()` for each pending include directory. That method throws if any directory cannot be added, even though `WorkspaceContext.addDirectories()` already logs and skips unreadable paths.

This switches initialization to the batched optional-add path and derives sandbox include directories from the validated workspace context when the sandbox manager is created or refreshed. That keeps missing paths out of sandbox options while preserving successfully added include directories.

## Related Issues

Fixes #27311

## How to Validate

- `npx vitest run packages/core/src/config/config.include-directories.test.ts --root packages/core`
  - Expected: 1 test passes; missing `.kilocode/rules` is skipped while existing `.cursor/rules` remains available.
- `npx vitest run packages/core/src/config/config.test.ts --root packages/core`
  - Expected: existing config coverage passes.
- `npx eslint packages/core/src/config/config.ts packages/core/src/config/config.include-directories.test.ts`
  - Expected: no lint errors in changed files.
- `npm run typecheck --workspace @google/gemini-cli-core`
  - Expected: TypeScript completes with no errors.
- `npm run build --workspace @google/gemini-cli-core`
  - Expected: core package build completes.
- `npx prettier --check packages/core/src/config/config.ts packages/core/src/config/config.include-directories.test.ts && git diff --check`
  - Expected: formatting and whitespace checks pass.
- `node scripts/pre-commit.js`
  - Expected: lint-staged hook passes for staged files.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker
