### PR TITLE
fix(core): keep auto visible without preview access

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -407,7 +407,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     auto: {
       displayName: 'Auto',
       tier: 'auto',
-      isPreview: true,
+      isPreview: false,
       isVisible: true,
       features: { thinking: true, multimodalToolUse: false },
     },

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -1152,5 +1152,31 @@ describe('ModelConfigService', () => {
         'gemini-3-pro',
       );
     });
+
+    it('should keep Auto visible without preview access', () => {
+      const config: ModelConfigServiceConfig = {
+        modelDefinitions: {
+          auto: {
+            displayName: 'Auto',
+            tier: 'auto',
+            isPreview: false,
+            isVisible: true,
+          },
+          'auto-gemini-3': {
+            tier: 'auto',
+            isPreview: true,
+            isVisible: true,
+          },
+        },
+      };
+      const service = new ModelConfigService(config);
+
+      const options = service.getAvailableModelOptions({
+        hasAccessToPreview: false,
+      });
+
+      expect(options.map((o) => o.modelId)).toContain('auto');
+      expect(options.map((o) => o.modelId)).not.toContain('auto-gemini-3');
+    });
   });
 });


### PR DESCRIPTION
Fixes #27715

## What changed

- Mark the top-level `auto` alias as non-preview so it remains visible in `/model` when dynamic model configuration is enabled.
- Keep preview-only auto aliases filtered for users without preview access.
- Add regression coverage for the no-preview-access model option list.

## Why

`auto` is a user-facing alias, not a preview-only model. It already resolves to a stable model when preview access is unavailable, but its `isPreview: true` metadata made `getAvailableModelOptions()` filter it out before that resolution could happen.

## Testing

- `npm run test --workspace=packages/core -- src/services/modelConfigService.test.ts`
- `npx prettier --check packages/core/src/config/defaultModelConfigs.ts packages/core/src/services/modelConfigService.test.ts`
- `npx eslint packages/core/src/config/defaultModelConfigs.ts packages/core/src/services/modelConfigService.test.ts --max-warnings 0`
- `git diff --check`
