### PR TITLE
fix(core): correctly identify Gemini 3 models with Vertex AI resource IDs

### DIFF
--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -326,12 +326,41 @@ describe('isGemini3Model', () => {
     expect(isGemini3Model(DEFAULT_GEMINI_MODEL_AUTO)).toBe(false);
   });
 
-  it('should return true for Vertex AI model resource paths', () => {
+  it('should correctly classify an exhaustive list of models as requested', () => {
+    // Expected true
+    expect(isGemini3Model('models/gemini-3.5-flash')).toBe(true);
+    expect(isGemini3Model('models/gemini-3.1-pro-preview')).toBe(true);
+    expect(isGemini3Model('models/gemini-3.1-flash-lite')).toBe(true);
+    expect(isGemini3Model('models/gemini-3.1-flash-lite-preview')).toBe(true);
+    expect(isGemini3Model('models/gemini-3-flash-preview')).toBe(true);
+
+    // Expected false
+    expect(isGemini3Model('models/gemini-2.5-pro')).toBe(false);
+    expect(isGemini3Model('models/gemini-2.5-flash')).toBe(false);
+    expect(isGemini3Model('models/gemini-2.5-flash-lite')).toBe(false);
+  });
+
+  it('should return true for Vertex AI model resource paths and handle false positives', () => {
     expect(
       isGemini3Model(
         'projects/test/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview',
       ),
     ).toBe(true);
+    expect(
+      isGemini3Model(
+        'projects/test/locations/us-central1/publishers/google/models/gemini-3-flash-preview',
+      ),
+    ).toBe(true);
+    expect(
+      isGemini3Model(
+        'projects/test/locations/us-central1/publishers/google/models/gemini-3.5-flash',
+      ),
+    ).toBe(true);
+    expect(
+      isGemini3Model(
+        'projects/gemini-3-project/locations/us-central1/publishers/google/models/gemini-2.5-pro',
+      ),
+    ).toBe(false);
   });
 
   it('should return false for arbitrary strings', () => {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -35,6 +35,7 @@ import {
   GEMMA_4_31B_IT_MODEL,
   GEMMA_4_26B_A4B_IT_MODEL,
   getAutoModelDescription,
+  type ModelCapabilityContext,
 } from './models.js';
 import type { Config } from './config.js';
 import { ModelConfigService } from '../services/modelConfigService.js';
@@ -361,6 +362,28 @@ describe('isGemini3Model', () => {
         'projects/gemini-3-project/locations/us-central1/publishers/google/models/gemini-2.5-pro',
       ),
     ).toBe(false);
+  });
+
+  it('should return true for Vertex AI model resource paths with dynamic configuration', () => {
+    // We use a mock config object directly as per the bot's suggestion
+    // to use hardcoded literals rather than imported constants for self-contained tests.
+    expect(
+      isGemini3Model(
+        'projects/test/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview',
+        {
+          getExperimentalDynamicModelConfiguration: () => true,
+          modelConfigService: {
+            resolveModelId: (modelId: string) => modelId,
+            getModelDefinition: (modelId: string) => {
+              if (modelId === 'gemini-3.1-pro-preview') {
+                return { family: 'gemini-3' };
+              }
+              return undefined;
+            },
+          },
+        } as unknown as ModelCapabilityContext,
+      ),
+    ).toBe(true);
   });
 
   it('should return false for arbitrary strings', () => {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -326,6 +326,14 @@ describe('isGemini3Model', () => {
     expect(isGemini3Model(DEFAULT_GEMINI_MODEL_AUTO)).toBe(false);
   });
 
+  it('should return true for Vertex AI model resource paths', () => {
+    expect(
+      isGemini3Model(
+        'projects/test/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview',
+      ),
+    ).toBe(true);
+  });
+
   it('should return false for arbitrary strings', () => {
     expect(isGemini3Model('gpt-4')).toBe(false);
   });

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -386,6 +386,30 @@ describe('isGemini3Model', () => {
     ).toBe(true);
   });
 
+  it('should handle Vertex AI model resource paths consistently across all functions', () => {
+    const vertexPath =
+      'projects/test/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview';
+
+    expect(isPreviewModel(vertexPath)).toBe(true);
+    expect(isProModel(vertexPath)).toBe(true);
+    expect(isGemini3Model(vertexPath)).toBe(true);
+    expect(isGemini2Model(vertexPath)).toBe(false);
+    expect(isCustomModel(vertexPath)).toBe(false);
+    expect(isAutoModel(vertexPath)).toBe(false);
+    expect(supportsMultimodalFunctionResponse(vertexPath)).toBe(false); // starts with gemini-3.1, not gemini-3-
+
+    const vertexGemini2 =
+      'projects/test/locations/us-central1/publishers/google/models/gemini-2.5-flash';
+    expect(isGemini2Model(vertexGemini2)).toBe(true);
+    expect(isGemini3Model(vertexGemini2)).toBe(false);
+    expect(isCustomModel(vertexGemini2)).toBe(false);
+
+    const vertexCustom =
+      'projects/test/locations/us-central1/publishers/google/models/my-custom-model';
+    expect(isCustomModel(vertexCustom)).toBe(true);
+    expect(isGemini3Model(vertexCustom)).toBe(false);
+  });
+
   it('should return false for arbitrary strings', () => {
     expect(isGemini3Model('gpt-4')).toBe(false);
   });

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -396,7 +396,7 @@ describe('isGemini3Model', () => {
     expect(isGemini2Model(vertexPath)).toBe(false);
     expect(isCustomModel(vertexPath)).toBe(false);
     expect(isAutoModel(vertexPath)).toBe(false);
-    expect(supportsMultimodalFunctionResponse(vertexPath)).toBe(false); // starts with gemini-3.1, not gemini-3-
+    expect(supportsMultimodalFunctionResponse(vertexPath)).toBe(true);
 
     const vertexGemini2 =
       'projects/test/locations/us-central1/publishers/google/models/gemini-2.5-flash';

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -396,7 +396,6 @@ describe('isGemini3Model', () => {
     expect(isGemini2Model(vertexPath)).toBe(false);
     expect(isCustomModel(vertexPath)).toBe(false);
     expect(isAutoModel(vertexPath)).toBe(false);
-    expect(supportsMultimodalFunctionResponse(vertexPath)).toBe(true);
 
     const vertexGemini2 =
       'projects/test/locations/us-central1/publishers/google/models/gemini-2.5-flash';
@@ -461,8 +460,24 @@ describe('getDisplayString', () => {
 });
 
 describe('supportsMultimodalFunctionResponse', () => {
-  it('should return true for gemini-3 model', () => {
+  it('should return true for gemini-3 models', () => {
     expect(supportsMultimodalFunctionResponse('gemini-3-pro')).toBe(true);
+    expect(supportsMultimodalFunctionResponse('gemini-3.1-pro-preview')).toBe(
+      true,
+    );
+  });
+
+  it('should return true for aliases that resolve to Gemini 3', () => {
+    expect(supportsMultimodalFunctionResponse('auto')).toBe(true);
+    expect(supportsMultimodalFunctionResponse('pro')).toBe(true);
+  });
+
+  it('should return true for Vertex AI Gemini 3 resource paths', () => {
+    expect(
+      supportsMultimodalFunctionResponse(
+        'projects/test/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview',
+      ),
+    ).toBe(true);
   });
 
   it('should return false for gemini-2 models', () => {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -387,7 +387,7 @@ export function isGemini3Model(
   }
 
   const resolved = resolveModel(model);
-  return /^gemini-3(\.|-|$)/.test(resolved);
+  return /(^|\/)gemini-3(\.|-|$)/.test(resolved);
 }
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -380,8 +380,9 @@ export function isGemini3Model(
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     // Legacy behavior resolves the model first.
     const resolved = resolveModel(model, false, false, false, true, config);
+    const parsedModel = resolved.split('/').pop() ?? '';
     return (
-      config.modelConfigService.getModelDefinition(resolved)?.family ===
+      config.modelConfigService.getModelDefinition(parsedModel)?.family ===
       'gemini-3'
     );
   }

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -495,7 +495,7 @@ export function supportsMultimodalFunctionResponse(
         ?.multimodalToolUse === true
     );
   }
-  return baseModel.startsWith('gemini-3-');
+  return /^gemini-3(\.|-|$)/.test(baseModel);
 }
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -322,6 +322,13 @@ export function getDisplayString(
 }
 
 /**
+ * Extracts the base model name from a potentially full resource path.
+ */
+function getBaseModelName(modelId: string): string {
+  return modelId.split('/').pop() ?? '';
+}
+
+/**
  * Checks if the model is a preview model.
  *
  * @param model The model name to check.
@@ -332,20 +339,22 @@ export function isPreviewModel(
   model: string,
   config?: ModelCapabilityContext,
 ): boolean {
+  const baseModel = getBaseModelName(model);
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     return (
-      config.modelConfigService.getModelDefinition(model)?.isPreview === true
+      config.modelConfigService.getModelDefinition(baseModel)?.isPreview ===
+      true
     );
   }
 
   return (
-    model === PREVIEW_GEMINI_MODEL ||
-    model === PREVIEW_GEMINI_3_1_MODEL ||
-    model === PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL ||
-    model === PREVIEW_GEMINI_FLASH_MODEL ||
-    model === PREVIEW_GEMINI_MODEL_AUTO ||
-    model === GEMINI_MODEL_ALIAS_AUTO ||
-    model === PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL
+    baseModel === PREVIEW_GEMINI_MODEL ||
+    baseModel === PREVIEW_GEMINI_3_1_MODEL ||
+    baseModel === PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL ||
+    baseModel === PREVIEW_GEMINI_FLASH_MODEL ||
+    baseModel === PREVIEW_GEMINI_MODEL_AUTO ||
+    baseModel === GEMINI_MODEL_ALIAS_AUTO ||
+    baseModel === PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL
   );
 }
 
@@ -360,10 +369,13 @@ export function isProModel(
   model: string,
   config?: ModelCapabilityContext,
 ): boolean {
+  const baseModel = getBaseModelName(model);
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
-    return config.modelConfigService.getModelDefinition(model)?.tier === 'pro';
+    return (
+      config.modelConfigService.getModelDefinition(baseModel)?.tier === 'pro'
+    );
   }
-  return model.toLowerCase().includes('pro');
+  return baseModel.toLowerCase().includes('pro');
 }
 
 /**
@@ -380,15 +392,16 @@ export function isGemini3Model(
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     // Legacy behavior resolves the model first.
     const resolved = resolveModel(model, false, false, false, true, config);
-    const parsedModel = resolved.split('/').pop() ?? '';
+    const baseModel = getBaseModelName(resolved);
     return (
-      config.modelConfigService.getModelDefinition(parsedModel)?.family ===
+      config.modelConfigService.getModelDefinition(baseModel)?.family ===
       'gemini-3'
     );
   }
 
   const resolved = resolveModel(model);
-  return /^gemini-3(\.|-|$)/.test(resolved.split('/').pop() ?? '');
+  const baseModel = getBaseModelName(resolved);
+  return /^gemini-3(\.|-|$)/.test(baseModel);
 }
 
 /**
@@ -400,7 +413,8 @@ export function isGemini3Model(
 export function isGemini2Model(model: string): boolean {
   // This is legacy behavior, will remove this when gemini 2 models are no
   // longer needed.
-  return /^gemini-2(\.|$)/.test(model);
+  const baseModel = getBaseModelName(model);
+  return /^gemini-2(\.|$)/.test(baseModel);
 }
 
 /**
@@ -416,13 +430,15 @@ export function isCustomModel(
 ): boolean {
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     const resolved = resolveModel(model, false, false, false, true, config);
+    const baseModel = getBaseModelName(resolved);
     return (
-      config.modelConfigService.getModelDefinition(resolved)?.tier ===
-        'custom' || !resolved.startsWith('gemini-')
+      config.modelConfigService.getModelDefinition(baseModel)?.tier ===
+        'custom' || !baseModel.startsWith('gemini-')
     );
   }
   const resolved = resolveModel(model);
-  return !resolved.startsWith('gemini-');
+  const baseModel = getBaseModelName(resolved);
+  return !baseModel.startsWith('gemini-');
 }
 
 /**
@@ -448,13 +464,16 @@ export function isAutoModel(
   model: string,
   config?: ModelCapabilityContext,
 ): boolean {
+  const baseModel = getBaseModelName(model);
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
-    return config.modelConfigService.getModelDefinition(model)?.tier === 'auto';
+    return (
+      config.modelConfigService.getModelDefinition(baseModel)?.tier === 'auto'
+    );
   }
   return (
-    model === GEMINI_MODEL_ALIAS_AUTO ||
-    model === PREVIEW_GEMINI_MODEL_AUTO ||
-    model === DEFAULT_GEMINI_MODEL_AUTO
+    baseModel === GEMINI_MODEL_ALIAS_AUTO ||
+    baseModel === PREVIEW_GEMINI_MODEL_AUTO ||
+    baseModel === DEFAULT_GEMINI_MODEL_AUTO
   );
 }
 
@@ -469,13 +488,14 @@ export function supportsMultimodalFunctionResponse(
   model: string,
   config?: ModelCapabilityContext,
 ): boolean {
+  const baseModel = getBaseModelName(model);
   if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
     return (
-      config.modelConfigService.getModelDefinition(model)?.features
+      config.modelConfigService.getModelDefinition(baseModel)?.features
         ?.multimodalToolUse === true
     );
   }
-  return model.startsWith('gemini-3-');
+  return baseModel.startsWith('gemini-3-');
 }
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -488,14 +488,7 @@ export function supportsMultimodalFunctionResponse(
   model: string,
   config?: ModelCapabilityContext,
 ): boolean {
-  const baseModel = getBaseModelName(model);
-  if (config?.getExperimentalDynamicModelConfiguration?.() === true) {
-    return (
-      config.modelConfigService.getModelDefinition(baseModel)?.features
-        ?.multimodalToolUse === true
-    );
-  }
-  return /^gemini-3(\.|-|$)/.test(baseModel);
+  return isGemini3Model(model, config);
 }
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -387,7 +387,7 @@ export function isGemini3Model(
   }
 
   const resolved = resolveModel(model);
-  return /(^|\/)gemini-3(\.|-|$)/.test(resolved);
+  return /^gemini-3(\.|-|$)/.test(resolved.split('/').pop() ?? '');
 }
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -324,7 +324,10 @@ export function getDisplayString(
 /**
  * Extracts the base model name from a potentially full resource path.
  */
-function getBaseModelName(modelId: string): string {
+function getBaseModelName(modelId: string | undefined | null): string {
+  if (!modelId) {
+    return '';
+  }
   return modelId.split('/').pop() ?? '';
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where Vertex AI users on Gemini 3.1 models lost access to most tools (activate_skill, google_web_search, web_fetch, etc.) after v0.43.0. Vertex AI model IDs are full resource paths (projects/.../models/gemini-3.1-pro-preview) which failed the ^-anchored regex in isGemini3Model, causing a silent fallback to the legacy toolset containing only ReadFile, Shell, and WriteFile.

## Details

The regex in `isGemini3Model` used a `^` anchor which only matches model IDs starting with `gemini-3`. Vertex AI resource paths start with `projects/`, so detection always failed. Changing the anchor to `(^|\/)` makes it match the model name segment regardless of any preceding path prefix.

## Related Issues

Fixes #27370

## How to Validate

Authenticate via Vertex AI with a Gemini 3.1 model and verify that activate_skill, google_web_search, and web_fetch are present in the tool list. Alternatively, run the updated unit tests: `npm test -w @google/gemini-cli-core -- src/config/models.test.ts`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
