### PR TITLE
fix(core): skip missing includeDirectories instead of crashing CLI startup

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -512,6 +512,29 @@ describe('Server Config (config.ts)', () => {
       expect(mcpStarted).toBe(true);
     });
 
+    it('should not throw when an includeDirectories entry is missing', async () => {
+      const missingDir = '/path/to/missing/.kilocode/rules';
+      const presentDir = '/path/to/present';
+
+      const realExistsSync = vi.mocked(fs.existsSync).getMockImplementation();
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        if (p === missingDir) return false;
+        return realExistsSync ? !!realExistsSync(p) : true;
+      });
+
+      const config = new Config({
+        ...baseParams,
+        checkpointing: false,
+        includeDirectories: [missingDir, presentDir],
+      });
+
+      await expect(config.initialize()).resolves.toBeUndefined();
+
+      const directories = config.getWorkspaceContext().getDirectories();
+      expect(directories).toContain(presentDir);
+      expect(directories).not.toContain(missingDir);
+    });
+
     describe('getCompressionThreshold', () => {
       it('should return the local compression threshold if it is set', async () => {
         const config = new Config({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1445,10 +1445,10 @@ export class Config implements McpContext, AgentLoopContext {
     await this.storage.initialize();
     ragLogger.initialize(this.storage.getProjectTempLogsDir());
 
-    // Add pending directories to workspace context
-    for (const dir of this.pendingIncludeDirectories) {
-      this.workspaceContext.addDirectory(dir);
-    }
+    // Add pending directories to workspace context.
+    // Use the batch method so missing or invalid entries are warned and
+    // skipped rather than aborting startup (see #27311).
+    this.workspaceContext.addDirectories(this.pendingIncludeDirectories);
 
     // Add plans directory to workspace context for plan file storage
     if (this.planEnabled) {


### PR DESCRIPTION
## Summary

- `Config._initialize()` looped over `pendingIncludeDirectories` calling `WorkspaceContext.addDirectory(dir)` (singular), which re-throws on missing/invalid paths.
- One missing directory in `settings.json` (`context.includeDirectories`) aborted CLI startup with `Error: Directory does not exist: ...`, even though `WorkspaceContext` already logs the same path as "unreadable" and is designed to skip it.
- Switch to the existing batch `WorkspaceContext.addDirectories(...)` method, which warns and collects failures per its contract. Present directories are still added; missing ones are logged and skipped.

Fixes #27311

## Test plan

- [x] New unit test in `packages/core/src/config/config.test.ts` asserts `config.initialize()` resolves when one of `includeDirectories` is missing, and that the present directory is still added.
- [x] `npm test -w @google/gemini-cli-core -- src/config/config.test.ts` — 237/237 pass
- [x] `npm test -w @google/gemini-cli-core -- src/utils/workspaceContext.test.ts` — pass
- [x] `npm run typecheck -w @google/gemini-cli-core` — clean
- [x] `eslint` on changed files — clean
- [ ] Manual repro: `settings.json` with non-existent dir in `context.includeDirectories` → CLI starts, warns, continues.