### PR TITLE
fix(cli): refresh logger after session clear

### DIFF
--- a/packages/cli/src/ui/hooks/useLogger.test.tsx
+++ b/packages/cli/src/ui/hooks/useLogger.test.tsx
@@ -5,12 +5,18 @@
  */
 
 import { act } from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '../../test-utils/render.js';
 import { useLogger } from './useLogger.js';
-import { Logger, type Storage, type Config } from '@google/gemini-cli-core';
+import {
+  Logger,
+  uiTelemetryService,
+  type Storage,
+  type Config,
+} from '@google/gemini-cli-core';
 
-let deferredInit: { resolve: (val?: unknown) => void };
+const deferredInits: Array<{ resolve: (val?: unknown) => void }> = [];
+let unmounts: Array<() => void> = [];
 
 // Mock Logger
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -22,7 +28,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
       initialize: vi.fn().mockImplementation(
         () =>
           new Promise((resolve) => {
-            deferredInit = { resolve };
+            deferredInits.push({ resolve });
           }),
       ),
       sessionId: id,
@@ -39,18 +45,52 @@ describe('useLogger', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    deferredInits.length = 0;
+  });
+
+  afterEach(() => {
+    for (const unmount of unmounts) {
+      unmount();
+    }
+    unmounts = [];
   });
 
   it('should initialize with the sessionId from config', async () => {
-    const { result } = await renderHook(() => useLogger(mockConfig));
+    const { result, unmount } = await renderHook(() => useLogger(mockConfig));
+    unmounts.push(unmount);
 
     expect(result.current).toBeNull();
 
     await act(async () => {
-      deferredInit.resolve();
+      deferredInits[0].resolve();
     });
 
     expect(result.current).not.toBeNull();
     expect(Logger).toHaveBeenCalledWith('active-session-id', mockStorage);
+  });
+
+  it('should reinitialize when the session is cleared', async () => {
+    const { result, unmount } = await renderHook(() => useLogger(mockConfig));
+    unmounts.push(unmount);
+
+    await act(async () => {
+      deferredInits[0].resolve();
+    });
+
+    const activeLogger = result.current;
+    expect(activeLogger).not.toBeNull();
+
+    await act(async () => {
+      uiTelemetryService.clear('new-session-id');
+    });
+
+    expect(Logger).toHaveBeenCalledWith('new-session-id', mockStorage);
+    expect(result.current).toBe(activeLogger);
+
+    await act(async () => {
+      deferredInits[1].resolve();
+    });
+
+    expect(result.current).not.toBe(activeLogger);
   });
 });

--- a/packages/cli/src/ui/hooks/useLogger.ts
+++ b/packages/cli/src/ui/hooks/useLogger.ts
@@ -5,7 +5,11 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Logger, type Config } from '@google/gemini-cli-core';
+import {
+  Logger,
+  uiTelemetryService,
+  type Config,
+} from '@google/gemini-cli-core';
 
 /**
  * Hook to manage the logger instance.
@@ -14,17 +18,39 @@ export const useLogger = (config: Config): Logger | null => {
   const [logger, setLogger] = useState<Logger | null>(null);
 
   useEffect(() => {
-    const newLogger = new Logger(config.getSessionId(), config.storage);
+    let disposed = false;
+    let loggerToken = 0;
 
-    /**
-     * Start async initialization, no need to await. Using await slows down the
-     * time from launch to see the gemini-cli prompt and it's better to not save
-     * messages than for the cli to hanging waiting for the logger to loading.
-     */
-    newLogger
-      .initialize()
-      .then(() => setLogger(newLogger))
-      .catch(() => {});
+    const initializeLogger = (sessionId = config.getSessionId()) => {
+      const currentToken = ++loggerToken;
+      const newLogger = new Logger(sessionId, config.storage);
+
+      /**
+       * Start async initialization, no need to await. Using await slows down the
+       * time from launch to see the gemini-cli prompt and it's better to not save
+       * messages than for the cli to hanging waiting for the logger to loading.
+       */
+      newLogger
+        .initialize()
+        .then(() => {
+          if (!disposed && currentToken === loggerToken) {
+            setLogger(newLogger);
+          }
+        })
+        .catch(() => {});
+    };
+
+    const handleClear = (newSessionId?: string) => {
+      initializeLogger(newSessionId);
+    };
+
+    initializeLogger();
+    uiTelemetryService.on('clear', handleClear);
+
+    return () => {
+      disposed = true;
+      uiTelemetryService.off('clear', handleClear);
+    };
   }, [config]);
 
   return logger;


### PR DESCRIPTION
## Summary

Refreshes the UI logger when `/clear` starts a new session so later log entries use the active session ID.

## Details

`useLogger` now listens for the clear event used by session stats and recreates the logger with the new session ID. It also ignores stale async logger initialization results if a newer logger has started initializing.

## Related Issues

Fixes #27280

## How to Validate

- `npm run test --workspace @google/gemini-cli -- src/ui/hooks/useLogger.test.tsx`
- `npm run typecheck --workspace @google/gemini-cli`
- `npm exec -- eslint packages/cli/src/ui/hooks/useLogger.ts packages/cli/src/ui/hooks/useLogger.test.tsx`
- `npm exec -- prettier --check packages/cli/src/ui/hooks/useLogger.ts packages/cli/src/ui/hooks/useLogger.test.tsx`
- `git diff --check`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker