### PR TITLE
fix(core): parse tools.callCommand before discovered tool execution

### DIFF
--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -37,6 +37,7 @@ import fs from 'node:fs';
 import { MockTool } from '../test-utils/mock-tool.js';
 import { ToolErrorType } from './tool-error.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
+import type { SandboxManager } from '../services/sandboxManager.js';
 
 vi.mock('node:fs');
 
@@ -614,6 +615,121 @@ describe('ToolRegistry', () => {
       );
       expect(result.llmContent).toContain('Stderr: Something went wrong');
       expect(result.llmContent).toContain('Exit Code: 1');
+    });
+
+    it('should parse callCommand arguments before executing discovered tools', async () => {
+      const discoveryCommand = 'my-discovery-command';
+      mockConfigGetToolDiscoveryCommand.mockReturnValue(discoveryCommand);
+      vi.spyOn(config, 'getToolCallCommand').mockReturnValue(
+        'python3 script.py --call',
+      );
+
+      const toolDeclaration: FunctionDeclaration = {
+        name: 'callable-tool',
+        description: 'A tool that succeeds',
+        parametersJsonSchema: {
+          type: 'object',
+          properties: {},
+        },
+      };
+
+      const mockSpawn = vi.mocked(spawn);
+      mockSpawn.mockReturnValueOnce(
+        createDiscoveryProcess([toolDeclaration]) as any,
+      );
+
+      await toolRegistry.discoverAllTools();
+      const discoveredTool = toolRegistry.getTool(
+        DISCOVERED_TOOL_PREFIX + 'callable-tool',
+      );
+      expect(discoveredTool).toBeDefined();
+
+      const executionProcess = createExecutionProcess(0);
+      mockSpawn.mockReturnValueOnce(executionProcess as any);
+
+      const invocation = (discoveredTool as DiscoveredTool).build({});
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        'python3',
+        ['script.py', '--call', 'callable-tool'],
+        expect.objectContaining({
+          env: process.env,
+        }),
+      );
+      expect(executionProcess.stdin.write).toHaveBeenCalledWith('{}');
+    });
+
+    it('should pass parsed callCommand arguments to sandbox preparation', async () => {
+      const discoveryCommand = 'my-discovery-command';
+      mockConfigGetToolDiscoveryCommand.mockReturnValue(discoveryCommand);
+      vi.spyOn(config, 'getToolCallCommand').mockReturnValue(
+        'python3 script.py --call',
+      );
+
+      const toolDeclaration: FunctionDeclaration = {
+        name: 'sandboxed-tool',
+        description: 'A tool that succeeds',
+        parametersJsonSchema: {
+          type: 'object',
+          properties: {},
+        },
+      };
+
+      const mockSpawn = vi.mocked(spawn);
+      mockSpawn.mockReturnValueOnce(
+        createDiscoveryProcess([toolDeclaration]) as any,
+      );
+
+      await toolRegistry.discoverAllTools();
+      const discoveredTool = toolRegistry.getTool(
+        DISCOVERED_TOOL_PREFIX + 'sandboxed-tool',
+      );
+      expect(discoveredTool).toBeDefined();
+
+      const mockSandboxManager: SandboxManager = {
+        prepareCommand: vi.fn().mockResolvedValue({
+          program: 'sandbox-program',
+          args: ['sandbox-arg'],
+          env: process.env,
+        }),
+        isKnownSafeCommand: vi.fn().mockReturnValue(false),
+        isDangerousCommand: vi.fn().mockReturnValue(false),
+        parseDenials: vi.fn(),
+        getWorkspace: vi.fn().mockReturnValue('/tmp'),
+        getOptions: vi.fn(),
+      };
+      vi.spyOn(config, 'sandboxManager', 'get').mockReturnValue(
+        mockSandboxManager,
+      );
+
+      const executionProcess = createExecutionProcess(0);
+      mockSpawn.mockReturnValueOnce(executionProcess as any);
+
+      const invocation = (discoveredTool as DiscoveredTool).build({});
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(mockSandboxManager.prepareCommand).toHaveBeenCalledWith({
+        command: 'python3',
+        args: ['script.py', '--call', 'sandboxed-tool'],
+        cwd: process.cwd(),
+        env: process.env,
+      });
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        'sandbox-program',
+        ['sandbox-arg'],
+        expect.objectContaining({
+          env: process.env,
+        }),
+      );
     });
 
     it('should pass MessageBus to DiscoveredTool and its invocations', async () => {

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -40,6 +40,33 @@ import {
 
 type ToolParams = Record<string, unknown>;
 
+function parseConfiguredCommand(
+  configuredCommand: string,
+  commandType: string,
+): {
+  command: string;
+  args: string[];
+} {
+  const commandParts = parse(configuredCommand);
+  if (commandParts.length === 0) {
+    throw new Error(
+      `${commandType} command is empty or contains only whitespace.`,
+    );
+  }
+
+  const firstPart = commandParts[0];
+  if (typeof firstPart !== 'string') {
+    throw new Error(`${commandType} command must start with a program name.`);
+  }
+
+  return {
+    command: firstPart,
+    args: commandParts
+      .slice(1)
+      .filter((part): part is string => typeof part === 'string'),
+  };
+}
+
 class DiscoveredToolInvocation extends BaseToolInvocation<
   ToolParams,
   ToolResult
@@ -63,9 +90,10 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     updateOutput: _updateOutput,
   }: ExecuteOptions): Promise<ToolResult> {
     const callCommand = this.config.getToolCallCommand()!;
-    const args = [this.originalToolName];
+    const parsedCallCommand = parseConfiguredCommand(callCommand, 'Tool call');
+    const args = [...parsedCallCommand.args, this.originalToolName];
 
-    let finalCommand = callCommand;
+    let finalCommand = parsedCallCommand.command;
     let finalArgs = args;
     let finalEnv = process.env;
     let cleanupFunc: (() => void) | undefined;
@@ -73,7 +101,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     const sandboxManager = this.config.sandboxManager;
     if (sandboxManager) {
       const prepared = await sandboxManager.prepareCommand({
-        command: callCommand,
+        command: finalCommand,
         args,
         cwd: process.cwd(),
         env: process.env,
@@ -364,24 +392,13 @@ export class ToolRegistry {
     }
 
     try {
-      const cmdParts = parse(discoveryCmd);
-      if (cmdParts.length === 0) {
-        throw new Error(
-          'Tool discovery command is empty or contains only whitespace.',
-        );
-      }
+      const parsedDiscoveryCommand = parseConfiguredCommand(
+        discoveryCmd,
+        'Tool discovery',
+      );
 
-      const firstPart = cmdParts[0];
-      if (typeof firstPart !== 'string') {
-        throw new Error(
-          'Tool discovery command must start with a program name.',
-        );
-      }
-
-      let finalCommand: string = firstPart;
-      let finalArgs: string[] = cmdParts
-        .slice(1)
-        .filter((p): p is string => typeof p === 'string');
+      let finalCommand: string = parsedDiscoveryCommand.command;
+      let finalArgs: string[] = parsedDiscoveryCommand.args;
       let finalEnv = process.env;
       let cleanupFunc: (() => void) | undefined;
 


### PR DESCRIPTION
## Summary
- parse `tools.callCommand` into a program and argv before discovered tool execution
- pass the parsed program and argv through sandbox preparation instead of the raw command string
- add regression coverage for both spawned execution args and sandbox preparation inputs

## Root cause
`tools.discoveryCommand` was already parsed with `shell-quote`, but discovered tool execution treated `tools.callCommand` as a literal executable path. Commands like `python3 script.py --call` could therefore discover tools successfully and then fail at execution time with `ENOENT`.

## Testing
- `npm test -w @google/gemini-cli-core -- src/tools/tool-registry.test.ts`
- `npm run typecheck -w @google/gemini-cli-core`
- `npx eslint packages/core/src/tools/tool-registry.ts packages/core/src/tools/tool-registry.test.ts`

Fixes #27404
Refs #19783
