### PR TITLE
fix(a2a-server): delimit SSE events with a blank line in /executeCommand

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -1134,9 +1134,7 @@ describe('E2E Tests', () => {
     });
 
     describe('/executeCommand streaming', () => {
-      it('should execute a streaming command and stream back events', (done: (
-        err?: unknown,
-      ) => void) => {
+      it('should execute a streaming command and stream back events', async () => {
         const executeSpy = vi.fn(async (context: CommandContext) => {
           context.eventBus?.publish({
             kind: 'status-update',
@@ -1164,42 +1162,30 @@ describe('E2E Tests', () => {
         vi.spyOn(commandRegistry, 'get').mockReturnValue(mockStreamCommand);
 
         const agent = request.agent(app);
-        agent
+        const res = await agent
           .post('/executeCommand')
           .send({ command: 'stream-test', args: [] })
           .set('Content-Type', 'application/json')
           .set('Accept', 'text/event-stream')
-          .on('response', (res) => {
-            let data = '';
-            res.on('data', (chunk: Buffer) => {
-              data += chunk.toString();
-            });
-            res.on('end', () => {
-              try {
-                const events = streamToSSEEvents(data);
-                expect(events.length).toBe(2);
-                expect(events[0].result).toEqual({
-                  kind: 'status-update',
-                  status: { state: 'working' },
-                  taskId: 'test-task',
-                  contextId: 'test-context',
-                  final: false,
-                });
-                expect(events[1].result).toEqual({
-                  kind: 'status-update',
-                  status: { state: 'completed' },
-                  taskId: 'test-task',
-                  contextId: 'test-context',
-                  final: true,
-                });
-                expect(executeSpy).toHaveBeenCalled();
-                done();
-              } catch (e) {
-                done(e);
-              }
-            });
-          })
-          .end();
+          .expect(200);
+
+        const events = streamToSSEEvents(res.text);
+        expect(events.length).toBe(2);
+        expect(events[0].result).toEqual({
+          kind: 'status-update',
+          status: { state: 'working' },
+          taskId: 'test-task',
+          contextId: 'test-context',
+          final: false,
+        });
+        expect(events[1].result).toEqual({
+          kind: 'status-update',
+          status: { state: 'completed' },
+          taskId: 'test-task',
+          contextId: 'test-context',
+          final: true,
+        });
+        expect(executeSpy).toHaveBeenCalled();
       });
 
       it('should handle non-streaming commands gracefully', async () => {

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -167,7 +167,7 @@ async function handleExecuteCommand(
           id: 'taskId' in event ? event.taskId : (event as Message).messageId,
           result: event,
         };
-        res.write(`data: ${JSON.stringify(jsonRpcResponse)}\n`);
+        res.write(`data: ${JSON.stringify(jsonRpcResponse)}\n\n`);
       };
       eventBus.on('event', eventHandler);
 


### PR DESCRIPTION
## Summary

The streaming `/executeCommand` endpoint in the A2A server emits Server-Sent Events that are not separated by a blank line, so a spec-compliant SSE/`EventSource` client cannot parse the individual events. This is a one-line framing fix plus a test that actually exercises the path.

## Details

In `packages/a2a-server/src/http/app.ts` each event was written as:

```ts
res.write(`data: ${JSON.stringify(jsonRpcResponse)}\n`);
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), an event is only dispatched when a **blank line** (`\n\n`) is encountered. With a single `\n`, consecutive `data:` lines are concatenated into one record and the final event is never terminated, so a real `EventSource` consumer ends up with one malformed event instead of N. The rest of the codebase already uses `\n\n` for SSE (see `packages/core/src/code_assist/server.test.ts`). The fix appends the missing newline.

While fixing this I found the existing streaming test never actually asserted anything: it used the Mocha-style `done` callback, which Vitest 3 does not honor, so the test body returned before the `res.on('end')` assertions ran and it passed regardless of output. I converted it to `async`/`await` (matching the other SSE tests in the file) so it genuinely validates the stream — it fails before this fix (`expected 1 to be 2`) and passes after.

## Related Issues

Fixes #27587

## How to Validate

```bash
cd packages/a2a-server
npm run typecheck
npx vitest run src/http/app.test.ts   # 20 passed
```

To see the bug without the production fix, revert only the `app.ts` change and re-run the streaming test — it fails with `expected 1 to be 2`, confirming the new test guards the regression.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (not needed — internal behavior fix)
- [x] Added/updated tests (converted the ineffective streaming test into a real regression test)
- [x] Noted breaking changes (none — output becomes spec-compliant SSE)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (`vitest` + `tsc --noEmit` for `@google/gemini-cli-a2a-server`)

> Note: this is a platform-independent string-framing change covered by automated unit tests, so it was validated via the package test suite on Linux rather than the full per-OS runtime matrix.