### PR TITLE
feat(core): add configurable per-tool-call timeout (tools.callTimeout)

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -221,6 +221,10 @@ export interface TelemetrySettings {
   useCliAuth?: boolean;
 }
 
+export interface ToolSettings {
+  callTimeout?: number;
+}
+
 export interface OutputSettings {
   format?: OutputFormat;
 }
@@ -563,6 +567,11 @@ export const ConfigSchema = z.object({
       }
     })
     .optional(),
+  tools: z
+    .object({
+      callTimeout: z.number().optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -744,6 +753,7 @@ export interface ConfigParameters {
   };
   vertexAiRouting?: VertexAiRoutingConfig;
   logRagSnippets?: boolean;
+  tools?: ToolSettings;
 }
 
 export class Config implements McpContext, AgentLoopContext {
@@ -982,12 +992,14 @@ export class Config implements McpContext, AgentLoopContext {
   private lastModeSwitchTime: number = performance.now();
   readonly injectionService: InjectionService;
   private approvedPlanPath: string | undefined;
+  private readonly toolCallTimeout: number;
 
   constructor(params: ConfigParameters) {
     this._sessionId = params.sessionId;
     this.clientName = params.clientName;
     this._clientVersion = params.clientVersion ?? 'unknown';
     this.approvedPlanPath = undefined;
+    this.toolCallTimeout = params.tools?.callTimeout ?? 600000;
 
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
@@ -3735,6 +3747,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getShellToolInactivityTimeout(): number {
     return this.shellToolInactivityTimeout;
+  }
+
+  getToolCallTimeout(): number {
+    return this.toolCallTimeout;
   }
 
   getShellExecutionConfig(): ShellExecutionConfig {

--- a/packages/core/src/scheduler/scheduler_hooks.test.ts
+++ b/packages/core/src/scheduler/scheduler_hooks.test.ts
@@ -77,6 +77,7 @@ function createMockConfig(overrides: Partial<Config> = {}): Config {
         check: async () => ({ decision: 'allow' }),
       }) as unknown as PolicyEngine,
     isContextManagementEnabled: () => false,
+    getToolCallTimeout: () => 600000,
   } as unknown as Config;
 
   const mockConfig = Object.assign({}, baseConfig, overrides) as Config;

--- a/packages/core/src/scheduler/tool-executor.ts
+++ b/packages/core/src/scheduler/tool-executor.ts
@@ -22,6 +22,7 @@ import { SHELL_TOOL_NAME } from '../tools/tool-names.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { ToolOutputDistillationService } from '../context/toolDistillationService.js';
 import { executeToolWithHooks } from '../core/coreToolHookTriggers.js';
+import { withTimeout } from '../utils/withTimeout.js';
 import {
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
@@ -123,7 +124,12 @@ export class ToolExecutor {
             true, // skipBeforeHook
           );
 
-          const toolResult: ToolResult = await promise;
+          const timeoutMs = this.config.getToolCallTimeout();
+          const toolResult: ToolResult = await withTimeout(
+            promise,
+            timeoutMs,
+            `Tool execution timed out after ${timeoutMs}ms`,
+          );
 
           if (call.request.inputModifiedByHook) {
             const modificationMsg = `\n\n[System] Tool input parameters were modified by a hook before execution.`;

--- a/packages/core/src/utils/withTimeout.test.ts
+++ b/packages/core/src/utils/withTimeout.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { withTimeout } from './withTimeout.js';
+
+describe('withTimeout', () => {
+  it('should resolve before timeout', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 1000)).resolves.toBe('ok');
+  });
+
+  it('should reject after timeout', async () => {
+    await expect(
+      withTimeout(new Promise((resolve) => setTimeout(resolve, 2000)), 100),
+    ).rejects.toThrow('Execution timed out');
+  });
+
+  it('should disable timeout when timeout <= 0', async () => {
+    await expect(
+      withTimeout(
+        new Promise((resolve) => setTimeout(() => resolve('done'), 100)),
+        0,
+      ),
+    ).resolves.toBe('done');
+  });
+});

--- a/packages/core/src/utils/withTimeout.ts
+++ b/packages/core/src/utils/withTimeout.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message?: string,
+): Promise<T> {
+  if (timeoutMs <= 0) {
+    return promise;
+  }
+
+  let timeoutId: NodeJS.Timeout | undefined;
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(message ?? `Execution timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
Introduced a centralized configurable timeout mechanism for tool execution.

Changes:
- Added `tools.callTimeout` configuration support
- Added `Config#getToolCallTimeout()`
- Added reusable `withTimeout()` utility
- Applied global timeout enforcement in `ToolExecutor`
- Preserved existing tool-specific timeout behavior
  (shell inactivity timeout, MCP timeout, etc.)
- Added unit tests for timeout utility

Behavior:
- Applies timeout across all tool invocations centrally
- Supports disabling timeout with values <= 0
- Existing tool implementations remain unchanged

## Testing

### Unit Tests
- Added tests for `withTimeout`
  - resolves before timeout
  - rejects after timeout
  - disables timeout when `<= 0`

### Validation
- Verified timeout enforcement in `ToolExecutor`
- Verified existing test suite compatibility
- Verified existing tool-specific timeout behavior remains unchanged

Note:
This implementation enforces timeout behavior at the
promise/execution layer and does not actively terminate
underlying processes lacking cancellation semantics.