### PR TITLE
fix(core): block private OAuth metadata URLs

### DIFF
--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -10,6 +10,12 @@ import {
   type OAuthAuthorizationServerMetadata,
   type OAuthProtectedResourceMetadata,
 } from './oauth-utils.js';
+import { isLoopbackHost, isPrivateIpAsync } from '../utils/fetch.js';
+
+vi.mock('../utils/fetch.js', () => ({
+  isLoopbackHost: vi.fn().mockReturnValue(false),
+  isPrivateIpAsync: vi.fn().mockResolvedValue(false),
+}));
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -17,7 +23,11 @@ global.fetch = mockFetch;
 
 describe('OAuthUtils', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.mocked(isLoopbackHost).mockReset();
+    vi.mocked(isLoopbackHost).mockReturnValue(false);
+    vi.mocked(isPrivateIpAsync).mockReset();
+    vi.mocked(isPrivateIpAsync).mockResolvedValue(false);
     vi.spyOn(console, 'debug').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -115,6 +125,29 @@ describe('OAuthUtils', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should not fetch protected resource metadata from a private IP', async () => {
+      vi.mocked(isPrivateIpAsync).mockResolvedValueOnce(true);
+
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(
+        'http://169.254.169.254/.well-known/oauth-protected-resource',
+      );
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch protected resource metadata from loopback', async () => {
+      vi.mocked(isLoopbackHost).mockReturnValueOnce(true);
+
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(
+        'http://127.0.0.1/.well-known/oauth-protected-resource',
+      );
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(isPrivateIpAsync).not.toHaveBeenCalled();
+    });
   });
 
   describe('fetchAuthorizationServerMetadata', () => {
@@ -148,6 +181,29 @@ describe('OAuthUtils', () => {
       );
 
       expect(result).toBeNull();
+    });
+
+    it('should not fetch authorization server metadata from a private IP', async () => {
+      vi.mocked(isPrivateIpAsync).mockResolvedValueOnce(true);
+
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
+        'http://169.254.169.254/.well-known/oauth-authorization-server',
+      );
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should not fetch authorization server metadata from loopback', async () => {
+      vi.mocked(isLoopbackHost).mockReturnValueOnce(true);
+
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
+        'http://localhost/.well-known/oauth-authorization-server',
+      );
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(isPrivateIpAsync).not.toHaveBeenCalled();
     });
   });
 
@@ -299,6 +355,38 @@ describe('OAuthUtils', () => {
         tokenUrl: 'https://auth.example.com/token',
         scopes: ['read', 'write'],
       });
