### PR TITLE
feat: add support for Gemini 3.5 Flash model family

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -89,6 +89,18 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         model: 'gemini-3.1-flash-lite-preview',
       },
     },
+    'gemini-3.5-flash-preview': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.5-flash-preview',
+      },
+    },
+    'gemini-3.5-flash-lite-preview': {
+      extends: 'chat-base-3',
+      modelConfig: {
+        model: 'gemini-3.5-flash-lite-preview',
+      },
+    },
     'gemini-2.5-pro': {
       extends: 'chat-base-2.5',
       modelConfig: {
@@ -318,6 +330,20 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
       isVisible: true,
       features: { thinking: false, multimodalToolUse: true },
     },
+    'gemini-3.5-flash-preview': {
+      tier: 'flash',
+      family: 'gemini-3.5',
+      isPreview: true,
+      isVisible: true,
+      features: { thinking: false, multimodalToolUse: true },
+    },
+    'gemini-3.5-flash-lite-preview': {
+      tier: 'flash-lite',
+      family: 'gemini-3.5',
+      isPreview: true,
+      isVisible: true,
+      features: { thinking: false, multimodalToolUse: true },
+    },
     'gemini-3.1-pro-preview': {
       tier: 'pro',
       family: 'gemini-3',
@@ -501,9 +527,31 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     'gemini-3.1-flash-lite': {
       default: 'gemini-3.1-flash-lite',
     },
+    'gemini-3.5-flash-preview': {
+      default: 'gemini-3.5-flash-preview',
+      contexts: [
+        {
+          condition: { hasAccessToPreview: false },
+          target: 'gemini-2.5-flash',
+        },
+      ],
+    },
+    'gemini-3.5-flash-lite-preview': {
+      default: 'gemini-3.5-flash-lite-preview',
+      contexts: [
+        {
+          condition: { hasAccessToPreview: false },
+          target: 'gemini-3.1-flash-lite',
+        },
+      ],
+    },
     flash: {
       default: 'gemini-3-flash-preview',
       contexts: [
+        {
+          condition: { useGemini3_5: true },
+          target: 'gemini-3.5-flash-preview',
+        },
         {
           condition: { hasAccessToPreview: false },
           target: 'gemini-2.5-flash',
@@ -512,6 +560,12 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     },
     'flash-lite': {
       default: 'gemini-3.1-flash-lite',
+      contexts: [
+        {
+          condition: { useGemini3_5FlashLite: true },
+          target: 'gemini-3.5-flash-lite-preview',
+        },
+      ],
     },
     'auto-gemini-3': {
       default: 'gemini-3-pro-preview',
@@ -535,6 +589,10 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     flash: {
       default: 'gemini-3-flash-preview',
       contexts: [
+        {
+          condition: { useGemini3_5: true },
+          target: 'gemini-3.5-flash-preview',
+        },
         {
           condition: { hasAccessToPreview: false },
           target: 'gemini-2.5-flash',

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -220,6 +220,12 @@ describe('Dynamic Configuration Parity', () => {
   it('isGemini3Model should return true for Gemini 3.5 models', () => {
     expect(isGemini3Model('gemini-3.5-flash-preview')).toBe(true);
     expect(isGemini3Model('gemini-3.5-flash-lite-preview')).toBe(true);
+    expect(isGemini3Model('gemini-3.5-flash-preview', dynamicConfig)).toBe(
+      true,
+    );
+    expect(isGemini3Model('gemini-3.5-flash-lite-preview', dynamicConfig)).toBe(
+      true,
+    );
   });
 
   it('isCustomModel should match legacy behavior', () => {

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -199,6 +199,29 @@ describe('Dynamic Configuration Parity', () => {
     }
   });
 
+  it('should resolve Gemini 3.5 models correctly', () => {
+    const flash35 = resolveModel('gemini-3.5-flash-preview', false, false, true, dynamicConfig);
+    expect(flash35).toBe('gemini-3.5-flash-preview');
+
+    const flashLite35 = resolveModel('gemini-3.5-flash-lite-preview', false, false, true, dynamicConfig);
+    expect(flashLite35).toBe('gemini-3.5-flash-lite-preview');
+  });
+
+  it('should resolve flash to 3.5 when useGemini3_5 is true', () => {
+    const resolved = modelConfigService.resolveModelId('flash', { useGemini3_5: true });
+    expect(resolved).toBe('gemini-3.5-flash-preview');
+  });
+
+  it('should resolve flash-lite to 3.5 when useGemini3_5FlashLite is true', () => {
+    const resolved = modelConfigService.resolveModelId('flash-lite', { useGemini3_5FlashLite: true });
+    expect(resolved).toBe('gemini-3.5-flash-lite-preview');
+  });
+
+  it('isGemini3Model should return true for Gemini 3.5 models', () => {
+    expect(isGemini3Model('gemini-3.5-flash-preview')).toBe(true);
+    expect(isGemini3Model('gemini-3.5-flash-lite-preview')).toBe(true);
+  });
+
   it('isCustomModel should match legacy behavior', () => {
     for (const model of modelsToTest) {
       const legacy = isCustomModel(model, legacyConfig);

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -385,8 +385,9 @@ export function isGemini3Model(
     // Legacy behavior resolves the model first.
     const resolved = resolveModel(model, false, false, true, config);
     return (
-      config.modelConfigService.getModelDefinition(resolved)?.family ===
-      'gemini-3'
+      config.modelConfigService
+        .getModelDefinition(resolved)
+        ?.family?.startsWith('gemini-3') ?? false
     );
   }
 

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -55,6 +55,9 @@ export const PREVIEW_GEMINI_3_1_MODEL = 'gemini-3.1-pro-preview';
 export const PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL =
   'gemini-3.1-pro-preview-customtools';
 export const PREVIEW_GEMINI_FLASH_MODEL = 'gemini-3-flash-preview';
+export const PREVIEW_GEMINI_3_5_FLASH_MODEL = 'gemini-3.5-flash-preview';
+export const PREVIEW_GEMINI_3_5_FLASH_LITE_MODEL =
+  'gemini-3.5-flash-lite-preview';
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-3.1-flash-lite';
@@ -69,6 +72,8 @@ export const VALID_GEMINI_MODELS = new Set([
   PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_3_1_CUSTOM_TOOLS_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
+  PREVIEW_GEMINI_3_5_FLASH_MODEL,
+  PREVIEW_GEMINI_3_5_FLASH_LITE_MODEL,
   PREVIEW_GEMINI_FLASH_LITE_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
@@ -473,7 +478,7 @@ export function supportsMultimodalFunctionResponse(
         ?.multimodalToolUse === true
     );
   }
-  return model.startsWith('gemini-3-');
+  return /^gemini-3(\.|-)/.test(model);
 }
 
 /**

--- a/packages/core/src/context/chatCompressionService.ts
+++ b/packages/core/src/context/chatCompressionService.ts
@@ -29,6 +29,8 @@ import {
   DEFAULT_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
+  PREVIEW_GEMINI_3_5_FLASH_MODEL,
+  PREVIEW_GEMINI_3_5_FLASH_LITE_MODEL,
   PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_FLASH_LITE_MODEL,
 } from '../config/models.js';
@@ -105,7 +107,9 @@ export function modelStringToModelConfigAlias(model: string): string {
     case PREVIEW_GEMINI_3_1_MODEL:
       return 'chat-compression-3-pro';
     case PREVIEW_GEMINI_FLASH_MODEL:
+    case PREVIEW_GEMINI_3_5_FLASH_MODEL:
       return 'chat-compression-3-flash';
+    case PREVIEW_GEMINI_3_5_FLASH_LITE_MODEL:
     case PREVIEW_GEMINI_FLASH_LITE_MODEL:
     // fallthrough
     case DEFAULT_GEMINI_FLASH_LITE_MODEL:

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -97,6 +97,8 @@ export interface ModelResolution {
 export interface ResolutionContext {
   useGemini3_1?: boolean;
   useGemini3_1FlashLite?: boolean;
+  useGemini3_5?: boolean;
+  useGemini3_5FlashLite?: boolean;
   useCustomTools?: boolean;
   hasAccessToPreview?: boolean;
   hasAccessToProModel?: boolean;
@@ -107,6 +109,8 @@ export interface ResolutionContext {
 export interface ResolutionCondition {
   useGemini3_1?: boolean;
   useGemini3_1FlashLite?: boolean;
+  useGemini3_5?: boolean;
+  useGemini3_5FlashLite?: boolean;
   useCustomTools?: boolean;
   hasAccessToPreview?: boolean;
   /** Matches if the current model is in this list. */
@@ -250,6 +254,10 @@ export class ModelConfigService {
           return value === context.useGemini3_1;
         case 'useGemini3_1FlashLite':
           return value === context.useGemini3_1FlashLite;
+        case 'useGemini3_5':
+          return value === context.useGemini3_5;
+        case 'useGemini3_5FlashLite':
+          return value === context.useGemini3_5FlashLite;
         case 'useCustomTools':
           return value === context.useCustomTools;
         case 'hasAccessToPreview':


### PR DESCRIPTION
This PR adds support for the Gemini 3.5 Flash model family, including `gemini-3.5-flash-preview` and `gemini-3.5-flash-lite-preview`. 

Key changes:
- Added constants for Gemini 3.5 models in `models.ts`.
- Updated model configurations and resolutions in `defaultModelConfigs.ts`.
- Added flags `useGemini3_5` and `useGemini3_5FlashLite` to `ModelConfigService`.
- Updated `chatCompressionService` to handle the new models.
- Added comprehensive unit tests in `models.test.ts`.

With Google ending support for this project on June 18th, 2026, this update ensures the CLI remains functional with the latest model offerings.