### PR TITLE
test(a2a-server): use vi.stubEnv() for env vars per GEMINI.md

### DIFF
--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InitCommand } from './init.js';
 import {
   performInit,
@@ -60,7 +60,7 @@ describe('InitCommand', () => {
   const mockWorkspacePath = path.resolve('/tmp');
 
   beforeEach(() => {
-    process.env['CODER_AGENT_WORKSPACE_PATH'] = mockWorkspacePath;
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', mockWorkspacePath);
     eventBus = {
       publish: vi.fn(),
     } as unknown as ExecutionEventBus;
@@ -78,6 +78,10 @@ describe('InitCommand', () => {
     mockExecute = vi.fn();
     vi.spyOn(mockExecutorInstance, 'execute').mockImplementation(mockExecute);
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('has requiresWorkspace set to true', () => {

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -131,6 +131,7 @@ describe('E2E Tests', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('should create a new task and stream status updates (text-content) via POST /', async () => {
@@ -1059,7 +1060,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockCommand);
 
-      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'test-command', args: [] });
@@ -1079,7 +1080,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
-      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });
@@ -1101,7 +1102,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
-      process.env['CODER_AGENT_WORKSPACE_PATH'] = '/tmp/test-workspace';
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '/tmp/test-workspace');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });


### PR DESCRIPTION
## Summary

Migrate the remaining direct `process.env` usage in the `a2a-server` tests to `vi.stubEnv()` / `vi.unstubAllEnvs()`, following the testing convention documented in `GEMINI.md`. Direct `process.env` mutation can leak state between tests. `config.test.ts` already follows the convention, so this completes the migration for the package.

## Details

From `GEMINI.md`:

> When testing code that depends on environment variables, use `vi.stubEnv('NAME', 'value')` in `beforeEach` and `vi.unstubAllEnvs()` in `afterEach`. Avoid modifying `process.env` directly as it can lead to test leakage and is less reliable. To "unset" a variable, use an empty string `vi.stubEnv('NAME', '')`.

Changes:

- `src/commands/init.test.ts`: stub `CODER_AGENT_WORKSPACE_PATH` in `beforeEach`, and add an `afterEach` that calls `vi.unstubAllEnvs()`.
- `src/http/app.test.ts`: replace the inline set/delete of `CODER_AGENT_WORKSPACE_PATH` with `vi.stubEnv()`; use an empty string when testing an unset value, matching `GEMINI.md`; and add `vi.unstubAllEnvs()` to the suite `afterEach`.

No production code changes.

## Related Issues

Fixes #19826

## How to Validate

From `packages/a2a-server`:

- `npx vitest run src/commands/init.test.ts src/http/app.test.ts` -> 25 tests pass (5 + 20).
- `npx prettier --check src/commands/init.test.ts src/http/app.test.ts` -> passes.
- `npx eslint src/commands/init.test.ts src/http/app.test.ts` -> no warnings/errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — N/A
- [x] Added/updated tests (if needed) — test-only change
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (vitest, prettier, eslint)