+    });
+
+    it('should not fetch attacker-supplied private authorization server metadata', async () => {
+      vi.mocked(isPrivateIpAsync).mockImplementation(async (url) =>
+        url.includes('169.254.169.254'),
+      );
+
+      mockFetch
+        // fetchProtectedResourceMetadata
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              resource: 'https://attacker.example.com',
+              authorization_servers: ['http://169.254.169.254/'],
+              bearer_methods_supported: ['header'],
+            }),
+        })
+        // Fallback discovery against the original public server URL.
+        .mockResolvedValue({
+          ok: false,
+        });
+
+      const result = await OAuthUtils.discoverOAuthConfig(
+        'https://attacker.example.com',
+      );
+
+      const fetchedUrls = mockFetch.mock.calls.map(([url]) => String(url));
+      expect(result).toBeNull();
+      expect(
+        fetchedUrls.some((url) => url.includes('169.254.169.254')),
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -10,24 +10,19 @@ import {
   type OAuthAuthorizationServerMetadata,
   type OAuthProtectedResourceMetadata,
 } from './oauth-utils.js';
-import { isLoopbackHost, isPrivateIpAsync } from '../utils/fetch.js';
+import { fetchWithPrivateIpBlock } from '../utils/fetch.js';
 
 vi.mock('../utils/fetch.js', () => ({
-  isLoopbackHost: vi.fn().mockReturnValue(false),
-  isPrivateIpAsync: vi.fn().mockResolvedValue(false),
+  fetchWithPrivateIpBlock: vi.fn(),
 }));
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
-
 describe('OAuthUtils', () => {
+  const mockFetchWithPrivateIpBlock = vi.mocked(
+    fetchWithPrivateIpBlock,
+  ) as unknown as ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
-    mockFetch.mockReset();
-    vi.mocked(isLoopbackHost).mockReset();
-    vi.mocked(isLoopbackHost).mockReturnValue(false);
-    vi.mocked(isPrivateIpAsync).mockReset();
-    vi.mocked(isPrivateIpAsync).mockResolvedValue(false);
+    mockFetchWithPrivateIpBlock.mockReset();
     vi.spyOn(console, 'debug').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -102,7 +97,7 @@ describe('OAuthUtils', () => {
     };
 
     it('should fetch protected resource metadata successfully', async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockFetchWithPrivateIpBlock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResourceMetadata),
       });
@@ -115,7 +110,7 @@ describe('OAuthUtils', () => {
     });
 
     it('should return null when fetch fails', async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockFetchWithPrivateIpBlock.mockResolvedValueOnce({
         ok: false,
       });
 
@@ -126,27 +121,28 @@ describe('OAuthUtils', () => {
       expect(result).toBeNull();
     });
 
-    it('should not fetch protected resource metadata from a private IP', async () => {
-      vi.mocked(isPrivateIpAsync).mockResolvedValueOnce(true);
-
-      const result = await OAuthUtils.fetchProtectedResourceMetadata(
-        'http://169.254.169.254/.well-known/oauth-protected-resource',
+    it('should return null when protected resource metadata is blocked by the safe fetch helper', async () => {
+      const url = 'http://169.254.169.254/.well-known/oauth-protected-resource';
+      mockFetchWithPrivateIpBlock.mockRejectedValueOnce(
+        new Error('Access to private network is blocked'),
       );
 
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(url);
+
       expect(result).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockFetchWithPrivateIpBlock).toHaveBeenCalledWith(url);
     });
 
-    it('should not fetch protected resource metadata from loopback', async () => {
-      vi.mocked(isLoopbackHost).mockReturnValueOnce(true);
-
-      const result = await OAuthUtils.fetchProtectedResourceMetadata(
-        'http://127.0.0.1/.well-known/oauth-protected-resource',
+    it('should return null when protected resource metadata loopback is blocked by the safe fetch helper', async () => {
+      const url = 'http://127.0.0.1/.well-known/oauth-protected-resource';
+      mockFetchWithPrivateIpBlock.mockRejectedValueOnce(
+        new Error('Access to private network is blocked'),
       );
 
+      const result = await OAuthUtils.fetchProtectedResourceMetadata(url);
+
       expect(result).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(isPrivateIpAsync).not.toHaveBeenCalled();
+      expect(mockFetchWithPrivateIpBlock).toHaveBeenCalledWith(url);
     });
   });
 
@@ -159,7 +155,7 @@ describe('OAuthUtils', () => {
     };
 
     it('should fetch authorization server metadata successfully', async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockFetchWithPrivateIpBlock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockAuthServerMetadata),
       });
@@ -172,7 +168,7 @@ describe('OAuthUtils', () => {
     });
 
     it('should return null when fetch fails', async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockFetchWithPrivateIpBlock.mockResolvedValueOnce({
         ok: false,
       });
 
@@ -183,27 +179,29 @@ describe('OAuthUtils', () => {
       expect(result).toBeNull();
     });
 
-    it('should not fetch authorization server metadata from a private IP', async () => {
-      vi.mocked(isPrivateIpAsync).mockResolvedValueOnce(true);
-
-      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
-        'http://169.254.169.254/.well-known/oauth-authorization-server',
+    it('should return null when authorization server metadata is blocked by the safe fetch helper', async () => {
+      const url =
+        'http://169.254.169.254/.well-known/oauth-authorization-server';
+      mockFetchWithPrivateIpBlock.mockRejectedValueOnce(
+        new Error('Access to private network is blocked'),
       );
 
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(url);
+
       expect(result).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockFetchWithPrivateIpBlock).toHaveBeenCalledWith(url);
     });
 
-    it('should not fetch authorization server metadata from loopback', async () => {
-      vi.mocked(isLoopbackHost).mockReturnValueOnce(true);
-
-      const result = await OAuthUtils.fetchAuthorizationServerMetadata(
-        'http://localhost/.well-known/oauth-authorization-server',
+    it('should return null when authorization server metadata loopback is blocked by the safe fetch helper', async () => {
+      const url = 'http://localhost/.well-known/oauth-authorization-server';
+      mockFetchWithPrivateIpBlock.mockRejectedValueOnce(
+        new Error('Access to private network is blocked'),
       );
 
+      const result = await OAuthUtils.fetchAuthorizationServerMetadata(url);
+
       expect(result).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(isPrivateIpAsync).not.toHaveBeenCalled();
+      expect(mockFetchWithPrivateIpBlock).toHaveBeenCalledWith(url);
     });
   });
 
@@ -216,7 +214,7 @@ describe('OAuthUtils', () => {
     };
 
     it('should handle URLs without path components correctly', async () => {
-      mockFetch
+      mockFetchWithPrivateIpBlock
         .mockResolvedValueOnce({
           ok: false,
         })
@@ -231,18 +229,18 @@ describe('OAuthUtils', () => {
 
       expect(result).toEqual(mockAuthServerMetadata);
 
-      expect(mockFetch).nthCalledWith(
+      expect(mockFetchWithPrivateIpBlock).nthCalledWith(
         1,
         'https://auth.example.com/.well-known/oauth-authorization-server',
       );
-      expect(mockFetch).nthCalledWith(
+      expect(mockFetchWithPrivateIpBlock).nthCalledWith(
         2,
         'https://auth.example.com/.well-known/openid-configuration',
       );
     });
 
     it('should handle URLs with path components correctly', async () => {
-      mockFetch
+      mockFetchWithPrivateIpBlock
         .mockResolvedValueOnce({
           ok: false,
         })
@@ -260,15 +258,15 @@ describe('OAuthUtils', () => {
 
       expect(result).toEqual(mockAuthServerMetadata);
 
-      expect(mockFetch).nthCalledWith(
+      expect(mockFetchWithPrivateIpBlock).nthCalledWith(
         1,
         'https://auth.example.com/.well-known/oauth-authorization-server/mcp',
       );
-      expect(mockFetch).nthCalledWith(
+      expect(mockFetchWithPrivateIpBlock).nthCalledWith(
         2,
         'https://auth.example.com/.well-known/openid-configuration/mcp',
       );
-      expect(mockFetch).nthCalledWith(
+      expect(mockFetchWithPrivateIpBlock).nthCalledWith(
         3,
         'https://auth.example.com/mcp/.well-known/openid-configuration',
       );
@@ -290,7 +288,7 @@ describe('OAuthUtils', () => {
     };
 
     it('should succeed when resource metadata matches server URL', async () => {
-      mockFetch
+      mockFetchWithPrivateIpBlock
         // fetchProtectedResourceMetadata
         .mockResolvedValueOnce({
           ok: true,
@@ -315,7 +313,7 @@ describe('OAuthUtils', () => {
     });
 
     it('should throw error when resource metadata does not match server URL', async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockFetchWithPrivateIpBlock.mockResolvedValueOnce({
         ok: true,
         json: () =>
           Promise.resolve({
@@ -330,7 +328,7 @@ describe('OAuthUtils', () => {
     });
 
     it('should accept equivalent root resources with and without trailing slash', async () => {
-      mockFetch
+      mockFetchWithPrivateIpBlock
         // fetchProtectedResourceMetadata
         .mockResolvedValueOnce({
           ok: true,
@@ -357,12 +355,8 @@ describe('OAuthUtils', () => {
       });
     });
 
-    it('should not fetch attacker-supplied private authorization server metadata', async () => {
-      vi.mocked(isPrivateIpAsync).mockImplementation(async (url) =>
-        url.includes('169.254.169.254'),
-      );
-
-      mockFetch
+    it('should return null when attacker-supplied private authorization server metadata is blocked', async () => {
+      mockFetchWithPrivateIpBlock
         // fetchProtectedResourceMetadata
         .mockResolvedValueOnce({
           ok: true,
@@ -373,6 +367,10 @@ describe('OAuthUtils', () => {
               bearer_methods_supported: ['header'],
             }),
         })
+        // discoverAuthorizationServerMetadata for attacker-supplied private URL.
+        .mockRejectedValueOnce(
+          new Error('Access to private network is blocked'),
+        )
         // Fallback discovery against the original public server URL.
         .mockResolvedValue({
           ok: false,
@@ -382,11 +380,10 @@ describe('OAuthUtils', () => {
         'https://attacker.example.com',
       );
 
-      const fetchedUrls = mockFetch.mock.calls.map(([url]) => String(url));
       expect(result).toBeNull();
-      expect(
-        fetchedUrls.some((url) => url.includes('169.254.169.254')),
-      ).toBe(false);
+      expect(mockFetchWithPrivateIpBlock).toHaveBeenCalledWith(
+        'http://169.254.169.254/.well-known/oauth-authorization-server',
+      );
     });
   });
 
@@ -461,7 +458,7 @@ describe('OAuthUtils', () => {
     };
 
     it('should accept equivalent root resources with and without trailing slash', async () => {
-      mockFetch
+      mockFetchWithPrivateIpBlock
         // fetchProtectedResourceMetadata(resource_metadata URL)
         .mockResolvedValueOnce({
           ok: true,

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -7,7 +7,7 @@
 import type { MCPOAuthConfig } from './oauth-provider.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { isLoopbackHost, isPrivateIpAsync } from '../utils/fetch.js';
+import { fetchWithPrivateIpBlock } from '../utils/fetch.js';
 
 /**
  * Error thrown when the discovered resource metadata does not match the expected resource.
@@ -55,11 +55,6 @@ export const FIVE_MIN_BUFFER_MS = 5 * 60 * 1000;
  * Utility class for common OAuth operations.
  */
 export class OAuthUtils {
-  private static async isPrivateOrLoopbackUrl(url: string): Promise<boolean> {
-    const hostname = new URL(url).hostname;
-    return isLoopbackHost(hostname) || (await isPrivateIpAsync(url));
-  }
-
   /**
    * Construct well-known OAuth endpoint URLs per RFC 9728 §3.1.
    *
@@ -103,13 +98,7 @@ export class OAuthUtils {
     resourceMetadataUrl: string,
   ): Promise<OAuthProtectedResourceMetadata | null> {
     try {
-      if (await this.isPrivateOrLoopbackUrl(resourceMetadataUrl)) {
-        debugLogger.warn(
-          `[OAuthUtils] Blocked SSRF attempt to private host in OAuth metadata URL: ${resourceMetadataUrl}`,
-        );
-        return null;
-      }
-      const response = await fetch(resourceMetadataUrl);
+      const response = await fetchWithPrivateIpBlock(resourceMetadataUrl);
       if (!response.ok) {
         return null;
       }
@@ -133,13 +122,7 @@ export class OAuthUtils {
     authServerMetadataUrl: string,
   ): Promise<OAuthAuthorizationServerMetadata | null> {
     try {
-      if (await this.isPrivateOrLoopbackUrl(authServerMetadataUrl)) {
-        debugLogger.warn(
-          `[OAuthUtils] Blocked SSRF attempt to private host in OAuth auth server URL: ${authServerMetadataUrl}`,
-        );
-        return null;
-      }
-      const response = await fetch(authServerMetadataUrl);
+      const response = await fetchWithPrivateIpBlock(authServerMetadataUrl);
       if (!response.ok) {
         return null;
       }

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -7,6 +7,7 @@
 import type { MCPOAuthConfig } from './oauth-provider.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import { isLoopbackHost, isPrivateIpAsync } from '../utils/fetch.js';
 
 /**
  * Error thrown when the discovered resource metadata does not match the expected resource.
@@ -54,6 +55,11 @@ export const FIVE_MIN_BUFFER_MS = 5 * 60 * 1000;
  * Utility class for common OAuth operations.
  */
 export class OAuthUtils {
+  private static async isPrivateOrLoopbackUrl(url: string): Promise<boolean> {
+    const hostname = new URL(url).hostname;
+    return isLoopbackHost(hostname) || (await isPrivateIpAsync(url));
+  }
+
   /**
    * Construct well-known OAuth endpoint URLs per RFC 9728 §3.1.
    *
@@ -97,6 +103,12 @@ export class OAuthUtils {
     resourceMetadataUrl: string,
   ): Promise<OAuthProtectedResourceMetadata | null> {
     try {
+      if (await this.isPrivateOrLoopbackUrl(resourceMetadataUrl)) {
+        debugLogger.warn(
+          `[OAuthUtils] Blocked SSRF attempt to private host in OAuth metadata URL: ${resourceMetadataUrl}`,
+        );
+        return null;
+      }
       const response = await fetch(resourceMetadataUrl);
       if (!response.ok) {
         return null;
@@ -121,6 +133,12 @@ export class OAuthUtils {
     authServerMetadataUrl: string,
   ): Promise<OAuthAuthorizationServerMetadata | null> {
     try {
+      if (await this.isPrivateOrLoopbackUrl(authServerMetadataUrl)) {
+        debugLogger.warn(
+          `[OAuthUtils] Blocked SSRF attempt to private host in OAuth auth server URL: ${authServerMetadataUrl}`,
+        );
+        return null;
+      }
       const response = await fetch(authServerMetadataUrl);
       if (!response.ok) {
         return null;

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -8,18 +8,22 @@ import { updateGlobalFetchTimeouts } from './fetch.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as dnsPromises from 'node:dns/promises';
 import type { LookupAddress, LookupAllOptions } from 'node:dns';
+import type { LookupFunction } from 'node:net';
 import ipaddr from 'ipaddr.js';
 
-const { setGlobalDispatcher, Agent, EnvHttpProxyAgent } = vi.hoisted(() => ({
-  setGlobalDispatcher: vi.fn(),
-  Agent: vi.fn(),
-  EnvHttpProxyAgent: vi.fn(),
-}));
+const { setGlobalDispatcher, Agent, EnvHttpProxyAgent, undiciFetch } =
+  vi.hoisted(() => ({
+    setGlobalDispatcher: vi.fn(),
+    Agent: vi.fn(),
+    EnvHttpProxyAgent: vi.fn(),
+    undiciFetch: vi.fn(),
+  }));
 
 vi.mock('undici', () => ({
   setGlobalDispatcher,
   Agent,
   EnvHttpProxyAgent,
+  fetch: undiciFetch,
 }));
 
 vi.mock('node:dns/promises', () => ({
@@ -31,6 +35,9 @@ const {
   isPrivateIp,
   isPrivateIpAsync,
   isAddressPrivate,
+  PrivateIpError,
+  createPrivateIpBlockingDispatcher,
+  fetchWithPrivateIpBlock,
   fetchWithTimeout,
   setGlobalProxy,
   createSafeProxyAgent,
@@ -55,6 +62,7 @@ describe('fetch utils', () => {
       }
       return [{ address: '93.184.216.34', family: 4 }];
     });
+    vi.mocked(undiciFetch).mockReset();
     vi.unstubAllEnvs();
     updateGlobalFetchTimeouts(60000);
   });
@@ -172,6 +180,97 @@ describe('fetch utils', () => {
 
     it('should return false for invalid URLs instead of throwing verification error', async () => {
       expect(await isPrivateIpAsync('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('createPrivateIpBlockingDispatcher', () => {
+    type AgentOptionsWithLookup = {
+      connect?: {
+        lookup?: LookupFunction;
+      };
+    };
+
+    function getLastLookup(): LookupFunction {
+      createPrivateIpBlockingDispatcher();
+      const agentOptions = vi.mocked(Agent).mock.calls.at(-1)?.[0] as
+        | AgentOptionsWithLookup
+        | undefined;
+      const safeLookup = agentOptions?.connect?.lookup;
+      expect(safeLookup).toBeDefined();
+      return safeLookup!;
+    }
+
+    function runLookup(
+      safeLookup: LookupFunction,
+      hostname: string,
+    ): Promise<{
+      error: NodeJS.ErrnoException | null;
+      address: string | LookupAddress[];
+      family?: number;
+    }> {
+      return new Promise((resolve) => {
+        safeLookup(hostname, {}, (error, address, family) => {
+          resolve({ error, address, family });
+        });
+      });
+    }
+
+    it('should return public lookup results to undici', async () => {
+      vi.mocked(dnsPromises.lookup).mockResolvedValueOnce({
+        address: '8.8.8.8',
+        family: 4,
+      } as never);
+
+      const result = await runLookup(getLastLookup(), 'example.com');
+
+      expect(result.error).toBeNull();
+      expect(result.address).toBe('8.8.8.8');
+      expect(result.family).toBe(4);
+    });
+
+    it('should block DNS results that resolve to private or link-local IPs', async () => {
+      vi.mocked(dnsPromises.lookup).mockResolvedValueOnce({
+        address: '169.254.169.254',
+        family: 4,
+      } as never);
+
+      const result = await runLookup(getLastLookup(), 'attacker.example.com');
+
+      expect(result.error).toBeInstanceOf(PrivateIpError);
+      expect(result.error?.message).toContain('169.254.169.254');
+      expect(result.address).toBe('');
+      expect(result.family).toBe(0);
+    });
+  });
+
+  describe('fetchWithPrivateIpBlock', () => {
+    it('should call undici fetch with a private-IP blocking dispatcher', async () => {
+      const dispatcher = { dispatch: vi.fn() };
+      vi.mocked(Agent).mockReturnValueOnce(dispatcher as never);
+      const response = new Response('{}');
+      vi.mocked(undiciFetch).mockResolvedValueOnce(response);
+
+      const result = await fetchWithPrivateIpBlock('https://example.com/');
+
+      expect(result).toBe(response);
+      expect(undiciFetch).toHaveBeenCalledWith(
+        'https://example.com/',
+        expect.objectContaining({
+          dispatcher,
+          redirect: 'manual',
+        }),
+      );
+    });
+
+    it('should block loopback and private IP literals before calling undici fetch', async () => {
+      await expect(
+        fetchWithPrivateIpBlock('http://127.0.0.1/'),
+      ).rejects.toThrow(PrivateIpError);
+      await expect(
+        fetchWithPrivateIpBlock('http://169.254.169.254/'),
+      ).rejects.toThrow(PrivateIpError);
+
+      expect(undiciFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -103,6 +103,13 @@ describe('fetch utils', () => {
       expect(isAddressPrivate('febf::')).toBe(true);
     });
 
+    it('should identify IPv6 addresses with zone identifiers as private', () => {
+      expect(isAddressPrivate('fe80::1%25eth0')).toBe(true);
+      expect(isAddressPrivate('fe80::1%eth0')).toBe(true);
+      expect(isAddressPrivate('[fe80::1%25eth0]')).toBe(true);
+      expect(isAddressPrivate('[::1%25lo]')).toBe(true);
+    });
+
     it('should identify special local addresses', () => {
       expect(isAddressPrivate('0.0.0.0')).toBe(true);
       expect(isAddressPrivate('::')).toBe(true);
@@ -269,6 +276,20 @@ describe('fetch utils', () => {
       await expect(
         fetchWithPrivateIpBlock('http://169.254.169.254/'),
       ).rejects.toThrow(PrivateIpError);
+
+      expect(undiciFetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject IPv6 zone identifier URL forms before calling undici fetch', async () => {
+      await expect(
+        fetchWithPrivateIpBlock('http://[fe80::1%25eth0]/'),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        fetchWithPrivateIpBlock('http://[fe80::1%eth0]/'),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        fetchWithPrivateIpBlock('http://[::1%25lo]/'),
+      ).rejects.toThrow(TypeError);
 
       expect(undiciFetch).not.toHaveBeenCalled();
     });

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -6,9 +6,16 @@
 
 import { getErrorMessage, isAbortError } from './errors.js';
 import { URL } from 'node:url';
-import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+import {
+  Agent,
+  EnvHttpProxyAgent,
+  fetch as undiciFetch,
+  setGlobalDispatcher,
+} from 'undici';
+import type { Dispatcher } from 'undici';
 import ipaddr from 'ipaddr.js';
 import { lookup } from 'node:dns/promises';
+import type { LookupFunction } from 'node:net';
 
 export class FetchError extends Error {
   constructor(
@@ -31,6 +38,7 @@ export class PrivateIpError extends Error {
 let defaultHeadersTimeout = 60000; // 60 seconds
 const defaultBodyTimeout = 300000; // 5 minutes
 let currentProxy: string | undefined = undefined;
+let privateIpBlockingDispatcher: Dispatcher | undefined = undefined;
 
 // Configure default global dispatcher with higher timeouts
 setGlobalDispatcher(
@@ -47,6 +55,7 @@ export function updateGlobalFetchTimeouts(timeoutMs: number) {
     );
   }
   defaultHeadersTimeout = timeoutMs;
+  privateIpBlockingDispatcher = undefined;
   // We keep body timeout high for LLM streaming responses
   if (currentProxy) {
     setGlobalProxy(currentProxy);
@@ -166,6 +175,104 @@ export async function isPrivateIpAsync(url: string): Promise<boolean> {
       cause: error,
     });
   }
+}
+
+const privateIpBlockingLookup: LookupFunction = (
+  hostname,
+  options,
+  callback,
+) => {
+  void lookup(hostname, options)
+    .then((result) => {
+      const addresses = Array.isArray(result) ? result : [result];
+      const blockedAddress = addresses.find((addr) =>
+        isAddressPrivate(addr.address),
+      );
+
+      if (blockedAddress) {
+        callback(
+          new PrivateIpError(
+            `Access to private network is blocked: ${hostname} resolved to ${blockedAddress.address}`,
+          ),
+          '',
+          0,
+        );
+        return;
+      }
+
+      if (Array.isArray(result)) {
+        callback(null, result);
+        return;
+      }
+
+      callback(null, result.address, result.family);
+    })
+    .catch((error: unknown) => {
+      callback(
+        error instanceof Error ? error : new Error(String(error)),
+        '',
+        0,
+      );
+    });
+};
+
+export function createPrivateIpBlockingDispatcher(): Dispatcher {
+  return new Agent({
+    headersTimeout: defaultHeadersTimeout,
+    bodyTimeout: defaultBodyTimeout,
+    connect: {
+      lookup: privateIpBlockingLookup,
+    },
+  });
+}
+
+function getPrivateIpBlockingDispatcher(): Dispatcher {
+  privateIpBlockingDispatcher ??= createPrivateIpBlockingDispatcher();
+  return privateIpBlockingDispatcher;
+}
+
+function getLoopbackOrPrivateIp(url: string): string | undefined {
+  const hostname = new URL(url).hostname;
+  if (isLoopbackHost(hostname) || isAddressPrivate(hostname)) {
+    return hostname;
+  }
+  return undefined;
+}
+
+export async function fetchWithPrivateIpBlock(
+  url: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const blockedHost = getLoopbackOrPrivateIp(url);
+  if (blockedHost) {
+    throw new PrivateIpError(
+      `Access to private network is blocked: ${blockedHost}`,
+    );
+  }
+
+  if (currentProxy) {
+    if (await isPrivateIpAsync(url)) {
+      throw new PrivateIpError('Access to private network is blocked');
+    }
+    return fetch(url, {
+      ...options,
+      redirect: 'manual',
+    });
+  }
+
+  const fetchOptions: RequestInit & { dispatcher: Dispatcher } = {
+    ...options,
+    redirect: 'manual',
+    dispatcher: getPrivateIpBlockingDispatcher(),
+  };
+
+  const response = await undiciFetch(
+    url,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    fetchOptions as unknown as import('undici').RequestInit,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return response as unknown as Response;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds SSRF protection to MCP OAuth metadata discovery.

`OAuthUtils.fetchProtectedResourceMetadata()` and
`OAuthUtils.fetchAuthorizationServerMetadata()` previously called `fetch()`
directly on OAuth metadata URLs. Those URLs can come from a remote MCP server's
OAuth discovery responses, including the `authorization_servers` field in
protected resource metadata.

This change blocks loopback, private, reserved, and link-local destinations for
OAuth metadata requests. It also routes those requests through a shared safe-fetch
helper that validates DNS results in the Undici dispatcher lookup used for the
actual connection, closing the DNS pre-check/fetch TOCTOU gap for direct
connections. Automatic redirects are disabled for this safe fetch path so a
public metadata URL cannot redirect into a private network.

Closes #27635.

## Changes

- Add initial OAuth metadata guards using the existing `isLoopbackHost()` and
  `isPrivateIpAsync()` helpers.
- Add a reusable `fetchWithPrivateIpBlock()` helper in `utils/fetch.ts`.
- Use an Undici dispatcher with a private-IP-blocking DNS lookup for direct
  requests.
- Preserve the existing proxy path while keeping private-IP checks enabled.
- Apply the safe fetch helper before both OAuth metadata fetch methods.
- Add tests for dispatcher DNS validation, private/link-local blocking, literal
  loopback/private IP blocking, IPv6 zone identifier handling, manual redirects,
  and OAuth discovery behavior.

## Test

```bash
npm test -w @google/gemini-cli-core -- src/utils/fetch.test.ts src/mcp/oauth-utils.test.ts
npm run lint -w @google/gemini-cli-core
npm run build -w @google/gemini-cli-core
```

Result:

```text
Test Files  2 passed (2)
Tests       67 passed (67)
Lint        passed
Build       passed
```