### PR TITLE
fix(core): add platform-aware shell guidance

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -147,6 +147,11 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -341,6 +346,11 @@ An approved plan is available for this task at \`../plans/feature-x.md\`.
 - **New Plan:** Only create a new plan file if the user explicitly asks for a "new plan".
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -650,6 +660,11 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -823,6 +838,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -982,6 +1002,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -1123,6 +1148,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 4. **Verify:** Review work against the original request. Fix bugs and deviations. **Build the application and ensure there are no compile errors.**
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -1808,6 +1838,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -1980,6 +2015,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -2158,6 +2198,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2335,6 +2380,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2508,6 +2558,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2675,6 +2730,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -2815,6 +2875,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 3. **Implementation:** Once the plan is approved, follow the standard **Execution** cycle to build the application, utilizing platform-native primitives to realize the rich aesthetic you planned.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -2988,6 +3053,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -3306,6 +3376,11 @@ You are operating with a persistent file-based task tracking system located at \
 9.  **TURN EFFICIENCY**: Update the tracker immediately when a step is completed. Combine \`tracker_update_task\` calls with other tool calls in the same turn to save turns.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -3733,6 +3808,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -3905,6 +3985,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 
@@ -4197,6 +4282,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 
 # Operational Guidelines
 
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -4369,6 +4459,11 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 5. **Solicit Feedback:** Provide instructions on how to start the application and request user feedback on the prototype.
 
 # Operational Guidelines
+
+## Shell tool usage
+
+- The host platform is Unix-like (linux). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection using commands like 'grep', 'tail', 'head'.
 
 ## Tone and Style
 

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -673,6 +673,21 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     });
 
+    it('should include Windows host platform guidance for preview models on win32', () => {
+      mockPlatform('win32');
+      vi.mocked(mockConfig.getActiveModel).mockReturnValue(
+        PREVIEW_GEMINI_MODEL,
+      );
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).toContain('The host platform is Windows (win32)');
+      expect(prompt).toContain(
+        "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)",
+      );
+      expect(prompt).not.toContain(
+        "using commands like 'grep', 'tail', 'head'",
+      );
+    });
+
     it('should include generic shell efficiency commands on non-Windows', () => {
       mockPlatform('linux');
       vi.mocked(mockConfig.getActiveModel).mockReturnValue(

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -681,7 +681,7 @@ describe('Core System Prompt (prompts.ts)', () => {
       const prompt = getCoreSystemPrompt(mockConfig);
       expect(prompt).toContain('The host platform is Windows (win32)');
       expect(prompt).toContain(
-        "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)",
+        "using commands like 'findstr' (on CMD) and 'Get-Content -Tail' or 'Select-String' (on PowerShell)",
       );
       expect(prompt).not.toContain(
         "using commands like 'grep', 'tail', 'head'",

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -434,7 +434,7 @@ function shellEfficiencyGuidelines(enabled: boolean): string {
   const isWindows = process.platform === 'win32';
   const platformName = isWindows ? 'Windows' : 'Unix-like';
   const inspectExample = isWindows
-    ? "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)"
+    ? "using commands like 'findstr' (on CMD) and 'Get-Content -Tail' or 'Select-String' (on PowerShell)"
     : "using commands like 'grep', 'tail', 'head'";
   return `
 ## Shell tool usage

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -83,6 +83,7 @@ export interface PrimaryWorkflowsOptions {
 export interface OperationalGuidelinesOptions {
   interactive: boolean;
   interactiveShellEnabled: boolean;
+  enableShellEfficiency?: boolean;
   topicUpdateNarration: boolean;
   /**
    * Absolute path to the user's per-project private memory index
@@ -387,6 +388,8 @@ export function renderOperationalGuidelines(
   return `
 # Operational Guidelines
 
+${shellEfficiencyGuidelines(options.enableShellEfficiency ?? false)}
+
 ## Tone and Style
 
 - **Role:** A senior software engineer and collaborative peer programmer.
@@ -424,6 +427,20 @@ export function renderOperationalGuidelines(
 - **Help Command:** The user can use '/help' to display help information.
 - **Feedback:** To report a bug or provide feedback, please use the /bug command.
 `.trim();
+}
+
+function shellEfficiencyGuidelines(enabled: boolean): string {
+  if (!enabled) return '';
+  const isWindows = process.platform === 'win32';
+  const platformName = isWindows ? 'Windows' : 'Unix-like';
+  const inspectExample = isWindows
+    ? "using commands like 'type' or 'findstr' (on CMD) and 'Get-Content' or 'Select-String' (on PowerShell)"
+    : "using commands like 'grep', 'tail', 'head'";
+  return `
+## Shell tool usage
+
+- The host platform is ${platformName} (${process.platform}). Use commands and path conventions compatible with this platform.
+- When inspecting large command output, prefer targeted inspection ${inspectExample}.`;
 }
 
 export function renderSandbox(options?: SandboxOptions): string {


### PR DESCRIPTION
## Summary
- add platform-aware shell usage guidance to the preview-model operational prompt
- call out Windows-specific inspection commands instead of Unix-only examples on `win32`
- cover the Windows prompt snippet in the core prompt test

Fixes #27751

## Test plan
- `npm test --workspace @google/gemini-cli-core -- prompts.test.ts`
