### PR TITLE
fix(core): bypass node-pty on WSL for Windows executables

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -33,6 +33,7 @@ const mockIsBinary = vi.hoisted(() => vi.fn());
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockHomedir = vi.hoisted(() => vi.fn());
 const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockCreateWriteStream = vi.hoisted(() => vi.fn());
 const mockGetPty = vi.hoisted(() => vi.fn());
 const mockSerializeTerminalToObject = vi.hoisted(() => vi.fn());
@@ -42,6 +43,10 @@ const mockDebugLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
   debug: vi.fn(),
+}));
+
+const mockReadFileSyncObj = vi.hoisted(() => ({
+  original: null as typeof import('node:fs').readFileSync | null,
 }));
 
 // Top-level Mocks
@@ -58,15 +63,19 @@ vi.mock('@lydell/node-pty', () => ({
 }));
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
+  mockReadFileSyncObj.original = actual.readFileSync;
+  mockReadFileSync.mockImplementation(actual.readFileSync);
   return {
     ...actual,
     default: {
       ...actual,
       mkdirSync: mockMkdirSync,
       createWriteStream: mockCreateWriteStream,
+      readFileSync: mockReadFileSync,
     },
     mkdirSync: mockMkdirSync,
     createWriteStream: mockCreateWriteStream,
+    readFileSync: mockReadFileSync,
   };
 });
 vi.mock('../utils/shell-utils.js', async (importOriginal) => {
@@ -1813,6 +1822,102 @@ describe('ShellExecutionService execution method selection', () => {
     expect(mockPtySpawn).not.toHaveBeenCalled();
     expect(mockCpSpawn).toHaveBeenCalled();
     expect(result.executionMethod).toBe('child_process');
+  });
+
+  it('should bypass node-pty and use child_process on WSL when executing a command with .exe', async () => {
+    mockPlatform.mockReturnValue('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+    mockSerializeTerminalToObject.mockReturnValue([]);
+
+    const abortController = new AbortController();
+    const handle = await ShellExecutionService.execute(
+      'adb.exe devices',
+      '/test/dir',
+      onOutputEventMock,
+      abortController.signal,
+      true, // shouldUseNodePty
+      shellExecutionConfig,
+    );
+
+    // Simulate exit of child_process fallback
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    const result = await handle.result;
+
+    expect(mockPtySpawn).not.toHaveBeenCalled();
+    expect(mockCpSpawn).toHaveBeenCalled();
+    expect(result.executionMethod).toBe('child_process');
+
+    vi.unstubAllEnvs();
+  });
+
+  it('should use node-pty on WSL when executing a non-.exe command', async () => {
+    mockPlatform.mockReturnValue('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+    mockSerializeTerminalToObject.mockReturnValue([]);
+
+    const abortController = new AbortController();
+    const handle = await ShellExecutionService.execute(
+      'ls -la',
+      '/test/dir',
+      onOutputEventMock,
+      abortController.signal,
+      true, // shouldUseNodePty
+      shellExecutionConfig,
+    );
+
+    if (!mockPtyProcess.onExit.mock.calls[0]) {
+      const res = await handle.result;
+      throw new Error(`Failed early in executeWithPty: ${res.error}`);
+    }
+    mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+    const result = await handle.result;
+
+    expect(mockPtySpawn).toHaveBeenCalled();
+    expect(mockCpSpawn).not.toHaveBeenCalled();
+    expect(result.executionMethod).toBe('mock-pty');
+
+    vi.unstubAllEnvs();
+  });
+
+  it('should use node-pty on standard Linux when executing a command with .exe', async () => {
+    mockPlatform.mockReturnValue('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', ''); // No WSL
+    vi.stubEnv('WSLENV', '');
+    vi.stubEnv('WSL_INTEROP', '');
+    mockSerializeTerminalToObject.mockReturnValue([]);
+
+    // Mock readFileSync to simulate a standard (non-microsoft/WSL) kernel version
+    mockReadFileSync.mockImplementation((path, options) => {
+      if (typeof path === 'string' && path.includes('/proc/version')) {
+        return 'Linux version 5.4.0-generic (buildd@lgw01-amd64-060)';
+      }
+      return mockReadFileSyncObj.original!(path, options);
+    });
+
+    const abortController = new AbortController();
+    const handle = await ShellExecutionService.execute(
+      'some_program.exe --version',
+      '/test/dir',
+      onOutputEventMock,
+      abortController.signal,
+      true, // shouldUseNodePty
+      shellExecutionConfig,
+    );
+
+    if (!mockPtyProcess.onExit.mock.calls[0]) {
+      const res = await handle.result;
+      throw new Error(`Failed early in executeWithPty: ${res.error}`);
+    }
+    mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+    const result = await handle.result;
+
+    expect(mockPtySpawn).toHaveBeenCalled();
+    expect(mockCpSpawn).not.toHaveBeenCalled();
+    expect(result.executionMethod).toBe('mock-pty');
+
+    mockReadFileSync.mockImplementation(mockReadFileSyncObj.original!);
+    vi.unstubAllEnvs();
   });
 });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1880,6 +1880,35 @@ describe('ShellExecutionService execution method selection', () => {
     vi.unstubAllEnvs();
   });
 
+  it('should use node-pty on WSL when executing a command with .exe only in arguments', async () => {
+    mockPlatform.mockReturnValue('linux');
+    vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
+    mockSerializeTerminalToObject.mockReturnValue([]);
+
+    const abortController = new AbortController();
+    const handle = await ShellExecutionService.execute(
+      'vim app.exe',
+      '/test/dir',
+      onOutputEventMock,
+      abortController.signal,
+      true, // shouldUseNodePty
+      shellExecutionConfig,
+    );
+
+    if (!mockPtyProcess.onExit.mock.calls[0]) {
+      const res = await handle.result;
+      throw new Error(`Failed early in executeWithPty: ${res.error}`);
+    }
+    mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+    const result = await handle.result;
+
+    expect(mockPtySpawn).toHaveBeenCalled();
+    expect(mockCpSpawn).not.toHaveBeenCalled();
+    expect(result.executionMethod).toBe('mock-pty');
+
+    vi.unstubAllEnvs();
+  });
+
   it('should use node-pty on standard Linux when executing a command with .exe', async () => {
     mockPlatform.mockReturnValue('linux');
     vi.stubEnv('WSL_DISTRO_NAME', ''); // No WSL

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -386,7 +386,35 @@ export class ShellExecutionService {
     shouldUseNodePty: boolean,
     shellExecutionConfig: ShellExecutionConfig,
   ): Promise<ShellExecutionHandle> {
-    if (shouldUseNodePty) {
+    let finalShouldUseNodePty = shouldUseNodePty;
+
+    // Detect if we are on WSL and running a Windows executable (.exe).
+    // WSL has known terminal/PTY interop issues when running Windows binaries within a Linux PTY (like node-pty),
+    // which can lead to hangs, lost/missing output, or indefinite waiting for process exit.
+    if (finalShouldUseNodePty && os.platform() === 'linux') {
+      const isWSL =
+        Boolean(
+          process.env['WSL_DISTRO_NAME'] ||
+            process.env['WSLENV'] ||
+            process.env['WSL_INTEROP'],
+        ) ||
+        (() => {
+          try {
+            return fs
+              .readFileSync('/proc/version', 'utf8')
+              .toLowerCase()
+              .includes('microsoft');
+          } catch {
+            return false;
+          }
+        })();
+
+      if (isWSL && /\.exe\b/i.test(commandToExecute)) {
+        finalShouldUseNodePty = false;
+      }
+    }
+
+    if (finalShouldUseNodePty) {
       const ptyInfo = await getPty();
       if (ptyInfo) {
         try {
@@ -410,7 +438,7 @@ export class ShellExecutionService {
       onOutputEvent,
       abortSignal,
       shellExecutionConfig,
-      shouldUseNodePty,
+      finalShouldUseNodePty,
     );
   }
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -18,6 +18,8 @@ import {
   resolveExecutable,
   type ShellType,
   BASH_HUP_GUARD,
+  getCommandRoots,
+  initializeShellParsers,
 } from '../utils/shell-utils.js';
 import { isBinary, truncateString } from '../utils/textUtils.js';
 import pkg from '@xterm/headless';
@@ -409,8 +411,12 @@ export class ShellExecutionService {
           }
         })();
 
-      if (isWSL && /\.exe\b/i.test(commandToExecute)) {
-        finalShouldUseNodePty = false;
+      if (isWSL) {
+        await initializeShellParsers();
+        const commands = getCommandRoots(commandToExecute);
+        if (commands.some((cmd) => cmd.toLowerCase().endsWith('.exe'))) {
+          finalShouldUseNodePty = false;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

This PR addresses known terminal/PTY interop issues on Windows Subsystem for Linux (WSL) when running Windows executables (`.exe`) inside a Linux PTY (like `node-pty`). It implements a fallback mechanism that automatically bypasses `node-pty` and uses standard Node `child_process` execution for `.exe` commands in WSL environments.

## Details

- **WSL Detection:** Automatically detects WSL using standard environment variables (`WSL_DISTRO_NAME`, `WSLENV`, `WSL_INTEROP`) and `/proc/version` reading.
- **Windows Binaries Bypass:** Detects Windows binaries in the command string via `getCommandRoots` from our parsing utility to ensure we don't bypass PTY for Linux commands with `.exe` in arguments (e.g. `vim app.exe` remains interactive).
- **Mock Type Safety:** Properly types the mocked `readFileSync` helper in unit tests to adhere strictly to `@typescript-eslint/no-explicit-any`.
- **Unit Tests:** Adds comprehensive test coverage inside `packages/core/src/services/shellExecutionService.test.ts` to verify fallback behavior on WSL and correct path-routing on standard Linux/non-.exe commands.

## Related Issues

- Fixes #27355 (Primary Bug)
- Fixes #15233 (`run_shell_command` hangs when running `.exe` under WSL)
- Fixes #24410 (`dotnet.exe` hangs indefinitely under WSL)
- Related to #25203 (Cross-OS process execution deadlocks)

## How to Validate

Run the unit tests in the core package:
```bash
npm test -w @google/gemini-cli-core -- src/services/shellExecutionService.test.ts
```
All tests should pass, including the target scenarios:
1. `should bypass node-pty and use child_process on WSL when executing a command with .exe`
2. `should use node-pty on WSL when executing a non-.exe command`
3. `should use node-pty on WSL when executing a command with .exe only in arguments`
4. `should use node-pty on standard Linux when executing a command with .exe`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
