### PR TITLE
fix(core): harden PTY resize against native crashes

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -21,9 +21,12 @@ import {
 // Tracking bug: https://github.com/microsoft/node-pty/issues/827
 process.on('uncaughtException', (error) => {
   if (error instanceof Error) {
+    const message = error.message || '';
     const isPtyResizeError =
-      error.message === 'Cannot resize a pty that has already exited';
-    const isEbadfError = error.message.includes('EBADF');
+      message === 'Cannot resize a pty that has already exited';
+    const isEbadfError =
+      message.includes('EBADF') ||
+      (error as { code?: string }).code === 'EBADF';
     const isFromNodePty =
       error.stack?.includes('node-pty') || error.stack?.includes('PtyResize');
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1511,16 +1511,15 @@ export class ShellExecutionService {
       return;
     }
 
-    // Defensive check: Verify with the OS that the process is actually still alive.
-    // This helps avoid a native crash in node-pty if the process died but our
-    // internal map hasn't updated yet.
-    try {
-      process.kill(pid, 0);
-    } catch (e) {
-      // If the OS explicitly says the process is gone (ESRCH), bail.
-      // Other errors (like EPERM) or successes (no error) mean we should proceed.
-      if (e instanceof Error && 'code' in e && e.code === 'ESRCH') {
-        return;
+    // Skip Windows: process.kill(pid, 0) is heavy and native errors are catchable there.
+    if (process.platform !== 'win32') {
+      try {
+        process.kill(pid, 0);
+      } catch (e) {
+        // Bail only if the process is explicitly confirmed dead (ESRCH).
+        if (e instanceof Error && 'code' in e && e.code === 'ESRCH') {
+          return;
+        }
       }
     }
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -37,6 +37,7 @@ import {
 } from './sandboxManager.js';
 import type { SandboxConfig } from '../config/config.js';
 import { killProcessGroup } from '../utils/process-utils.js';
+import { isNodeError } from '../utils/errors.js';
 import {
   ExecutionLifecycleService,
   type ExecutionHandle,
@@ -1517,7 +1518,7 @@ export class ShellExecutionService {
         process.kill(pid, 0);
       } catch (e) {
         // Bail only if the process is explicitly confirmed dead (ESRCH).
-        if (e instanceof Error && 'code' in e && e.code === 'ESRCH') {
+        if (isNodeError(e) && e.code === 'ESRCH') {
           return;
         }
       }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1507,28 +1507,43 @@ export class ShellExecutionService {
     }
 
     const activePty = this.activePtys.get(pid);
-    if (activePty) {
-      try {
-        activePty.ptyProcess.resize(cols, rows);
-        activePty.headlessTerminal.resize(cols, rows);
-      } catch (e) {
-        // Ignore errors if the pty has already exited, which can happen
-        // due to a race condition between the exit event and this call.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        const err = e as { code?: string; message?: string };
-        const isEsrch = err.code === 'ESRCH';
-        const isEbadf = err.code === 'EBADF' || err.message?.includes('EBADF');
-        const isWindowsPtyError = err.message?.includes(
-          'Cannot resize a pty that has already exited',
-        );
+    if (!activePty) {
+      return;
+    }
 
-        if (isEsrch || isEbadf || isWindowsPtyError) {
-          // On Unix, we get an ESRCH or EBADF error.
-          // On Windows, we get a message-based error.
-          // In both cases, it's safe to ignore.
-        } else {
-          throw e;
-        }
+    // Defensive check: Verify with the OS that the process is actually still alive.
+    // This helps avoid a native crash in node-pty if the process died but our
+    // internal map hasn't updated yet.
+    try {
+      process.kill(pid, 0);
+    } catch (e) {
+      // If the OS explicitly says the process is gone (ESRCH), bail.
+      // Other errors (like EPERM) or successes (no error) mean we should proceed.
+      if (e instanceof Error && 'code' in e && e.code === 'ESRCH') {
+        return;
+      }
+    }
+
+    try {
+      activePty.ptyProcess.resize(cols, rows);
+      activePty.headlessTerminal.resize(cols, rows);
+    } catch (e) {
+      // Ignore errors if the pty has already exited, which can happen
+      // due to a race condition between the exit event and this call.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const err = e as { code?: string; message?: string };
+      const isEsrch = err.code === 'ESRCH';
+      const isEbadf = err.code === 'EBADF' || err.message?.includes('EBADF');
+      const isWindowsPtyError = err.message?.includes(
+        'Cannot resize a pty that has already exited',
+      );
+
+      if (isEsrch || isEbadf || isWindowsPtyError) {
+        // On Unix, we get an ESRCH or EBADF error.
+        // On Windows, we get a message-based error.
+        // In both cases, it's safe to ignore.
+      } else {
+        throw e;
       }
     }
 


### PR DESCRIPTION
## Summary

Harden PTY resize logic to prevent native C++ crashes (`libc++abi: terminating`) caused by race conditions when a process exits during a UI-triggered resize.

## Details

This PR implements a "Defense in Depth" strategy to resolve intermittent crashes where `node-pty` triggers a `libc++abi` termination due to an uncaught `Napi::Error` (Bad File Descriptor) at the C++ level.

1. **Kernel Guard**: Added a synchronous OS-level check (`process.kill(pid, 0)`) immediately before native resize calls in `ShellExecutionService.ts`. This asks the OS directly if the process is alive, closing the race condition window that our internal JS state maps cannot catch.
2. **Robust Global Handler**: Updated the `uncaughtException` listener in `packages/cli/index.ts` to safely handle native errors that lack message strings, preventing secondary crashes.
3. **Consolidated Logic**: Simplified `resizePty` to use a single map lookup and ensured it only bails if the Kernel explicitly confirms the process is gone (`ESRCH`), maintaining test compatibility.

## Related Issues

Closes #26433
Closes #27443

## How to Validate

1. Run core unit tests: `npm test -w @google/gemini-cli-core -- src/services/shellExecutionService.test.ts`
2. Manual verification: Spawn many short-lived shell tools (e.g., `sleep 1`) and rapidly resize the terminal window. The CLI should remain stable.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
