### PR TITLE
fix(acp): accept string protocolVersion during initialize

### DIFF
--- a/packages/cli/src/acp/acpStdioTransport.test.ts
+++ b/packages/cli/src/acp/acpStdioTransport.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import * as acp from '@agentclientprotocol/sdk';
+import { createAcpStream } from './acpStdioTransport.js';
+
+describe('ACP stdio transport', () => {
+  it('normalizes string initialize protocolVersion values before SDK validation', async () => {
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    let inputController!: ReadableStreamDefaultController<Uint8Array>;
+    let output = '';
+
+    const input = new ReadableStream<Uint8Array>({
+      start(controller) {
+        inputController = controller;
+      },
+    });
+    const writable = new WritableStream<Uint8Array>({
+      write(chunk) {
+        output += decoder.decode(chunk, { stream: true });
+      },
+    });
+    const stream = createAcpStream(writable, input);
+
+    const initialize = vi.fn(async () => ({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: { loadSession: false },
+      authMethods: [],
+    }));
+    const unexpectedRequest = async () => {
+      throw new Error('unexpected ACP request');
+    };
+    const agent: acp.Agent = {
+      initialize,
+      newSession: unexpectedRequest,
+      authenticate: async () => {},
+      prompt: unexpectedRequest,
+      cancel: async () => {},
+    };
+    const connection = new acp.AgentSideConnection(() => agent, stream);
+
+    inputController.enqueue(
+      encoder.encode(
+        `${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '1.0.0' },
+          },
+        })}\n`,
+      ),
+    );
+
+    await vi.waitFor(() => expect(initialize).toHaveBeenCalledTimes(1));
+    expect(initialize).toHaveBeenCalledWith(
+      expect.objectContaining({ protocolVersion: acp.PROTOCOL_VERSION }),
+    );
+    await vi.waitFor(() => expect(output).toContain('"result"'));
+    expect(output).toContain('"protocolVersion":1');
+
+    inputController.close();
+    await connection.closed;
+  });
+});

--- a/packages/cli/src/acp/acpStdioTransport.ts
+++ b/packages/cli/src/acp/acpStdioTransport.ts
@@ -12,6 +12,77 @@ import type { LoadedSettings } from '../config/settings.js';
 import type { CliArgs } from '../config/config.js';
 import { GeminiAgent } from './acpRpcDispatcher.js';
 
+type AcpMessage =
+  acp.Stream['readable'] extends ReadableStream<infer Message>
+    ? Message
+    : never;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function coerceProtocolVersion(protocolVersion: string): number {
+  const trimmedProtocolVersion = protocolVersion.trim();
+
+  if (/^\d+$/.test(trimmedProtocolVersion)) {
+    const numericProtocolVersion = Number(trimmedProtocolVersion);
+    if (numericProtocolVersion <= 65535) {
+      return numericProtocolVersion;
+    }
+  }
+
+  return acp.PROTOCOL_VERSION;
+}
+
+export function normalizeIncomingInitializeProtocolVersion(
+  message: AcpMessage,
+): AcpMessage {
+  if (
+    !('method' in message) ||
+    message.method !== acp.AGENT_METHODS.initialize
+  ) {
+    return message;
+  }
+
+  const params = message.params;
+  if (!isRecord(params)) {
+    return message;
+  }
+
+  const protocolVersion = params['protocolVersion'];
+  if (typeof protocolVersion === 'string') {
+    params['protocolVersion'] = coerceProtocolVersion(protocolVersion);
+  }
+
+  return message;
+}
+
+export function normalizeIncomingInitializeProtocolVersionStream(
+  stream: acp.Stream,
+): acp.Stream {
+  return {
+    writable: stream.writable,
+    readable: stream.readable.pipeThrough(
+      new TransformStream<AcpMessage, AcpMessage>({
+        transform(message, controller) {
+          controller.enqueue(
+            normalizeIncomingInitializeProtocolVersion(message),
+          );
+        },
+      }),
+    ),
+  };
+}
+
+export function createAcpStream(
+  output: WritableStream<Uint8Array>,
+  input: ReadableStream<Uint8Array>,
+): acp.Stream {
+  return normalizeIncomingInitializeProtocolVersionStream(
+    acp.ndJsonStream(output, input),
+  );
+}
+
 export async function runAcpClient(
   config: Config,
   settings: LoadedSettings,
@@ -22,7 +93,7 @@ export async function runAcpClient(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 
-  const stream = acp.ndJsonStream(stdout, stdin);
+  const stream = createAcpStream(stdout, stdin);
   const connection = new acp.AgentSideConnection(
     (connection) => new GeminiAgent(config, settings, argv, connection),
     stream,


### PR DESCRIPTION
## Summary

- Accepts string `protocolVersion` values on incoming ACP `initialize` requests before SDK schema validation.
- Normalizes date-style/string protocol versions to the current ACP numeric protocol version while preserving numeric strings when possible.
- Adds a targeted stdio transport test that reproduces the string-version initialize handshake.

## Details

The ACP SDK validates `initialize` params before `GeminiAgent.initialize` is called. Clients that send MCP-style date strings such as `"2024-11-05"` currently fail during SDK Zod validation with `expected number, received string`.

This change adds a small transport-level normalization step for incoming `initialize` messages so Gemini CLI can complete the handshake and respond with its ACP protocol version.

## Related Issues

Fixes #25731

## How to Validate

- `npm test -w @google/gemini-cli -- src/acp/acpStdioTransport.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck -w @google/gemini-cli`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run lint -w @google/gemini-cli`
- `git diff --check`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (not needed for this bug fix)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
