### PR TITLE
fix(core): Ensure zero-quota limits fail fast to prevent retry loop hang

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -823,4 +823,22 @@ describe('classifyGoogleError', () => {
 
     expect(result).toBeInstanceOf(TerminalQuotaError);
   });
+
+  it('should return TerminalQuotaError when limit is 0 even if structured RetryInfo is present', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message: 'Quota exceeded for limit: 0',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+          retryDelay: '59s',
+        },
+      ],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(
+      new Error('Quota exceeded for limit: 0'),
+    );
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
 });

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -898,6 +898,25 @@ describe('classifyGoogleError', () => {
     expect((result as ModelNotFoundError).message).toBe('Model not found');
   });
 
+  it('should parse custom 404 message from plain object correctly', () => {
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
+    const result = classifyGoogleError({
+      status: 404,
+      message: 'Custom 404 message',
+    });
+    expect(result).toBeInstanceOf(ModelNotFoundError);
+    expect((result as ModelNotFoundError).message).toBe('Custom 404 message');
+  });
+
+  it('should classify plain object with limit: 0 message as TerminalQuotaError correctly', () => {
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
+    const result = classifyGoogleError({
+      status: 429,
+      message: 'Quota exceeded, limit: 0',
+    });
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
   it('should handle Error instances with undefined message gracefully', () => {
     const malformedError = new Error();
     delete (malformedError as { message?: string }).message;

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -806,4 +806,21 @@ describe('classifyGoogleError', () => {
     const result = classifyGoogleError(new Error());
     expect(result).toBeInstanceOf(ValidationRequiredError);
   });
+
+  it('should return TerminalQuotaError when limit is 0 even if message contains "Please retry in Xs"', () => {
+    const complexError = {
+      error: {
+        message:
+          '{"error": {"code": 429, "status": 429, "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/usage?tab=rate-limit. \\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0\\nPlease retry in 59.906331105s.", "details": [{"detail": "??? to (unknown) : APP_ERROR(8) You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/usage?tab=rate-limit. \\n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0\\nPlease retry in 59.906331105s."}]}}',
+        code: 429,
+        status: 'Too Many Requests',
+      },
+    };
+    const rawError = new Error(JSON.stringify(complexError));
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
+
+    const result = classifyGoogleError(rawError);
+
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
 });

--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -816,7 +816,10 @@ describe('classifyGoogleError', () => {
         status: 'Too Many Requests',
       },
     };
-    const rawError = new Error(JSON.stringify(complexError));
+    const rawError = new Error(JSON.stringify(complexError)) as Error & {
+      status?: number;
+    };
+    rawError.status = 429;
     vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
 
     const result = classifyGoogleError(rawError);
@@ -840,5 +843,67 @@ describe('classifyGoogleError', () => {
       new Error('Quota exceeded for limit: 0'),
     );
     expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
+  it('should return TerminalQuotaError when limit is 0 and message contains actual newlines', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message: 'Quota exceeded for metric: ...\nlimit: 0, model: gemini-3-pro',
+      details: [],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(
+      new Error(
+        'Quota exceeded for metric: ...\nlimit: 0, model: gemini-3-pro',
+      ),
+    );
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
+  it('should return TerminalQuotaError when limit is 0 followed by a period', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message: 'Quota exceeded for metric: ...\nlimit: 0. Please retry in 59s.',
+      details: [],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(
+      new Error(
+        'Quota exceeded for metric: ...\nlimit: 0. Please retry in 59s.',
+      ),
+    );
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
+  it('should return RetryableQuotaError when limit is fractional (e.g., 0.5)', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message:
+        'Quota exceeded for metric: ...\nlimit: 0.5. Please retry in 59s.',
+      details: [],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(
+      new Error(
+        'Quota exceeded for metric: ...\nlimit: 0.5. Please retry in 59s.',
+      ),
+    );
+    expect(result).toBeInstanceOf(RetryableQuotaError);
+  });
+
+  it('should fall back to "Model not found" for 404 error with plain object', () => {
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
+    const result = classifyGoogleError({ status: 404 });
+    expect(result).toBeInstanceOf(ModelNotFoundError);
+    expect((result as ModelNotFoundError).message).toBe('Model not found');
+  });
+
+  it('should handle Error instances with undefined message gracefully', () => {
+    const malformedError = new Error();
+    delete (malformedError as { message?: string }).message;
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(null);
+
+    const result = classifyGoogleError(malformedError);
+    expect(result).toBe(malformedError); // Should return the original error without crashing
   });
 });

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -247,7 +247,7 @@ export function classifyGoogleError(error: unknown): unknown {
       googleApiError?.message ||
       (error instanceof Error ? error.message : String(error));
 
-    if (errorMessage.includes('limit: 0') || errorMessage.includes('limit:0')) {
+    if (/limit:\s*0(?!\d|\.)/.test(errorMessage)) {
       const cause = googleApiError ?? {
         code: status ?? 429,
         message: errorMessage,

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -219,16 +219,10 @@ function classifyValidationRequiredError(
 export function classifyGoogleError(error: unknown): unknown {
   const googleApiError = parseGoogleApiError(error);
   const status = googleApiError?.code ?? getErrorStatus(error);
-  const errorMessage =
-    googleApiError?.message ||
-    (error instanceof Error ? error.message : String(error)) ||
-    '';
+  const errorMessage = googleApiError?.message || extractErrorMessage(error);
 
   if (status === 404) {
-    const message =
-      googleApiError?.message?.trim() ||
-      (error instanceof Error ? error.message?.trim() : '') ||
-      'Model not found';
+    const message = errorMessage.trim() || 'Model not found';
     return new ModelNotFoundError(message, status);
   }
 
@@ -411,4 +405,17 @@ export function classifyGoogleError(error: unknown): unknown {
   // If we reached this point, the status is 429, 499, or 503 and we have details,
   // but no specific violation was matched. We return a generic retryable error.
   return new RetryableQuotaError(errorMessage, googleApiError);
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const msg = (error as { message: unknown }).message;
+    if (typeof msg === 'string') {
+      return msg;
+    }
+  }
+  return '';
 }

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -219,12 +219,12 @@ function classifyValidationRequiredError(
 export function classifyGoogleError(error: unknown): unknown {
   const googleApiError = parseGoogleApiError(error);
   const status = googleApiError?.code ?? getErrorStatus(error);
+  const errorMessage =
+    googleApiError?.message ||
+    (error instanceof Error ? error.message : String(error));
 
   if (status === 404) {
-    const message =
-      googleApiError?.message ||
-      (error instanceof Error ? error.message : 'Model not found');
-    return new ModelNotFoundError(message, status);
+    return new ModelNotFoundError(errorMessage || 'Model not found', status);
   }
 
   // Check for 403 VALIDATION_REQUIRED errors from Cloud Code API
@@ -235,6 +235,22 @@ export function classifyGoogleError(error: unknown): unknown {
     }
   }
 
+  // Universal limit: 0 check (moved outside and before the fallback block)
+  if (
+    (status === 429 ||
+      status === 499 ||
+      status === 503 ||
+      status === undefined) &&
+    /(?:Quota exceeded|quota_exceeded).*limit:\s*0(?!\d|\.)/i.test(errorMessage)
+  ) {
+    const cause = googleApiError ?? {
+      code: status ?? 429,
+      message: errorMessage,
+      details: [],
+    };
+    return new TerminalQuotaError(errorMessage, cause);
+  }
+
   if (
     !googleApiError ||
     (googleApiError.code !== 429 &&
@@ -243,19 +259,6 @@ export function classifyGoogleError(error: unknown): unknown {
     googleApiError.details.length === 0
   ) {
     // Fallback: try to parse the error message for a retry delay
-    const errorMessage =
-      googleApiError?.message ||
-      (error instanceof Error ? error.message : String(error));
-
-    if (/limit:\s*0(?!\d|\.)/.test(errorMessage)) {
-      const cause = googleApiError ?? {
-        code: status ?? 429,
-        message: errorMessage,
-        details: [],
-      };
-      return new TerminalQuotaError(errorMessage, cause);
-    }
-
     const match = errorMessage.match(/Please retry in ([0-9.]+(?:ms|s))/);
     if (match?.[1]) {
       const retryDelaySeconds = parseDurationInSeconds(match[1]);
@@ -404,8 +407,5 @@ export function classifyGoogleError(error: unknown): unknown {
 
   // If we reached this point, the status is 429, 499, or 503 and we have details,
   // but no specific violation was matched. We return a generic retryable error.
-  const errorMessage =
-    googleApiError.message ||
-    (error instanceof Error ? error.message : String(error));
   return new RetryableQuotaError(errorMessage, googleApiError);
 }

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -221,10 +221,15 @@ export function classifyGoogleError(error: unknown): unknown {
   const status = googleApiError?.code ?? getErrorStatus(error);
   const errorMessage =
     googleApiError?.message ||
-    (error instanceof Error ? error.message : String(error));
+    (error instanceof Error ? error.message : String(error)) ||
+    '';
 
   if (status === 404) {
-    return new ModelNotFoundError(errorMessage || 'Model not found', status);
+    const message =
+      googleApiError?.message?.trim() ||
+      (error instanceof Error ? error.message?.trim() : '') ||
+      'Model not found';
+    return new ModelNotFoundError(message, status);
   }
 
   // Check for 403 VALIDATION_REQUIRED errors from Cloud Code API
@@ -236,12 +241,10 @@ export function classifyGoogleError(error: unknown): unknown {
   }
 
   // Universal limit: 0 check (moved outside and before the fallback block)
+  const lowerMessage = errorMessage.toLowerCase();
   if (
-    (status === 429 ||
-      status === 499 ||
-      status === 503 ||
-      status === undefined) &&
-    /(?:Quota exceeded|quota_exceeded).*limit:\s*0(?!\d|\.)/i.test(errorMessage)
+    (status === 429 || status === 499 || status === 503) &&
+    /limit:\s*0(?!\d|\.\d)/.test(lowerMessage)
   ) {
     const cause = googleApiError ?? {
       code: status ?? 429,

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -246,6 +246,16 @@ export function classifyGoogleError(error: unknown): unknown {
     const errorMessage =
       googleApiError?.message ||
       (error instanceof Error ? error.message : String(error));
+
+    if (errorMessage.includes('limit: 0') || errorMessage.includes('limit:0')) {
+      const cause = googleApiError ?? {
+        code: status ?? 429,
+        message: errorMessage,
+        details: [],
+      };
+      return new TerminalQuotaError(errorMessage, cause);
+    }
+
     const match = errorMessage.match(/Please retry in ([0-9.]+(?:ms|s))/);
     if (match?.[1]) {
       const retryDelaySeconds = parseDurationInSeconds(match[1]);


### PR DESCRIPTION
Fail fast on zero-quota limits to prevent retry loop hang

## Summary

This PR fixes a critical bug in the error classification logic where the Gemini-CLI gets trapped in a futile 10-attempt retry loop when hitting a hard quota limit of `0` (e.g., on unbilled free-tier accounts). This bug causes the CLI to hang for up to 10 minutes before failing, severely degrading the user experience.

## Details

- **The Bug:** When the Gemini API returns a `429` error with `limit: 0` and a `"Please retry in 59.906331105s."` message, `classifyGoogleError` matches the retry delay and incorrectly classifies it as a `RetryableQuotaError`.
- **The Fix:** We added a defensive check in `classifyGoogleError` (inside `packages/core/src/utils/googleQuotaErrors.ts`) to intercept any error message containing `"limit: 0"` or `"limit:0"` and immediately classify it as a `TerminalQuotaError`. This check is executed *before* the retry delay regex is evaluated.
- **Impact:** The CLI now fails fast on zero-quota limits, immediately propagating the error to the user instead of hanging for 10 minutes. Standard rate limits (which do not contain `limit: 0`) are unaffected and will still be retried with backoff as expected.

## Related Issues


## How to Validate

1. Run the newly added unit test case to verify that `limit: 0` errors are correctly classified as `TerminalQuotaError`:
   ```bash
   npx vitest run packages/core/src/utils/googleQuotaErrors.test.ts
   ```
   **Expected Result:** All 35 tests pass successfully, including the new test case `should return TerminalQuotaError when limit is 0 even if message contains "Please retry in Xs"`.

2. Run the retry utility tests to ensure no regressions in the core retry logic:
   ```bash
   npx vitest run packages/core/src/utils/retry.test.ts
   ```
   **Expected Result:** All 41 tests pass successfully.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
