### PR TITLE
fix: add command validation to prevent natural language being saved a…

### DIFF
--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -7,11 +7,60 @@
 import * as fs from 'node:fs';
 import { parse, stringify } from 'comment-json';
 import { coreEvents } from '@google/gemini-cli-core';
+import { isLikelyShellCommand } from './shellCommandValidator.js';
 
 /**
  * Type representing an object that may contain Symbol keys for comments.
  */
 type CommentedRecord = Record<string | symbol, unknown>;
+
+/**
+ * Recursively walks the updates object and warns about any object with
+ * `type: "command"` whose `command` value looks like natural language
+ * rather than a valid shell command.
+ */
+function warnAboutNaturalLanguageCommandValues(
+  updates: Record<string, unknown>,
+  path: string,
+): void {
+  for (const [key, value] of Object.entries(updates)) {
+    const currentPath = path ? `${path}.${key}` : key;
+
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      const objValue = value as Record<string, unknown>;
+      if (
+        objValue['type'] === 'command' &&
+        typeof objValue['command'] === 'string'
+      ) {
+        if (!isLikelyShellCommand(objValue['command'] as string)) {
+          coreEvents.emitFeedback(
+            'warn',
+            `Setting "${currentPath}.command" contains text that does not look like a valid shell command. ` +
+              'The value will be saved, but it may fail when executed.',
+          );
+        }
+      }
+      warnAboutNaturalLanguageCommandValues(objValue, currentPath);
+    } else if (Array.isArray(value)) {
+      (value as unknown[]).forEach((item, index) => {
+        if (
+          typeof item === 'object' &&
+          item !== null &&
+          !Array.isArray(item)
+        ) {
+          warnAboutNaturalLanguageCommandValues(
+            item as Record<string, unknown>,
+            `${currentPath}[${index}]`,
+          );
+        }
+      });
+    }
+  }
+}
 
 /**
  * Updates a JSON file while preserving comments and formatting.
@@ -20,6 +69,8 @@ export function updateSettingsFilePreservingFormat(
   filePath: string,
   updates: Record<string, unknown>,
 ): void {
+  warnAboutNaturalLanguageCommandValues(updates, '');
+
   if (!fs.existsSync(filePath)) {
     fs.writeFileSync(filePath, JSON.stringify(updates, null, 2), 'utf-8');
     return;

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -14,11 +14,11 @@ import { isLikelyShellCommand } from './shellCommandValidator.js';
  */
 type CommentedRecord = Record<string | symbol, unknown>;
 
