### PR TITLE
fix(core): re-seed metadata when chat session file is recreated mid-session

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -967,6 +967,46 @@ describe('ChatRecordingService', () => {
       expect(result).not.toBeNull();
       expect(result!.messages).toHaveLength(1);
     });
+
+    it('preserves the rewound history when the file was deleted mid-session', async () => {
+      await chatRecordingService.initialize();
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'msg1',
+        model: 'm',
+      });
+      chatRecordingService.recordMessage({
+        type: 'gemini',
+        content: 'msg2',
+        model: 'm',
+      });
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'msg3',
+        model: 'm',
+      });
+
+      const sessionFile = chatRecordingService.getConversationFilePath()!;
+      const before = (await loadConversationRecord(
+        sessionFile,
+      )) as ConversationRecord;
+      const secondMsgId = before.messages[1].id;
+
+      // Delete the file mid-session, then rewind. The re-seeded snapshot already
+      // reflects the rewound state, so the $rewindTo delta must not be replayed
+      // on top of it: its target message is gone from the snapshot, and on load
+      // an unmatched $rewindTo clears the entire history.
+      fs.unlinkSync(sessionFile);
+      chatRecordingService.rewindTo(secondMsgId);
+
+      const conversation = (await loadConversationRecord(
+        sessionFile,
+      )) as ConversationRecord | null;
+      expect(conversation).not.toBeNull();
+      const loaded = conversation as ConversationRecord;
+      expect(loaded.messages).toHaveLength(1);
+      expect(loaded.messages[0].content).toBe('msg1');
+    });
   });
 
   describe('ENOSPC (disk full) graceful degradation - issue #16266', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -276,6 +276,41 @@ describe('ChatRecordingService', () => {
       expect(conversation.messages).toHaveLength(1);
       expect(conversation.messages[0].content).toBe('World');
     });
+
+    it('re-seeds metadata and prior messages when the file is deleted mid-session', async () => {
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'first message',
+        model: 'gemini-pro',
+      });
+
+      const sessionFile = chatRecordingService.getConversationFilePath()!;
+
+      // Simulate an external cleanup or manual deletion while the session is
+      // still live. Before the fix the next append recreated the file with no
+      // metadata line, producing a "zombie" file that could never be parsed.
+      fs.unlinkSync(sessionFile);
+      expect(fs.existsSync(sessionFile)).toBe(false);
+
+      chatRecordingService.recordMessage({
+        type: 'gemini',
+        content: 'second message',
+        model: 'gemini-pro',
+      });
+
+      // The recreated file must still load as a valid session...
+      const conversation = (await loadConversationRecord(
+        sessionFile,
+      )) as ConversationRecord | null;
+      expect(conversation).not.toBeNull();
+      const loaded = conversation as ConversationRecord;
+      expect(loaded.sessionId).toBe('test-session-id');
+      expect(loaded.projectHash).toBe('test-project-hash');
+      // ...and no message recorded before the deletion should be lost.
+      expect(loaded.messages).toHaveLength(2);
+      expect(loaded.messages[0].content).toBe('first message');
+      expect(loaded.messages[1].content).toBe('second message');
+    });
   });
 
   describe('recordThought', () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -518,6 +518,7 @@ export class ChatRecordingService {
       // in-memory record first so the file stays a valid, resumable session.
       // The initial metadata line written during initialize() is itself a
       // metadata record, so it is skipped here to avoid duplicating the header.
+      let reSeeded = false;
       if (
         this.cachedConversation &&
         !isPartialMetadataRecord(record) &&
@@ -527,6 +528,15 @@ export class ChatRecordingService {
           this.conversationFile,
           JSON.stringify(this.cachedConversation) + '\n',
         );
+        reSeeded = true;
+      }
+      // A re-seeded snapshot already reflects the current in-memory state,
+      // including any rewind that was just applied to cachedConversation. A
+      // $rewindTo record is a destructive delta whose target message no longer
+      // exists in that snapshot, so replaying it on load would clear the entire
+      // history. Skip it when we just re-seeded the file.
+      if (reSeeded && isRewindRecord(record)) {
+        return;
       }
       const line = JSON.stringify(record) + '\n';
       fs.appendFileSync(this.conversationFile, line);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -510,8 +510,25 @@ export class ChatRecordingService {
   private appendRecord(record: unknown): void {
     if (!this.conversationFile) return;
     try {
-      const line = JSON.stringify(record) + '\n';
       fs.mkdirSync(path.dirname(this.conversationFile), { recursive: true });
+      // If the conversation file was removed mid-session (e.g. by an external
+      // cleanup or a manual deletion) the appendFileSync() below would recreate
+      // it containing only this record and no metadata line, leaving a "zombie"
+      // file that loadConversationRecord() can never parse. Re-seed it from the
+      // in-memory record first so the file stays a valid, resumable session.
+      // The initial metadata line written during initialize() is itself a
+      // metadata record, so it is skipped here to avoid duplicating the header.
+      if (
+        this.cachedConversation &&
+        !isPartialMetadataRecord(record) &&
+        !fs.existsSync(this.conversationFile)
+      ) {
+        fs.appendFileSync(
+          this.conversationFile,
+          JSON.stringify(this.cachedConversation) + '\n',
+        );
+      }
+      const line = JSON.stringify(record) + '\n';
       fs.appendFileSync(this.conversationFile, line);
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOSPC') {


### PR DESCRIPTION
## Summary

`ChatRecordingService.appendRecord()` could leave a session file that
`loadConversationRecord()` can never parse. It only checked that
`this.conversationFile` was non-null — not that the file still existed on disk.
If the session file was removed mid-session (by an external cleanup or a manual
deletion), the next `fs.appendFileSync()` silently recreated it containing
**only** the record being appended and no metadata line. Because a valid
session requires a metadata line (`sessionId` + `projectHash`),
`loadConversationRecord()` falls back and returns `null`, so the recreated file
becomes a "zombie" that `/chat` listing and `--resume` can never load.

## Details

`appendRecord()` now checks whether the file still exists before appending.
When the file is missing and a valid in-memory `cachedConversation` exists, it
re-seeds the file from that cached record (metadata **and** the prior messages)
before writing the new record. This keeps the session valid and resumable
without dropping any messages that were already recorded — the recorder owns
the full conversation in memory, so there is no reason to recreate a truncated
or unparseable file.

The initial metadata line written during `initialize()` is itself a metadata
record (`isPartialMetadataRecord`), so it is excluded from the re-seed check to
avoid duplicating the session header during normal startup and legacy-file
migration. Because `pushMessage()` appends before updating the in-memory cache,
re-seeding from `cachedConversation` and then writing the current record
produces no duplicate entries.

## Related Issues

Closes #27279

## How to Validate

Automated:

```bash
# from packages/core
npx vitest run src/services/chatRecordingService.test.ts
```

The new regression test, `re-seeds metadata and prior messages when the file is
deleted mid-session`, passes with this change and fails without it (before the
fix the recreated file loads back as `null`).

Manual:

1. Start a session and send a message.
2. While the CLI is still running, delete the active session `.jsonl` file
   under `<project temp dir>/chats/`.
3. Send another message, then run `/chat list` (or relaunch with `--resume`).
   The session still appears and loads, with the earlier message preserved
   instead of being silently dropped.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — n/a (internal bug fix, no user-facing surface change)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
