### PR TITLE
docs(cli): clarify that /clear resets the conversation context

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -101,11 +101,15 @@ Slash commands provide meta-level control over the CLI itself.
 
 ### `/clear`
 
-- **Description:** Clear the terminal screen, including the visible session
-  history and scrollback within the CLI. The underlying session data (for
-  history recall) might be preserved depending on the exact implementation, but
-  the visual display is cleared.
-- **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
+- **Description:** Clear the terminal screen and start a new session. This
+  removes the visible session history and scrollback within the CLI and resets
+  the agent's conversation context, so the model no longer has access to the
+  previous conversation. Use it to start a fresh thread without context
+  pollution from earlier turns.
+- **Alias:** `/new`
+- **Keyboard shortcut:** Press **Ctrl+L** to clear the terminal screen. Unlike
+  `/clear`, this only clears the visible output and keeps the current
+  conversation context intact.
 
 ### `/commands`
 


### PR DESCRIPTION
## Summary

The `/clear` command reference only documented clearing the terminal screen. It did not mention that `/clear` (and its `/new` alias) also resets the agent's conversation context and starts a new session, so users were left unsure how to start a fresh thread without context pollution.

## Details

`clearCommand` (`packages/cli/src/ui/commands/clearCommand.ts`) calls `geminiClient.resetChat()` and `config.resetNewSessionState(...)`. These reset the conversation context the model sees and start a new session — not just the visible output.

In contrast, the **Ctrl+L** shortcut maps to `CLEAR_SCREEN` (`handleClearScreen`), which only clears the visible items (`historyManager.clearItems()`) and does **not** reset the conversation. The previous wording implied Ctrl+L was equivalent to `/clear`.

This PR updates `docs/reference/commands.md`:

- Clarifies that `/clear` clears the screen **and** resets the conversation context (fresh thread).
- Documents the `/new` alias.
- Notes that Ctrl+L only clears the visible screen and keeps the conversation context intact.

Documentation only; no code behavior changes.

## Related Issues

Fixes #19239

## How to Validate

- `npx prettier --check docs/reference/commands.md` → passes.
- Open `docs/reference/commands.md` at the `### /clear` section and confirm it now describes the context reset, the `/new` alias, and the Ctrl+L distinction.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) — N/A, documentation-only change
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (`prettier --check` on the changed file)