### PR TITLE
fix(core,cli): defensively check for directories in session/checkpoint scans

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -124,9 +124,9 @@ describe('chatCommand', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockFs.stat.mockImplementation(async (path: any): Promise<Stats> => {
         if (path.endsWith('test1.json')) {
-          return { mtime: date1 } as Stats;
+          return { mtime: date1, isFile: () => true } as Stats;
         }
-        return { mtime: date2 } as Stats;
+        return { mtime: date2, isFile: () => true } as Stats;
       });
 
       await listCommand?.action?.(mockContext, '');
@@ -141,6 +141,37 @@ describe('chatCommand', () => {
           {
             name: 'test2',
             mtime: date2.toISOString(),
+          },
+        ],
+      });
+    });
+
+    it('should ignore directories matching the checkpoint pattern', async () => {
+      const fakeFiles = ['checkpoint-file.json', 'checkpoint-directory.json'];
+      const date = new Date();
+
+      mockFs.readdir.mockResolvedValue(fakeFiles as any);
+      mockFs.stat.mockImplementation(async (filePath: any): Promise<Stats> => {
+        if (filePath.endsWith('file.json')) {
+          return {
+            mtime: date,
+            isFile: () => true,
+          } as Stats;
+        }
+        return {
+          mtime: date,
+          isFile: () => false,
+        } as Stats;
+      });
+
+      await listCommand?.action?.(mockContext, '');
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith({
+        type: 'chat_list',
+        chats: [
+          {
+            name: 'file',
+            mtime: date.toISOString(),
           },
         ],
       });
@@ -347,6 +378,7 @@ describe('chatCommand', () => {
           (async (_: string): Promise<Stats> =>
             ({
               mtime: new Date(),
+              isFile: () => true,
             }) as Stats) as unknown as typeof fsPromises.stat,
         );
 
@@ -366,9 +398,12 @@ describe('chatCommand', () => {
           path: string,
         ): Promise<Stats> => {
           if (path.endsWith('test1.json')) {
-            return { mtime: date } as Stats;
+            return { mtime: date, isFile: () => true } as Stats;
           }
-          return { mtime: new Date(date.getTime() + 1000) } as Stats;
+          return {
+            mtime: new Date(date.getTime() + 1000),
+            isFile: () => true,
+          } as Stats;
         }) as unknown as typeof fsPromises.stat);
 
         const result = await resumeCommand?.completion?.(mockContext, '');
@@ -427,6 +462,7 @@ describe('chatCommand', () => {
           (async (_: string): Promise<Stats> =>
             ({
               mtime: new Date(),
+              isFile: () => true,
             }) as Stats) as unknown as typeof fsPromises.stat,
         );
 

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -15,7 +15,7 @@ import * as fsPromises from 'node:fs/promises';
 // ... (rest of imports)
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual = await importOriginal<any>();
+  const actual = await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
     resolveToRealPath: vi.fn((p: string) => p),
@@ -130,14 +130,12 @@ describe('chatCommand', () => {
       const date1 = new Date();
       const date2 = new Date(date1.getTime() + 1000);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.readdir as any).mockResolvedValue(fakeFiles as any);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.stat as any).mockImplementation(async (path: any): Promise<any> => {
+      (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
+      (mockFs.stat as unknown as vi.Mock).mockImplementation(async (path: string): Promise<Stats> => {
         if (path.endsWith('test1.json')) {
-          return { mtime: date1, isFile: () => true } as any;
+          return { mtime: date1, isFile: () => true } as unknown as Stats;
         }
-        return { mtime: date2, isFile: () => true } as any;
+        return { mtime: date2, isFile: () => true } as unknown as Stats;
       });
 
       await listCommand?.action?.(mockContext, '');
@@ -161,20 +159,18 @@ describe('chatCommand', () => {
       const fakeFiles = ['checkpoint-file.json', 'checkpoint-directory.json'];
       const date = new Date();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.readdir as any).mockResolvedValue(fakeFiles as any);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.stat as any).mockImplementation(async (filePath: any): Promise<any> => {
+      (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
+      (mockFs.stat as unknown as vi.Mock).mockImplementation(async (filePath: string): Promise<Stats> => {
         if (filePath.endsWith('file.json')) {
           return {
             mtime: date,
             isFile: () => true,
-          } as any;
+          } as unknown as Stats;
         }
         return {
           mtime: date,
           isFile: () => false,
-        } as any;
+        } as unknown as Stats;
       });
 
       await listCommand?.action?.(mockContext, '');
@@ -748,10 +744,6 @@ Hi there!`;
 
       beforeEach(() => {
         mockGetLatestApiRequest = vi.fn();
-        if (!mockContext.services.agentContext!.config) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (mockContext.services.agentContext!.config as any) = {};
-        }
         mockContext.services.agentContext!.config.getLatestApiRequest =
           mockGetLatestApiRequest;
         vi.spyOn(process, 'cwd').mockReturnValue('/project/root');

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -15,7 +15,8 @@ import * as fsPromises from 'node:fs/promises';
 // ... (rest of imports)
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
     resolveToRealPath: vi.fn((p: string) => p),
@@ -71,6 +72,7 @@ describe('chatCommand', () => {
   };
 
   beforeEach(() => {
+    mockExport.mockClear();
     mockGetHistory = vi.fn().mockReturnValue([]);
     mockGetChat = vi.fn().mockReturnValue({
       getHistory: mockGetHistory,
@@ -131,12 +133,14 @@ describe('chatCommand', () => {
       const date2 = new Date(date1.getTime() + 1000);
 
       (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
-      (mockFs.stat as unknown as vi.Mock).mockImplementation(async (path: string): Promise<Stats> => {
-        if (path.endsWith('test1.json')) {
-          return { mtime: date1, isFile: () => true } as unknown as Stats;
-        }
-        return { mtime: date2, isFile: () => true } as unknown as Stats;
-      });
+      (mockFs.stat as unknown as vi.Mock).mockImplementation(
+        async (path: string): Promise<Stats> => {
+          if (path.endsWith('test1.json')) {
+            return { mtime: date1, isFile: () => true } as unknown as Stats;
+          }
+          return { mtime: date2, isFile: () => true } as unknown as Stats;
+        },
+      );
 
       await listCommand?.action?.(mockContext, '');
 
@@ -160,18 +164,20 @@ describe('chatCommand', () => {
       const date = new Date();
 
       (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
-      (mockFs.stat as unknown as vi.Mock).mockImplementation(async (filePath: string): Promise<Stats> => {
-        if (filePath.endsWith('file.json')) {
+      (mockFs.stat as unknown as vi.Mock).mockImplementation(
+        async (filePath: string): Promise<Stats> => {
+          if (filePath.endsWith('file.json')) {
+            return {
+              mtime: date,
+              isFile: () => true,
+            } as unknown as Stats;
+          }
           return {
             mtime: date,
-            isFile: () => true,
+            isFile: () => false,
           } as unknown as Stats;
-        }
-        return {
-          mtime: date,
-          isFile: () => false,
-        } as unknown as Stats;
-      });
+        },
+      );
 
       await listCommand?.action?.(mockContext, '');
 

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -9,9 +9,20 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { SlashCommand, CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import type { Content } from '@google/genai';
-import { AuthType, type GeminiClient } from '@google/gemini-cli-core';
+import { AuthType, type GeminiClient, resolveToRealPath, isSubpath } from '@google/gemini-cli-core';
 
 import * as fsPromises from 'node:fs/promises';
+// ... (rest of imports)
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    resolveToRealPath: vi.fn((p: string) => p),
+    isSubpath: vi.fn(() => true),
+    EDITOR_OPTIONS: actual.EDITOR_OPTIONS || [],
+  };
+});
 import { chatCommand, debugCommand } from './chatCommand.js';
 import {
   serializeHistoryToMarkdown,

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -120,9 +120,9 @@ describe('chatCommand', () => {
       const date2 = new Date(date1.getTime() + 1000);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockFs.readdir.mockResolvedValue(fakeFiles as string[]);
+      (mockFs.readdir as any).mockResolvedValue(fakeFiles);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockFs.stat.mockImplementation(async (path: string): Promise<Stats> => {
+      (mockFs.stat as any).mockImplementation(async (path: any): Promise<Stats> => {
         if (path.endsWith('test1.json')) {
           return { mtime: date1, isFile: () => true } as Stats;
         }
@@ -150,8 +150,10 @@ describe('chatCommand', () => {
       const fakeFiles = ['checkpoint-file.json', 'checkpoint-directory.json'];
       const date = new Date();
 
-      mockFs.readdir.mockResolvedValue(fakeFiles as string[]);
-      mockFs.stat.mockImplementation(async (filePath: string): Promise<Stats> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockFs.readdir as any).mockResolvedValue(fakeFiles);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockFs.stat as any).mockImplementation(async (filePath: any): Promise<Stats> => {
         if (filePath.endsWith('file.json')) {
           return {
             mtime: date,

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -131,13 +131,13 @@ describe('chatCommand', () => {
       const date2 = new Date(date1.getTime() + 1000);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.readdir as any).mockResolvedValue(fakeFiles);
+      (mockFs.readdir as any).mockResolvedValue(fakeFiles as any);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.stat as any).mockImplementation(async (path: any): Promise<Stats> => {
+      (mockFs.stat as any).mockImplementation(async (path: any): Promise<any> => {
         if (path.endsWith('test1.json')) {
-          return { mtime: date1, isFile: () => true } as Stats;
+          return { mtime: date1, isFile: () => true } as any;
         }
-        return { mtime: date2, isFile: () => true } as Stats;
+        return { mtime: date2, isFile: () => true } as any;
       });
 
       await listCommand?.action?.(mockContext, '');
@@ -162,19 +162,19 @@ describe('chatCommand', () => {
       const date = new Date();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.readdir as any).mockResolvedValue(fakeFiles);
+      (mockFs.readdir as any).mockResolvedValue(fakeFiles as any);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mockFs.stat as any).mockImplementation(async (filePath: any): Promise<Stats> => {
+      (mockFs.stat as any).mockImplementation(async (filePath: any): Promise<any> => {
         if (filePath.endsWith('file.json')) {
           return {
             mtime: date,
             isFile: () => true,
-          } as Stats;
+          } as any;
         }
         return {
           mtime: date,
           isFile: () => false,
-        } as Stats;
+        } as any;
       });
 
       await listCommand?.action?.(mockContext, '');

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
 
 import type { SlashCommand, CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
@@ -15,8 +15,7 @@ import * as fsPromises from 'node:fs/promises';
 // ... (rest of imports)
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const actual = await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
     resolveToRealPath: vi.fn((p: string) => p),
@@ -132,8 +131,8 @@ describe('chatCommand', () => {
       const date1 = new Date();
       const date2 = new Date(date1.getTime() + 1000);
 
-      (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
-      (mockFs.stat as unknown as vi.Mock).mockImplementation(
+      (mockFs.readdir as unknown as Mock).mockResolvedValue(fakeFiles);
+      (mockFs.stat as unknown as Mock).mockImplementation(
         async (path: string): Promise<Stats> => {
           if (path.endsWith('test1.json')) {
             return { mtime: date1, isFile: () => true } as unknown as Stats;
@@ -163,8 +162,8 @@ describe('chatCommand', () => {
       const fakeFiles = ['checkpoint-file.json', 'checkpoint-directory.json'];
       const date = new Date();
 
-      (mockFs.readdir as unknown as vi.Mock).mockResolvedValue(fakeFiles);
-      (mockFs.stat as unknown as vi.Mock).mockImplementation(
+      (mockFs.readdir as unknown as Mock).mockResolvedValue(fakeFiles);
+      (mockFs.stat as unknown as Mock).mockImplementation(
         async (filePath: string): Promise<Stats> => {
           if (filePath.endsWith('file.json')) {
             return {

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -9,7 +9,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type { SlashCommand, CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import type { Content } from '@google/genai';
-import { AuthType, type GeminiClient, resolveToRealPath, isSubpath } from '@google/gemini-cli-core';
+import { AuthType, type GeminiClient } from '@google/gemini-cli-core';
 
 import * as fsPromises from 'node:fs/promises';
 // ... (rest of imports)

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -120,9 +120,9 @@ describe('chatCommand', () => {
       const date2 = new Date(date1.getTime() + 1000);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockFs.readdir.mockResolvedValue(fakeFiles as any);
+      mockFs.readdir.mockResolvedValue(fakeFiles as string[]);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockFs.stat.mockImplementation(async (path: any): Promise<Stats> => {
+      mockFs.stat.mockImplementation(async (path: string): Promise<Stats> => {
         if (path.endsWith('test1.json')) {
           return { mtime: date1, isFile: () => true } as Stats;
         }
@@ -150,8 +150,8 @@ describe('chatCommand', () => {
       const fakeFiles = ['checkpoint-file.json', 'checkpoint-directory.json'];
       const date = new Date();
 
-      mockFs.readdir.mockResolvedValue(fakeFiles as any);
-      mockFs.stat.mockImplementation(async (filePath: any): Promise<Stats> => {
+      mockFs.readdir.mockResolvedValue(fakeFiles as string[]);
+      mockFs.stat.mockImplementation(async (filePath: string): Promise<Stats> => {
         if (filePath.endsWith('file.json')) {
           return {
             mtime: date,

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -48,12 +48,13 @@ export const getSavedChatTags = async (
     const file_tail = '.json';
     const files = await fsPromises.readdir(geminiDir);
     const chatDetails: ChatDetail[] = [];
+    const realGeminiDir = resolveToRealPath(geminiDir);
 
     const statPromises = files.map(async (file) => {
       if (file.startsWith(file_head) && file.endsWith(file_tail)) {
         try {
           const filePath = resolveToRealPath(path.join(geminiDir, file));
-          if (!isSubpath(geminiDir, filePath)) {
+          if (!isSubpath(realGeminiDir, filePath)) {
             return null;
           }
           const stats = await fsPromises.stat(filePath);

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -31,7 +31,7 @@ import { convertToRestPayload } from '@google/gemini-cli-core';
 
 const CHECKPOINT_MENU_GROUP = 'checkpoints';
 
-const getSavedChatTags = async (
+export const getSavedChatTags = async (
   context: CommandContext,
   mtSortDesc: boolean,
 ): Promise<ChatDetail[]> => {
@@ -50,11 +50,13 @@ const getSavedChatTags = async (
       if (file.startsWith(file_head) && file.endsWith(file_tail)) {
         const filePath = path.join(geminiDir, file);
         const stats = await fsPromises.stat(filePath);
-        const tagName = file.slice(file_head.length, -file_tail.length);
-        chatDetails.push({
-          name: decodeTagName(tagName),
-          mtime: stats.mtime.toISOString(),
-        });
+        if (stats.isFile()) {
+          const tagName = file.slice(file_head.length, -file_tail.length);
+          chatDetails.push({
+            name: decodeTagName(tagName),
+            mtime: stats.mtime.toISOString(),
+          });
+        }
       }
     }
 

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -20,6 +20,7 @@ import {
   INITIAL_HISTORY_LENGTH,
   resolveToRealPath,
   isSubpath,
+  debugLogger,
 } from '@google/gemini-cli-core';
 import path from 'node:path';
 import type {
@@ -63,8 +64,8 @@ export const getSavedChatTags = async (
               mtime: stats.mtime.toISOString(),
             };
           }
-        } catch {
-          // Ignore individual file errors
+        } catch (e) {
+          debugLogger.debug(`Failed to stat checkpoint file ${file}:`, e);
         }
       }
       return null;

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -19,6 +19,7 @@ import {
   type MessageActionReturn,
   INITIAL_HISTORY_LENGTH,
   resolveToRealPath,
+  isSubpath,
 } from '@google/gemini-cli-core';
 import path from 'node:path';
 import type {
@@ -51,6 +52,9 @@ export const getSavedChatTags = async (
       if (file.startsWith(file_head) && file.endsWith(file_tail)) {
         try {
           const filePath = resolveToRealPath(path.join(geminiDir, file));
+          if (!isSubpath(geminiDir, filePath)) {
+            return null;
+          }
           const stats = await fsPromises.stat(filePath);
           if (stats.isFile()) {
             const tagName = file.slice(file_head.length, -file_tail.length);

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -18,6 +18,7 @@ import {
   decodeTagName,
   type MessageActionReturn,
   INITIAL_HISTORY_LENGTH,
+  resolveToRealPath,
 } from '@google/gemini-cli-core';
 import path from 'node:path';
 import type {
@@ -46,17 +47,29 @@ export const getSavedChatTags = async (
     const files = await fsPromises.readdir(geminiDir);
     const chatDetails: ChatDetail[] = [];
 
-    for (const file of files) {
+    const statPromises = files.map(async (file) => {
       if (file.startsWith(file_head) && file.endsWith(file_tail)) {
-        const filePath = path.join(geminiDir, file);
-        const stats = await fsPromises.stat(filePath);
-        if (stats.isFile()) {
-          const tagName = file.slice(file_head.length, -file_tail.length);
-          chatDetails.push({
-            name: decodeTagName(tagName),
-            mtime: stats.mtime.toISOString(),
-          });
+        try {
+          const filePath = resolveToRealPath(path.join(geminiDir, file));
+          const stats = await fsPromises.stat(filePath);
+          if (stats.isFile()) {
+            const tagName = file.slice(file_head.length, -file_tail.length);
+            return {
+              name: decodeTagName(tagName),
+              mtime: stats.mtime.toISOString(),
+            };
+          }
+        } catch {
+          // Ignore individual file errors
         }
+      }
+      return null;
+    });
+
+    const results = await Promise.all(statPromises);
+    for (const result of results) {
+      if (result) {
+        chatDetails.push(result);
       }
     }
 

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -1181,4 +1181,28 @@ describe('getAllSessionFiles', () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].fileName).toBe(sessionFile);
   });
+
+  it('should include symbolic links to files', async () => {
+    const chatsDir = path.join(tmpDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+
+    // Create a valid session file
+    const sessionId = randomUUID();
+    const sessionFile = `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`;
+    const sessionPath = path.join(chatsDir, sessionFile);
+    await fs.writeFile(
+      sessionPath,
+      JSON.stringify({ sessionId, projectHash: 'abc', messages: [] }),
+    );
+
+    // Create a symlink to it
+    const symlinkFile = `${SESSION_FILE_PREFIX}2024-01-01T12-00-symlink.json`;
+    const symlinkPath = path.join(chatsDir, symlinkFile);
+    await fs.symlink(sessionPath, symlinkPath);
+
+    const sessions = await getAllSessionFiles(chatsDir);
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((s) => s.fileName)).toContain(symlinkFile);
+  });
 });

--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -12,6 +12,7 @@ import {
   hasUserOrAssistantMessage,
   SessionError,
   convertSessionToHistoryFormats,
+  getAllSessionFiles,
 } from './sessionUtils.js';
 import {
   SESSION_FILE_PREFIX,
@@ -1140,5 +1141,44 @@ describe('convertSessionToHistoryFormats', () => {
     } else {
       throw new Error('Expected tool_group history item');
     }
+  });
+});
+
+describe('getAllSessionFiles', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = path.join(process.cwd(), '.tmp-test-get-all-sessions');
+    await fs.mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should list only session files and ignore directories', async () => {
+    const chatsDir = path.join(tmpDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+
+    // Create a valid session file
+    const sessionId = randomUUID();
+    const sessionFile = `${SESSION_FILE_PREFIX}2024-01-01T10-00-${sessionId.slice(0, 8)}.json`;
+    await fs.writeFile(
+      path.join(chatsDir, sessionFile),
+      JSON.stringify({ sessionId, projectHash: 'abc', messages: [] }),
+    );
+
+    // Create a directory matching the session pattern
+    const sessionDir = `${SESSION_FILE_PREFIX}2024-01-01T11-00-directory.json`;
+    await fs.mkdir(path.join(chatsDir, sessionDir), { recursive: true });
+
+    const sessions = await getAllSessionFiles(chatsDir);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].fileName).toBe(sessionFile);
   });
 });

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -266,6 +266,7 @@ export const getAllSessionFiles = async (
         try {
           const content = await loadConversationRecord(filePath, {
             metadataOnly: !options.includeFullContent,
+            baseDir: chatsDir,
           });
           if (!content) {
             return { fileName: file, sessionInfo: null };

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -253,7 +253,7 @@ export const getAllSessionFiles = async (
     const sessionFiles = entries
       .filter(
         (e) =>
-          e.isFile() &&
+          (e.isFile() || e.isSymbolicLink()) &&
           e.name.startsWith(SESSION_FILE_PREFIX) &&
           (e.name.endsWith('.json') || e.name.endsWith('.jsonl')),
       )

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -249,13 +249,15 @@ export const getAllSessionFiles = async (
   options: GetSessionOptions = {},
 ): Promise<SessionFileEntry[]> => {
   try {
-    const files = await fs.readdir(chatsDir);
-    const sessionFiles = files
+    const entries = await fs.readdir(chatsDir, { withFileTypes: true });
+    const sessionFiles = entries
       .filter(
-        (f) =>
-          f.startsWith(SESSION_FILE_PREFIX) &&
-          (f.endsWith('.json') || f.endsWith('.jsonl')),
+        (e) =>
+          e.isFile() &&
+          e.name.startsWith(SESSION_FILE_PREFIX) &&
+          (e.name.endsWith('.json') || e.name.endsWith('.jsonl')),
       )
+      .map((e) => e.name)
       .sort(); // Sort by filename, which includes timestamp
 
     const sessionPromises = sessionFiles.map(

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -83,6 +83,8 @@ describe('ChatRecordingService', () => {
     vi.restoreAllMocks();
   });
   beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(fs.appendFileSync).mockRestore();
     testTempDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'chat-recording-test-'),
     );

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -52,7 +52,14 @@ import type { Config } from '../config/config.js';
 import { getProjectHash } from '../utils/paths.js';
 import type { HistoryTurn } from '../core/agentChatHistory.js';
 
-vi.mock('../utils/paths.js');
+vi.mock('../utils/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/paths.js')>();
+  return {
+    ...actual,
+    getProjectHash: vi.fn(),
+    resolveToRealPath: vi.fn((p) => p),
+  };
+});
 vi.mock('node:crypto', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:crypto')>();
   let count = 0;
@@ -1421,6 +1428,22 @@ describe('ChatRecordingService', () => {
       const nonExistentPath = path.join(testTempDir, 'non-existent.json');
       const result = await loadConversationRecord(nonExistentPath);
       expect(result).toBeNull();
+    });
+
+    it('should resolve symbolic links via resolveToRealPath', async () => {
+      const sessionId = 'real-session';
+      const realPath = path.join(testTempDir, 'real-session.json');
+      await fs.promises.writeFile(
+        realPath,
+        JSON.stringify({ sessionId, messages: [] }),
+      );
+
+      const symlinkPath = path.join(testTempDir, 'symlink-session.json');
+      await fs.promises.symlink(realPath, symlinkPath);
+
+      const result = await loadConversationRecord(symlinkPath);
+      expect(result).not.toBeNull();
+      expect(result!.sessionId).toBe(sessionId);
     });
   });
 });

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -1407,4 +1407,20 @@ describe('ChatRecordingService', () => {
       expect(record2!.messages[1].id).toBe('h2');
     });
   });
+
+  describe('loadConversationRecord', () => {
+    it('should return null for a directory to avoid EISDIR errors', async () => {
+      const dirPath = path.join(testTempDir, 'session-directory.json');
+      await fs.promises.mkdir(dirPath, { recursive: true });
+
+      const result = await loadConversationRecord(dirPath);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for non-existent files', async () => {
+      const nonExistentPath = path.join(testTempDir, 'non-existent.json');
+      const result = await loadConversationRecord(nonExistentPath);
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -244,7 +244,7 @@ export async function loadConversationRecord(
     }
 
     if (!metadata.sessionId || !metadata.projectHash) {
-      return await parseLegacyRecordFallback(filePath, options);
+      return await parseLegacyRecordFallback(realPath, options);
     }
 
     const metadataMessages = Array.isArray(metadata.messages)

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -118,11 +118,14 @@ export async function loadConversationRecord(
   try {
     const realPath = resolveToRealPath(filePath);
 
-    if (options?.baseDir && !isSubpath(options.baseDir, realPath)) {
-      debugLogger.warn(
-        `loadConversationRecord: blocked traversal attempt. ${realPath} is not within ${options.baseDir}`,
-      );
-      return null;
+    if (options?.baseDir) {
+      const realBaseDir = resolveToRealPath(options.baseDir);
+      if (!isSubpath(realBaseDir, realPath)) {
+        debugLogger.warn(
+          `loadConversationRecord: blocked traversal attempt. ${realPath} is not within ${realBaseDir} (original baseDir: ${options.baseDir})`,
+        );
+        return null;
+      }
     }
 
     const stats = await fs.promises.stat(realPath);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -5,7 +5,7 @@
  */
 
 import { type ThoughtSummary } from '../utils/thoughtUtils.js';
-import { getProjectHash } from '../utils/paths.js';
+import { getProjectHash, resolveToRealPath } from '../utils/paths.js';
 import path from 'node:path';
 import * as fs from 'node:fs';
 import { sanitizeFilenamePart } from '../utils/fileUtils.js';
@@ -115,8 +115,9 @@ export async function loadConversationRecord(
     })
   | null
 > {
+  const realPath = resolveToRealPath(filePath);
   try {
-    const stats = await fs.promises.stat(filePath);
+    const stats = await fs.promises.stat(realPath);
     if (!stats.isFile()) {
       return null;
     }
@@ -128,7 +129,7 @@ export async function loadConversationRecord(
   }
 
   try {
-    const fileStream = fs.createReadStream(filePath);
+    const fileStream = fs.createReadStream(realPath);
     const rl = readline.createInterface({
       input: fileStream,
       crlfDelay: Infinity,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -5,7 +5,7 @@
  */
 
 import { type ThoughtSummary } from '../utils/thoughtUtils.js';
-import { getProjectHash, resolveToRealPath } from '../utils/paths.js';
+import { getProjectHash, resolveToRealPath, isSubpath } from '../utils/paths.js';
 import path from 'node:path';
 import * as fs from 'node:fs';
 import { sanitizeFilenamePart } from '../utils/fileUtils.js';
@@ -117,6 +117,14 @@ export async function loadConversationRecord(
 > {
   try {
     const realPath = resolveToRealPath(filePath);
+
+    if (options?.baseDir && !isSubpath(options.baseDir, realPath)) {
+      debugLogger.warn(
+        `loadConversationRecord: blocked traversal attempt. ${realPath} is not within ${options.baseDir}`,
+      );
+      return null;
+    }
+
     const stats = await fs.promises.stat(realPath);
     if (!stats.isFile()) {
       return null;

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -115,8 +115,16 @@ export async function loadConversationRecord(
     })
   | null
 > {
-  if (!fs.existsSync(filePath)) {
-    return null;
+  try {
+    const stats = await fs.promises.stat(filePath);
+    if (!stats.isFile()) {
+      return null;
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
   }
 
   try {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -115,20 +115,12 @@ export async function loadConversationRecord(
     })
   | null
 > {
-  const realPath = resolveToRealPath(filePath);
   try {
+    const realPath = resolveToRealPath(filePath);
     const stats = await fs.promises.stat(realPath);
     if (!stats.isFile()) {
       return null;
     }
-  } catch (error) {
-    if (isNodeError(error) && error.code === 'ENOENT') {
-      return null;
-    }
-    throw error;
-  }
-
-  try {
     const fileStream = fs.createReadStream(realPath);
     const rl = readline.createInterface({
       input: fileStream,

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -118,6 +118,8 @@ export interface ResumedSessionData {
 export interface LoadConversationOptions {
   maxMessages?: number;
   metadataOnly?: boolean;
+  /** Optional base directory to enforce for the session file path (prevents traversal) */
+  baseDir?: string;
 }
 
 export interface RewindRecord {


### PR DESCRIPTION
Fixes #27135. This PR adds defensive checks to ensure that directories matching session or checkpoint filename patterns are ignored during scans, preventing EISDIR errors when the CLI attempts to read them.