### PR TITLE
chore(lint): mark intentional fire-and-forget promises with void in a2a-server

### DIFF
--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -415,8 +415,7 @@ export class CoderAgentExecutor implements AgentExecutor {
           `[CoderAgentExecutor] Error creating task ${taskId}:`,
           error,
         );
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        pushTaskStateFailed(error, eventBus, taskId, contextId);
+        void pushTaskStateFailed(error, eventBus, taskId, contextId);
         return;
       }
       const newTaskSDK = wrapper.toSDKTask();

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -1097,8 +1097,7 @@ export class Task {
       } else {
         parts = [response];
       }
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.geminiClient.addHistory({
+      void this.geminiClient.addHistory({
         role: 'user',
         parts,
       });


### PR DESCRIPTION
## Summary

Part of the linter hygiene epic (#19440), which calls out **misuse of promises** as a target. This eliminates the two `@typescript-eslint/no-floating-promises` suppressions in a2a-server using the `void` operator — the idiomatic way to mark an intentionally un-awaited promise.

Both call sites are deliberately fire-and-forget and cannot/should not be awaited:

- **`agent/executor.ts`** — `pushTaskStateFailed` is `async`, but its body only performs a synchronous `eventBus.publish`, so the returned promise is already settled by the time it is created; not awaiting it is harmless.
- **`agent/task.ts`** — the enclosing `addToolResponsesToHistory` method is synchronous (returns `void`), so `addHistory` cannot be awaited without changing the method's public signature.

## Behavior

Unchanged — `void` only documents the already-existing fire-and-forget intent; no `await` is introduced, so timing and control flow are identical.

## Testing

- `eslint` clean on both files
- `tsc --noEmit` passes for `@google/gemini-cli-a2a-server`
- Existing unit tests pass: `executor.test.ts` (2) and `task.test.ts` (16)