### PR TITLE
fix(cli): fallback to TERMUX_ORIGINAL_EXE_PATH to prevent linker64 crash in Termux

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -101,7 +101,8 @@ async function run() {
     const runner = () => {
       process.stdin.pause();
 
-      const child = spawn(process.execPath, spawnArgs, {
+      const execPath = process.env['TERMUX_ORIGINAL_EXE_PATH'] || process.execPath;
+      const child = spawn(execPath, spawnArgs, {
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         env: newEnv,
       });

--- a/packages/cli/src/utils/processUtils.ts
+++ b/packages/cli/src/utils/processUtils.ts
@@ -111,7 +111,8 @@ export function getSpawnConfig(
     // we must provide a placeholder for the script path.
     // We explicitly use process.execPath to break the cycle and prevent
     // compounding argument duplication on subsequent relaunches.
-    finalSpawnArgs.push(process.execPath, ...scriptArgs);
+    const execPath = process.env['TERMUX_ORIGINAL_EXE_PATH'] || process.execPath;
+    finalSpawnArgs.push(execPath, ...scriptArgs);
   } else {
     // Standard Node mode: pass all flags via command line.
     finalSpawnArgs.push(

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -56,7 +56,8 @@ export async function relaunchAppInChildProcess(
     // The parent process should not be reading from stdin while the child is running.
     process.stdin.pause();
 
-    const child = spawn(process.execPath, spawnArgs, {
+    const execPath = process.env['TERMUX_ORIGINAL_EXE_PATH'] || process.execPath;
+    const child = spawn(execPath, spawnArgs, {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
       env: newEnv,
     });


### PR DESCRIPTION
This fixes the issue where termux-exec replaces the process.execPath with linker64, causing Node.js spawn to fail when arguments start with a dash. We now use TERMUX_ORIGINAL_EXE_PATH if available.