### PR TITLE
fix(core): insert content literally into LLM prompts to avoid $ substitution

### DIFF
--- a/packages/core/src/services/sessionSummaryService.ts
+++ b/packages/core/src/services/sessionSummaryService.ts
@@ -10,6 +10,7 @@ import { partListUnionToString } from '../core/geminiRequest.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { Content } from '@google/genai';
 import { getResponseText } from '../utils/partUtils.js';
+import { safeLiteralReplace } from '../utils/textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const DEFAULT_MAX_MESSAGES = 20;
@@ -104,7 +105,14 @@ export class SessionSummaryService {
         })
         .join('\n\n');
 
-      const prompt = SUMMARY_PROMPT.replace('{conversation}', conversationText);
+      // Use safeLiteralReplace so that `$`-sequences in the conversation text
+      // (e.g. `$&`, `$$`) are inserted literally instead of being interpreted as
+      // String.prototype.replace substitution patterns.
+      const prompt = safeLiteralReplace(
+        SUMMARY_PROMPT,
+        '{conversation}',
+        conversationText,
+      );
 
       // Create abort controller with timeout
       const abortController = new AbortController();

--- a/packages/core/src/services/sessionSummaryService.ts
+++ b/packages/core/src/services/sessionSummaryService.ts
@@ -10,7 +10,6 @@ import { partListUnionToString } from '../core/geminiRequest.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { Content } from '@google/genai';
 import { getResponseText } from '../utils/partUtils.js';
-import { safeLiteralReplace } from '../utils/textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const DEFAULT_MAX_MESSAGES = 20;
@@ -105,13 +104,12 @@ export class SessionSummaryService {
         })
         .join('\n\n');
 
-      // Use safeLiteralReplace so that `$`-sequences in the conversation text
-      // (e.g. `$&`, `$$`) are inserted literally instead of being interpreted as
+      // Use a replacer function so that `$`-sequences in the conversation text
+      // (e.g. `$&`, `$$`) are inserted literally instead of being treated as
       // String.prototype.replace substitution patterns.
-      const prompt = safeLiteralReplace(
-        SUMMARY_PROMPT,
+      const prompt = SUMMARY_PROMPT.replace(
         '{conversation}',
-        conversationText,
+        () => conversationText,
       );
 
       // Create abort controller with timeout

--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -156,6 +156,46 @@ describe('FixLLMEditWithInstruction', () => {
     );
   });
 
