### PR TITLE
fix(core): prevent --resume from injecting session context into metadata

### DIFF
--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -824,34 +824,49 @@ export class ChatRecordingService {
       let updated = false;
 
       // 1. Sync content and IDs
-      const newMessages: MessageRecord[] = history.map((turn) => {
-        const existing = this.cachedConversation?.messages.find(
-          (m) => m.id === turn.id,
-        );
+      const newMessages: MessageRecord[] = history
+        .filter((turn) => {
+          // Filter out injected session context prompts to prevent metadata corruption on resume.
+          // The <session_context> tag is the only reliable identifier for these synthetic turns
+          // because HistoryTurn is bound to the raw GenAI SDK Content interface (role + parts only)
+          // and the stable ID assigned in environmentContext.ts gets overwritten with a random UUID
+          // during session initialization in geminiChat.ts. A schema change to HistoryTurn would
+          // be a more robust long-term fix.
+          const isSystemContext =
+            turn.content.role === 'user' &&
+            turn.content.parts?.some(
+              (p) => 'text' in p && p.text?.includes('<session_context>'),
+            );
+          return !isSystemContext;
+        })
+        .map((turn) => {
+          const existing = this.cachedConversation?.messages.find(
+            (m) => m.id === turn.id,
+          );
 
-        if (existing) {
-          // If content parts have changed (e.g. masking), update them
-          if (
-            JSON.stringify(existing.content) !==
-            JSON.stringify(turn.content.parts)
-          ) {
-            updated = true;
+          if (existing) {
+            // If content parts have changed (e.g. masking), update them
+            if (
+              JSON.stringify(existing.content) !==
+              JSON.stringify(turn.content.parts)
+            ) {
+              updated = true;
+            }
+            return {
+              ...existing,
+              content: turn.content.parts || [],
+            };
           }
-          return {
-            ...existing,
-            content: turn.content.parts || [],
-          };
-        }
 
-        // It's a new (possibly synthetic) turn like a summary
-        updated = true;
-        return this.newMessage(
-          turn.content.role === 'user' ? 'user' : 'gemini',
-          turn.content.parts || [],
-          undefined,
-          turn.id,
-        );
-      });
+          // It's a new (possibly synthetic) turn like a summary
+          updated = true;
+          return this.newMessage(
+            turn.content.role === 'user' ? 'user' : 'gemini',
+            turn.content.parts || [],
+            undefined,
+            turn.id,
+          );
+        });
 
       // 2. Specialized 'Masking Sync' for tool call results
       // If a user turn in history contains a functionResponse, we update the

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -825,7 +825,7 @@ export class ChatRecordingService {
 
       // 1. Sync content and IDs
       const newMessages: MessageRecord[] = history
-        .filter((turn) => {
+        .filter((turn, index) => {
           // Filter out injected session context prompts to prevent metadata corruption on resume.
           // The <session_context> tag is the only reliable identifier for these synthetic turns
           // because HistoryTurn is bound to the raw GenAI SDK Content interface (role + parts only)
@@ -833,9 +833,10 @@ export class ChatRecordingService {
           // during session initialization in geminiChat.ts. A schema change to HistoryTurn would
           // be a more robust long-term fix.
           const isSystemContext =
+            index === 0 &&
             turn.content.role === 'user' &&
             turn.content.parts?.some(
-              (p) => 'text' in p && p.text?.includes('<session_context>'),
+              (p) => isTextPart(p) && p.text.includes('<session_context>'),
             );
           return !isSystemContext;
         })


### PR DESCRIPTION
# Fix Chat Session Disappearance on Resume Flag

## Summary

This pull request resolves a critical UI regression where launching the CLI with the `--resume` flag caused active chat sessions to permanently disappear from the `/chat` Session Browser list.

## Technical Details

When a session is resumed, `GeminiChat` prepends (unshifts) a synthetic environment context prompt into the conversational history. The `ChatRecordingService.updateMessagesFromHistory` function incorrectly identified this action as a length mismatch between the in-memory history and the on-disk record. This mismatch triggered an unintended full history synchronization into the `$set: { messages: [...] }` metadata block.

Because `loadConversationRecord` prioritizes `$set` metadata when resolving the `firstUserMessage`, the massive (10,000+ character) system prompt replaced the actual user-initiated message in the session index. Consequently, this oversized string caused the Ink-based `SessionBrowser` UI to crash during rendering, rendering the session completely invisible to the user on subsequent launches.

### Solution

This fix introduces a specialized filter in `updateMessagesFromHistory` to ignore synthetic `<session_context>` turns during synchronization. An explicit architectural comment has been added explaining why a string-based match is used instead of ID-matching: `deriveStableId` is overwritten by random UUIDs during initialization in `geminiChat.ts`.

## Related Issues

Fixes #27368

## How to Validate

### 1\. Manual Verification

1.  Build the project:
    
    ```bash
    npm run build
    ```
    
2.  Launch Gemini normally and submit a test message:
    
    ```bash
    npm run start
    ```
    
3.  Exit the session, then resume it:
    
    ```bash
    npm run start -- --resume
    ```
    
4.  Exit again and verify that the session remains visible in the browser:
    
    ```bash
    npm run start -- --chat
    ```
    

### 2\. Unit Tests

Execute the test suite for the recording service:

```bash
npm test -w @google/gemini-cli-core -- src/services/chatRecordingService.test.ts
```

*   **Result:** All 43 tests pass successfully.

### 3\. Preflight Validation

Execute the preflight checks:

```bash
npm run preflight
```

*   **Result:** Passed cleanly on Linux.

---

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker