### PR TITLE
fix(cli): stop merging shell history commands that end in a backslash

### DIFF
--- a/packages/cli/src/ui/hooks/useShellHistory.test.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.test.ts
@@ -230,6 +230,33 @@ describe('useShellHistory', () => {
     unmount();
   });
 
+  it('should not merge a command ending in a backslash with the next entry', async () => {
+    // The file stores commands verbatim, oldest-first. The first command ends in
+    // a single backslash (e.g. a Windows path); it must remain its own entry and
+    // not be concatenated with the following command.
+    mockedFs.readFile.mockResolvedValue('dir C:\\\nls');
+    const { result, unmount } = await renderHook(() =>
+      useShellHistory(MOCKED_PROJECT_ROOT),
+    );
+
+    await waitFor(() => {
+      expect(mockedFs.readFile).toHaveBeenCalled();
+    });
+
+    let command: string | null = null;
+    act(() => {
+      command = result.current.getPreviousCommand();
+    });
+    expect(command).toBe('ls');
+
+    act(() => {
+      command = result.current.getPreviousCommand();
+    });
+    expect(command).toBe('dir C:\\');
+
+    unmount();
+  });
+
   it('should not add empty or whitespace-only commands to history', async () => {
     const { result, unmount } = await renderHook(() =>
       useShellHistory(MOCKED_PROJECT_ROOT),

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -28,29 +28,16 @@ async function getHistoryFilePath(
   return storage.getHistoryFilePath();
 }
 
-// Handle multiline commands
 async function readHistoryFile(filePath: string): Promise<string[]> {
   try {
     const text = await fs.readFile(filePath, 'utf-8');
-    const result: string[] = [];
-    let cur = '';
-
-    for (const raw of text.split(/\r?\n/)) {
-      if (!raw.trim()) continue;
-      const line = raw;
-
-      const m = cur.match(/(\\+)$/);
-      if (m && m[1].length % 2) {
-        // odd number of trailing '\'
-        cur = cur.slice(0, -1) + ' ' + line;
-      } else {
-        if (cur) result.push(cur);
-        cur = line;
-      }
-    }
-
-    if (cur) result.push(cur);
-    return result;
+    // Each non-empty line is exactly one command, mirroring writeHistoryFile
+    // which stores commands verbatim, one per line. (A previous version tried to
+    // treat a trailing odd number of backslashes as a line-continuation marker,
+    // but writeHistoryFile never produced that escaped format, so the only effect
+    // was to merge real commands that legitimately end in a backslash — e.g. a
+    // Windows path like `C:\` — into the following entry.)
+    return text.split(/\r?\n/).filter((line) => line.trim() !== '');
   } catch (err) {
     if (isNodeError(err) && err.code === 'ENOENT') return [];
     debugLogger.error('Error reading history:', err);


### PR DESCRIPTION
## Summary

Shell history corrupts any command that ends in a backslash (for example a Windows path like `dir C:\`): on the next launch it is silently merged with the following command into a single mangled entry.

## Details

`readHistoryFile` treated any stored line ending in an **odd** number of backslashes as a line-continuation marker and merged it into the next line (joined with a space, dropping one backslash):

```ts
const m = cur.match(/(\\+)$/);
if (m && m[1].length % 2) {
  cur = cur.slice(0, -1) + ' ' + line; // merge
}
```

However `writeHistoryFile` never produces that escaped format — it stores commands verbatim with `history.join('\n')`, one per line. So nothing ever legitimately ends in a continuation backslash, and the decode step only ever fired on **real** commands that happen to end in a backslash, concatenating them with the next entry.

Reproduction: run `dir C:\`, then `ls`. The file contains:

```text
dir C:\
ls
```

On reload the reader returns a single entry `dir C: ls` instead of the two commands `dir C:\` and `ls`.

The fix reads each non-empty line as exactly one command, matching how the writer stores them. This is fully backward compatible with existing history files (commands are still read verbatim; only the unpaired merge step is removed).

## Related Issues

Fixes #27585

## How to Validate

```bash
cd packages/cli
npm run typecheck
npx vitest run src/ui/hooks/useShellHistory.test.ts
```

The new test `should not merge a command ending in a backslash with the next entry` fails on the previous implementation (it returns `dir C: ls`) and passes with this fix. All existing history tests continue to pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (not needed — behavior fix)
- [x] Added/updated tests (regression test for a command ending in a backslash)
- [x] Noted breaking changes (none — read path is backward compatible)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (`vitest` + `tsc --noEmit`)

> Note: platform-independent history-parsing fix covered by automated unit tests, validated via the package test suite on Linux.