### PR TITLE
fix(core): prevent SSRF via open redirect in web-fetch tool

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -53,6 +53,9 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
     ...actual,
     fetchWithTimeout: vi.fn(),
     isPrivateIp: vi.fn(),
+    // Default to false (public) so unit tests don't make real DNS lookups;
+    // individual tests override this when DNS-based SSRF behaviour is under test.
+    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
   };
 });
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,11 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithSafeRedirects, isPrivateIp } from '../utils/fetch.js';
+import {
+  fetchWithSafeRedirects,
+  isPrivateIp,
+  isPrivateIpAsync,
+} from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -280,12 +284,28 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     }
   }
 
+  /**
+   * Async variant of isBlockedHost that also resolves hostnames via DNS.
+   * Prevents SSRF via domains that resolve to private/link-local addresses
+   * (e.g. 169.254.169.254.nip.io → AWS IMDS).
+   */
+  private async isBlockedHostAsync(urlStr: string): Promise<boolean> {
+    if (this.isBlockedHost(urlStr)) {
+      return true;
+    }
+    try {
+      return await isPrivateIpAsync(urlStr);
+    } catch {
+      return true; // fail closed on DNS errors
+    }
+  }
+
   private async executeFallbackForUrl(
     urlStr: string,
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHostAsync(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
@@ -295,7 +315,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     const response = await retryWithBackoff(
       async () => {
         const res = await fetchWithSafeRedirects(
-          this.isBlockedHost.bind(this),
+          this.isBlockedHostAsync.bind(this),
           url,
           URL_FETCH_TIMEOUT_MS,
           {
@@ -620,7 +640,7 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHostAsync(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -639,7 +659,7 @@ ${aggregatedContent}
       const response = await retryWithBackoff(
         async () => {
           const res = await fetchWithSafeRedirects(
-            this.isBlockedHost.bind(this),
+            this.isBlockedHostAsync.bind(this),
             url,
             URL_FETCH_TIMEOUT_MS,
             {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import { fetchWithSafeRedirects, isPrivateIp } from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -294,12 +294,17 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-          signal,
-          headers: {
-            'User-Agent': USER_AGENT,
+        const res = await fetchWithSafeRedirects(
+          this.isBlockedHost.bind(this),
+          url,
+          URL_FETCH_TIMEOUT_MS,
+          {
+            signal,
+            headers: {
+              'User-Agent': USER_AGENT,
+            },
           },
-        });
+        );
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -633,14 +638,19 @@ ${aggregatedContent}
     try {
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-            signal,
-            headers: {
-              Accept:
-                'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
-              'User-Agent': USER_AGENT,
+          const res = await fetchWithSafeRedirects(
+            this.isBlockedHost.bind(this),
+            url,
+            URL_FETCH_TIMEOUT_MS,
+            {
+              signal,
+              headers: {
+                Accept:
+                  'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
+                'User-Agent': USER_AGENT,
+              },
             },
-          });
+          );
           return res;
         },
         {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -287,16 +287,21 @@ class WebFetchToolInvocation extends BaseToolInvocation<
   /**
    * Async variant of isBlockedHost that also resolves hostnames via DNS.
    * Prevents SSRF via domains that resolve to private/link-local addresses
-   * (e.g. 169.254.169.254.nip.io → AWS IMDS).
+   * (e.g. 169.254.169.254.nip.io → AWS IMDS) and rejects non-http(s) protocols
+   * in redirect destinations (e.g. file:, ftp:).
    */
   private async isBlockedHostAsync(urlStr: string): Promise<boolean> {
     if (this.isBlockedHost(urlStr)) {
       return true;
     }
     try {
+      const url = new URL(urlStr);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return true;
+      }
       return await isPrivateIpAsync(urlStr);
     } catch {
-      return true; // fail closed on DNS errors
+      return true; // fail closed on DNS errors or invalid URL
     }
   }
 

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -229,6 +229,75 @@ export async function fetchWithTimeout(
   }
 }
 
+/**
+ * Maximum number of redirects followed by fetchWithSafeRedirects.
+ */
+const MAX_SAFE_REDIRECTS = 10;
+
+/**
+ * Fetches a URL while re-validating each redirect destination for SSRF risk.
+ *
+ * fetchWithTimeout follows redirects automatically (WHATWG default), which
+ * means the initial isBlockedHost check is bypassed for redirect destinations.
+ * This function opts-out of automatic redirect following and re-validates each
+ * Location header value before following it, preventing open-redirect SSRF.
+ *
+ * @param isBlockedHost Predicate returning true for URLs that must not be fetched.
+ * @param url The URL to fetch.
+ * @param timeout Per-hop timeout in milliseconds.
+ * @param options Fetch options. Must NOT include a `redirect` key.
+ * @param hopsLeft Remaining redirect budget (default MAX_SAFE_REDIRECTS).
+ */
+export async function fetchWithSafeRedirects(
+  isBlockedHost: (url: string) => boolean,
+  url: string,
+  timeout: number,
+  options?: Omit<RequestInit, 'redirect'>,
+  hopsLeft = MAX_SAFE_REDIRECTS,
+): Promise<Response> {
+  const response = await fetchWithTimeout(url, timeout, {
+    ...(options as RequestInit),
+    redirect: 'manual',
+  });
+
+  const { status } = response;
+  if (status >= 300 && status < 400) {
+    if (hopsLeft <= 0) {
+      throw new FetchError('Too many redirects', 'ERR_TOO_MANY_REDIRECTS');
+    }
+    const location = response.headers.get('location');
+    if (!location) {
+      // No Location header — return the redirect response as-is.
+      return response;
+    }
+    // Resolve relative Location values against the current URL.
+    let redirectUrl: string;
+    try {
+      redirectUrl = new URL(location, url).href;
+    } catch {
+      throw new FetchError(
+        `Invalid redirect location: ${location}`,
+        'ERR_INVALID_REDIRECT',
+      );
+    }
+    if (isBlockedHost(redirectUrl)) {
+      throw new FetchError(
+        `SSRF protection: redirect destination "${redirectUrl}" resolves to a blocked or private host`,
+        'ERR_SSRF_REDIRECT',
+      );
+    }
+    return fetchWithSafeRedirects(
+      isBlockedHost,
+      redirectUrl,
+      timeout,
+      options,
+      hopsLeft - 1,
+    );
+  }
+
+  return response;
+}
+
 export function setGlobalProxy(proxy: string) {
   const trimmedProxy = proxy.trim();
   currentProxy = trimmedProxy;

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -249,7 +249,7 @@ const MAX_SAFE_REDIRECTS = 10;
  * @param hopsLeft Remaining redirect budget (default MAX_SAFE_REDIRECTS).
  */
 export async function fetchWithSafeRedirects(
-  isBlockedHost: (url: string) => boolean,
+  isBlockedHost: (url: string) => boolean | Promise<boolean>,
   url: string,
   timeout: number,
   options?: Omit<RequestInit, 'redirect'>,
@@ -280,7 +280,7 @@ export async function fetchWithSafeRedirects(
         'ERR_INVALID_REDIRECT',
       );
     }
-    if (isBlockedHost(redirectUrl)) {
+    if (await isBlockedHost(redirectUrl)) {
       throw new FetchError(
         `SSRF protection: redirect destination "${redirectUrl}" resolves to a blocked or private host`,
         'ERR_SSRF_REDIRECT',

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -235,12 +235,38 @@ export async function fetchWithTimeout(
 const MAX_SAFE_REDIRECTS = 10;
 
 /**
+ * Resolves the hostname of `url` to a non-private IP address.
+ *
+ * Returns the IP string on success, or null if all resolved addresses are
+ * private or the hostname cannot be resolved. Used to pin DNS results before
+ * the actual fetch so that a DNS rebinding attack cannot swap a public IP for
+ * a private one between the isBlockedHost check and the connection.
+ */
+async function resolveToSafeIp(url: string): Promise<string | null> {
+  try {
+    const { hostname } = new URL(url);
+    if (ipaddr.isValid(hostname)) {
+      return hostname; // already a literal IP, validated by caller
+    }
+    const addresses = await lookup(hostname, { all: true });
+    const safe = addresses.find((a) => !isAddressPrivate(a.address));
+    return safe?.address ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetches a URL while re-validating each redirect destination for SSRF risk.
  *
  * fetchWithTimeout follows redirects automatically (WHATWG default), which
  * means the initial isBlockedHost check is bypassed for redirect destinations.
  * This function opts-out of automatic redirect following and re-validates each
  * Location header value before following it, preventing open-redirect SSRF.
+ *
+ * DNS pinning: to prevent DNS rebinding attacks, the hostname is resolved once
+ * and the connection is made to the pinned IP address. The original hostname is
+ * preserved in the Host header for virtual-hosting compatibility.
  *
  * @param isBlockedHost Predicate returning true for URLs that must not be fetched.
  * @param url The URL to fetch.
@@ -255,8 +281,29 @@ export async function fetchWithSafeRedirects(
   options?: Omit<RequestInit, 'redirect'>,
   hopsLeft = MAX_SAFE_REDIRECTS,
 ): Promise<Response> {
-  const response = await fetchWithTimeout(url, timeout, {
-    ...(options as RequestInit),
+  // Pin the resolved IP to prevent DNS rebinding between the caller's
+  // isBlockedHost check and the actual TCP connection.
+  const parsed = new URL(url);
+  const originalHostname = parsed.hostname;
+  let fetchUrl = url;
+  let fetchOptions = options;
+  if (!ipaddr.isValid(originalHostname)) {
+    const resolvedIp = await resolveToSafeIp(url);
+    if (resolvedIp) {
+      parsed.hostname = resolvedIp;
+      fetchUrl = parsed.href;
+      fetchOptions = {
+        ...options,
+        headers: {
+          ...(options?.headers as Record<string, string>),
+          Host: originalHostname,
+        },
+      };
+    }
+  }
+
+  const response = await fetchWithTimeout(fetchUrl, timeout, {
+    ...(fetchOptions as RequestInit),
     redirect: 'manual',
   });
 
@@ -270,7 +317,9 @@ export async function fetchWithSafeRedirects(
       // No Location header — return the redirect response as-is.
       return response;
     }
-    // Resolve relative Location values against the current URL.
+    // Resolve relative Location values against the original (pre-pin) URL so
+    // that relative paths are interpreted against the public hostname, not the
+    // pinned IP address.
     let redirectUrl: string;
     try {
       redirectUrl = new URL(location, url).href;
@@ -286,6 +335,8 @@ export async function fetchWithSafeRedirects(
         'ERR_SSRF_REDIRECT',
       );
     }
+    // Pass original options (without the Host pin) so the next hop re-resolves
+    // and pins its own hostname independently.
     return fetchWithSafeRedirects(
       isBlockedHost,
       redirectUrl,


### PR DESCRIPTION
## Summary

\`fetchWithTimeout\` follows HTTP redirects automatically (WHATWG default). The
initial \`isBlockedHost\` SSRF check applies only to the first URL; redirect
destinations are never validated. A server at a public host can redirect the
web-fetch tool to \`http://169.254.169.254/latest/meta-data/\` (AWS IMDS) or
any other private/internal endpoint and bypass all protection.

**Fix — redirect chain validation (commit 1):**
- \`fetchWithSafeRedirects\` uses \`redirect: 'manual'\` and re-validates each
  \`Location\` header with \`isBlockedHost\` before following it
- Added async \`isBlockedHostAsync\` that calls \`isPrivateIpAsync\` for DNS-based
  validation of hostnames (catches domains like \`169.254.169.254.nip.io →
  169.254.169.254\`)

**Fix — DNS pinning / DNS rebinding prevention (commit 2+4):**
- Between the \`isBlockedHost\` check and the TCP connect, a TTL-0 A record
  could flip from public IP → private IP (TOCTOU / DNS rebinding attack).
  Added \`resolveToSafeIp()\` in \`fetch.ts\`: pins the resolved IP before
  fetching, replaces the URL hostname with the pinned IP, and preserves the
  original hostname in the \`Host\` header for virtual-hosting compatibility.

**Fix — protocol validation (commit 5):**
- \`isBlockedHostAsync\` now rejects any scheme that is not \`http:\` or
  \`https:\` (e.g. \`file:\`, \`ftp:\`, \`data:\`), preventing non-http redirect
  targets from bypassing the private-IP check.

## Test plan

- [ ] \`packages/core/src/tools/web-fetch.test.ts\` — private-host redirect,
  loopback redirect, allowed public redirect
- [ ] Manual: \`web-fetch\` with a redirect to \`http://localhost/\` → blocked
- [ ] Manual: \`web-fetch\` with a redirect to a public HTTPS URL → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)