### PR TITLE
fix(agents): prevent duplicate agent loading from home directory

### DIFF
--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -5,6 +5,7 @@
  */
 
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import { Storage } from '../config/storage.js';
 import { CoreEvent, coreEvents } from '../utils/events.js';
 import type { AgentOverride, Config } from '../config/config.js';
@@ -233,28 +234,38 @@ export class AgentRegistry {
 
     // Load user-level agents: ~/.gemini/agents/
     const userAgentsDir = Storage.getUserAgentsDir();
-    const userAgents = await loadAgentsFromDirectory(userAgentsDir);
-    for (const error of userAgents.errors) {
-      debugLogger.warn(
-        `[AgentRegistry] Error loading user agent: ${error.message}`,
+    const projectAgentsDir = this.config.storage.getProjectAgentsDir();
+
+    // Fix: if user agents dir is the same as project agents dir (e.g. started in home dir),
+    // skip loading to avoid duplicate warnings.
+    if (path.resolve(userAgentsDir) !== path.resolve(projectAgentsDir)) {
+      const userAgents = await loadAgentsFromDirectory(userAgentsDir);
+      for (const error of userAgents.errors) {
+        debugLogger.warn(
+          `[AgentRegistry] Error loading user agent: ${error.message}`,
+        );
+        const msg = `Agent loading error: ${error.message}`;
+        errors?.push(msg);
+        coreEvents.emitFeedback('error', msg);
+      }
+      await Promise.allSettled(
+        userAgents.agents.map(async (agent) => {
+          try {
+            this.ensureRemoteAgentHash(agent);
+            await this.registerAgent(agent, errors);
+          } catch (e) {
+            const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
+            debugLogger.warn(`[AgentRegistry] ${msg}`, e);
+            errors?.push(msg);
+            coreEvents.emitFeedback('error', msg);
+          }
+        }),
       );
-      const msg = `Agent loading error: ${error.message}`;
-      errors?.push(msg);
-      coreEvents.emitFeedback('error', msg);
+    } else if (this.config.getDebugMode()) {
+      debugLogger.log(
+        `[AgentRegistry] Skipping user agents load because userAgentsDir is the same as projectAgentsDir.`,
+      );
     }
-    await Promise.allSettled(
-      userAgents.agents.map(async (agent) => {
-        try {
-          this.ensureRemoteAgentHash(agent);
-          await this.registerAgent(agent, errors);
-        } catch (e) {
-          const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
-          debugLogger.warn(`[AgentRegistry] ${msg}`, e);
-          errors?.push(msg);
-          coreEvents.emitFeedback('error', msg);
-        }
-      }),
-    );
 
     // Load agents from extensions
     for (const extension of this.config.getExtensions()) {


### PR DESCRIPTION
Fixes an issue where duplicate agent warnings occur if the CLI is started in the user's home directory. This is resolved by adding a path comparison between userAgentsDir and projectAgentsDir.

## Summary

Fixes an issue where duplicate agent warnings occur if the CLI is started in the user's home directory. This prevents redundant loading of agents and cleans up the startup log output.

## Details

The bug was caused by both `userAgentsDir` and `projectAgentsDir` pointing to the exact same path when the project root is the user's home directory. This resulted in the user's agents being loaded twice. 
The fix introduces a simple path comparison (using `node:path`'s `path.resolve`) before attempting to load user agents. If the absolute paths of the user and project agent directories match, the redundant load is skipped.

## Related Issues

Fixes #27692

## How to Validate

1. Run the test suite: `npm run test --workspace @google/gemini-cli-core`
2. Start the CLI in a folder that is NOT your home directory and ensure agents load normally.
3. Start the CLI in your home directory and ensure there are no `Duplicate agent name` warnings in the logs.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
