### PR TITLE
fix(cli):  Fix a regression where Gateway authentication is rejected with `Invalid auth method selected.` when `GOOGLE_GEMINI_BASE_URL` is configured.

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -30,7 +30,7 @@ describe('validateAuthMethod', () => {
     vi.stubEnv('GOOGLE_CLOUD_PROJECT', undefined);
     vi.stubEnv('GOOGLE_CLOUD_LOCATION', undefined);
     vi.stubEnv('GOOGLE_API_KEY', undefined);
-    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', undefined);
+    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', '');
   });
 
   afterEach(() => {

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -30,6 +30,7 @@ describe('validateAuthMethod', () => {
     vi.stubEnv('GOOGLE_CLOUD_PROJECT', undefined);
     vi.stubEnv('GOOGLE_CLOUD_LOCATION', undefined);
     vi.stubEnv('GOOGLE_API_KEY', undefined);
+    vi.stubEnv('GOOGLE_GEMINI_BASE_URL', undefined);
   });
 
   afterEach(() => {
@@ -91,6 +92,22 @@ describe('validateAuthMethod', () => {
         '• GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION environment variables.\n' +
         '• GOOGLE_API_KEY environment variable (if using express mode).\n' +
         'Update your environment and try again (no reload needed if using .env)!',
+    },
+    {
+      description:
+        'should return null for GATEWAY if GOOGLE_GEMINI_BASE_URL is set',
+      authType: AuthType.GATEWAY,
+      envs: {
+        GOOGLE_GEMINI_BASE_URL: 'http://127.0.0.1:8080',
+      },
+      expected: null,
+    },
+    {
+      description:
+        'should return an error message for GATEWAY if GOOGLE_GEMINI_BASE_URL is not set',
+      authType: AuthType.GATEWAY,
+      envs: {},
+      expected: 'When using Gateway auth, GOOGLE_GEMINI_BASE_URL must be set.',
     },
     {
       description: 'should return an error message for an invalid auth method',

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -45,5 +45,13 @@ export async function validateAuthMethod(
     return null;
   }
 
+  if (authMethod === AuthType.GATEWAY) {
+    if (!process.env['GOOGLE_GEMINI_BASE_URL']) {
+      return 'When using Gateway auth, GOOGLE_GEMINI_BASE_URL must be set.';
+    }
+
+    return null;
+  }
+
   return 'Invalid auth method selected.';
 }


### PR DESCRIPTION
## Summary

Fix a regression where Gateway authentication is rejected with `Invalid auth method selected.` when `GOOGLE_GEMINI_BASE_URL` is configured.

`getAuthTypeFromEnv()` returns `AuthType.GATEWAY` when `GOOGLE_GEMINI_BASE_URL` is set, but `validateAuthMethod()` did not handle `AuthType.GATEWAY`, causing validation to fail before requests were sent.

## Details

Adds validation support for `AuthType.GATEWAY` in `validateAuthMethod()`.

Gateway authentication now:

* succeeds when `GOOGLE_GEMINI_BASE_URL` is configured
* returns a clear validation error when `GOOGLE_GEMINI_BASE_URL` is missing

Also adds regression tests covering successful and failing Gateway validation scenarios.

## Related Issues

Fixes #27550

## How to Validate

1. Run the auth validation tests:

```bash
npx vitest packages/cli/src/config/auth.test.ts
```

Expected result:

```text
10 passed
```

2. Run the non-interactive auth tests:

```bash
npx vitest packages/cli/src/validateNonInterActiveAuth.test.ts
```

Expected result:

```text
17 passed
```

3. Build the project:

```bash
npm run build
```

Expected result:

```text
Build is up-to-date.
Successfully copied files.
```

4. Reproduce the original issue:

```bash
GOOGLE_API_KEY=proxy-token
GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:8080
GOOGLE_GENAI_USE_VERTEXAI=false
```

Run:

```bash
gemini --prompt "Hello world" --yolo
```

Before this change:

```text
Invalid auth method selected.
```

After this change:

Authentication validation succeeds and execution proceeds to the network layer (e.g. `fetch failed` if no proxy is listening on the configured endpoint).

## Pre-Merge Checklist

* [ ] Updated relevant documentation and README (not needed)
* [x] Added/updated tests
* [ ] Noted breaking changes (none)
* [x] Validated on required platforms/methods:

  * [ ] MacOS

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
    * [ ] Podman
    * [ ] Seatbelt
  * [x] Windows

    * [x] npm run
    * [ ] npx
    * [ ] Docker
  * [ ] Linux

    * [ ] npm run
    * [ ] npx
    * [ ] Docker
