### PR TITLE
feat(cli): add [Skill] tag to slash command autocomplete suggestions

### DIFF
--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -122,6 +122,30 @@ describe('SuggestionsDisplay', () => {
     expect(lastFrame()).toMatchSnapshot();
   });
 
+  it('renders Skill tag for skill commands', async () => {
+    const skillSuggestions = [
+      {
+        label: 'my-skill',
+        value: 'my-skill',
+        description: 'Activate my skill',
+        commandKind: CommandKind.SKILL,
+      },
+    ];
+
+    const { lastFrame } = await render(
+      <SuggestionsDisplay
+        suggestions={skillSuggestions}
+        activeIndex={0}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput=""
+        mode="reverse"
+      />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
   it('renders command section separators for slash mode', async () => {
     const groupedSuggestions = [
       {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -68,6 +68,7 @@ export function SuggestionsDisplay({
   const COMMAND_KIND_SUFFIX: Partial<Record<CommandKind, string>> = {
     [CommandKind.MCP_PROMPT]: ' [MCP]',
     [CommandKind.AGENT]: ' [Agent]',
+    [CommandKind.SKILL]: ' [Skill]',
   };
 
   const getFullLabel = (s: Suggestion) =>

--- a/packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap
@@ -27,6 +27,11 @@ exports[`SuggestionsDisplay > renders MCP tag for MCP prompts 1`] = `
 "
 `;
 
+exports[`SuggestionsDisplay > renders Skill tag for skill commands 1`] = `
+" my-skill [Skill]   Activate my skill
+"
+`;
+
 exports[`SuggestionsDisplay > renders loading state 1`] = `
 " Loading suggestions...
 "


### PR DESCRIPTION
## Summary

Adds a `[Skill]` tag to skill-backed slash commands in the `/` autocomplete menu, mirroring the existing `[MCP]` and `[Agent]` visual treatment. Makes it immediately obvious which entries in the menu are user-installed skills vs. built-in commands.

**Before:**

    my-skill                      Activate my skill
    help                          Show help

**After:**

    my-skill [Skill]              Activate my skill
    help                          Show help

## Context

The original feature request asked for two things:

1. Manual skill activation via `/skill-name`
2. Skills appearing in the `/` autocomplete menu (with descriptions)

While digging into the codebase I found that **both behaviors were already implemented** by `SkillCommandLoader` (introduced in #21758, with follow-ups in #21942 and #25327). Skills already appear in the menu and `/skill-name` already activates them via the existing `activate_skill` tool.

What was missing was the small but useful visual cue: skills had no `[Skill]` suffix in the suggestion list, unlike MCP prompts (`[MCP]`) and agents (`[Agent]`), so they were visually indistinguishable from built-in commands. This PR closes that gap.

If maintainers agree the issue is otherwise complete, this PR can be the final piece before closing #21165.

## Changes

- `packages/cli/src/ui/components/SuggestionsDisplay.tsx` — add `[CommandKind.SKILL]: ' [Skill]'` to the `COMMAND_KIND_SUFFIX` map.
- `packages/cli/src/ui/components/SuggestionsDisplay.test.tsx` — new snapshot test mirroring the existing `[MCP]` test.
- `packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap` — generated snapshot for the new test.

Net change: **+30 lines, 1 line of production logic.**

## Testing

- New snapshot test passes.
- All 8 existing `SkillCommandLoader` tests still pass.
- `eslint` clean on the modified files.
- `tsc --noEmit` clean for the cli package.

## Related

Refs #21165
