### PR TITLE
fix(core): hide ignored folders from session context

### DIFF
--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -121,6 +121,7 @@ describe('getEnvironmentContext', () => {
     expect(context).toContain('</session_context>');
     expect(getFolderStructure).toHaveBeenCalledWith('/test/dir', {
       fileService: undefined,
+      showIgnoredFolders: false,
     });
   });
 

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -27,6 +27,7 @@ export async function getDirectoryContextString(
     workspaceDirectories.map((dir) =>
       getFolderStructure(dir, {
         fileService: config.getFileService(),
+        showIgnoredFolders: false,
       }),
     ),
   );

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -292,6 +292,26 @@ ${testRootDir}${path.sep}
       expect(structure).toContain('ignored.txt');
       expect(structure).toContain('file1.txt');
     });
+
+    it('should omit ignored folder names when requested', async () => {
+      await fsPromises.writeFile(
+        path.join(testRootDir, '.gitignore'),
+        'node_modules/\n.pytest_cache/',
+      );
+      await createTestFile('file1.txt');
+      await createTestFile('node_modules', 'some-package', 'index.js');
+      await createTestFile('.pytest_cache', 'README.md');
+
+      const fileService = new FileDiscoveryService(testRootDir);
+      const structure = await getFolderStructure(testRootDir, {
+        fileService,
+        showIgnoredFolders: false,
+      });
+
+      expect(structure).toContain('file1.txt');
+      expect(structure).not.toContain('node_modules');
+      expect(structure).not.toContain('.pytest_cache');
+    });
   });
 
   describe('with geminiignore', () => {

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -41,6 +41,8 @@ interface FolderStructureOptions {
   fileService?: FileDiscoveryService;
   /** File filtering ignore options. */
   fileFilteringOptions?: FileFilteringOptions;
+  /** Whether ignored folders should be shown as truncated entries. */
+  showIgnoredFolders?: boolean;
 }
 // Define a type for the merged options where fileIncludePattern remains optional
 type MergedFolderStructureOptions = Required<
@@ -186,6 +188,9 @@ async function readFullStructure(
           ) ?? false;
 
         if (options.ignoredFolders.has(subFolderName) || isIgnored) {
+          if (!options.showIgnoredFolders) {
+            continue;
+          }
           const ignoredSubFolder: FullFolderInfo = {
             name: subFolderName,
             path: subFolderPath,
@@ -315,6 +320,7 @@ export async function getFolderStructure(
     fileService: options?.fileService,
     fileFilteringOptions:
       options?.fileFilteringOptions ?? DEFAULT_FILE_FILTERING_OPTIONS,
+    showIgnoredFolders: options?.showIgnoredFolders ?? true,
   };
 
   try {


### PR DESCRIPTION
## Summary

Hide `.gitignore` / `.geminiignore` ignored directory names from the initial `session_context` directory tree.

The folder tree helper still keeps its existing default behavior for other callers: ignored directories can be shown as truncated entries. The session context opts out so caches, virtualenvs, and other ignored paths are not sent to the model just because they exist at the workspace root.

## Details

- Adds a `showIgnoredFolders` option to `getFolderStructure` with the current behavior as the default.
- Passes `showIgnoredFolders: false` from `getDirectoryContextString`.
- Adds a regression test for omitted ignored directory names and updates the environment-context mock assertion.

## Related Issues

Fixes #27674

## How to Validate

Validated locally on Windows:

```bash
npm exec --workspace @google/gemini-cli-core -- vitest run src/utils/getFolderStructure.test.ts src/utils/environmentContext.test.ts
npm exec -- prettier --check packages/core/src/utils/getFolderStructure.ts packages/core/src/utils/environmentContext.ts packages/core/src/utils/environmentContext.test.ts packages/core/src/utils/getFolderStructure.test.ts
git diff --check origin/main..HEAD
```

The focused Vitest run passed 24 tests. A plain `npm run test --workspace @google/gemini-cli-core -- getFolderStructure.test.ts environmentContext.test.ts` also ran the same tests successfully, but its `posttest` build failed in my local worktree because I reused another checkout's `node_modules`, and that dependency tree is behind the current lockfile (`@a2a-js/sdk`, `fdir`, `chokidar`, `mime/lite`, and related type packages were missing). I did not count that as a source failure.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
