### PR TITLE
fix: dedupe home agent directories

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -17,6 +17,7 @@ import type {
   GeminiCLIExtension,
   ConfigParameters,
 } from '../config/config.js';
+import { Storage } from '../config/storage.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents, CoreEvent } from '../utils/events.js';
 import type { A2AClientManager } from './a2a-client-manager.js';
@@ -266,6 +267,39 @@ describe('AgentRegistry', () => {
       expect(
         vi.mocked(tomlLoader.loadAgentsFromDirectory),
       ).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not load the same project and user agents directory twice', async () => {
+      mockConfig = makeMockedConfig({ enableAgents: true });
+      registry = new TestableAgentRegistry(mockConfig);
+
+      const sharedAgentsDir = '/home/tester/.gemini/agents';
+      vi.spyOn(mockConfig.storage, 'getProjectAgentsDir').mockReturnValue(
+        sharedAgentsDir,
+      );
+      vi.spyOn(Storage, 'getUserAgentsDir').mockReturnValue(sharedAgentsDir);
+      const feedbackSpy = vi
+        .spyOn(coreEvents, 'emitFeedback')
+        .mockImplementation(() => {});
+
+      vi.mocked(tomlLoader.loadAgentsFromDirectory).mockResolvedValueOnce({
+        agents: [{ ...MOCK_AGENT_V1, name: 'home-agent' }],
+        errors: [],
+      });
+
+      await registry.initialize();
+
+      expect(
+        vi.mocked(tomlLoader.loadAgentsFromDirectory),
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(tomlLoader.loadAgentsFromDirectory),
+      ).toHaveBeenCalledWith(sharedAgentsDir);
+      expect(registry.getDefinition('home-agent')).toBeDefined();
+      expect(feedbackSpy).not.toHaveBeenCalledWith(
+        'warning',
+        expect.stringContaining("Duplicate agent name 'home-agent' detected"),
+      );
     });
 
     it('should NOT load TOML agents when enableAgents is false', async () => {

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -24,6 +24,7 @@ import { A2AAuthProviderFactory } from './auth-provider/factory.js';
 import type { AuthenticationHandler } from '@a2a-js/sdk/client';
 import { type z } from 'zod';
 import { debugLogger } from '../utils/debugLogger.js';
+import { normalizePath } from '../utils/paths.js';
 import { isAutoModel } from '../config/models.js';
 import {
   type ModelConfig,
@@ -173,9 +174,22 @@ export class AgentRegistry {
     const folderTrustEnabled = this.config.getFolderTrust();
     const isTrustedFolder = this.config.isTrustedFolder();
 
+    const loadedAgentDirs = new Set<string>();
+    const shouldLoadAgentDir = (dir: string): boolean => {
+      const key = normalizePath(dir);
+      if (loadedAgentDirs.has(key)) {
+        return false;
+      }
+      loadedAgentDirs.add(key);
+      return true;
+    };
+
     if (!folderTrustEnabled || isTrustedFolder) {
       const projectAgentsDir = this.config.storage.getProjectAgentsDir();
-      const projectAgents = await loadAgentsFromDirectory(projectAgentsDir);
+      const shouldLoadProjectAgents = shouldLoadAgentDir(projectAgentsDir);
+      const projectAgents = shouldLoadProjectAgents
+        ? await loadAgentsFromDirectory(projectAgentsDir)
+        : { agents: [], errors: [] };
       for (const error of projectAgents.errors) {
         const msg = `Agent loading error: ${error.message}`;
         errors?.push(msg);
@@ -233,7 +247,10 @@ export class AgentRegistry {
 
     // Load user-level agents: ~/.gemini/agents/
     const userAgentsDir = Storage.getUserAgentsDir();
-    const userAgents = await loadAgentsFromDirectory(userAgentsDir);
+    const shouldLoadUserAgents = shouldLoadAgentDir(userAgentsDir);
+    const userAgents = shouldLoadUserAgents
+      ? await loadAgentsFromDirectory(userAgentsDir)
+      : { agents: [], errors: [] };
     for (const error of userAgents.errors) {
       debugLogger.warn(
         `[AgentRegistry] Error loading user agent: ${error.message}`,


### PR DESCRIPTION
Fixes #27692.

## Summary
- deduplicate project-level and user-level agent directories before loading local agents
- keep project/user precedence unchanged when the directories are different
- add a regression test for the home-directory workspace case where both paths resolve to `~/.gemini/agents`

## To verify
- `npm exec -- vitest run packages/core/src/agents/registry.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm exec -- eslint packages/core/src/agents/registry.ts packages/core/src/agents/registry.test.ts --max-warnings 0`
- `git diff --check HEAD~1..HEAD`
