### PR TITLE
fix(cli): read bootstrap settings from custom home

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -14,6 +14,7 @@ import {
   getSpawnConfig,
   getScriptArgs,
 } from './src/utils/processUtils.js';
+import { getBootstrapSettingsPath } from './src/utils/bootstrapSettings.js';
 
 // --- Global Entry Point ---
 
@@ -44,11 +45,7 @@ async function getMemoryNodeArgs(): Promise<string[]> {
   let autoConfigureMemory = true;
   try {
     const { readFileSync } = await import('node:fs');
-    const { join } = await import('node:path');
-    // Respect GEMINI_CLI_HOME environment variable, falling back to os.homedir()
-    const baseDir =
-      process.env['GEMINI_CLI_HOME'] || join(os.homedir(), '.gemini');
-    const settingsPath = join(baseDir, 'settings.json');
+    const settingsPath = getBootstrapSettingsPath();
     const rawSettings = readFileSync(settingsPath, 'utf8');
     const settings = JSON.parse(rawSettings);
     if (settings?.advanced?.autoConfigureMemory === false) {

--- a/packages/cli/src/utils/bootstrapSettings.test.ts
+++ b/packages/cli/src/utils/bootstrapSettings.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { getBootstrapSettingsPath } from './bootstrapSettings.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+it('resolves settings under the default home .gemini directory', () => {
+  vi.stubEnv('GEMINI_CLI_HOME', '');
+
+  expect(getBootstrapSettingsPath()).toBe(
+    path.join(os.homedir(), '.gemini', 'settings.json'),
+  );
+});
+
+it('treats GEMINI_CLI_HOME as the replacement home directory', () => {
+  const customHome = path.join(os.tmpdir(), 'gemini-custom-home');
+  vi.stubEnv('GEMINI_CLI_HOME', customHome);
+
+  expect(getBootstrapSettingsPath()).toBe(
+    path.join(customHome, '.gemini', 'settings.json'),
+  );
+});

--- a/packages/cli/src/utils/bootstrapSettings.ts
+++ b/packages/cli/src/utils/bootstrapSettings.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+
+const GEMINI_DIR = '.gemini';
+const SETTINGS_FILE = 'settings.json';
+
+/**
+ * Resolves the global user settings path without importing the full core package.
+ *
+ * The lightweight parent process runs before core is loaded, but it still needs
+ * to honor the same global settings path used by Storage.getGlobalSettingsPath().
+ */
+export function getBootstrapSettingsPath(): string {
+  const homeDir = process.env['GEMINI_CLI_HOME'] || os.homedir();
+  const globalGeminiDir = homeDir
+    ? path.join(homeDir, GEMINI_DIR)
+    : path.join(os.tmpdir(), GEMINI_DIR);
+  return path.join(globalGeminiDir, SETTINGS_FILE);
+}


### PR DESCRIPTION
## Summary

Fix the lightweight CLI bootstrap so it reads global user settings from the same path as the normal storage layer when `GEMINI_CLI_HOME` is set.

## Details

The bootstrap process reads `advanced.autoConfigureMemory` before loading the full settings system. It previously treated `GEMINI_CLI_HOME` as the `.gemini` directory itself, so `$GEMINI_CLI_HOME/.gemini/settings.json` was ignored during initial memory configuration.

This adds a small bootstrap settings-path helper that mirrors `Storage.getGlobalSettingsPath()` without importing core, then uses it from `packages/cli/index.ts`. The new unit test covers both the default home path and the custom `GEMINI_CLI_HOME` path.

## Related Issues

Fixes #27421

## How to Validate

- `./node_modules/.bin/prettier --check packages/cli/index.ts packages/cli/src/utils/bootstrapSettings.ts packages/cli/src/utils/bootstrapSettings.test.ts`
- `./node_modules/.bin/eslint packages/cli/index.ts packages/cli/src/utils/bootstrapSettings.ts packages/cli/src/utils/bootstrapSettings.test.ts --max-warnings 0`
- `timeout 180s ./node_modules/.bin/tsc -p packages/cli/tsconfig.json --noEmit --pretty false`
- From `packages/cli`: `timeout 180s ../../node_modules/.bin/vitest run src/utils/bootstrapSettings.test.ts --coverage.enabled=false --pool=threads`
- Manually checked `getBootstrapSettingsPath()` resolves `GEMINI_CLI_HOME=/tmp/custom-gemini-home` to `/tmp/custom-gemini-home/.gemini/settings.json`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker