### PR TITLE
chore(lint): type JSON-parsed task data in a2a-server

### DIFF
--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -69,8 +69,7 @@ export class RestoreCommand implements Command {
         throw error;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const toolCallData = JSON.parse(data);
+      const toolCallData: unknown = JSON.parse(data);
       const ToolCallDataSchema = getToolCallDataSchema();
       const parseResult = ToolCallDataSchema.safeParse(toolCallData);
 

--- a/packages/a2a-server/src/persistence/gcs.ts
+++ b/packages/a2a-server/src/persistence/gcs.ts
@@ -15,7 +15,11 @@ import type { Task as SDKTask } from '@a2a-js/sdk';
 import type { TaskStore } from '@a2a-js/sdk/server';
 import { logger } from '../utils/logger.js';
 import { setTargetDir } from '../config/config.js';
-import { getPersistedState, type PersistedTaskMetadata } from '../types.js';
+import {
+  getContextIdFromMetadata,
+  getPersistedState,
+  type PersistedTaskMetadata,
+} from '../types.js';
 import { v4 as uuidv4 } from 'uuid';
 
 type ObjectType = 'metadata' | 'workspace';
@@ -246,8 +250,8 @@ export class GCSTaskStore implements TaskStore {
       }
       const [compressedMetadata] = await metadataFile.download();
       const jsonData = gunzipSync(compressedMetadata).toString();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const loadedMetadata = JSON.parse(jsonData);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      const loadedMetadata = JSON.parse(jsonData) as PersistedTaskMetadata;
       logger.info(`Task ${taskId} metadata loaded from GCS.`);
 
       const persistedState = getPersistedState(loadedMetadata);
@@ -283,14 +287,12 @@ export class GCSTaskStore implements TaskStore {
 
       return {
         id: taskId,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        contextId: loadedMetadata._contextId || uuidv4(),
+        contextId: getContextIdFromMetadata(loadedMetadata) || uuidv4(),
         kind: 'task',
         status: {
           state: persistedState._taskState,
           timestamp: new Date().toISOString(),
         },
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         metadata: loadedMetadata,
         history: [],
         artifacts: [],


### PR DESCRIPTION
## Summary

Part of the linter hygiene epic (#19440), which calls out **unsafe assignments** as a target. This eliminates four `@typescript-eslint/no-unsafe-assignment` suppressions in the a2a-server persistence/restore paths by typing the values deserialized from JSON instead of leaving them as `any`.

## Changes

- **`commands/restore.ts`** — annotate the parsed checkpoint as `unknown`; it is immediately validated by a Zod `safeParse`, which already accepts `unknown`. No new suppression.
- **`persistence/gcs.ts`** — type the loaded task metadata as `PersistedTaskMetadata` (consistent with the existing `as PersistedTaskMetadata` usage elsewhere in the same file) and reuse the existing `getContextIdFromMetadata` helper to read the context id in a type-safe way.

**Net result:** four `no-unsafe-assignment` suppressions removed, one `no-unsafe-type-assertion` added in `gcs.ts`.

## Behavior

Unchanged for the documented metadata shape — `_contextId` is always written as a string (see `agent/executor.ts`), and `getContextIdFromMetadata` returns it directly. For malformed/non-string values it now falls back to a fresh `uuidv4()` instead of propagating a non-string, which is slightly more robust.

## Testing

- `eslint` clean on both files
- `tsc --noEmit` passes for `@google/gemini-cli-a2a-server`
- Existing unit tests pass: `gcs.test.ts` (12) and `restore.test.ts` (6)