### PR TITLE
feat(core): support list format in trustedFolders.json

### DIFF
--- a/packages/core/src/utils/trust.test.ts
+++ b/packages/core/src/utils/trust.test.ts
@@ -119,6 +119,38 @@ describe('Trust Utility (Core)', () => {
     expect(savedContent[finalKey]).toBe(TrustLevel.TRUST_FOLDER);
   });
 
+  it('should load list format config from file', () => {
+    const paths = [
+      path.resolve('/trusted/path'),
+      path.resolve('/another/trusted'),
+    ];
+    fs.writeFileSync(trustedFoldersPath, JSON.stringify(paths));
+
+    const folders = loadTrustedFolders();
+    const isWindows = process.platform === 'win32';
+
+    for (const p of paths) {
+      const normalizedKey = p.replace(/\\/g, '/');
+      const finalKey = isWindows ? normalizedKey.toLowerCase() : normalizedKey;
+      expect(folders.user.config[finalKey]).toBe(TrustLevel.TRUST_FOLDER);
+    }
+    expect(folders.errors).toEqual([]);
+  });
+
+  it('should report errors for invalid entries in list format', () => {
+    const content = JSON.stringify(['/valid/path', 123, '', null]);
+    fs.writeFileSync(trustedFoldersPath, content);
+
+    const folders = loadTrustedFolders();
+    expect(folders.errors.length).toBeGreaterThan(0);
+    // Valid path should still be loaded
+    expect(
+      Object.values(folders.user.config).some(
+        (v) => v === TrustLevel.TRUST_FOLDER,
+      ),
+    ).toBe(true);
+  });
+
   it('should handle comments in JSON', () => {
     const content = `
     {

--- a/packages/core/src/utils/trust.ts
+++ b/packages/core/src/utils/trust.ts
@@ -289,12 +289,19 @@ export function loadTrustedFolders(): LoadedTrustedFolders {
       const content = fs.readFileSync(userPath, 'utf-8');
       const parsed = parseTrustedFoldersJson(content);
 
-      if (!isRecord(parsed)) {
-        errors.push({
-          message: 'Trusted folders file is not a valid JSON object.',
-          path: userPath,
-        });
-      } else {
+      if (Array.isArray(parsed)) {
+        for (const rawPath of parsed) {
+          if (typeof rawPath !== 'string' || rawPath.trim() === '') {
+            errors.push({
+              message: `Invalid entry "${String(rawPath)}" in trusted folders list. Each entry must be a non-empty path string.`,
+              path: userPath,
+            });
+            continue;
+          }
+          const normalizedPath = normalizePath(rawPath);
+          userConfig[normalizedPath] = TrustLevel.TRUST_FOLDER;
+        }
+      } else if (isRecord(parsed)) {
         for (const [rawPath, trustLevel] of Object.entries(parsed)) {
           const normalizedPath = normalizePath(rawPath);
           if (isTrustLevel(trustLevel)) {
@@ -307,6 +314,12 @@ export function loadTrustedFolders(): LoadedTrustedFolders {
             });
           }
         }
+      } else {
+        errors.push({
+          message:
+            'Trusted folders file must be a JSON array of paths or an object mapping paths to trust levels.',
+          path: userPath,
+        });
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Adds support for a JSON array (list) format in `trustedFolders.json`, making it easier to maintain a simple list of trusted directories manually. The existing object format continues to work unchanged.

## Background

Fixes #27647. Currently, `trustedFolders.json` only supports a JSON object format where each path must be mapped to a trust level:

```json
{
  /home/user/projects/trusted: TRUST_FOLDER,
  /home/user/projects/partial: TRUST_PARENT
}
```

This requires users to remember the exact trust level enum values and can feel verbose when all entries are simply trusted folders.

## Changes

### `packages/core/src/utils/trust.ts`

- Modified `loadTrustedFolders()` to detect JSON array format
- Array entries default to `TRUST_FOLDER` trust level
- Non-string or empty entries in array produce validation errors
- Non-array, non-object inputs produce a clearer error message

### `packages/core/src/utils/trust.test.ts`

- Added test for loading list format
- Added test for error reporting on invalid list entries

## Usage

Users can now use either format:

**List format (new):**
```json
[/home/user/projects/trusted, /home/user/projects/another]
```

**Object format (existing, unchanged):**
```json
{
  /home/user/projects/trusted: TRUST_FOLDER,
  /home/user/projects/untrusted: DO_NOT_TRUST
}
```

The list format is simpler for the common case where all paths are simply trusted at `TRUST_FOLDER` level. The object format remains necessary when using `TRUST_PARENT` or `DO_NOT_TRUST` levels.