+  it('inserts content containing `$` sequences literally into the prompt', async () => {
+    mockGenerateJson.mockResolvedValue(mockApiResponse);
+    // Each of these is a special pattern for String.prototype.replace's
+    // replacement argument ($&, $$, $`, $') and must be preserved verbatim.
+    const dollarInstruction = 'replace $& with $$';
+    const dollarOldString = 'const price = "$$";';
+    const dollarNewString = 'const cmd = "echo $\'x\'";';
+    const dollarError = 'no match for `$`';
+    const dollarContent = "a$&b $` c $' d $$ e";
+
+    await promptIdContext.run('test-prompt-id-dollar', async () => {
+      await FixLLMEditWithInstruction(
+        dollarInstruction,
+        dollarOldString,
+        dollarNewString,
+        dollarError,
+        dollarContent,
+        mockBaseLlmClient,
+        abortSignal,
+      );
+    });
+
+    const userPromptContent =
+      mockGenerateJson.mock.calls[0][0].contents[0].parts[0].text;
+
+    expect(userPromptContent).toContain(
+      `<instruction>\n${dollarInstruction}\n</instruction>`,
+    );
+    expect(userPromptContent).toContain(
+      `<search>\n${dollarOldString}\n</search>`,
+    );
+    expect(userPromptContent).toContain(
+      `<replace>\n${dollarNewString}\n</replace>`,
+    );
+    expect(userPromptContent).toContain(`<error>\n${dollarError}\n</error>`);
+    expect(userPromptContent).toContain(
+      `<file_content>\n${dollarContent}\n</file_content>`,
+    );
+  });
+
   it('should return a cached result on subsequent identical calls', async () => {
     mockGenerateJson.mockResolvedValue(mockApiResponse);
     const testPromptId = 'test-prompt-id-caching';

--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -196,6 +196,33 @@ describe('FixLLMEditWithInstruction', () => {
     );
   });
 
+  it('does not re-interpolate placeholder tokens that appear inside inputs', async () => {
+    mockGenerateJson.mockResolvedValue(mockApiResponse);
+    // An edit parameter that itself contains a template placeholder string must
+    // be inserted verbatim, not substituted again by a later replacement.
+    await promptIdContext.run('test-prompt-id-injection', async () => {
+      await FixLLMEditWithInstruction(
+        'do the edit',
+        '{current_content}',
+        'replacement',
+        'an error',
+        'THE REAL FILE CONTENT',
+        mockBaseLlmClient,
+        abortSignal,
+      );
+    });
+
+    const userPromptContent =
+      mockGenerateJson.mock.calls[0][0].contents[0].parts[0].text;
+
+    expect(userPromptContent).toContain(
+      `<search>\n{current_content}\n</search>`,
+    );
+    expect(userPromptContent).toContain(
+      `<file_content>\nTHE REAL FILE CONTENT\n</file_content>`,
+    );
+  });
+
   it('should return a cached result on subsequent identical calls', async () => {
     mockGenerateJson.mockResolvedValue(mockApiResponse);
     const testPromptId = 'test-prompt-id-caching';

--- a/packages/core/src/utils/llm-edit-fixer.ts
+++ b/packages/core/src/utils/llm-edit-fixer.ts
@@ -10,7 +10,6 @@ import { type BaseLlmClient } from '../core/baseLlmClient.js';
 import { LRUCache } from 'mnemonist';
 import { getPromptIdWithFallback } from './promptIdContext.js';
 import { debugLogger } from './debugLogger.js';
-import { safeLiteralReplace } from './textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const MAX_CACHE_SIZE = 50;
@@ -160,21 +159,23 @@ export async function FixLLMEditWithInstruction(
   if (cachedResult) {
     return cachedResult;
   }
-  // Use safeLiteralReplace so that `$`-sequences (e.g. `$&`, `$$`, `` $` ``) in
-  // file content or edit parameters are inserted literally instead of being
-  // interpreted as String.prototype.replace substitution patterns.
-  let userPrompt = safeLiteralReplace(
-    EDIT_USER_PROMPT,
-    '{instruction}',
+  // Interpolate every placeholder in a single pass with a replacer function.
+  // Using a function (rather than a string) means `$`-sequences in the values
+  // (e.g. `$&`, `$$`, `` $` ``) are inserted literally instead of being treated
+  // as String.prototype.replace substitution patterns, and the single pass
+  // prevents a placeholder token that appears inside one value (e.g. an edit
+  // parameter containing the text `{current_content}`) from being re-interpolated
+  // by a later replacement.
+  const replacements: Record<string, string> = {
     instruction,
-  );
-  userPrompt = safeLiteralReplace(userPrompt, '{old_string}', old_string);
-  userPrompt = safeLiteralReplace(userPrompt, '{new_string}', new_string);
-  userPrompt = safeLiteralReplace(userPrompt, '{error}', error);
-  userPrompt = safeLiteralReplace(
-    userPrompt,
-    '{current_content}',
+    old_string,
+    new_string,
+    error,
     current_content,
+  };
+  const userPrompt = EDIT_USER_PROMPT.replace(
+    /\{(\w+)\}/g,
+    (match, key: string) => replacements[key] ?? match,
   );
 
   const contents: Content[] = [

--- a/packages/core/src/utils/llm-edit-fixer.ts
+++ b/packages/core/src/utils/llm-edit-fixer.ts
@@ -10,6 +10,7 @@ import { type BaseLlmClient } from '../core/baseLlmClient.js';
 import { LRUCache } from 'mnemonist';
 import { getPromptIdWithFallback } from './promptIdContext.js';
 import { debugLogger } from './debugLogger.js';
+import { safeLiteralReplace } from './textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const MAX_CACHE_SIZE = 50;
@@ -159,11 +160,22 @@ export async function FixLLMEditWithInstruction(
   if (cachedResult) {
     return cachedResult;
   }
-  const userPrompt = EDIT_USER_PROMPT.replace('{instruction}', instruction)
-    .replace('{old_string}', old_string)
-    .replace('{new_string}', new_string)
-    .replace('{error}', error)
-    .replace('{current_content}', current_content);
+  // Use safeLiteralReplace so that `$`-sequences (e.g. `$&`, `$$`, `` $` ``) in
+  // file content or edit parameters are inserted literally instead of being
+  // interpreted as String.prototype.replace substitution patterns.
+  let userPrompt = safeLiteralReplace(
+    EDIT_USER_PROMPT,
+    '{instruction}',
+    instruction,
+  );
+  userPrompt = safeLiteralReplace(userPrompt, '{old_string}', old_string);
+  userPrompt = safeLiteralReplace(userPrompt, '{new_string}', new_string);
+  userPrompt = safeLiteralReplace(userPrompt, '{error}', error);
+  userPrompt = safeLiteralReplace(
+    userPrompt,
+    '{current_content}',
+    current_content,
+  );
 
   const contents: Content[] = [
     {

--- a/packages/core/src/utils/summarizer.ts
+++ b/packages/core/src/utils/summarizer.ts
@@ -9,7 +9,6 @@ import type { Content } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import { getResponseText, partToString } from './partUtils.js';
 import { debugLogger } from './debugLogger.js';
-import { safeLiteralReplace } from './textUtils.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import type { Config } from '../config/config.js';
 import { LlmRole } from '../telemetry/llmRole.js';
@@ -85,16 +84,16 @@ export async function summarizeToolOutput(
   if (!textToSummarize || textToSummarize.length < maxOutputTokens) {
     return textToSummarize;
   }
-  // Use safeLiteralReplace for the tool output so that `$`-sequences in the
-  // text (e.g. `$&`, `$$`) are inserted literally rather than being interpreted
-  // as String.prototype.replace substitution patterns.
-  const prompt = safeLiteralReplace(
-    SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
-      '{maxOutputTokens}',
-      String(maxOutputTokens),
-    ),
-    '{textToSummarize}',
+  // Interpolate placeholders in a single pass with a replacer function so that
+  // `$`-sequences in the tool output (e.g. `$&`, `$$`) are inserted literally
+  // rather than being treated as String.prototype.replace substitution patterns.
+  const replacements: Record<string, string> = {
+    maxOutputTokens: String(maxOutputTokens),
     textToSummarize,
+  };
+  const prompt = SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
+    /\{(\w+)\}/g,
+    (match, key: string) => replacements[key] ?? match,
   );
 
   const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];

--- a/packages/core/src/utils/summarizer.ts
+++ b/packages/core/src/utils/summarizer.ts
@@ -9,6 +9,7 @@ import type { Content } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import { getResponseText, partToString } from './partUtils.js';
 import { debugLogger } from './debugLogger.js';
+import { safeLiteralReplace } from './textUtils.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import type { Config } from '../config/config.js';
 import { LlmRole } from '../telemetry/llmRole.js';
@@ -84,10 +85,17 @@ export async function summarizeToolOutput(
   if (!textToSummarize || textToSummarize.length < maxOutputTokens) {
     return textToSummarize;
   }
-  const prompt = SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
-    '{maxOutputTokens}',
-    String(maxOutputTokens),
-  ).replace('{textToSummarize}', textToSummarize);
+  // Use safeLiteralReplace for the tool output so that `$`-sequences in the
+  // text (e.g. `$&`, `$$`) are inserted literally rather than being interpreted
+  // as String.prototype.replace substitution patterns.
+  const prompt = safeLiteralReplace(
+    SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
+      '{maxOutputTokens}',
+      String(maxOutputTokens),
+    ),
+    '{textToSummarize}',
+    textToSummarize,
+  );
 
   const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];
   try {


### PR DESCRIPTION
## Summary

Several LLM prompt builders interpolate user/file content into a template with `String.prototype.replace('{placeholder}', value)`. The replacement argument honors special patterns, so any value containing `$` is silently corrupted before being sent to the model. This interpolates each prompt in a single pass with a replacer function, which both inserts content literally and avoids re-interpolating placeholder tokens that appear inside input values.

## Details

`String.prototype.replace(searchString, replacement)` interprets `$$`, `$&`, `` $` `` and `$'` in the **replacement** argument even when the search is a plain string. The affected values are file contents, shell/tool output, and conversation text — which routinely contain `$`. Concrete corruption (verified):

| input fragment | becomes |
| --- | --- |
| `$&` | the placeholder name, e.g. `{current_content}` |
| `$$` | a single `$` |
| `` $` `` | everything in the prompt **before** the placeholder (dumps the template) |
| `$'` | everything **after** the placeholder (truncates the content) |

So e.g. `echo $$ > pid.txt` is sent to the model as `echo $ > pid.txt`, and a file containing `` $` `` leaks the prompt template into the `<file_content>` block.

Fix: interpolate in a single pass with a replacer function, e.g.

```ts
const userPrompt = EDIT_USER_PROMPT.replace(
  /\{(\w+)\}/g,
  (match, key) => replacements[key] ?? match,
);
```

The function form inserts `$`-sequences literally (no `GetSubstitution`), and the single pass also fixes a **sequential-interpolation** issue: a placeholder token appearing inside one input value (e.g. an edit parameter that itself contains `{current_content}`) is no longer re-substituted by a later replacement.

Affected call sites (all fixed):
- `packages/core/src/utils/llm-edit-fixer.ts` — edit self-correction prompt
- `packages/core/src/utils/summarizer.ts` — tool-output summarizer
- `packages/core/src/services/sessionSummaryService.ts` — session summary

(`bugCommand.ts` uses the same `.replace('{x}', value)` shape but wraps values in `encodeURIComponent`, so it is already safe and left unchanged.)

## Related Issues

Closes #27556

## How to Validate

```bash
cd packages/core
npm run typecheck
npx vitest run src/utils/llm-edit-fixer.test.ts src/utils/summarizer.test.ts src/services/sessionSummaryService.test.ts
```

New tests in `llm-edit-fixer.test.ts` cover (a) `$`-content (`$&`, `$$`, `` $` ``, `$'`) being inserted literally and (b) a placeholder token supplied as input not being re-interpolated. Both fail on the previous code and pass with this change. The pre-existing prompt test only used `$`-free fixtures, which is why the bug slipped through.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (not needed — internal behavior fix)
- [x] Added/updated tests (regression tests for `$` sequences and placeholder-in-input)
- [x] Noted breaking changes (none — prompts now contain the intended literal content)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (`vitest` + `tsc --noEmit` for `@google/gemini-cli-core`)

> Note: platform-independent string-handling fix covered by automated unit tests, validated via the package test suite on Linux.