### PR TITLE
chore(lint): eliminate no-unsafe-return suppressions

### DIFF
--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -186,8 +186,10 @@ function resolveEnvVarsInObject<T>(obj: T): T {
   }
 
   if (Array.isArray(obj)) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-return
-    return obj.map((item) => resolveEnvVarsInObject(item)) as unknown as T;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return (obj as unknown[]).map((item) =>
+      resolveEnvVarsInObject(item),
+    ) as unknown as T;
   }
 
   if (typeof obj === 'object') {

--- a/packages/cli/src/utils/activityLogger.ts
+++ b/packages/cli/src/utils/activityLogger.ts
@@ -522,8 +522,11 @@ export class ActivityLogger extends EventEmitter {
                   ),
           );
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-return
-        return (oldWrite as any).apply(this, [chunk, ...etc]);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        return (oldWrite as (...args: unknown[]) => boolean).apply(this, [
+          chunk,
+          ...etc,
+        ]);
       };
 
       req.end = function (
@@ -559,8 +562,11 @@ export class ActivityLogger extends EventEmitter {
           body,
           pending: true,
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-return
-        return (oldEnd as any).apply(this, [chunkOrCb, ...etc]);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        return (oldEnd as (...args: unknown[]) => http.ClientRequest).apply(
+          this,
+          [chunkOrCb, ...etc],
+        );
       };
 
       req.on('response', (res: http.IncomingMessage) => {


### PR DESCRIPTION
## Summary

Part of the linter hygiene epic (#19440), which calls out **unsafe returns** as a target. This removes all three `@typescript-eslint/no-unsafe-return` suppressions in the codebase by giving the suppressed expressions proper types instead of relying on `any`.

## Changes

- **`packages/a2a-server/src/config/settings.ts`** — in `resolveEnvVarsInObject`, cast the value to `unknown[]` before `.map()` so the recursive result is `unknown[]` rather than `any[]`. The return is now type-safe.
- **`packages/cli/src/utils/activityLogger.ts`** (x2) — type the preserved `req.write` / `req.end` references as concrete function types (`(...args: unknown[]) => boolean` and `(...args: unknown[]) => http.ClientRequest`) instead of `as any`. This also drops the now-unneeded `no-explicit-any` suppressions.

The remaining `@typescript-eslint/no-unsafe-type-assertion` directives are still required and were kept.

## Behavior

These are **type-level only** changes — runtime behavior is identical (the `as any` was replaced with a more specific assertion; the `.map()` call is unchanged at runtime).

## Testing

- `eslint` clean on both files (no unused-directive warnings, confirming the remaining suppressions are still needed)
- `tsc --noEmit` passes for both `@google/gemini-cli` and `@google/gemini-cli-a2a-server`
- Existing unit tests pass: `activityLogger.test.ts` (8) and `settings.test.ts` (6)