### PR TITLE
fix(security): prevent command injection in findCommand via safe spawnSync

### DIFF
--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -25,23 +25,37 @@ async function findCommand(
   command: string,
   platform: NodeJS.Platform = process.platform,
 ): Promise<string | null> {
-  // 1. Check PATH first.
+  // Security: Validate the command name to prevent injection attacks.
+  // Only allow alphanumeric characters, hyphens, underscores, dots, and path separators.
+  const safeCommandPattern = /^[a-zA-Z0-9.\-_/\\]+$/;
+  if (!safeCommandPattern.test(command)) {
+    return null;
+  }
+
+  // 1. Check PATH first using safe argument passing (no shell interpolation).
   try {
     if (platform === 'win32') {
       const result = child_process
-        .execSync(`where.exe ${command}`)
-        .toString()
-        .trim();
-      // `where.exe` can return multiple paths. Return the first one.
-      const firstPath = result.split(/\r?\n/)[0];
-      if (firstPath) {
-        return firstPath;
+        .spawnSync('where.exe', [command], {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          shell: false,
+        });
+      if (result.status === 0 && result.stdout) {
+        const firstPath = result.stdout.trim().split(/\r?\n/)[0];
+        if (firstPath) {
+          return firstPath;
+        }
       }
     } else {
-      child_process.execSync(`command -v ${command}`, {
-        stdio: 'ignore',
+      const result = child_process.spawnSync('which', [command], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: false,
       });
-      return command;
+      if (result.status === 0) {
+        return command;
+      }
     }
   } catch {
     // Not in PATH, continue to check common locations.

--- a/packages/core/src/ide/ide-installer.ts
+++ b/packages/core/src/ide/ide-installer.ts
@@ -44,7 +44,14 @@ async function findCommand(
       if (result.status === 0 && result.stdout) {
         const firstPath = result.stdout.trim().split(/\r?\n/)[0];
         if (firstPath) {
-          return firstPath;
+          // Sanitize: resolve to absolute path and reject null bytes
+          // to prevent path traversal or null byte injection from
+          // untrusted command output.
+          const resolved = path.resolve(firstPath);
+          if (resolved.includes('\0')) {
+            return null;
+          }
+          return resolved;
         }
       }
     } else {

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exec, execSync, spawn, spawnSync } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
 import { debugLogger } from './debugLogger.js';
 import { coreEvents, CoreEvent, type EditorSelectedPayload } from './events.js';
@@ -102,30 +101,39 @@ interface DiffCommand {
   args: string[];
 }
 
-const execAsync = promisify(exec);
-
-function getCommandExistsCmd(cmd: string): string {
-  return process.platform === 'win32'
-    ? `where.exe ${cmd}`
-    : `command -v ${cmd}`;
-}
-
 function commandExists(cmd: string): boolean {
   try {
-    execSync(getCommandExistsCmd(cmd), { stdio: 'ignore' });
-    return true;
+    // Security: Use spawnSync with argument arrays (shell: false) to prevent
+    // command injection via shell metacharacters in the cmd parameter.
+    if (process.platform === 'win32') {
+      const result = spawnSync('where.exe', [cmd], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: false,
+      });
+      return result.status === 0;
+    } else {
+      const result = spawnSync('which', [cmd], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: false,
+      });
+      return result.status === 0;
+    }
   } catch {
     return false;
   }
 }
 
 async function commandExistsAsync(cmd: string): Promise<boolean> {
-  try {
-    await execAsync(getCommandExistsCmd(cmd));
-    return true;
-  } catch {
-    return false;
-  }
+  return new Promise<boolean>((resolve) => {
+    // Security: Use spawn with argument arrays (shell: false) to prevent
+    // command injection via shell metacharacters in the cmd parameter.
+    const bin = process.platform === 'win32' ? 'where.exe' : 'which';
+    const child = spawn(bin, [cmd], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    child.on('close', (code) => resolve(code === 0));
+    child.on('error', () => resolve(false));
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Security fix: Replace shell-interpolated `execSync` calls with safe `spawnSync`/`spawn` to prevent command injection via shell metacharacters in **two files**:
- `packages/core/src/ide/ide-installer.ts` — `findCommand()`
- `packages/core/src/utils/editor.ts` — `commandExists()` and `commandExistsAsync()`

Fixes #27576

## Details

Both files construct shell commands via string interpolation with `execSync`:

```typescript
// ide-installer.ts (line 32, 41)
child_process.execSync(`where.exe ${command}`)
child_process.execSync(`command -v ${command}`)

// editor.ts (line 108-110, used at line 115 and 124)
function getCommandExistsCmd(cmd: string): string {
  return process.platform === 'win32'
    ? `where.exe ${cmd}`
    : `command -v ${cmd}`;
}
execSync(getCommandExistsCmd(cmd), { stdio: 'ignore' });
```

If the parameters contain shell metacharacters (`;`, `|`, `` ` ``, `$()`), these are interpreted by the shell, allowing arbitrary command execution.

**Fixes applied:**

### `ide-installer.ts`
1. Replace `execSync` with `spawnSync` using argument arrays (`shell: false`)
2. Add input validation regex (`/^[a-zA-Z0-9.\-_/\\]+$/`) as defense-in-depth
3. Use `which` instead of `command -v` (shell builtin incompatible with `spawnSync`)
4. Sanitize `where.exe` output with `path.resolve()` and null byte check

### `editor.ts`
1. Replace `execSync(getCommandExistsCmd(cmd))` with `spawnSync('where.exe'/'which', [cmd])`
2. Replace `execAsync(getCommandExistsCmd(cmd))` with `spawn('where.exe'/'which', [cmd])`
3. Remove `getCommandExistsCmd()` helper (no longer needed)
4. Remove unused `exec`, `execSync`, `promisify` imports

## Related Issues

Fixes #27576

## How to Validate

1. **Verify existing functionality**: Run `gemini-cli` — editor detection and IDE installation should work as before
2. **Verify injection is blocked**: `spawnSync`/`spawn` with `shell: false` prevents shell metacharacter interpretation
3. **Run unit tests**: `npm test` in `packages/core`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — None, behavior is identical for valid command names
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker
