### PR TITLE
feat(core): Add Amazon URL parsing and metadata extraction

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -38,6 +38,12 @@ import { resolveToolDeclaration } from './definitions/resolver.js';
 import { LRUCache } from 'mnemonist';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 
+import {
+  isAmazonUrl,
+  extractAmazonMetadata,
+  formatAmazonContext,
+} from '../utils/amazon-url-parser.js';
+
 const URL_FETCH_TIMEOUT_MS = 10000;
 const MAX_CONTENT_LENGTH = 250000;
 const MAX_EXPERIMENTAL_FETCH_SIZE = 10 * 1024 * 1024; // 10MB
@@ -614,6 +620,25 @@ ${aggregatedContent}
 
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
+
+    // Amazon product metadata extraction
+    if (isAmazonUrl(url)) {
+      try {
+        const metadata = await extractAmazonMetadata(url);
+
+        const formattedContext = formatAmazonContext(metadata);
+
+        return {
+          llmContent: formattedContext,
+          returnDisplay: metadata.title || 'Amazon product metadata extracted.',
+        };
+      } catch (error) {
+        debugLogger.warn(
+          '[WebFetchTool] Amazon metadata extraction failed',
+          error,
+        );
+      }
+    }
 
     if (this.isBlockedHost(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;

--- a/packages/core/src/utils/amazon-url-parser.test.ts
+++ b/packages/core/src/utils/amazon-url-parser.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  isAmazonUrl,
+  extractTitle,
+  extractPrice,
+  extractBullets,
+} from './amazon-url-parser.js';
+
+describe('amazon-url-parser', () => {
+  describe('isAmazonUrl', () => {
+    it('detects amazon domains', () => {
+      expect(isAmazonUrl('https://amzn.in/d/test')).toBe(true);
+
+      expect(isAmazonUrl('https://www.amazon.in/product/dp/123')).toBe(true);
+
+      expect(isAmazonUrl('https://google.com')).toBe(false);
+    });
+  });
+
+  describe('extractTitle', () => {
+    it('extracts product title', () => {
+      const html = `
+        <span id="productTitle">
+          ASUS Vivobook 15
+        </span>
+      `;
+
+      expect(extractTitle(html)).toBe('ASUS Vivobook 15');
+    });
+  });
+
+  describe('extractPrice', () => {
+    it('extracts product price', () => {
+      const html = `
+        <span class="a-price-whole">
+          54,990
+        </span>
+      `;
+
+      expect(extractPrice(html)).toBe('54,990');
+    });
+  });
+
+  describe('extractBullets', () => {
+    it('extracts feature bullets', () => {
+      const html = `
+        <span class="a-list-item">
+          Intel i5 Processor
+        </span>
+
+        <span class="a-list-item">
+          16GB RAM
+        </span>
+      `;
+
+      expect(extractBullets(html)).toEqual(['Intel i5 Processor', '16GB RAM']);
+    });
+  });
+});

--- a/packages/core/src/utils/amazon-url-parser.ts
+++ b/packages/core/src/utils/amazon-url-parser.ts
@@ -9,7 +9,6 @@ import { fetchWithTimeout, isPrivateIp, PrivateIpError } from './fetch.js';
 const REQUEST_TIMEOUT_MS = 10000;
 
 const USER_AGENT = 'Mozilla/5.0 (compatible; GeminiCLI-AmazonParser/1.0)';
-
 export interface AmazonProductMetadata {
   canonicalUrl: string;
   title?: string;

--- a/packages/core/src/utils/amazon-url-parser.ts
+++ b/packages/core/src/utils/amazon-url-parser.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fetchWithTimeout } from './fetch.js';
-
-const AMAZON_HOST_PATTERNS = ['amazon.', 'amzn.in', 'amzn.to'];
+import { fetchWithTimeout, isPrivateIp, PrivateIpError } from './fetch.js';
 
 const REQUEST_TIMEOUT_MS = 10000;
 
@@ -30,7 +28,9 @@ export function isAmazonUrl(url: string): boolean {
 
     const host = parsed.hostname.toLowerCase();
 
-    return AMAZON_HOST_PATTERNS.some((pattern) => host.includes(pattern));
+    return /^(.*\.)?(amazon\.[a-z]{2,3}(\.[a-z]{2})?|amzn\.(in|to))$/i.test(
+      host,
+    );
   } catch {
     return false;
   }
@@ -179,6 +179,12 @@ export async function extractAmazonMetadata(
   url: string,
 ): Promise<AmazonProductMetadata> {
   const canonicalUrl = await expandAmazonUrl(url);
+
+  if (isPrivateIp(canonicalUrl)) {
+    throw new PrivateIpError(
+      `Access to private network is blocked: ${canonicalUrl}`,
+    );
+  }
 
   const html = await fetchAmazonHtml(canonicalUrl);
 

--- a/packages/core/src/utils/amazon-url-parser.ts
+++ b/packages/core/src/utils/amazon-url-parser.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fetchWithTimeout } from './fetch.js';
+
+const AMAZON_HOST_PATTERNS = ['amazon.', 'amzn.in', 'amzn.to'];
+
+const REQUEST_TIMEOUT_MS = 10000;
+
+const USER_AGENT = 'Mozilla/5.0 (compatible; GeminiCLI-AmazonParser/1.0)';
+
+export interface AmazonProductMetadata {
+  canonicalUrl: string;
+  title?: string;
+  price?: string;
+  bullets: string[];
+  brand?: string;
+  model?: string;
+}
+
+/**
+ * Checks whether a URL belongs to Amazon or Amazon short links.
+ */
+export function isAmazonUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+
+    const host = parsed.hostname.toLowerCase();
+
+    return AMAZON_HOST_PATTERNS.some((pattern) => host.includes(pattern));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Expands shortened Amazon URLs (amzn.in / amzn.to)
+ * into canonical redirected product URLs.
+ */
+export async function expandAmazonUrl(url: string): Promise<string> {
+  const response = await fetchWithTimeout(url, REQUEST_TIMEOUT_MS, {
+    method: 'HEAD',
+    redirect: 'follow',
+    headers: {
+      'User-Agent': USER_AGENT,
+    },
+  });
+
+  return response.url;
+}
+
+/**
+ * Removes HTML tags and decodes common entities.
+ */
+function cleanText(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract product title from Amazon HTML.
+ */
+export function extractTitle(html: string): string | undefined {
+  const match = html.match(/<span[^>]*id="productTitle"[^>]*>(.*?)<\/span>/is);
+
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  return cleanText(match[1]);
+}
+
+/**
+ * Extract product price.
+ */
+export function extractPrice(html: string): string | undefined {
+  const patterns = [
+    /<span[^>]*class="a-price-whole"[^>]*>(.*?)<\/span>/is,
+    /<span[^>]*id="priceblock_ourprice"[^>]*>(.*?)<\/span>/is,
+    /<span[^>]*id="priceblock_dealprice"[^>]*>(.*?)<\/span>/is,
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+
+    if (match?.[1]) {
+      return cleanText(match[1]);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract product brand.
+ */
+export function extractBrand(html: string): string | undefined {
+  const patterns = [
+    /<a[^>]*id="bylineInfo"[^>]*>(.*?)<\/a>/is,
+    /"brand"\s*:\s*"([^"]+)"/is,
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+
+    if (match?.[1]) {
+      return cleanText(match[1]);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract model name if available.
+ */
+export function extractModel(html: string): string | undefined {
+  const patterns = [
+    /"model"\s*:\s*"([^"]+)"/is,
+    /Item model number<\/span>\s*<span[^>]*>(.*?)<\/span>/is,
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+
+    if (match?.[1]) {
+      return cleanText(match[1]);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract bullet-point specifications/features.
+ */
+export function extractBullets(html: string): string[] {
+  const matches = [
+    ...html.matchAll(/<span[^>]*class="a-list-item"[^>]*>(.*?)<\/span>/gis),
+  ];
+
+  const cleaned = matches
+    .map((match) => cleanText(match[1]))
+    .filter((text) => text.length > 3 && text.length < 300);
+
+  return [...new Set(cleaned)].slice(0, 8);
+}
+
+/**
+ * Fetch raw HTML from product page.
+ */
+export async function fetchAmazonHtml(url: string): Promise<string> {
+  const response = await fetchWithTimeout(url, REQUEST_TIMEOUT_MS, {
+    method: 'GET',
+    redirect: 'follow',
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+    },
+  });
+
+  return response.text();
+}
+
+/**
+ * Extract structured Amazon product metadata.
+ */
+export async function extractAmazonMetadata(
+  url: string,
+): Promise<AmazonProductMetadata> {
+  const canonicalUrl = await expandAmazonUrl(url);
+
+  const html = await fetchAmazonHtml(canonicalUrl);
+
+  return {
+    canonicalUrl,
+    title: extractTitle(html),
+    price: extractPrice(html),
+    bullets: extractBullets(html),
+    brand: extractBrand(html),
+    model: extractModel(html),
+  };
+}
+
+/**
+ * Format structured metadata into LLM-friendly context.
+ */
+export function formatAmazonContext(metadata: AmazonProductMetadata): string {
+  const sections: string[] = [];
+
+  sections.push('Amazon Product Metadata');
+
+  if (metadata.title) {
+    sections.push(`Title: ${metadata.title}`);
+  }
+
+  if (metadata.brand) {
+    sections.push(`Brand: ${metadata.brand}`);
+  }
+
+  if (metadata.model) {
+    sections.push(`Model: ${metadata.model}`);
+  }
+
+  if (metadata.price) {
+    sections.push(`Price: ${metadata.price}`);
+  }
+
+  sections.push(`URL: ${metadata.canonicalUrl}`);
+
+  if (metadata.bullets.length > 0) {
+    sections.push('\nKey Features:');
+
+    for (const bullet of metadata.bullets) {
+      sections.push(`- ${bullet}`);
+    }
+  }
+
+  return sections.join('\n');
+}


### PR DESCRIPTION
## Summary

Adds Amazon URL parsing and product metadata extraction support to `web-fetch`.

This enables the CLI to automatically resolve Amazon short URLs (`amzn.in`, `amzn.to`) and extract structured product information for comparison and analysis workflows.

## Details

### Features Added

* Detects Amazon and Amazon short URLs
* Expands shortened Amazon URLs to canonical product URLs
* Extracts structured metadata from Amazon product pages:

  * Product title
  * Price
  * Brand
  * Model
  * Key feature bullets/specifications
* Injects extracted metadata into LLM context through `web-fetch`
* Gracefully falls back to standard fetch behavior if extraction fails

### Implementation Notes

* Added utility parser:

  * `packages/core/src/utils/amazon-url-parser.ts`
* Added unit tests:

  * `packages/core/src/utils/amazon-url-parser.test.ts`
* Integrated metadata extraction into:

  * `packages/core/src/tools/web-fetch.ts`

This implementation intentionally keeps scope lightweight and avoids browser automation or anti-bot bypassing systems to remain maintainable and focused.

## Related Issues

Fixes #27448

## How to Validate

### Build

```bash
npm run build --workspace=@google/gemini-cli-core
```

### Typecheck

```bash
npm run typecheck --workspace=@google/gemini-cli-core
```

### Run Tests

```bash
npx vitest src/utils/amazon-url-parser.test.ts
```

### Manual Validation

Use an Amazon product URL such as:

```text
https://amzn.in/d/00geRr5g
```

Expected behavior:

* URL resolves successfully
* Product metadata is extracted
* Structured product details are returned instead of raw HTML

## Pre-Merge Checklist

* [x] Added/updated tests
* [x] Validated on Windows

  * [x] npm run
  * [x] npx
