### PR TITLE
fix(core): mitigate data corruption during write_file on massive text blocks

### DIFF
--- a/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
+++ b/packages/core/src/tools/definitions/__snapshots__/coreToolsModelSnapshots.test.ts.snap
@@ -667,12 +667,12 @@ exports[`coreTools snapshots for specific models > Model: gemini-2.5-pro > snaps
 {
   "description": "Writes content to a specified file in the local filesystem.
 
-      The user has the ability to modify \`content\`. If modified, this will be stated in the response.",
+      The user has the ability to modify \`content\`. If modified, this will be stated in the response. WARNING: Do NOT use this tool if the file contains massive literal text sequences (like a 6000+ character string, large arrays, or inline base64 images), as LLMs are prone to corrupting or truncating such sequences during a full file rewrite. Use the 'replace' tool instead.",
   "name": "write_file",
   "parametersJsonSchema": {
     "properties": {
       "content": {
-        "description": "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
+        "description": "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content. WARNING: Do not use this tool to rewrite files containing massive literal text blocks (e.g., inline base64 images or >6000 character strings) because you may corrupt them. Use the replace tool instead.",
         "type": "string",
       },
       "file_path": {
@@ -1439,12 +1439,12 @@ exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview >
 
 exports[`coreTools snapshots for specific models > Model: gemini-3-pro-preview > snapshot for tool: write_file 1`] = `
 {
-  "description": "Writes the complete content to a file, automatically creating missing parent directories. Overwrites existing files. The user has the ability to modify 'content' before it is saved. Best for new or small files; use 'replace' for targeted edits to large files to minimize token usage and simplify reviews.",
+  "description": "Writes the complete content to a file, automatically creating missing parent directories. Overwrites existing files. The user has the ability to modify 'content' before it is saved. Best for new or small files; use 'replace' for targeted edits to large files to minimize token usage and simplify reviews. WARNING: Do NOT use this tool if the file contains massive literal text sequences (like a 6000+ character string, large arrays, or inline base64 images), as LLMs are prone to corrupting or truncating such sequences during a full file rewrite. Use the 'replace' tool instead.",
   "name": "write_file",
   "parametersJsonSchema": {
     "properties": {
       "content": {
-        "description": "The complete content to write. Provide the full file; do not use placeholders like '// ... rest of code'.",
+        "description": "The complete content to write. Provide the full file; do not use placeholders like '// ... rest of code'. WARNING: Do not use this tool to rewrite files containing massive literal text blocks (e.g., inline base64 images or >6000 character strings) because you may corrupt them. Use the replace tool instead.",
         "type": "string",
       },
       "file_path": {

--- a/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/default-legacy.ts
@@ -112,7 +112,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
     name: WRITE_FILE_TOOL_NAME,
     description: `Writes content to a specified file in the local filesystem.
 
-      The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
+      The user has the ability to modify \`content\`. If modified, this will be stated in the response. WARNING: Do NOT use this tool if the file contains massive literal text sequences (like a 6000+ character string, large arrays, or inline base64 images), as LLMs are prone to corrupting or truncating such sequences during a full file rewrite. Use the '${EDIT_TOOL_NAME}' tool instead.`,
     parametersJsonSchema: {
       type: 'object',
       properties: {
@@ -122,7 +122,7 @@ export const DEFAULT_LEGACY_SET: CoreToolSet = {
         },
         [WRITE_FILE_PARAM_CONTENT]: {
           description:
-            "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
+            "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content. WARNING: Do not use this tool to rewrite files containing massive literal text blocks (e.g., inline base64 images or >6000 character strings) because you may corrupt them. Use the replace tool instead.",
           type: 'string',
         },
       },

--- a/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
+++ b/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts
@@ -119,7 +119,7 @@ export const GEMINI_3_SET: CoreToolSet = {
 
   write_file: {
     name: WRITE_FILE_TOOL_NAME,
-    description: `Writes the complete content to a file, automatically creating missing parent directories. Overwrites existing files. The user has the ability to modify 'content' before it is saved. Best for new or small files; use '${EDIT_TOOL_NAME}' for targeted edits to large files to minimize token usage and simplify reviews.`,
+    description: `Writes the complete content to a file, automatically creating missing parent directories. Overwrites existing files. The user has the ability to modify 'content' before it is saved. Best for new or small files; use '${EDIT_TOOL_NAME}' for targeted edits to large files to minimize token usage and simplify reviews. WARNING: Do NOT use this tool if the file contains massive literal text sequences (like a 6000+ character string, large arrays, or inline base64 images), as LLMs are prone to corrupting or truncating such sequences during a full file rewrite. Use the '${EDIT_TOOL_NAME}' tool instead.`,
     parametersJsonSchema: {
       type: 'object',
       properties: {
@@ -129,7 +129,7 @@ export const GEMINI_3_SET: CoreToolSet = {
         },
         [WRITE_FILE_PARAM_CONTENT]: {
           description:
-            "The complete content to write. Provide the full file; do not use placeholders like '// ... rest of code'.",
+            "The complete content to write. Provide the full file; do not use placeholders like '// ... rest of code'. WARNING: Do not use this tool to rewrite files containing massive literal text blocks (e.g., inline base64 images or >6000 character strings) because you may corrupt them. Use the replace tool instead.",
           type: 'string',
         },
       },

--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -9,6 +9,8 @@ import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 
 describe('detectOmissionPlaceholders', () => {
   it('detects standalone placeholder lines', () => {
+    expect(detectOmissionPlaceholders('...')).toEqual([' ...']);
+    expect(detectOmissionPlaceholders('// ...')).toEqual([' ...']);
     expect(detectOmissionPlaceholders('(rest of methods ...)')).toEqual([
       'rest of methods ...',
     ]);

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -5,6 +5,7 @@
  */
 
 const OMITTED_PREFIXES = new Set([
+  '',
   'rest of',
   'rest of method',
   'rest of methods',


### PR DESCRIPTION
## Summary

This PR mitigates a data corruption issue (Issue #27213) that occurs when the agent attempts to rewrite files containing massive literal text blocks (e.g., 6000+ character strings, inline base64 images) using the `write_file` tool. Due to token output limits and LLM attention degradation, these rewrites often result in structural truncation, malformed objects, or altered capitalization.

## Details

- **Tool Warnings**: Added explicit warnings to the `write_file` tool definitions (in `default-legacy.ts` and `gemini-3.ts`) advising the LLM against using `write_file` for files with massive literal sequences and guiding it to use the surgical `replace` tool instead.
- **Omission Detection Hardening**: Updated `detectOmissionPlaceholders` to aggressively catch standalone ellipsis (`...` or `// ...`) without explicit "rest of" phrases, preventing the model from lazily truncating content and silently corrupting files.
- **Test Coverage**: Added a Vitest test case to verify the new ellipsis placeholder detection logic.

## Related Issues

Fixes #27213

## How to Validate

1. Attempt to run the agent in a workspace containing a file with a large block of text (e.g., a 7000-character object or base64 string).
2. Instruct the agent to modify a small portion of that file.
3. Verify that the agent correctly utilizes the `replace` tool instead of attempting a full `write_file` rewrite.
4. Run `npm run test -w @google/gemini-cli-core -- src/tools/omissionPlaceholderDetector.test.ts` to ensure the newly added tests pass.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
