### PR TITLE
fix(core): treat configured includeDirectories as optional to prevent startup crash

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -513,6 +513,41 @@ describe('Server Config (config.ts)', () => {
       expect(mcpStarted).toBe(true);
     });
 
+    it('should not crash when an entry in includeDirectories is missing on disk (#27311)', async () => {
+      // Regression for #27311: a configured includeDirectories entry that
+      // does not exist on disk (e.g. an optional `.kilocode/rules` dir)
+      // must not bring down the CLI on startup. The expected behaviour
+      // is that addDirectories logs a warning and continues with the
+      // directories that do exist.
+      const missingDir = '/path/to/missing/.kilocode/rules';
+      const presentDir = '/path/to/present/.cursor/rules';
+
+      const fsMod = await import('node:fs');
+      vi.mocked(fsMod.existsSync).mockImplementation(
+        (p) => String(p) !== missingDir,
+      );
+      const warnSpy = vi
+        .spyOn(debugLogger, 'warn')
+        .mockImplementation(() => {});
+
+      const config = new Config({
+        ...baseParams,
+        checkpointing: false,
+        includeDirectories: [missingDir, presentDir],
+      });
+
+      await expect(config.initialize()).resolves.toBeUndefined();
+
+      const dirs = config.getWorkspaceContext().getDirectories();
+      expect(dirs).not.toContain(missingDir);
+      expect(dirs).toContain(presentDir);
+
+      const warnedAboutMissing = warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes(missingDir),
+      );
+      expect(warnedAboutMissing).toBe(true);
+    });
+
     describe('getCompressionThreshold', () => {
       it('should return the local compression threshold if it is set', async () => {
         const config = new Config({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1446,10 +1446,12 @@ export class Config implements McpContext, AgentLoopContext {
     await this.storage.initialize();
     ragLogger.initialize(this.storage.getProjectTempLogsDir());
 
-    // Add pending directories to workspace context
-    for (const dir of this.pendingIncludeDirectories) {
-      this.workspaceContext.addDirectory(dir);
-    }
+    // Add pending directories to workspace context. Use addDirectories
+    // (plural) so missing optional directories — e.g. a project that
+    // configures `.kilocode/rules` in settings.context.includeDirectories
+    // but does not have that directory on disk — emit a warning and are
+    // skipped rather than throwing and crashing startup. See #27311.
+    this.workspaceContext.addDirectories(this.pendingIncludeDirectories);
 
     // Add plans directory to workspace context for plan file storage
     if (this.planEnabled) {


### PR DESCRIPTION
## Summary

Switch the startup loop in `Config._initialize` from the strict `WorkspaceContext.addDirectory` (singular) to the lenient `addDirectories` (plural) so that a missing entry in `settings.context.includeDirectories` (e.g. an optional `.kilocode/rules` directory) no longer crashes the CLI on startup.

## Details

**Root cause.** `Config._initialize` adds each pending include-directory one at a time:

```ts
for (const dir of this.pendingIncludeDirectories) {
  this.workspaceContext.addDirectory(dir);
}
```

`WorkspaceContext.addDirectory` is the strict singular form: if `resolveAndValidateDir` cannot stat the path, it throws. Because the surrounding loop has no try/catch, the first missing directory escapes `_initialize` and surfaces as the user-visible

```
[WARN] Skipping unreadable directory: .kilocode/rules (Directory does not exist: …)
An unexpected critical error occurred: Error: Directory does not exist: …/.kilocode/rules
    at WorkspaceContext.resolveAndValidateDir
    …
```

reported in #27311.

**Fix.** `WorkspaceContext.addDirectories` (plural) already exists and is the documented "warn-and-continue" path — it tries each directory, catches per-directory errors, emits the same `[WARN] Skipping unreadable directory: …` line that the issue reporter sees just before the crash, and returns `{ added, failed }`. Its lenient behaviour is pinned by the existing `workspaceContext.test.ts` → `should skip a missing optional directory and log a warning`.

The fix simply routes through the existing lenient API. No new error-suppression is introduced. Configured `includeDirectories` are opt-in workspace extensions and the per-directory warning has always been there to support that intent.

Other `addDirectory` call sites are intentionally strict and remain untouched:
- `tools/activate-skill.ts` — user-driven skill activation; missing dir is a real error.
- `config.ts` plansDir / nextPlansDir paths — already wrapped in their own try/catch.

## Related Issues

Fixes #27311

## How to Validate

- `npm test -w @google/gemini-cli-core -- src/config/config.test.ts` — all 236 config tests pass, including the new regression test `should not crash when an entry in includeDirectories is missing on disk (#27311)`.
- The new regression test fails on unfixed code with the same stack trace from the issue (`Error: Directory does not exist … at Config._initialize src/config/config.ts:1451:29`), confirming it pins the bug.
- Manual: add a path that does not exist to `settings.context.includeDirectories` and run `gemini --prompt "test"`; the CLI now logs a warning and starts normally instead of crashing.

## Pre-Merge Checklist

- [x] Conventional-commit title and message format
- [x] Single-purpose change; no drive-by edits
- [x] Regression test added that fails on unfixed code and passes on fixed code
- [x] `npm run typecheck -w @google/gemini-cli-core` passes
- [x] `npx eslint` and `npx prettier --check` clean on changed files
- [x] No public API or behavioural change for any other call site
- [x] No new dependencies