### PR TITLE
Use consolidated MCP server lists in the ACP and policy-engine paths

### DIFF
--- a/packages/cli/src/acp/acpSessionManager.ts
+++ b/packages/cli/src/acp/acpSessionManager.ts
@@ -330,7 +330,15 @@ export class AcpSessionManager {
       mcpServers: mergedMcpServers,
     };
 
-    const config = await loadCliConfig(settings, sessionId, this.argv, { cwd });
+    const config = await loadCliConfig(settings, sessionId, this.argv, {
+      cwd,
+      // Pass the LoadedSettings so loadCliConfig uses the consolidated (union
+      // of excluded / intersection of allowed) MCP server lists across all
+      // settings scopes, matching the interactive path. Without this, the ACP
+      // path fell back to the raw merged settings, where a workspace
+      // mcp.excluded could REPLACE (drop) a user-level block.
+      loadedSettings: currentSettings,
+    });
 
     createPolicyUpdater(
       config.getPolicyEngine(),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -814,7 +814,17 @@ export async function loadCliConfig(
     },
     mcp: {
       ...settings.mcp,
-      allowed: argv.allowedMcpServerNames ?? settings.mcp?.allowed,
+      // Use the consolidated MCP lists (union of excluded across all scopes,
+      // intersection of allowed) for the policy engine, so a workspace-scoped
+      // mcp.excluded cannot drop a user/system block via REPLACE merge.
+      allowed:
+        argv.allowedMcpServerNames ??
+        (loadedSettings
+          ? loadedSettings.getConsolidatedAllowedMcpServers()
+          : settings.mcp?.allowed),
+      excluded: loadedSettings
+        ? loadedSettings.getConsolidatedExcludedMcpServers()
+        : settings.mcp?.excluded,
     },
     policyPaths: (argv.policy ?? settings.policyPaths)?.map((p) =>
       resolvePath(p),


### PR DESCRIPTION
## Summary

#27377 fixed an MCP allow/block list bypass by adding `getConsolidatedExcludedMcpServers()` / `getConsolidatedAllowedMcpServers()` (which union `mcp.excluded` and intersect `mcp.allowed` across all settings scopes, so a workspace-scoped setting cannot drop a user/system entry via the default REPLACE merge). Those were wired into the interactive `loadCliConfig` path and `mcp list`.

Two call paths still read the raw, workspace-overridable `mcp.excluded` / `mcp.allowed`:

1. **ACP path** — `acpSessionManager` called `loadCliConfig(..., { cwd })` without `loadedSettings`, so `loadCliConfig` fell back to `settings.mcp?.excluded` / `settings.mcp?.allowed` (raw merged, REPLACE). A workspace `.gemini/settings.json` with `mcp.excluded: []` therefore dropped a user-level block when running under ACP (e.g. in an editor), allowing an MCP server the user had blocked to connect.
2. **Policy engine** — `effectiveSettings.mcp` (passed to `createPolicyEngineConfig`) used raw `settings.mcp?.allowed` and inherited raw `settings.mcp?.excluded`, so the generated DENY/ALLOW policy rules were also workspace-overridable.

## Change

- `acpSessionManager` now passes `loadedSettings: currentSettings` to `loadCliConfig`, matching the interactive path, so `blockedMcpServers` / `allowedMcpServers` use the consolidated lists.
- `effectiveSettings.mcp` now uses `getConsolidatedAllowedMcpServers()` / `getConsolidatedExcludedMcpServers()` when `loadedSettings` is available, so the policy engine's MCP rules use the consolidated lists too.

This makes system- and user-scoped MCP blocks consistent across the interactive, ACP, and policy-engine paths.