-/**
- * Recursively walks the updates object and warns about any object with
- * `type: "command"` whose `command` value looks like natural language
- * rather than a valid shell command.
- */
+  /**
+   * Recursively walks the updates object and warns about any object with
+   * `type: "command"` or `type: "stdio"` whose `command` value looks like
+   * natural language rather than a valid shell command.
+   */
 function warnAboutNaturalLanguageCommandValues(
   updates: Record<string, unknown>,
   path: string,
@@ -33,10 +33,10 @@ function warnAboutNaturalLanguageCommandValues(
     ) {
       const objValue = value as Record<string, unknown>;
       if (
-        objValue['type'] === 'command' &&
+        (objValue['type'] === 'command' || objValue['type'] === 'stdio') &&
         typeof objValue['command'] === 'string'
       ) {
-        if (!isLikelyShellCommand(objValue['command'] as string)) {
+        if (!isLikelyShellCommand(objValue['command'])) {
           coreEvents.emitFeedback(
             'warn',
             `Setting "${currentPath}.command" contains text that does not look like a valid shell command. ` +

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -14,10 +14,42 @@ import { isLikelyShellCommand } from './shellCommandValidator.js';
  */
 type CommentedRecord = Record<string | symbol, unknown>;
 
+/** Keys that can cause prototype pollution if merged into settings. */
+const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Recursively strips prototype-pollution keys from a nested object
+ * to prevent untrusted updates from polluting Object.prototype.
+ */
+function stripPrototypeKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripPrototypeKeys) as unknown as T;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const clean: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (!PROTOTYPE_POLLUTION_KEYS.has(k)) {
+        clean[k] = stripPrototypeKeys(v);
+      }
+    }
+    return clean as unknown as T;
+  }
+  return value;
+}
+
+/**
+ * Strips characters from a command string that could enable injection
+ * (e.g., newlines that break command boundaries).
+ */
+function sanitizeCommandValue(command: string): string {
+  return command.replace(/[\n\r]/g, ' ');
+}
+
   /**
    * Recursively walks the updates object and warns about any object with
    * `type: "command"` or `type: "stdio"` whose `command` value looks like
    * natural language rather than a valid shell command.
+   * Also sanitizes command values to strip injection vectors.
    */
 function warnAboutNaturalLanguageCommandValues(
   updates: Record<string, unknown>,
@@ -36,6 +68,7 @@ function warnAboutNaturalLanguageCommandValues(
         (objValue['type'] === 'command' || objValue['type'] === 'stdio') &&
         typeof objValue['command'] === 'string'
       ) {
+        objValue['command'] = sanitizeCommandValue(objValue['command']);
         if (!isLikelyShellCommand(objValue['command'])) {
           coreEvents.emitFeedback(
             'warn',
@@ -69,10 +102,12 @@ export function updateSettingsFilePreservingFormat(
   filePath: string,
   updates: Record<string, unknown>,
 ): void {
-  warnAboutNaturalLanguageCommandValues(updates, '');
+  // Sanitize untrusted input before any processing
+  const sanitizedUpdates = stripPrototypeKeys(updates);
+  warnAboutNaturalLanguageCommandValues(sanitizedUpdates, '');
 
   if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, JSON.stringify(updates, null, 2), 'utf-8');
+    fs.writeFileSync(filePath, JSON.stringify(sanitizedUpdates, null, 2), 'utf-8');
     return;
   }
 
@@ -91,7 +126,7 @@ export function updateSettingsFilePreservingFormat(
     return;
   }
 
-  const updatedStructure = applyUpdates(parsed, updates);
+  const updatedStructure = applyUpdates(parsed, sanitizedUpdates);
   const updatedContent = stringify(updatedStructure, null, 2);
 
   fs.writeFileSync(filePath, updatedContent, 'utf-8');

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -23,14 +23,25 @@ const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'prototype', 'constructor
  */
 function stripPrototypeKeys<T>(value: T): T {
   if (Array.isArray(value)) {
-    return value.map(stripPrototypeKeys) as unknown as T;
+    const cleanArr = value.map(stripPrototypeKeys);
+    for (const sym of Object.getOwnPropertySymbols(value)) {
+      (cleanArr as Record<string | symbol, unknown>)[sym] = stripPrototypeKeys(
+        (value as Record<string | symbol, unknown>)[sym],
+      );
+    }
+    return cleanArr as unknown as T;
   }
   if (typeof value === 'object' && value !== null) {
-    const clean: Record<string, unknown> = {};
+    const clean: Record<string | symbol, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       if (!PROTOTYPE_POLLUTION_KEYS.has(k)) {
         clean[k] = stripPrototypeKeys(v);
       }
+    }
+    for (const sym of Object.getOwnPropertySymbols(value)) {
+      clean[sym] = stripPrototypeKeys(
+        (value as Record<string | symbol, unknown>)[sym],
+      );
     }
     return clean as unknown as T;
   }
@@ -38,8 +49,8 @@ function stripPrototypeKeys<T>(value: T): T {
 }
 
 /**
- * Strips characters from a command string that could enable injection
- * (e.g., newlines that break command boundaries).
+ * Strips newline characters from a command string that could break
+ * command boundaries when the value is later executed by a shell.
  */
 function sanitizeCommandValue(command: string): string {
   return command.replace(/[\n\r]/g, ' ');
@@ -54,44 +65,62 @@ function sanitizeCommandValue(command: string): string {
 function warnAboutNaturalLanguageCommandValues(
   updates: Record<string, unknown>,
   path: string,
-): void {
+): Record<string, unknown> {
+  const result: Record<string | symbol, unknown> = {};
+  for (const k of Object.getOwnPropertyNames(updates)) {
+    result[k] = updates[k];
+  }
+  for (const sym of Object.getOwnPropertySymbols(updates)) {
+    result[sym] = updates[sym];
+  }
+
   if (
-    (updates['type'] === 'command' || updates['type'] === 'stdio') &&
-    typeof updates['command'] === 'string'
+    (result['type'] === 'command' || result['type'] === 'stdio') &&
+    typeof result['command'] === 'string'
   ) {
-    updates['command'] = sanitizeCommandValue(updates['command']);
-    if (!isLikelyShellCommand(updates['command'])) {
+    result['command'] = sanitizeCommandValue(result['command'] as string);
+    if (!isLikelyShellCommand(result['command'] as string)) {
       coreEvents.emitFeedback(
-        'warn',
+        'warning',
         `Setting "${path}.command" contains text that does not look like a valid shell command. ` +
           'The value will be saved, but it may fail when executed.',
       );
     }
+  } else if (typeof result['command'] === 'string') {
+    result['command'] = sanitizeCommandValue(result['command'] as string);
   }
 
-  for (const [key, value] of Object.entries(updates)) {
+  for (const key of Object.getOwnPropertyNames(result)) {
+    const value = result[key];
     const currentPath = path ? `${path}.${key}` : key;
 
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      warnAboutNaturalLanguageCommandValues(
+      result[key] = warnAboutNaturalLanguageCommandValues(
         value as Record<string, unknown>,
         currentPath,
       );
     } else if (Array.isArray(value)) {
-      (value as unknown[]).forEach((item, index) => {
+      const cleanArr = (value as unknown[]).map((item, index) => {
         if (
           typeof item === 'object' &&
           item !== null &&
           !Array.isArray(item)
         ) {
-          warnAboutNaturalLanguageCommandValues(
+          return warnAboutNaturalLanguageCommandValues(
             item as Record<string, unknown>,
             `${currentPath}[${index}]`,
           );
         }
+        return item;
       });
+      for (const sym of Object.getOwnPropertySymbols(value)) {
+        (cleanArr as Record<string | symbol, unknown>)[sym] =
+          (value as Record<string | symbol, unknown>)[sym];
+      }
+      result[key] = cleanArr;
     }
   }
+  return result as Record<string, unknown>;
 }
 
 /**
@@ -103,10 +132,13 @@ export function updateSettingsFilePreservingFormat(
 ): void {
   // Sanitize untrusted input before any processing
   const sanitizedUpdates = stripPrototypeKeys(updates);
-  warnAboutNaturalLanguageCommandValues(sanitizedUpdates, '');
+  const warnedUpdates = warnAboutNaturalLanguageCommandValues(
+    sanitizedUpdates,
+    '',
+  );
 
   if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, JSON.stringify(sanitizedUpdates, null, 2), 'utf-8');
+    fs.writeFileSync(filePath, JSON.stringify(warnedUpdates, null, 2), 'utf-8');
     return;
   }
 
@@ -125,7 +157,7 @@ export function updateSettingsFilePreservingFormat(
     return;
   }
 
-  const updatedStructure = applyUpdates(parsed, sanitizedUpdates);
+  const updatedStructure = applyUpdates(parsed, warnedUpdates);
   const updatedContent = stringify(updatedStructure, null, 2);
 
   fs.writeFileSync(filePath, updatedContent, 'utf-8');
@@ -238,8 +270,48 @@ function applyKeyDiff(
       for (const el of desiredArr) {
         baseArr.push(el);
       }
+      for (const sym of Object.getOwnPropertySymbols(desiredArr)) {
+        (baseArr as Record<string | symbol, unknown>)[sym] =
+          (desiredArr as Record<string | symbol, unknown>)[sym];
+      }
     } else {
       base[nextKey] = nextVal;
+    }
+  }
+
+  for (const sym of Object.getOwnPropertySymbols(desired)) {
+    const nextVal = desired[sym];
+    const baseVal = (base as Record<string | symbol, unknown>)[sym];
+
+    const isObj =
+      typeof nextVal === 'object' &&
+      nextVal !== null &&
+      !Array.isArray(nextVal);
+    const isBaseObj =
+      typeof baseVal === 'object' &&
+      baseVal !== null &&
+      !Array.isArray(baseVal);
+    const isArr = Array.isArray(nextVal);
+    const isBaseArr = Array.isArray(baseVal);
+
+    if (isObj && isBaseObj) {
+      applyKeyDiff(
+        baseVal as Record<string, unknown>,
+        nextVal as Record<string, unknown>,
+      );
+    } else if (isArr && isBaseArr) {
+      const baseArr = baseVal as unknown[];
+      const desiredArr = nextVal as unknown[];
+      baseArr.length = 0;
+      for (const el of desiredArr) {
+        baseArr.push(el);
+      }
+      for (const arrSym of Object.getOwnPropertySymbols(desiredArr)) {
+        (baseArr as Record<string | symbol, unknown>)[arrSym] =
+          (desiredArr as Record<string | symbol, unknown>)[arrSym];
+      }
+    } else {
+      (base as Record<string | symbol, unknown>)[sym] = nextVal;
     }
   }
 }

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -55,29 +55,28 @@ function warnAboutNaturalLanguageCommandValues(
   updates: Record<string, unknown>,
   path: string,
 ): void {
+  if (
+    (updates['type'] === 'command' || updates['type'] === 'stdio') &&
+    typeof updates['command'] === 'string'
+  ) {
+    updates['command'] = sanitizeCommandValue(updates['command']);
+    if (!isLikelyShellCommand(updates['command'])) {
+      coreEvents.emitFeedback(
+        'warn',
+        `Setting "${path}.command" contains text that does not look like a valid shell command. ` +
+          'The value will be saved, but it may fail when executed.',
+      );
+    }
+  }
+
   for (const [key, value] of Object.entries(updates)) {
     const currentPath = path ? `${path}.${key}` : key;
 
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      const objValue = value as Record<string, unknown>;
-      if (
-        (objValue['type'] === 'command' || objValue['type'] === 'stdio') &&
-        typeof objValue['command'] === 'string'
-      ) {
-        objValue['command'] = sanitizeCommandValue(objValue['command']);
-        if (!isLikelyShellCommand(objValue['command'])) {
-          coreEvents.emitFeedback(
-            'warn',
-            `Setting "${currentPath}.command" contains text that does not look like a valid shell command. ` +
-              'The value will be saved, but it may fail when executed.',
-          );
-        }
-      }
-      warnAboutNaturalLanguageCommandValues(objValue, currentPath);
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      warnAboutNaturalLanguageCommandValues(
+        value as Record<string, unknown>,
+        currentPath,
+      );
     } else if (Array.isArray(value)) {
       (value as unknown[]).forEach((item, index) => {
         if (

--- a/packages/cli/src/utils/shellCommandValidator.test.ts
+++ b/packages/cli/src/utils/shellCommandValidator.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isLikelyShellCommand } from './shellCommandValidator.js';
+
+describe('isLikelyShellCommand', () => {
+  it('returns false for empty string', () => {
+    expect(isLikelyShellCommand('')).toBe(false);
+  });
+
+  it('returns false for whitespace-only string', () => {
+    expect(isLikelyShellCommand('   ')).toBe(false);
+  });
+
+  it('returns true for commands with shell pipe operator', () => {
+    expect(isLikelyShellCommand('echo hello | grep world')).toBe(true);
+  });
+
+  it('returns true for commands with redirection', () => {
+    expect(isLikelyShellCommand('ls > output.txt')).toBe(true);
+    expect(isLikelyShellCommand('cat < input.txt')).toBe(true);
+  });
+
+  it('returns true for commands with shell variable', () => {
+    expect(isLikelyShellCommand('echo $HOME')).toBe(true);
+  });
+
+  it('returns true for commands with && chaining', () => {
+    expect(isLikelyShellCommand('cd /tmp && rm -rf test')).toBe(true);
+  });
+
+  it('returns true for commands with known binary', () => {
+    expect(isLikelyShellCommand('ls -la')).toBe(true);
+    expect(isLikelyShellCommand('git status')).toBe(true);
+    expect(isLikelyShellCommand('docker ps')).toBe(true);
+    expect(isLikelyShellCommand('npm install')).toBe(true);
+    expect(isLikelyShellCommand('cat file.txt')).toBe(true);
+  });
+
+  it('returns true for command with backtick', () => {
+    expect(isLikelyShellCommand('echo `date`')).toBe(true);
+  });
+
+  it('returns true for command with $() substitution', () => {
+    expect(isLikelyShellCommand('echo $(date)')).toBe(true);
+  });
+
+  it('returns true for command with ${} variable', () => {
+    expect(isLikelyShellCommand('echo ${HOME}')).toBe(true);
+  });
+
+  it('returns false for natural language text', () => {
+    expect(isLikelyShellCommand('mostrar diretório, modelo e contexto')).toBe(
+      false,
+    );
+    expect(isLikelyShellCommand('show directory, model and context')).toBe(
+      false,
+    );
+    expect(
+      isLikelyShellCommand('please list all files in the current directory'),
+    ).toBe(false);
+  });
+
+  it('returns false for natural language with punctuation', () => {
+    expect(isLikelyShellCommand('Hello, how are you?')).toBe(false);
+    expect(isLikelyShellCommand('This is a test.')).toBe(false);
+  });
+
+  it('returns true for simple known commands without arguments', () => {
+    expect(isLikelyShellCommand('ls')).toBe(true);
+    expect(isLikelyShellCommand('pwd')).toBe(true);
+  });
+});

--- a/packages/cli/src/utils/shellCommandValidator.test.ts
+++ b/packages/cli/src/utils/shellCommandValidator.test.ts
@@ -16,6 +16,15 @@ describe('isLikelyShellCommand', () => {
     expect(isLikelyShellCommand('   ')).toBe(false);
   });
 
+  it('returns true for single-word inputs (no spaces)', () => {
+    expect(isLikelyShellCommand('ls')).toBe(true);
+    expect(isLikelyShellCommand('pwd')).toBe(true);
+    expect(isLikelyShellCommand('touch')).toBe(true);
+    expect(isLikelyShellCommand('clear')).toBe(true);
+    expect(isLikelyShellCommand('my-script')).toBe(true);
+    expect(isLikelyShellCommand('./my-script')).toBe(true);
+  });
+
   it('returns true for commands with shell pipe operator', () => {
     expect(isLikelyShellCommand('echo hello | grep world')).toBe(true);
   });
@@ -41,6 +50,20 @@ describe('isLikelyShellCommand', () => {
     expect(isLikelyShellCommand('cat file.txt')).toBe(true);
   });
 
+  it('returns true for newly added binaries', () => {
+    expect(isLikelyShellCommand('gh pr list')).toBe(true);
+    expect(isLikelyShellCommand('tsc --noEmit')).toBe(true);
+    expect(isLikelyShellCommand('eslint src/')).toBe(true);
+    expect(isLikelyShellCommand('prettier --write .')).toBe(true);
+    expect(isLikelyShellCommand('vitest run')).toBe(true);
+    expect(isLikelyShellCommand('jest --coverage')).toBe(true);
+    expect(isLikelyShellCommand('vite build')).toBe(true);
+    expect(isLikelyShellCommand('terraform apply')).toBe(true);
+    expect(isLikelyShellCommand('poetry install')).toBe(true);
+    expect(isLikelyShellCommand('uv pip install')).toBe(true);
+    expect(isLikelyShellCommand('jq .name')).toBe(true);
+  });
+
   it('returns true for command with backtick', () => {
     expect(isLikelyShellCommand('echo `date`')).toBe(true);
   });
@@ -51,6 +74,31 @@ describe('isLikelyShellCommand', () => {
 
   it('returns true for command with ${} variable', () => {
     expect(isLikelyShellCommand('echo ${HOME}')).toBe(true);
+  });
+
+  it('returns true for command-line flags', () => {
+    expect(isLikelyShellCommand('node --max-old-space-size=4096')).toBe(true);
+    expect(isLikelyShellCommand('npm run build -s')).toBe(true);
+    expect(isLikelyShellCommand('git commit --amend')).toBe(true);
+  });
+
+  it('returns true for path-prefixed commands', () => {
+    expect(isLikelyShellCommand('./my-script')).toBe(true);
+    expect(isLikelyShellCommand('../run.sh')).toBe(true);
+    expect(isLikelyShellCommand('/usr/bin/custom-tool')).toBe(true);
+    expect(isLikelyShellCommand('C:\\tools\\run.exe')).toBe(true);
+    expect(isLikelyShellCommand('node_modules/.bin/tsc')).toBe(true);
+    expect(isLikelyShellCommand('bin/test')).toBe(true);
+  });
+
+  it('returns true for commands ending with executable extensions', () => {
+    expect(isLikelyShellCommand('my-script.sh')).toBe(true);
+    expect(isLikelyShellCommand('run.bat')).toBe(true);
+    expect(isLikelyShellCommand('app.exe --help')).toBe(true);
+  });
+
+  it('returns true for g++ commands', () => {
+    expect(isLikelyShellCommand('g++ main.cpp')).toBe(true);
   });
 
   it('returns false for natural language text', () => {
@@ -70,31 +118,9 @@ describe('isLikelyShellCommand', () => {
     expect(isLikelyShellCommand('This is a test.')).toBe(false);
   });
 
-  it('returns true for simple known commands without arguments', () => {
-    expect(isLikelyShellCommand('ls')).toBe(true);
-    expect(isLikelyShellCommand('pwd')).toBe(true);
-  });
-
-  it('returns true for common shells and interpreters', () => {
-    expect(isLikelyShellCommand('bash script.sh')).toBe(true);
-    expect(isLikelyShellCommand('sh script.sh')).toBe(true);
-    expect(isLikelyShellCommand('powershell -Command Get-Process')).toBe(true);
-  });
-
-  it('returns true for path-prefixed commands', () => {
-    expect(isLikelyShellCommand('./my-script')).toBe(true);
-    expect(isLikelyShellCommand('../run.sh')).toBe(true);
-    expect(isLikelyShellCommand('/usr/bin/custom-tool')).toBe(true);
-    expect(isLikelyShellCommand('C:\\tools\\run.exe')).toBe(true);
-  });
-
-  it('returns true for commands ending with executable extensions', () => {
-    expect(isLikelyShellCommand('my-script.sh')).toBe(true);
-    expect(isLikelyShellCommand('run.bat')).toBe(true);
-    expect(isLikelyShellCommand('app.exe --help')).toBe(true);
-  });
-
-  it('returns true for g++ commands', () => {
-    expect(isLikelyShellCommand('g++ main.cpp')).toBe(true);
+  it('returns false for natural language containing common command words', () => {
+    expect(isLikelyShellCommand('please go to the store')).toBe(false);
+    expect(isLikelyShellCommand('show me a picture of a cat')).toBe(false);
+    expect(isLikelyShellCommand('how to find the best model')).toBe(false);
   });
 });

--- a/packages/cli/src/utils/shellCommandValidator.test.ts
+++ b/packages/cli/src/utils/shellCommandValidator.test.ts
@@ -74,4 +74,27 @@ describe('isLikelyShellCommand', () => {
     expect(isLikelyShellCommand('ls')).toBe(true);
     expect(isLikelyShellCommand('pwd')).toBe(true);
   });
+
+  it('returns true for common shells and interpreters', () => {
+    expect(isLikelyShellCommand('bash script.sh')).toBe(true);
+    expect(isLikelyShellCommand('sh script.sh')).toBe(true);
+    expect(isLikelyShellCommand('powershell -Command Get-Process')).toBe(true);
+  });
+
+  it('returns true for path-prefixed commands', () => {
+    expect(isLikelyShellCommand('./my-script')).toBe(true);
+    expect(isLikelyShellCommand('../run.sh')).toBe(true);
+    expect(isLikelyShellCommand('/usr/bin/custom-tool')).toBe(true);
+    expect(isLikelyShellCommand('C:\\tools\\run.exe')).toBe(true);
+  });
+
+  it('returns true for commands ending with executable extensions', () => {
+    expect(isLikelyShellCommand('my-script.sh')).toBe(true);
+    expect(isLikelyShellCommand('run.bat')).toBe(true);
+    expect(isLikelyShellCommand('app.exe --help')).toBe(true);
+  });
+
+  it('returns true for g++ commands', () => {
+    expect(isLikelyShellCommand('g++ main.cpp')).toBe(true);
+  });
 });

--- a/packages/cli/src/utils/shellCommandValidator.ts
+++ b/packages/cli/src/utils/shellCommandValidator.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Patterns that indicate a string is likely a shell command rather than
+ * natural language text.
+ */
+const SHELL_SYNTAX_PATTERNS = [
+  /[|;&<>`$]/,
+  /\$\{/,
+  /\$\(/,
+  /\(\)\s*\{/,
+  /&&/,
+  /\|\|/,
+  /\b(?:echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem|cargo)\b/i,
+];
+
+/**
+ * Checks whether a string is likely a valid shell command as opposed to
+ * natural language text.
+ *
+ * Uses two heuristics:
+ * 1. Presence of shell operators or known command names.
+ * 2. Invoking the platform shell to verify the command is executable.
+ *
+ * Returns true if the text appears to be a shell command, false if it
+ * looks like natural language or is empty.
+ */
+export function isLikelyShellCommand(text: string): boolean {
+  if (!text || text.trim().length === 0) {
+    return false;
+  }
+
+  const trimmed = text.trim();
+
+  if (SHELL_SYNTAX_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/cli/src/utils/shellCommandValidator.ts
+++ b/packages/cli/src/utils/shellCommandValidator.ts
@@ -19,15 +19,11 @@ const SHELL_SYNTAX_PATTERNS = [
 ];
 
 /**
- * Checks whether a string is likely a valid shell command as opposed to
- * natural language text.
+ * Checks whether a string looks like a shell command rather than
+ * natural language text, using heuristic regex matching.
  *
- * Uses two heuristics:
- * 1. Presence of shell operators or known command names.
- * 2. Invoking the platform shell to verify the command is executable.
- *
- * Returns true if the text appears to be a shell command, false if it
- * looks like natural language or is empty.
+ * Returns true if the text contains shell operators or known
+ * command names, false if it looks like natural language or is empty.
  */
 export function isLikelyShellCommand(text: string): boolean {
   if (!text || text.trim().length === 0) {

--- a/packages/cli/src/utils/shellCommandValidator.ts
+++ b/packages/cli/src/utils/shellCommandValidator.ts
@@ -15,7 +15,7 @@ const SHELL_SYNTAX_PATTERNS = [
   /\(\)\s*\{/,
   /&&/,
   /\|\|/,
-  /\b(?:echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem|cargo)\b/i,
+  /\b(?:echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem)\b/i,
 ];
 
 /**

--- a/packages/cli/src/utils/shellCommandValidator.ts
+++ b/packages/cli/src/utils/shellCommandValidator.ts
@@ -15,7 +15,10 @@ const SHELL_SYNTAX_PATTERNS = [
   /\(\)\s*\{/,
   /&&/,
   /\|\|/,
-  /\b(?:echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem)\b/i,
+  /^(?:\.\.?|~)?[/\\]/,
+  /^[a-zA-Z]:[/\\]/,
+  /^\S+\.(?:sh|bat|cmd|exe)\b/i,
+  /\b(?:bash|sh|zsh|cmd|powershell|pwsh|echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem)(?!\w)/i,
 ];
 
 /**

--- a/packages/cli/src/utils/shellCommandValidator.ts
+++ b/packages/cli/src/utils/shellCommandValidator.ts
@@ -10,23 +10,22 @@
  */
 const SHELL_SYNTAX_PATTERNS = [
   /[|;&<>`$]/,
-  /\$\{/,
-  /\$\(/,
   /\(\)\s*\{/,
-  /&&/,
-  /\|\|/,
-  /^(?:\.\.?|~)?[/\\]/,
+  /^\s*\S+[/\\]\S+/,
   /^[a-zA-Z]:[/\\]/,
   /^\S+\.(?:sh|bat|cmd|exe)\b/i,
-  /\b(?:bash|sh|zsh|cmd|powershell|pwsh|echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem)(?!\w)/i,
+  /\s--?[a-zA-Z0-9]/,
+  /^\s*(?:sudo\s+|env\s+)?(?:[a-zA-Z_][a-zA-Z0-9_]*=\S+\s+)*\b(?:bash|sh|zsh|cmd|powershell|pwsh|echo|cat|ls|cd|pwd|grep|find|sort|uniq|wc|head|tail|sed|awk|cut|tr|tee|xargs|mkdir|rmdir|rm|cp|mv|chmod|chown|ps|kill|top|df|du|mount|umount|tar|gzip|gunzip|zip|unzip|curl|wget|ssh|scp|git|npm|npx|yarn|pnpm|docker|kubectl|node|python|python3|ruby|perl|php|java|javac|mvn|gradle|make|cmake|cc|gcc|g\+\+|clang|go|rustc|cargo|deno|bun|dotnet|pip|pip3|composer|gem|sudo|apt|apt-get|brew|gcloud|aws|nvm|export|source|gh|tsc|eslint|prettier|vitest|jest|vite|next|terraform|ping|poetry|uv|jq|yq|touch|clear|cls|open|xdg-open|start|py|tsx|ts-node|docker-compose)(?!\w)/i,
 ];
 
 /**
  * Checks whether a string looks like a shell command rather than
  * natural language text, using heuristic regex matching.
  *
- * Returns true if the text contains shell operators or known
- * command names, false if it looks like natural language or is empty.
+ * Returns true if the text contains shell operators, known
+ * command names, path-prefixed commands, or is a single-word
+ * input (highly likely to be an executable name). Returns false
+ * if it looks like natural language or is empty.
  */
 export function isLikelyShellCommand(text: string): boolean {
   if (!text || text.trim().length === 0) {
@@ -34,6 +33,10 @@ export function isLikelyShellCommand(text: string): boolean {
   }
 
   const trimmed = text.trim();
+
+  if (!trimmed.includes(' ')) {
+    return true;
+  }
 
   if (SHELL_SYNTAX_PATTERNS.some((pattern) => pattern.test(trimmed))) {
     return true;


### PR DESCRIPTION
Title: fix: add command validation to prevent natural language being saved as shell commands


## Summary
When a `/statusline` (or similar MCP/discovered tool) command is executed with natural language input like "mostrar diretório, modelo e contexto", the raw text gets saved directly into `settings.json` as a `command` value. The CLI then tries to execute this as a shell command and fails repeatedly with "command not found".

## Details
- Added `shellCommandValidator.ts` with `isLikelyShellCommand()` — a heuristic utility that detects shell operators (`|`, `>`, `$`, `&&`), known executable names (ls, git, docker, etc.), and shell syntax patterns
- Integrated into `updateSettingsFilePreservingFormat()` — recursively walks settings updates and warns via `coreEvents` when any object with `type: "command"` has a natural language command value
- The warning is emitted early during the save, giving users a chance to fix the value before it's executed

- Added 13 unit tests covering shell operators, known binaries, natural language rejection, and edge cases

## How to Validate
1. Run `npx vitest run --config vitest.config.ts src/utils/shellCommandValidator.test.ts` in `packages/cli/`
2. All 13 tests should pass
3. Verify that natural language like "mostrar diretório, modelo e contexto" returns `false` from `isLikelyShellCommand()`
4. Verify that valid commands like "ls -la", "git status", "docker ps" return `true`

## Related Issues
Fixes #27322