### PR TITLE
fix(build): resolve parallel workspace compilation race condition

### DIFF
--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -56,11 +56,11 @@ SOFTWARE.
 
 ============================================================
 ajv@6.14.0
-(https://github.com/ajv-validator/ajv.git)
+(No repository found)
 
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Evgeny Poberezkin
+Copyright (c) 2015-2021 Evgeny Poberezkin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -418,7 +418,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ============================================================
 which@2.0.2
-(git://github.com/isaacs/node-which.git)
+(git+https://github.com/npm/node-which.git)
 
 The ISC License
 
@@ -927,7 +927,7 @@ SOFTWARE.
 
 ============================================================
 iconv-lite@0.6.3
-(git://github.com/ashtuchkin/iconv-lite.git)
+(https://github.com/pillarjs/iconv-lite.git)
 
 Copyright (c) 2011 Alexander Shtuchkin
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -44,17 +44,26 @@ if (process.env.CI) {
     cwd: root,
   });
 
-  // Build the rest in parallel
-  console.log('Building other workspaces in parallel...');
-  const workspaceInfo = JSON.parse(
-    execSync('npm query .workspace --json', { cwd: root, encoding: 'utf-8' }),
-  );
-  const parallelWorkspaces = workspaceInfo
-    .map((w) => w.name)
-    .filter((name) => name !== '@google/gemini-cli-core');
-
+  // Build the rest in topological groups to prevent race conditions
+  console.log('Building libraries (devtools, sdk, test-utils)...');
+  const libWorkspaces = [
+    '@google/gemini-cli-devtools',
+    '@google/gemini-cli-sdk',
+    '@google/gemini-cli-test-utils'
+  ];
   execSync(
-    `npx npm-run-all --parallel ${parallelWorkspaces.map((w) => `"build -w ${w}"`).join(' ')}`,
+    `npx npm-run-all --parallel ${libWorkspaces.map((w) => `"build -w ${w}"`).join(' ')}`,
+    { stdio: 'inherit', cwd: root },
+  );
+
+  console.log('Building applications (cli, a2a-server, vscode-companion)...');
+  const appWorkspaces = [
+    '@google/gemini-cli',
+    '@google/gemini-cli-a2a-server',
+    'gemini-cli-vscode-ide-companion'
+  ];
+  execSync(
+    `npx npm-run-all --parallel ${appWorkspaces.map((w) => `"build -w ${w}"`).join(' ')}`,
     { stdio: 'inherit', cwd: root },
   );
 }


### PR DESCRIPTION
This PR resolves a race condition during parallel workspace builds by splitting the build process into sequential topological stages:
1. Core (`@google/gemini-cli-core`)
2. Libraries (`devtools`, `sdk`, `test-utils`)
3. Applications (`cli`, `a2a-server`, `vscode-companion`)

This ensures dependent packages are not built in parallel before their dependencies are ready.