### PR TITLE
fix(core): catch EBADF when resizing an exited PTY

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1551,14 +1551,15 @@ export class ShellExecutionService {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const err = e as { code?: string; message?: string };
         const isEsrch = err.code === 'ESRCH';
+        const isEbadf = err.code === 'EBADF' || err.message?.includes('EBADF');
         const isWindowsPtyError = err.message?.includes(
           'Cannot resize a pty that has already exited',
         );
 
-        if (isEsrch || isWindowsPtyError) {
-          // On Unix, we get an ESRCH error.
+        if (isEsrch || isEbadf || isWindowsPtyError) {
+          // On Unix, we get an ESRCH error or EBADF if the fd is closed.
           // On Windows, we get a message-based error.
-          // In both cases, it's safe to ignore.
+          // In all cases, it's safe to ignore.
         } else {
           throw e;
         }


### PR DESCRIPTION
## Summary

Fixes a crash where the UI triggers a terminal resize immediately after a background shell process exits but before it's removed from `activePtys`. `node-pty` throws `EBADF` when `pty.resize()` is called on an already-closed file descriptor, which was not caught by the existing error handler and bubbled up to the React renderer, crashing the app.

## Details

`ShellExecutionService.resizePty` already has a try-catch for this race condition, handling `ESRCH` (Unix process-not-found) and a Windows-specific message string. `EBADF` (bad file descriptor) is the same semantic situation — resize called on a dead PTY — but was being re-thrown instead of silently ignored. This PR extends the existing guard to cover it.

The fix checks both `err.code === 'EBADF'` and `err.message?.includes('EBADF')` to cover any platform variation in how node-pty surfaces the error.

## Related Issues

Fixes #27366

## How to Validate

This race condition is not reliably reproducible manually. The fix is a two-line extension of an existing catch block and can be verified by code review alone. Multiple users confirmed the crash on the identical stack trace in #27366.

