### PR TITLE
Handle errors safely in shellExecutionService

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1526,8 +1526,8 @@ export class ShellExecutionService {
           // On Unix, we get an ESRCH or EBADF error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.
-          // return in order to mitigate the resize issue.
-          return; 
+          // Return early to prevent executing post-resize logic on a dead PTY.
+          return;
         } else {
           throw e;
         }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1526,6 +1526,8 @@ export class ShellExecutionService {
           // On Unix, we get an ESRCH or EBADF error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.
+          // return in order to mitigate the resize issue.
+          return; 
         } else {
           throw e;
         }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1526,7 +1526,7 @@ export class ShellExecutionService {
           // On Unix, we get an ESRCH or EBADF error.
           // On Windows, we get a message-based error.
           // In both cases, it's safe to ignore.
-          // Return early to prevent executing post-resize logic on a dead PTY.
+          // Return early to prevent a EBADF or ESRCH console crash yielding the gemini-cli useless.
           return;
         } else {
           throw e;


### PR DESCRIPTION
---

## Summary

This PR addresses a critical, unhandled application crash caused by an `EBADF` (Bad File Descriptor) error during pseudo-terminal resizing loops. By adding an explicit `return` statement within the caught exception block inside `ShellExecutionService.resizePty`, we gracefully halt execution when a stale terminal file descriptor is encountered, instead of falling through and triggering a fatal process crash.

## Details

When the interactive UI is tearing down a session or re-rendering elements dynamically, a race condition can occur: the layout engine triggers a `resizePty` execution immediately after or during terminal stream closure.

The codebase *intentionally* catches these predictable OS-level exceptions (`ESRCH`, `EBADF`, and Windows-specific exit errors). However, because the caught error block was empty, execution fell through to the terminal serialization logic at the bottom of the function. This forced an attempt to read from a closed terminal stream, causing a hard crash. Adding a simple `return;` safely cancels the stale resize cycle.

## Related Issues

Fixes #27344 ## How to Validate

1. **Simulate dynamically shrinking/maximizing window frames:** Launch the interactive CLI and aggressively resize or snap your host terminal window sideways while tasks are completing. The application should adapt smoothly or safely ignore closed pty frames without throwing an unhandled `ioctl(2) failed, EBADF` exception.
2. **Execute tests:** Ensure the workspace components build and match internal code standards by running the validation check script from the repository root:
```bash
npm run build
npm run preflight

```



## Pre-Merge Checklist

* [x] Updated relevant documentation and README (if needed)
* [x] Added/updated tests (if needed)
* [x] Noted breaking changes (if any)
* [x] Validated on required platforms/methods:
* [x] MacOS
* [x] npm run
* [x] npx
* [x] Docker
* [ ] Podman
* [x] Seatbelt


* [x] Windows
* [x] npm run
* [x] npx
* [x] Docker


* [x] Linux
* [x] npm run
* [x] npx
* [x] Docker