### PR TITLE
Docs: clarify settings.json path for GEMINI_CLI_HOME

### DIFF
--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -225,6 +225,9 @@ use the `GEMINI_CLI_HOME` environment variable to point to a unique directory
 for a specific user or job. The CLI will create a `.gemini` folder inside the
 specified path.
 
+This means your `settings.json` file must live at
+`$GEMINI_CLI_HOME/.gemini/settings.json` (not `$GEMINI_CLI_HOME/settings.json`).
+
 **macOS/Linux**
 
 ```bash

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2368,6 +2368,8 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
     storage.
   - By default, this is the user's system home directory. The CLI will create a
     `.gemini` folder inside this directory.
+  - `settings.json` location: `$GEMINI_CLI_HOME/.gemini/settings.json` (and
+    other user state is stored under `$GEMINI_CLI_HOME/.gemini/`).
   - Useful for shared compute environments or keeping CLI state isolated.
   - Example: `export GEMINI_CLI_HOME="/path/to/user/config"` (Windows
     PowerShell: `$env:GEMINI_CLI_HOME="C:\path\to\user\config"`)


### PR DESCRIPTION
Fixes #23622.\n\nWhen GEMINI_CLI_HOME is set, Gemini CLI stores user state under `/.gemini/`, so the settings file path is `/.gemini/settings.json`. This updates the enterprise docs and configuration reference to make that explicit.