### PR TITLE
feat(core): add allowCommandSubstitution toggle in settings

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1004,6 +1004,7 @@ export async function loadCliConfig(
     disableAlwaysAllow:
       settings.security?.disableAlwaysAllow ||
       settings.admin?.secureModeEnabled,
+    allowCommandSubstitution: settings.allowCommandSubstitution,
     showMemoryUsage: settings.ui?.showMemoryUsage || false,
     accessibility: {
       ...settings.ui?.accessibility,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -183,6 +183,17 @@ const SETTINGS_SCHEMA = {
     'Additional admin policy files or directories to load.',
   ),
 
+  allowCommandSubstitution: {
+    type: 'boolean',
+    label: 'Allow Command Substitution',
+    category: 'Security',
+    requiresRestart: true,
+    default: false,
+    description:
+      'Allow command substitution (e.g., $()) in shell tool execution.',
+    showInDialog: true,
+  },
+
   general: {
     type: 'object',
     label: 'General',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -639,6 +639,7 @@ export interface ConfigParameters {
   bugCommand?: BugCommandSettings;
   model: string;
   disableLoopDetection?: boolean;
+  allowCommandSubstitution?: boolean;
   maxSessionTurns?: number;
   acpMode?: boolean;
   listSessions?: boolean;
@@ -923,6 +924,7 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly maxAttempts: number;
   private readonly enableShellOutputEfficiency: boolean;
   private readonly shellToolInactivityTimeout: number;
+  private readonly allowCommandSubstitution: boolean;
   readonly fakeResponses?: string;
   readonly fakeResponsesNonStrict?: string;
   readonly recordResponses?: string;
@@ -1298,6 +1300,7 @@ export class Config implements McpContext, AgentLoopContext {
       params.enableShellOutputEfficiency ?? true;
     this.shellToolInactivityTimeout =
       (params.shellToolInactivityTimeout ?? 300) * 1000; // 5 minutes
+    this.allowCommandSubstitution = params.allowCommandSubstitution ?? false;
     this.extensionManagement = params.extensionManagement ?? true;
     this.extensionRegistryURI = params.extensionRegistryURI;
     this.enableExtensionReloading = params.enableExtensionReloading ?? false;
@@ -3731,6 +3734,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getEnableShellOutputEfficiency(): boolean {
     return this.enableShellOutputEfficiency;
+  }
+
+  getAllowCommandSubstitution(): boolean {
+    return this.allowCommandSubstitution;
   }
 
   getShellToolInactivityTimeout(): number {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -151,6 +151,7 @@ describe('ShellTool', () => {
       },
       getGeminiClient: vi.fn().mockReturnValue({}),
       getShellToolInactivityTimeout: vi.fn().mockReturnValue(1000),
+      getAllowCommandSubstitution: vi.fn().mockReturnValue(false),
       getEnableInteractiveShell: vi.fn().mockReturnValue(false),
       isInteractiveShellEnabled: vi.fn().mockReturnValue(false),
       getShellBackgroundCompletionBehavior: vi.fn().mockReturnValue('silent'),

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -464,7 +464,15 @@ export class ShellToolInvocation extends BaseToolInvocation<
     } = options;
     const strippedCommand = stripShellWrapper(this.params.command);
 
-    if (detectCommandSubstitution(strippedCommand)) {
+    const allowCommandSubstitution =
+      typeof this.context.config.getAllowCommandSubstitution === 'function'
+        ? this.context.config.getAllowCommandSubstitution()
+        : false;
+
+    if (
+      !allowCommandSubstitution &&
+      detectCommandSubstitution(strippedCommand)
+    ) {
       return {
         llmContent:
           'Command injection detected: command substitution syntax ' +

--- a/packages/core/src/tools/shell_proactive.test.ts
+++ b/packages/core/src/tools/shell_proactive.test.ts
@@ -86,6 +86,7 @@ describe('ShellTool Proactive Expansion', () => {
       isInteractiveShellEnabled: vi.fn().mockReturnValue(false),
       getEnableShellOutputEfficiency: vi.fn().mockReturnValue(true),
       getShellToolInactivityTimeout: vi.fn().mockReturnValue(1000),
+      getAllowCommandSubstitution: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     const bus = createMockMessageBus();


### PR DESCRIPTION
The current hardcoded block creates a problem: Token/turn waste. The model writes out a full command with command substitution, the CLI blocks it at execution time, and the entire turn is wasted with nothing to show for it. The model has no way to know in advance the command will be blocked.

A configurable toggle keeps the safe default for everyone while letting users who understand the risk opt out.
## Summary
Add a configurable `allowCommandSubstitution` toggle (default: `false`) to let users opt out of the hardcoded command substitution block. This eliminates wasted turns where the model generates a valid command with `$()` syntax that gets silently blocked at execution time, burning tokens with no output.

## Details
The existing block was unconditional — the model had no way to know a command would be rejected until after the turn was spent. The new setting surfaces in the settings dialog under the Security category and requires a restart. The safe default (`false`) is preserved for all users; only those who explicitly opt in take on the risk.

YOLO mode intentionally still respects this flag — auto-allowing command substitution in YOLO mode was considered but rejected for security reasons.

## Related Issues
Closes #27393

## How to Validate
1. Leave `allowCommandSubstitution` unset (or `false`) in `settings.json`
2. Run a command using `$()` substitution — confirm it is blocked with an error returned to the model
3. Set `allowCommandSubstitution: true` in `settings.json` and restart
4. Run the same command — confirm it executes successfully
5. Confirm the toggle appears in the settings dialog under Security

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker