### PR TITLE
Fix #18834: use docker inspect exit code instead of stdout parsing

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -299,18 +299,15 @@ describe('sandbox', () => {
       });
 
       // Mock image check to return true (image exists)
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
-      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess.stdout = new EventEmitter();
+      const mockImageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce((_cmd, args) => {
-        if (args && args[0] === 'images') {
+        if (args && args[0] === 'inspect') {
           setTimeout(() => {
-            mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
             mockImageCheckProcess.emit('close', 0);
           }, 1);
-          return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+          return mockImageCheckProcess;
         }
         return new EventEmitter() as unknown as ReturnType<typeof spawn>; // fallback
       });
@@ -425,45 +422,35 @@ describe('sandbox', () => {
         image: 'missing-image',
       });
 
-      // 1. Image check fails
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
+      // 1. Image check fails (exit code 1)
       const mockImageCheckProcess1 =
-        new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess1.stdout = new EventEmitter();
+        new EventEmitter() as unknown as ReturnType<typeof spawn>;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess1.emit('close', 0);
+          mockImageCheckProcess1.emit('close', 1);
         }, 1);
-        return mockImageCheckProcess1 as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess1;
       });
 
       // 2. Pull image succeeds
-      interface MockProcessWithStdoutStderr extends EventEmitter {
-        stdout: EventEmitter;
-        stderr: EventEmitter;
-      }
-      const mockPullProcess = new EventEmitter() as MockProcessWithStdoutStderr;
-      mockPullProcess.stdout = new EventEmitter();
-      mockPullProcess.stderr = new EventEmitter();
+      const mockPullProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
           mockPullProcess.emit('close', 0);
         }, 1);
-        return mockPullProcess as unknown as ReturnType<typeof spawn>;
+        return mockPullProcess;
       });
 
-      // 3. Image check succeeds
+      // 3. Image check succeeds (exit code 0)
       const mockImageCheckProcess2 =
-        new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess2.stdout = new EventEmitter();
+        new EventEmitter() as unknown as ReturnType<typeof spawn>;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess2.stdout.emit('data', Buffer.from('image-id'));
           mockImageCheckProcess2.emit('close', 0);
         }, 1);
-        return mockImageCheckProcess2 as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess2;
       });
 
       // 4. Docker run
@@ -494,33 +481,25 @@ describe('sandbox', () => {
         image: 'missing-image',
       });
 
-      // 1. Image check fails
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
+      // 1. Image check fails (exit code 1)
       const mockImageCheckProcess1 =
-        new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess1.stdout = new EventEmitter();
+        new EventEmitter() as unknown as ReturnType<typeof spawn>;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess1.emit('close', 0);
+          mockImageCheckProcess1.emit('close', 1);
         }, 1);
-        return mockImageCheckProcess1 as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess1;
       });
 
-      // 2. Pull image fails
-      interface MockProcessWithStdoutStderr extends EventEmitter {
-        stdout: EventEmitter;
-        stderr: EventEmitter;
-      }
-      const mockPullProcess = new EventEmitter() as MockProcessWithStdoutStderr;
-      mockPullProcess.stdout = new EventEmitter();
-      mockPullProcess.stderr = new EventEmitter();
+      // 2. Pull image fails (exit code 1)
+      const mockPullProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
           mockPullProcess.emit('close', 1);
         }, 1);
-        return mockPullProcess as unknown as ReturnType<typeof spawn>;
+        return mockPullProcess;
       });
 
       await expect(start_sandbox(config)).rejects.toThrow(FatalSandboxError);
@@ -535,17 +514,14 @@ describe('sandbox', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true); // For mount path check
 
       // Mock image check to return true
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
-      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess.stdout = new EventEmitter();
+      const mockImageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
           mockImageCheckProcess.emit('close', 0);
         }, 1);
-        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess;
       });
 
       const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
@@ -561,11 +537,12 @@ describe('sandbox', () => {
 
       await start_sandbox(config);
 
-      // The first call is 'docker images -q ...'
+      // The first call is 'docker inspect --type=image ...'
       expect(spawn).toHaveBeenNthCalledWith(
         1,
         'docker',
-        expect.arrayContaining(['images', '-q']),
+        expect.arrayContaining(['inspect', '--type=image']),
+        expect.objectContaining({ stdio: 'ignore' }),
       );
 
       // The second call is 'docker run ...'
@@ -711,17 +688,14 @@ describe('sandbox', () => {
       process.env['GOOGLE_VERTEX_BASE_URL'] = 'http://vertex.proxy';
 
       // Mock image check to return true
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
-      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess.stdout = new EventEmitter();
+      const mockImageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
           mockImageCheckProcess.emit('close', 0);
         }, 1);
-        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess;
       });
 
       const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
@@ -763,17 +737,14 @@ describe('sandbox', () => {
       });
 
       // Mock image check to return true
-      interface MockProcessWithStdout extends EventEmitter {
-        stdout: EventEmitter;
-      }
-      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
-      mockImageCheckProcess.stdout = new EventEmitter();
+      const mockImageCheckProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
       vi.mocked(spawn).mockImplementationOnce(() => {
         setTimeout(() => {
-          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
           mockImageCheckProcess.emit('close', 0);
         }, 1);
-        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+        return mockImageCheckProcess;
       });
 
       const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -1080,15 +1080,8 @@ async function start_lxc_sandbox(
 // Helper functions to ensure sandbox image is present
 async function imageExists(sandbox: string, image: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const args = ['images', '-q', image];
-    const checkProcess = spawn(sandbox, args);
-
-    let stdoutData = '';
-    if (checkProcess.stdout) {
-      checkProcess.stdout.on('data', (data) => {
-        stdoutData += data.toString();
-      });
-    }
+    const args = ['inspect', '--type=image', image];
+    const checkProcess = spawn(sandbox, args, { stdio: 'ignore' });
 
     checkProcess.on('error', (err) => {
       debugLogger.warn(
@@ -1098,12 +1091,7 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
     });
 
     checkProcess.on('close', (code) => {
-      // Non-zero code might indicate docker daemon not running, etc.
-      // The primary success indicator is non-empty stdoutData.
-      if (code !== 0) {
-        // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
-      }
-      resolve(stdoutData.trim() !== '');
+      resolve(code === 0);
     });
   });
 }


### PR DESCRIPTION
Summary

Fix sandbox imageExists returning false negatives when Docker outputs image names to stderr (e.g. with DOCKER_BUILDKIT). Switch from parsing docker images -q stdout to using docker inspect --type=image exit code.

Details
docker images -q may write the image name to stderr when DOCKER_BUILDKIT=1 is set, causing the old stdout-based parsing to return a false negative. The sandbox would then attempt to pull the image unnecessarily. The fix uses docker inspect --type=image and checks the exit code, which is reliable regardless of output channel.

Related Issues
Fixes #18834

How to Validate
1. cd packages/cli
2. npx vitest run src/utils/sandbox.test.ts — all 8 tests pass
3. If Docker is available: set DOCKER_BUILDKIT=1, run sandbox operation — no spurious pull

Pre-Merge Checklist
- Updated relevant documentation and README (if needed)
- Added/updated tests (if needed)
- Noted breaking changes (if any)
- Validated on required platforms/methods:
- MacOS
- Windows
- Linux (via CI)