### PR TITLE
fix(cli): disable auto-update for corporate release paths

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -71,6 +71,20 @@ describe('getInstallationInfo', () => {
     vi.unstubAllEnvs();
   });
 
+  it('should detect running from a Google corporate/internal release path', () => {
+    process.argv[1] = '/google/bin/releases/gemini-cli/tools/gemini';
+    mockedRealPathSync.mockReturnValue('/google/bin/releases/gemini-cli/tools/gemini');
+    mockedIsGitRepository.mockReturnValue(false);
+
+    const info = getInstallationInfo(projectRoot, true);
+    expect(info.packageManager).toBe(PackageManager.BINARY);
+    expect(info.isGlobal).toBe(true);
+    expect(info.updateMessage).toBe(
+      'Running from a corporate release. Automatic update is disabled.',
+    );
+    expect(info.updateCommand).toBeUndefined();
+  });
+
   it('should return UNKNOWN when cliPath is not available', () => {
     process.argv[1] = '';
     const info = getInstallationInfo(projectRoot, true);

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -59,7 +59,7 @@ export function getInstallationInfo(
     const isGit = isGitRepository(process.cwd());
 
     // Check if running from Google corporate/internal release paths
-    if (realPath.startsWith('/google/')) {
+    if (realPath.startsWith('/google/bin/')) {
       return {
         packageManager: PackageManager.BINARY,
         isGlobal: true,

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -58,6 +58,16 @@ export function getInstallationInfo(
     const normalizedProjectRoot = projectRoot?.replace(/\\/g, '/');
     const isGit = isGitRepository(process.cwd());
 
+    // Check if running from Google corporate/internal release paths
+    if (realPath.startsWith('/google/')) {
+      return {
+        packageManager: PackageManager.BINARY,
+        isGlobal: true,
+        updateMessage:
+          'Running from a corporate release. Automatic update is disabled.',
+      };
+    }
+
     // Check for local git clone first
     if (
       isGit &&


### PR DESCRIPTION
## Summary

This PR modifies the `getInstallationInfo` utility to detect when the CLI is running from a Google corporate or internal release path (`/google/bin/`). When running from this environment, it disables the automatic update prompt by setting `PackageManager.BINARY`, `isGlobal: true`, and assigning a specific update message indicating that the automatic update is disabled.

## Details

The `getInstallationInfo` logic has been augmented to examine `realPath` before performing Git or package manager checks. If the path starts with `/google/bin/`, the update message is set to `'Running from a corporate release. Automatic update is disabled.'`. The accompanying unit tests were also updated to verify this new detection rule.

## Related Issues

None

## How to Validate

1. Run the `npm run test` command locally to verify the new unit tests for `installationInfo.ts` pass.
2. Manually verify by spoofing `process.cwd()` or `argv[1]` to a `/google/bin/` path, ensuring the `updateMessage` matches.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
