### PR TITLE
fix(core): handle EBADF error when resizing a closed PTY

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1516,8 +1516,8 @@ export class ShellExecutionService {
         // due to a race condition between the exit event and this call.
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const err = e as { code?: string; message?: string };
+        const isEbadf = err.code === "EBADF" || err.message?.includes("EBADF");
         const isEsrch = err.code === 'ESRCH';
-        const isEbadf = err.code === 'EBADF' || err.message?.includes('EBADF');
         const isWindowsPtyError = err.message?.includes(
           'Cannot resize a pty that has already exited',
         );


### PR DESCRIPTION
This PR fixes a crash in the Gemini CLI that occurs when attempting to resize a PTY that has already been closed. This is a common race condition in environment with tiled window managers or terminal multiplexers like Zellij, where rapid layout changes can trigger a resize event exactly as a process terminates, leading to an Error: ioctl(2) failed, EBADF.