### PR TITLE
fix(a2a): derive task trust server-side

### DIFF
--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { CoderAgentExecutor } from './executor.js';
+import { Task } from './task.js';
 import type {
   ExecutionEventBus,
   RequestContext,
@@ -13,8 +14,21 @@ import type {
 } from '@a2a-js/sdk/server';
 import { EventEmitter } from 'node:events';
 import { requestStorage } from '../http/requestStorage.js';
+import { loadConfig } from '../config/config.js';
+import { checkPathTrust } from '@google/gemini-cli-core';
+import { CoderAgentEvent } from '../types.js';
 
 // Mocks for constructor dependencies
+vi.mock('@google/gemini-cli-core', async () => {
+  const actual = await vi.importActual('@google/gemini-cli-core');
+  return {
+    ...actual,
+    SimpleExtensionLoader: vi.fn(),
+    checkPathTrust: vi.fn().mockReturnValue({ isTrusted: false }),
+    isHeadlessMode: vi.fn().mockReturnValue(true),
+  };
+});
+
 vi.mock('../config/config.js', () => ({
   loadConfig: vi.fn().mockReturnValue({
     getSessionId: () => 'test-session',
@@ -111,6 +125,62 @@ describe('CoderAgentExecutor', () => {
     mockEventBus.finished = vi.fn();
 
     executor = new CoderAgentExecutor(mockTaskStore);
+  });
+
+  it('does not honor client-supplied trust or auto-execution settings', async () => {
+    await executor.createTask(
+      'test-task',
+      'test-context',
+      {
+        kind: CoderAgentEvent.StateAgentSettingsEvent,
+        workspacePath: '/tmp',
+        isTrusted: true,
+        autoExecute: true,
+      },
+      mockEventBus,
+    );
+
+    expect(checkPathTrust).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp',
+        isHeadless: true,
+      }),
+    );
+    expect(loadConfig).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'test-task',
+      false,
+    );
+    expect(Task.create).toHaveBeenLastCalledWith(
+      'test-task',
+      'test-context',
+      expect.anything(),
+      mockEventBus,
+      undefined,
+    );
+  });
+
+  it('keeps auto-execution available for internal opt-in flows', async () => {
+    await executor.createTask(
+      'test-task',
+      'test-context',
+      {
+        kind: CoderAgentEvent.StateAgentSettingsEvent,
+        workspacePath: '/tmp',
+        autoExecute: true,
+      },
+      mockEventBus,
+      { allowAutoExecute: true },
+    );
+
+    expect(Task.create).toHaveBeenLastCalledWith(
+      'test-task',
+      'test-context',
+      expect.anything(),
+      mockEventBus,
+      true,
+    );
   });
 
   it('should distinguish between primary and secondary execution', async () => {

--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -14,7 +14,8 @@ import type {
 } from '@a2a-js/sdk/server';
 import { EventEmitter } from 'node:events';
 import { requestStorage } from '../http/requestStorage.js';
-import { loadConfig } from '../config/config.js';
+import { loadConfig, loadEnvironment } from '../config/config.js';
+import { loadExtensions } from '../config/extension.js';
 import { checkPathTrust } from '@google/gemini-cli-core';
 import { CoderAgentEvent } from '../types.js';
 
@@ -152,12 +153,40 @@ describe('CoderAgentExecutor', () => {
       'test-task',
       false,
     );
+    expect(loadEnvironment).not.toHaveBeenCalled();
+    expect(loadExtensions).toHaveBeenLastCalledWith('/tmp', false);
     expect(Task.create).toHaveBeenLastCalledWith(
       'test-task',
       'test-context',
       expect.anything(),
       mockEventBus,
       undefined,
+    );
+  });
+
+  it('loads workspace environment and extensions after server-side trust succeeds', async () => {
+    vi.mocked(checkPathTrust).mockReturnValueOnce({
+      isTrusted: true,
+      source: 'file',
+    });
+
+    await executor.createTask(
+      'test-task',
+      'test-context',
+      {
+        kind: CoderAgentEvent.StateAgentSettingsEvent,
+        workspacePath: '/tmp',
+      },
+      mockEventBus,
+    );
+
+    expect(loadEnvironment).toHaveBeenCalledOnce();
+    expect(loadExtensions).toHaveBeenLastCalledWith('/tmp', true);
+    expect(loadConfig).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'test-task',
+      true,
     );
   });
 

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -15,6 +15,8 @@ import type {
 import {
   GeminiEventType,
   SimpleExtensionLoader,
+  checkPathTrust,
+  isHeadlessMode,
   type ToolCallRequestInfo,
   type Config,
 } from '@google/gemini-cli-core';
@@ -37,6 +39,10 @@ import { loadExtensions } from '../config/extension.js';
 import { Task } from './task.js';
 import { requestStorage } from '../http/requestStorage.js';
 import { pushTaskStateFailed } from '../utils/executor_utils.js';
+
+type ExecuteOptions = {
+  allowAutoExecute?: boolean;
+};
 
 /**
  * Provides a wrapper for Task. Passes data from Task to SDKTask.
@@ -93,7 +99,13 @@ export class CoderAgentExecutor implements AgentExecutor {
     taskId: string,
   ): Promise<Config> {
     const workspaceRoot = setTargetDir(agentSettings);
-    const isTrusted = agentSettings.isTrusted ?? false;
+    const initialSettings = loadSettings(workspaceRoot, false);
+    const { isTrusted: trustResult } = checkPathTrust({
+      path: workspaceRoot,
+      isFolderTrustEnabled: initialSettings.folderTrust ?? true,
+      isHeadless: isHeadlessMode(),
+    });
+    const isTrusted = trustResult ?? false;
     loadEnvironment(); // Will override any global env with workspace envs
     const settings = loadSettings(workspaceRoot, isTrusted);
     const extensions = loadExtensions(workspaceRoot);
@@ -103,6 +115,22 @@ export class CoderAgentExecutor implements AgentExecutor {
       taskId,
       isTrusted,
     );
+  }
+
+  private normalizeAgentSettings(
+    agentSettings: AgentSettings,
+    options: ExecuteOptions = {},
+  ): AgentSettings {
+    const normalized: AgentSettings = {
+      kind: CoderAgentEvent.StateAgentSettingsEvent,
+      workspacePath: agentSettings.workspacePath,
+    };
+
+    if (options.allowAutoExecute && agentSettings.autoExecute === true) {
+      normalized.autoExecute = true;
+    }
+
+    return normalized;
   }
 
   /**
@@ -121,7 +149,12 @@ export class CoderAgentExecutor implements AgentExecutor {
       );
     }
 
-    const agentSettings = persistedState._agentSettings;
+    const agentSettings = this.normalizeAgentSettings(
+      persistedState._agentSettings,
+      {
+        allowAutoExecute: true,
+      },
+    );
     const config = await this.getConfig(agentSettings, sdkTask.id);
     const contextId: string =
       getContextIdFromMetadata(metadata) || sdkTask.contextId;
@@ -146,11 +179,15 @@ export class CoderAgentExecutor implements AgentExecutor {
     contextId: string,
     agentSettingsInput?: AgentSettings,
     eventBus?: ExecutionEventBus,
+    options: ExecuteOptions = {},
   ): Promise<TaskWrapper> {
-    const agentSettings: AgentSettings = agentSettingsInput || {
-      kind: CoderAgentEvent.StateAgentSettingsEvent,
-      workspacePath: process.cwd(),
-    };
+    const agentSettings = this.normalizeAgentSettings(
+      agentSettingsInput || {
+        kind: CoderAgentEvent.StateAgentSettingsEvent,
+        workspacePath: process.cwd(),
+      },
+      options,
+    );
     const config = await this.getConfig(agentSettings, taskId);
     const runtimeTask = await Task.create(
       taskId,
@@ -296,6 +333,7 @@ export class CoderAgentExecutor implements AgentExecutor {
   async execute(
     requestContext: RequestContext,
     eventBus: ExecutionEventBus,
+    options: ExecuteOptions = {},
   ): Promise<void> {
     const userMessage = requestContext.userMessage;
     const sdkTask = requestContext.task;
@@ -409,6 +447,7 @@ export class CoderAgentExecutor implements AgentExecutor {
           contextId,
           agentSettings,
           eventBus,
+          options,
         );
       } catch (error) {
         logger.error(

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -106,9 +106,11 @@ export class CoderAgentExecutor implements AgentExecutor {
       isHeadless: isHeadlessMode(),
     });
     const isTrusted = trustResult ?? false;
-    loadEnvironment(); // Will override any global env with workspace envs
+    if (isTrusted) {
+      loadEnvironment(); // Will override any global env with workspace envs
+    }
     const settings = loadSettings(workspaceRoot, isTrusted);
-    const extensions = loadExtensions(workspaceRoot);
+    const extensions = loadExtensions(workspaceRoot, isTrusted);
     return loadConfig(
       settings,
       new SimpleExtensionLoader(extensions),

--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -182,6 +182,7 @@ describe('InitCommand', () => {
             }),
           }),
           eventBus,
+          { allowAutoExecute: true },
         );
       });
     });

--- a/packages/a2a-server/src/commands/init.ts
+++ b/packages/a2a-server/src/commands/init.ts
@@ -117,7 +117,9 @@ export class InitCommand implements Command {
 
     // The executor will handle the entire agentic loop, including
     // creating the task, streaming responses, and handling tools.
-    await agentExecutor.execute(requestContext, eventBus);
+    await agentExecutor.execute(requestContext, eventBus, {
+      allowAutoExecute: true,
+    });
     return {
       name: this.name,
       data: geminiMdPath,

--- a/packages/a2a-server/src/config/extension.ts
+++ b/packages/a2a-server/src/config/extension.ts
@@ -36,9 +36,12 @@ interface ExtensionConfig {
   excludeTools?: string[];
 }
 
-export function loadExtensions(workspaceDir: string): GeminiCLIExtension[] {
+export function loadExtensions(
+  workspaceDir: string,
+  includeWorkspaceExtensions = true,
+): GeminiCLIExtension[] {
   const allExtensions = [
-    ...loadExtensionsFromDir(workspaceDir),
+    ...(includeWorkspaceExtensions ? loadExtensionsFromDir(workspaceDir) : []),
     ...loadExtensionsFromDir(homedir()),
   ];
 

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -198,7 +198,6 @@ export async function createApp() {
   try {
     // Load the server configuration once on startup.
     const workspaceRoot = setTargetDir(undefined);
-    loadEnvironment();
 
     // Use a temporary settings load to check if folder trust is enabled.
     // This is similar to how the CLI handles the initial trust check.
@@ -209,13 +208,17 @@ export async function createApp() {
       isHeadless: isHeadlessMode(),
     });
 
-    const settings = loadSettings(workspaceRoot, isTrusted ?? false);
-    const extensions = loadExtensions(workspaceRoot);
+    const trustedWorkspace = isTrusted ?? false;
+    if (trustedWorkspace) {
+      loadEnvironment();
+    }
+    const settings = loadSettings(workspaceRoot, trustedWorkspace);
+    const extensions = loadExtensions(workspaceRoot, trustedWorkspace);
     const config = await loadConfig(
       settings,
       new SimpleExtensionLoader(extensions),
       'a2a-server',
-      isTrusted ?? false,
+      trustedWorkspace,
     );
 
     let git: GitService | undefined;


### PR DESCRIPTION
## Summary

- derive A2A task workspace trust with the server-side folder trust check instead of accepting `agentSettings.isTrusted` from request metadata
- normalize incoming agent settings so `autoExecute` is only honored when an internal server flow explicitly opts in
- keep the `init` command's intended auto-execute path by passing an internal opt-in flag, with tests for both boundaries

## Tests

- `npm run generate`
- `npm run build --workspace @google/gemini-cli-core`
- `npm run test --workspace @google/gemini-cli-a2a-server -- src/agent/executor.test.ts src/commands/init.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-a2a-server`
- `npx prettier --write packages/a2a-server/src/agent/executor.ts packages/a2a-server/src/agent/executor.test.ts packages/a2a-server/src/commands/init.ts packages/a2a-server/src/commands/init.test.ts`
- `npm run test --workspace @google/gemini-cli-a2a-server`
- `npm run lint --workspace @google/gemini-cli-a2a-server`
- `git diff --check`
