### PR TITLE
fix(core): strip functionCall.id and functionResponse.id before API call

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -18,7 +18,7 @@ import {
   StreamEventType,
   SYNTHETIC_THOUGHT_SIGNATURE,
   type StreamEvent,
-  stripToolCallIdPrefixes,
+  stripToolCallIds,
   type HistoryTurn,
 } from './geminiChat.js';
 import {
@@ -2985,21 +2985,48 @@ describe('GeminiChat', () => {
     });
   });
 
-  describe('stripToolCallIdPrefixes', () => {
-    it('should strip tool name prefix matching the tool name', () => {
+  describe('stripToolCallIds', () => {
+    it.each<{ desc: string; id: string; name: string }>([
+      {
+        desc: 'prefixed id matching tool name',
+        id: 'my_tool__call_123',
+        name: 'my_tool',
+      },
+      {
+        desc: 'non-matching prefix',
+        id: 'other_tool__call_123',
+        name: 'my_tool',
+      },
+      {
+        desc: 'whitespace tool name',
+        id: 'generic_tool__call_123',
+        name: '  ',
+      },
+      {
+        desc: 'empty string id',
+        id: '',
+        name: 'my_tool',
+      },
+    ])(
+      'should strip functionCall id and preserve other fields ($desc)',
+      ({ id, name }) => {
+        const contents: Content[] = [
+          {
+            role: 'model',
+            parts: [{ functionCall: { id, name, args: { key: 'value' } } }],
+          },
+        ];
+        const stripped = stripToolCallIds(contents);
+        expect(stripped[0].parts![0].functionCall!.id).toBeUndefined();
+        expect(stripped[0].parts![0].functionCall!.name).toBe(name);
+        expect(stripped[0].parts![0].functionCall!.args).toEqual({
+          key: 'value',
+        });
+      },
+    );
+
+    it('should strip functionResponse id and preserve other fields', () => {
       const contents: Content[] = [
-        {
-          role: 'model',
-          parts: [
-            {
-              functionCall: {
-                id: 'my_tool__call_123',
-                name: 'my_tool',
-                args: {},
-              },
-            },
-          ],
-        },
         {
           role: 'user',
           parts: [
@@ -3013,24 +3040,20 @@ describe('GeminiChat', () => {
           ],
         },
       ];
-
-      const stripped = stripToolCallIdPrefixes(contents);
-      expect(stripped[0].parts![0].functionCall!.id).toBe('call_123');
-      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_123');
+      const stripped = stripToolCallIds(contents);
+      expect(stripped[0].parts![0].functionResponse!.id).toBeUndefined();
+      expect(stripped[0].parts![0].functionResponse!.name).toBe('my_tool');
+      expect(stripped[0].parts![0].functionResponse!.response).toEqual({
+        result: 'success',
+      });
     });
 
-    it('should correctly handle tool names that contain double underscores', () => {
+    it('should be a no-op when neither functionCall nor functionResponse has an id', () => {
       const contents: Content[] = [
         {
           role: 'model',
           parts: [
-            {
-              functionCall: {
-                id: 'my__custom__tool__call_abc',
-                name: 'my__custom__tool',
-                args: {},
-              },
-            },
+            { functionCall: { name: 'my_tool', args: { key: 'value' } } },
           ],
         },
         {
@@ -3038,73 +3061,22 @@ describe('GeminiChat', () => {
           parts: [
             {
               functionResponse: {
-                id: 'my__custom__tool__call_abc',
-                name: 'my__custom__tool',
-                response: { result: 'success' },
-              },
-            },
-          ],
-        },
-      ];
-
-      const stripped = stripToolCallIdPrefixes(contents);
-      expect(stripped[0].parts![0].functionCall!.id).toBe('call_abc');
-      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_abc');
-    });
-
-    it('should not strip if prefix does not match the tool name', () => {
-      const contents: Content[] = [
-        {
-          role: 'model',
-          parts: [
-            {
-              functionCall: {
-                id: 'other_tool__call_123',
                 name: 'my_tool',
-                args: {},
+                response: { result: 'ok' },
               },
             },
           ],
         },
       ];
-
-      const stripped = stripToolCallIdPrefixes(contents);
-      expect(stripped[0].parts![0].functionCall!.id).toBe(
-        'other_tool__call_123',
-      );
-    });
-
-    it('should correctly handle fallback to generic_tool when name is missing or has whitespace', () => {
-      const contents: Content[] = [
-        {
-          role: 'model',
-          parts: [
-            {
-              functionCall: {
-                id: 'generic_tool__call_123',
-                name: '  ',
-                args: {},
-              },
-            },
-          ],
-        },
-        {
-          role: 'user',
-          parts: [
-            {
-              functionResponse: {
-                id: 'generic_tool__call_123',
-                name: undefined as unknown as string,
-                response: { result: 'success' },
-              },
-            },
-          ],
-        },
-      ];
-
-      const stripped = stripToolCallIdPrefixes(contents);
-      expect(stripped[0].parts![0].functionCall!.id).toBe('call_123');
-      expect(stripped[1].parts![0].functionResponse!.id).toBe('call_123');
+      const stripped = stripToolCallIds(contents);
+      expect(stripped[0].parts![0].functionCall).toEqual({
+        name: 'my_tool',
+        args: { key: 'value' },
+      });
+      expect(stripped[1].parts![0].functionResponse).toEqual({
+        name: 'my_tool',
+        response: { result: 'ok' },
+      });
     });
   });
 });

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -850,7 +850,7 @@ export class GeminiChat {
       lastConfig = config;
       lastContentsToUse = contentsToUse;
 
-      const finalContents = stripToolCallIdPrefixes(contentsToUse);
+      const finalContents = stripToolCallIds(contentsToUse);
 
       return this.context.config.getContentGenerator().generateContentStream(
         {
@@ -1441,31 +1441,27 @@ export function isInvalidArgumentError(errorMessage: string): boolean {
   return errorMessage.includes('Request contains an invalid argument');
 }
 
-export function stripToolCallIdPrefixes(contents: Content[]): Content[] {
+export function stripToolCallIds(contents: Content[]): Content[] {
   return contents.map((content) => ({
     ...content,
     parts: (content.parts || []).map((part) => {
       const newPart = { ...part };
       if (newPart.functionCall) {
         const fc = newPart.functionCall;
-        const name = fc.name?.trim() || 'generic_tool';
-        if (fc.id && fc.id.startsWith(`${name}__`)) {
-          newPart.functionCall = {
-            name: fc.name,
-            args: fc.args,
-            id: fc.id.substring(name.length + 2),
-          };
+        if ('id' in fc) {
+          // Gemini API does not accept `id` in functionCall.
+          // Always strip it before sending to the API.
+          const { id: _id, ...rest } = fc;
+          newPart.functionCall = rest;
         }
       }
       if (newPart.functionResponse) {
         const fr = newPart.functionResponse;
-        const name = fr.name?.trim() || 'generic_tool';
-        if (fr.id && fr.id.startsWith(`${name}__`)) {
-          newPart.functionResponse = {
-            name: fr.name,
-            response: fr.response,
-            id: fr.id.substring(name.length + 2),
-          };
+        if ('id' in fr) {
+          // Gemini API does not accept `id` in functionResponse.
+          // Always strip it before sending to the API.
+          const { id: _id, ...rest } = fr;
+          newPart.functionResponse = rest;
         }
       }
       return newPart;


### PR DESCRIPTION
## Summary

Fixes a 400 "Unknown name 'id'" error that occurs on any turn following a tool call.
`function_call` and `function_response` parts do not accept an `id` field in the
Gemini API, but internal IDs added for ACP IDE rendering were being forwarded in the
API payload.

Fixes #22774

## Details

`makeApiCallAndProcessStream` calls `stripToolCallIdPrefixes` (renamed here to
`stripToolCallIds`) at the API boundary before each request. Prior to this change
the function had two gaps:

1. **`functionResponse.id`** — stripped only when the value started with the
   `${name}__` prefix pattern; IDs with non-matching formats were forwarded to the API.
2. **`functionCall.id`** — never stripped after prefix removal; always forwarded to
   the API after #26676 added tool-name prefixes for ACP IDE call rendering.

The fix strips `id` unconditionally from both part types. Internal `agentHistory`
retains the prefixed IDs so ACP IDE call-to-response linking is unaffected.

The function is renamed `stripToolCallIds` because it now removes the field entirely
rather than transforming a prefix. It is not exported from the package index, so the
rename has no external impact.

**Prior art:** #22957 proposed the correct `functionResponse.id` fix but was
auto-closed by the stale bot before any maintainer review. This PR completes that
fix and additionally covers `functionCall.id`, which was introduced by #26676
(2026-05-08) after #22957 was filed.

## Related Issues

Fixes #22774
Refs #22957 (closed — correct `functionResponse.id` fix, never reviewed)
Refs #26676 (root cause: introduced ID fields without full API-boundary sanitization)
Refs #26691, #26352, #19856, #13082 (related prior `functionResponse` API-validation fixes)

## How to Validate

**Unit tests**

```bash
npm run test --workspace @google/gemini-cli-core -- src/core/geminiChat.test.ts
```

Expected: 60 tests pass (includes 3 parameterized `stripToolCallIds` cases and
1 new no-op case).

**Manual regression**

1. `npm run build && npm start`
2. Send a prompt that triggers a tool call, e.g. `> What time is it in US Eastern Time?`
   (triggers `GoogleSearch`).
3. **Before fix**: the next turn returns `[API Error: … Unknown name "id" at
   'contents[N].parts[0].function_call' …]`.
4. **After fix**: Gemini uses the tool result and responds normally.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker