### PR TITLE
fix(cli): fall back for oversized bug report URLs

### DIFF
--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -14,6 +14,8 @@ import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatBytes } from '../utils/formatters.js';
 import { MessageType } from '../types.js';
 import { captureHeapSnapshot } from '../utils/memorySnapshot.js';
+import { mkdtempSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 
 const { memoryUsageMock } = vi.hoisted(() => ({
   memoryUsageMock: vi.fn(() => ({
@@ -32,11 +34,21 @@ vi.mock('../utils/memorySnapshot.js', () => ({
   captureHeapSnapshot: vi.fn(),
   MEMORY_SNAPSHOT_AUTO_THRESHOLD_BYTES: 2 * 1024 * 1024 * 1024,
 }));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    mkdtempSync: vi
+      .fn()
+      .mockImplementation((prefix: string) => `${prefix}secure`),
+  };
+});
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
   return {
     ...actual,
     stat: vi.fn().mockResolvedValue({ size: 4096 }),
+    writeFile: vi.fn().mockResolvedValue(undefined),
   };
 });
 vi.mock('../utils/historyExportUtils.js', async (importOriginal) => {
@@ -247,6 +259,59 @@ describe('bugCommand', () => {
       .replace('{info}', encodeURIComponent(expectedInfo));
 
     expect(open).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  it('writes oversized bug reports to a local markdown file before opening GitHub', async () => {
+    const longDescription = 'A'.repeat(9000);
+    const mockContext = createMockCommandContext({
+      services: {
+        agentContext: {
+          config: {
+            getModel: () => 'gemini-pro',
+            getBugCommand: () => undefined,
+            getIdeMode: () => false,
+            getContentGeneratorConfig: () => ({ authType: 'oauth-personal' }),
+            storage: {
+              getProjectTempDir: () => '/tmp/gemini',
+            },
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
+          } as unknown as Config,
+          geminiClient: {
+            getChat: () => ({
+              getHistory: () => [],
+            }),
+          },
+        },
+      },
+    });
+
+    if (!bugCommand.action) throw new Error('Action is not defined');
+    await bugCommand.action(mockContext, longDescription);
+
+    const expectedDir = path.join('/tmp/gemini', 'bug-report-secure');
+    const expectedPath = path.join(expectedDir, 'report.md');
+    expect(mkdtempSync).toHaveBeenCalledWith(
+      path.join('/tmp/gemini', 'bug-report-'),
+    );
+    expect(writeFile).toHaveBeenCalledWith(
+      expectedPath,
+      expect.stringContaining(longDescription),
+      'utf8',
+    );
+
+    const openedUrl = vi.mocked(open).mock.calls[0][0];
+    expect(openedUrl).toBe(
+      `https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title=${encodeURIComponent(`${'A'.repeat(117)}...`)}`,
+    );
+    expect(openedUrl.length).toBeLessThan(1000);
+    expect(openedUrl).not.toContain('&info=');
+    expect(openedUrl).not.toContain('&problem=');
+
+    const addItemCall = vi.mocked(mockContext.ui.addItem).mock.calls[0];
+    expect(addItemCall[0].text).toContain(expectedPath);
+    expect(addItemCall[0].text).toContain(
+      'The generated report was too large for a browser URL.',
+    );
   });
 
   const buildHighMemoryContext = (tempDir: string | undefined) =>

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -26,8 +26,15 @@ import {
   captureHeapSnapshot,
   MEMORY_SNAPSHOT_AUTO_THRESHOLD_BYTES,
 } from '../utils/memorySnapshot.js';
-import { stat } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import { stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+
+const DEFAULT_BUG_REPORT_URL_TEMPLATE =
+  'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}&problem={problem}';
+const SHORT_BUG_REPORT_URL_TEMPLATE =
+  'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}';
+const MAX_BUG_REPORT_URL_LENGTH = 8000;
 
 export const bugCommand: SlashCommand = {
   name: 'bug',
@@ -100,23 +107,57 @@ export const bugCommand: SlashCommand = {
       }
     }
 
-    let bugReportUrl =
-      'https://github.com/google-gemini/gemini-cli/issues/new?template=bug_report.yml&title={title}&info={info}&problem={problem}';
-
     const bugCommandSettings = config?.getBugCommand();
-    if (bugCommandSettings?.urlTemplate) {
-      bugReportUrl = bugCommandSettings.urlTemplate;
-    }
+    const bugReportUrlTemplate =
+      bugCommandSettings?.urlTemplate ?? DEFAULT_BUG_REPORT_URL_TEMPLATE;
+    let bugReportUrl = buildBugReportUrl(
+      bugReportUrlTemplate,
+      bugDescription,
+      info,
+      problemValue,
+    );
+    let longUrlFallbackMessage = '';
 
-    bugReportUrl = bugReportUrl
-      .replace('{title}', encodeURIComponent(bugDescription))
-      .replace('{info}', encodeURIComponent(info))
-      .replace('{problem}', encodeURIComponent(problemValue));
+    if (bugReportUrl.length > MAX_BUG_REPORT_URL_LENGTH) {
+      const tempDir = config?.storage?.getProjectTempDir();
+      if (tempDir) {
+        try {
+          const bugReportDir = mkdtempSync(path.join(tempDir, 'bug-report-'));
+          const bugReportFilePath = path.join(bugReportDir, 'report.md');
+          await writeFile(
+            bugReportFilePath,
+            formatBugReportFile(bugDescription, info, problemValue),
+            'utf8',
+          );
+          const fallbackProblem = `The full bug report was too large to place in a browser URL. It was saved locally at:\n${bugReportFilePath}\n\nPlease paste the file contents into this issue before submitting.`;
+          const fallbackTitle = shortenBugTitle(bugDescription);
+          bugReportUrl = bugCommandSettings?.urlTemplate
+            ? buildBugReportUrl(
+                bugReportUrlTemplate,
+                fallbackTitle,
+                '',
+                fallbackProblem,
+              )
+            : buildBugReportUrl(
+                SHORT_BUG_REPORT_URL_TEMPLATE,
+                fallbackTitle,
+                '',
+                '',
+              );
+          longUrlFallbackMessage = `\n\n--------------------------------------------------------------------------------\n\nFull bug report saved to:\n${bugReportFilePath}\n\nThe generated report was too large for a browser URL. Paste the saved markdown into the GitHub issue before submitting.`;
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          debugLogger.error(
+            `Failed to write oversized bug report: ${errorMessage}`,
+          );
+        }
+      }
+    }
 
     context.ui.addItem(
       {
         type: MessageType.INFO,
-        text: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}${historyFileMessage}`,
+        text: `To submit your bug report, please open the following URL in your browser:\n${bugReportUrl}${historyFileMessage}${longUrlFallbackMessage}`,
       },
       Date.now(),
     );
@@ -191,4 +232,37 @@ async function getIdeClientName(context: CommandContext) {
   }
   const ideClient = await IdeClient.getInstance();
   return ideClient.getDetectedIdeDisplayName() ?? '';
+}
+
+function buildBugReportUrl(
+  template: string,
+  title: string,
+  info: string,
+  problem: string,
+) {
+  return template
+    .replace('{title}', encodeURIComponent(title))
+    .replace('{info}', encodeURIComponent(info))
+    .replace('{problem}', encodeURIComponent(problem));
+}
+
+function formatBugReportFile(title: string, info: string, problem: string) {
+  return `# ${title || 'Bug report'}
+
+## Client information
+
+${info.trim()}
+
+## Problem
+
+${problem || '_No description provided._'}
+`;
+}
+
+function shortenBugTitle(title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) {
+    return 'Bug report';
+  }
+  return trimmed.length > 120 ? `${trimmed.slice(0, 117)}...` : trimmed;
 }


### PR DESCRIPTION
﻿## Summary

Fix `/bug` for oversized GitHub issue URLs.

The command currently encodes the title, client info, and full problem description into a single issue-template URL. On Android/Termux, that can exceed the deep-link/intent limit and crash or fail before the user can submit the report.

This keeps the normal short-report path unchanged, but when the generated URL is too large it writes the full report to a local markdown file and opens a short GitHub issue URL instead.

## Changes

- move bug report URL construction into a small helper
- add an oversized-URL fallback that writes `bug-report-<timestamp>.md` under the project temp dir
- truncate only the issue title in the fallback URL; the full title/problem/info stay in the markdown file
- add regression coverage for the oversized-report path

## To verify

```bash
npm run generate
npm run build --workspace @google/gemini-cli-core
npm run build --workspace @google/gemini-cli-devtools
npm run test --workspace @google/gemini-cli -- src/ui/commands/bugCommand.test.ts
npm run typecheck --workspace @google/gemini-cli
npx eslint packages/cli/src/ui/commands/bugCommand.ts packages/cli/src/ui/commands/bugCommand.test.ts --max-warnings 0
npx prettier --check packages/cli/src/ui/commands/bugCommand.ts packages/cli/src/ui/commands/bugCommand.test.ts
git diff --check
```

Fixes #27590
