### PR TITLE
fix(core): suppress PTY resize EBADF errors

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -17,17 +17,21 @@ import {
 
 // --- Global Entry Point ---
 
-// Suppress known race condition error in node-pty on Windows
+// Suppress known race condition error in node-pty on Windows and Linux
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827
 process.on('uncaughtException', (error) => {
-  if (
-    process.platform === 'win32' &&
-    error instanceof Error &&
-    error.message === 'Cannot resize a pty that has already exited'
-  ) {
-    // This error happens on Windows with node-pty when resizing a pty that has just exited.
-    // It is a race condition in node-pty that we cannot prevent, so we silence it.
-    return;
+  if (error instanceof Error) {
+    const isPtyResizeError =
+      error.message === 'Cannot resize a pty that has already exited';
+    const isEbadfError = error.message.includes('EBADF');
+    const isFromNodePty =
+      error.stack?.includes('node-pty') || error.stack?.includes('PtyResize');
+
+    if ((isPtyResizeError || isEbadfError) && isFromNodePty) {
+      // This error happens with node-pty when resizing a pty that has just exited.
+      // It is a race condition in node-pty that we cannot prevent, so we silence it.
+      return;
+    }
   }
 
   // For other errors, we rely on the default behavior, but since we attached a listener,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1517,12 +1517,13 @@ export class ShellExecutionService {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const err = e as { code?: string; message?: string };
         const isEsrch = err.code === 'ESRCH';
+        const isEbadf = err.code === 'EBADF' || err.message?.includes('EBADF');
         const isWindowsPtyError = err.message?.includes(
           'Cannot resize a pty that has already exited',
         );
 
-        if (isEsrch || isWindowsPtyError) {
-          // On Unix, we get an ESRCH error.
+        if (isEsrch || isEbadf || isWindowsPtyError) {
+          // On Unix, we get an ESRCH or EBADF error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.
         } else {


### PR DESCRIPTION
## Summary

Matches upstream node-pty fix for issue #827. Suppresses crashes when resizing a PTY that is in the process of exiting. This issue was exacerbated by recent UI layout changes that increased resize frequency.

## Related Issues

b/516018762