### PR TITLE
Fix issue (https://github.com/google-gemini/gemini-cli/issues/27728) truncate telemetry metric attributes to 1024 chars to prevent GCP export errors

### DIFF
--- a/packages/core/src/telemetry/gcp-exporters.test.ts
+++ b/packages/core/src/telemetry/gcp-exporters.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
+import type { ResourceMetrics } from '@opentelemetry/sdk-metrics';
 import {
   GcpTraceExporter,
   GcpMetricExporter,
@@ -24,21 +25,40 @@ const mockLogging = {
   log: vi.fn().mockReturnValue(mockLog),
 };
 
-vi.mock('@google-cloud/opentelemetry-cloud-trace-exporter', () => ({
-  TraceExporter: vi.fn().mockImplementation(() => ({
-    export: vi.fn(),
-    shutdown: vi.fn(),
-    forceFlush: vi.fn(),
-  })),
-}));
+vi.mock('@google-cloud/opentelemetry-cloud-trace-exporter', () => {
+  class MockTraceExporter {
+    export(): void {}
+    shutdown(): Promise<void> {
+      return Promise.resolve();
+    }
+    forceFlush(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+  return {
+    TraceExporter: MockTraceExporter,
+  };
+});
 
-vi.mock('@google-cloud/opentelemetry-cloud-monitoring-exporter', () => ({
-  MetricExporter: vi.fn().mockImplementation(() => ({
-    export: vi.fn(),
-    shutdown: vi.fn(),
-    forceFlush: vi.fn(),
-  })),
-}));
+vi.mock('@google-cloud/opentelemetry-cloud-monitoring-exporter', () => {
+  class MockMetricExporter {
+    export(
+      metrics: unknown,
+      resultCallback: (result: { code: number }) => void,
+    ): void {
+      resultCallback({ code: 0 }); // 0 is ExportResultCode.SUCCESS
+    }
+    shutdown(): Promise<void> {
+      return Promise.resolve();
+    }
+    forceFlush(): Promise<void> {
+      return Promise.resolve();
+    }
+  }
+  return {
+    MetricExporter: MockMetricExporter,
+  };
+});
 
 vi.mock('@google-cloud/logging', () => ({
   Logging: vi.fn().mockImplementation(() => mockLogging),
@@ -66,6 +86,85 @@ describe('GCP Exporters', () => {
     it('should create a metric exporter without project ID', () => {
       const exporter = new GcpMetricExporter();
       expect(exporter).toBeDefined();
+    });
+
+    it('should truncate long metric attributes/labels to 1024 characters during export', () => {
+      const exporter = new GcpMetricExporter('test-project');
+
+      const longString = 'a'.repeat(2000);
+      const mockMetrics = {
+        resource: {
+          attributes: {
+            'resource.label': longString,
+          },
+        },
+        scopeMetrics: [
+          {
+            scope: {
+              name: 'test-scope',
+            },
+            metrics: [
+              {
+                descriptor: { name: 'test_metric' },
+                dataPoints: [
+                  {
+                    attributes: {
+                      routing_reasoning: longString,
+                      short_label: 'short',
+                    },
+                    value: 123,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const callback = vi.fn();
+      exporter.export(mockMetrics as unknown as ResourceMetrics, callback);
+
+      expect(mockMetrics.resource.attributes['resource.label'].length).toBe(
+        1024,
+      );
+      expect(mockMetrics.resource.attributes['resource.label']).toBe(
+        'a'.repeat(1024),
+      );
+
+      const dpAttrs =
+        mockMetrics.scopeMetrics[0].metrics[0].dataPoints[0].attributes;
+      expect(dpAttrs['routing_reasoning'].length).toBe(1024);
+      expect(dpAttrs['routing_reasoning']).toBe('a'.repeat(1024));
+      expect(dpAttrs['short_label']).toBe('short');
+    });
+
+    it('should handle undefined or empty fields defensively when exporting', () => {
+      const exporter = new GcpMetricExporter('test-project');
+
+      const mockMetrics = {
+        resource: undefined,
+        scopeMetrics: [
+          {
+            scope: undefined,
+            metrics: [
+              {
+                descriptor: { name: 'test_metric' },
+                dataPoints: [
+                  {
+                    attributes: undefined,
+                    value: 123,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const callback = vi.fn();
+      expect(() =>
+        exporter.export(mockMetrics as unknown as ResourceMetrics, callback),
+      ).not.toThrow();
     });
   });
 

--- a/packages/core/src/telemetry/gcp-exporters.test.ts
+++ b/packages/core/src/telemetry/gcp-exporters.test.ts
@@ -88,15 +88,17 @@ describe('GCP Exporters', () => {
       expect(exporter).toBeDefined();
     });
 
-    it('should truncate long metric attributes/labels to 1024 characters during export', () => {
+    it('should truncate long metric attributes/labels to 1024 characters during export without mutating frozen objects, and safely handle multi-byte characters', () => {
       const exporter = new GcpMetricExporter('test-project');
 
       const longString = 'a'.repeat(2000);
+      // Construct a string with 2000 emojis (each taking more than 1 code unit)
+      const longEmojiString = '🎈'.repeat(2000);
       const mockMetrics = {
         resource: {
-          attributes: {
+          attributes: Object.freeze({
             'resource.label': longString,
-          },
+          }),
         },
         scopeMetrics: [
           {
@@ -108,10 +110,10 @@ describe('GCP Exporters', () => {
                 descriptor: { name: 'test_metric' },
                 dataPoints: [
                   {
-                    attributes: {
-                      routing_reasoning: longString,
+                    attributes: Object.freeze({
+                      routing_reasoning: longEmojiString,
                       short_label: 'short',
-                    },
+                    }),
                     value: 123,
                   },
                 ],
@@ -133,8 +135,9 @@ describe('GCP Exporters', () => {
 
       const dpAttrs =
         mockMetrics.scopeMetrics[0].metrics[0].dataPoints[0].attributes;
-      expect(dpAttrs['routing_reasoning'].length).toBe(1024);
-      expect(dpAttrs['routing_reasoning']).toBe('a'.repeat(1024));
+
+      // '🎈' takes 2 UTF-16 code units. 1024 graphemes * 2 code units = 2048 code units.
+      expect(dpAttrs['routing_reasoning']).toBe('🎈'.repeat(1024));
       expect(dpAttrs['short_label']).toBe('short');
     });
 

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -37,6 +37,51 @@ export class GcpTraceExporter extends TraceExporter {
 }
 
 /**
+ * Truncates attribute string values to 1024 characters.
+ */
+function truncateAttributes(attributes: Record<string, unknown>): void {
+  for (const key of Object.keys(attributes)) {
+    const val = attributes[key];
+    if (typeof val === 'string' && val.length > 1024) {
+      attributes[key] = val.substring(0, 1024);
+    }
+  }
+}
+
+function processDataPoint(
+  dp: ResourceMetrics['scopeMetrics'][number]['metrics'][number]['dataPoints'][number],
+): void {
+  if (dp?.attributes) {
+    truncateAttributes(dp.attributes as Record<string, unknown>);
+  }
+}
+
+function processMetric(
+  metric: ResourceMetrics['scopeMetrics'][number]['metrics'][number],
+): void {
+  metric?.dataPoints?.forEach(processDataPoint);
+}
+
+function processScopeMetric(
+  scopeMetric: ResourceMetrics['scopeMetrics'][number],
+): void {
+  scopeMetric?.metrics?.forEach(processMetric);
+}
+
+/**
+ * Traverses ResourceMetrics and truncates all attribute values to 1024 characters.
+ */
+function truncateMetricAttributes(metrics: ResourceMetrics): void {
+  if (!metrics) return;
+
+  if (metrics.resource?.attributes) {
+    truncateAttributes(metrics.resource.attributes as Record<string, unknown>);
+  }
+
+  metrics.scopeMetrics?.forEach(processScopeMetric);
+}
+
+/**
  * Google Cloud Monitoring exporter that extends the official metrics exporter
  */
 export class GcpMetricExporter extends MetricExporter {
@@ -52,6 +97,7 @@ export class GcpMetricExporter extends MetricExporter {
     metrics: ResourceMetrics,
     resultCallback: (result: ExportResult) => void,
   ): void {
+    truncateMetricAttributes(metrics);
     super.export(metrics, (result: ExportResult) => {
       if (result.code === ExportResultCode.FAILED && result.error) {
         // Suppress errors related to writing too frequently, as they are

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -39,20 +39,31 @@ export class GcpTraceExporter extends TraceExporter {
 /**
  * Truncates attribute string values to 1024 characters.
  */
-function truncateAttributes(attributes: Record<string, unknown>): void {
+function truncateAttributes(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
+  let cloned: Record<string, unknown> | undefined;
   for (const key of Object.keys(attributes)) {
     const val = attributes[key];
-    if (typeof val === 'string' && val.length > 1024) {
-      attributes[key] = val.substring(0, 1024);
+    if (typeof val === 'string') {
+      const chars = Array.from(val);
+      if (chars.length > 1024) {
+        if (!cloned) {
+          cloned = { ...attributes };
+        }
+        cloned[key] = chars.slice(0, 1024).join('');
+      }
     }
   }
+  return cloned ?? attributes;
 }
 
 function processDataPoint(
   dp: ResourceMetrics['scopeMetrics'][number]['metrics'][number]['dataPoints'][number],
 ): void {
   if (dp?.attributes) {
-    truncateAttributes(dp.attributes as Record<string, unknown>);
+    (dp as { attributes: Record<string, unknown> }).attributes =
+      truncateAttributes(dp.attributes as Record<string, unknown>);
   }
 }
 
@@ -75,7 +86,10 @@ function truncateMetricAttributes(metrics: ResourceMetrics): void {
   if (!metrics) return;
 
   if (metrics.resource?.attributes) {
-    truncateAttributes(metrics.resource.attributes as Record<string, unknown>);
+    (metrics.resource as { attributes: Record<string, unknown> }).attributes =
+      truncateAttributes(
+        metrics.resource.attributes as Record<string, unknown>,
+      );
   }
 
   metrics.scopeMetrics?.forEach(processScopeMetric);


### PR DESCRIPTION
## Summary

Fixes an issue where `gemini-cli` floods the terminal with Node.js stack traces when exporting telemetry metrics, particularly noticeable when requesting JSON output (`-p ... --format json`).

The root cause is that the Google Cloud Monitoring exporter enforces a 1024-character limit for metric attribute/label values. When the `routing_reasoning` attribute (which explains model selection) exceeds this limit due to long transcripts (e.g., detailed contexts like the "Dmart CL" rollout), the export fails and throws errors that disrupt the user's terminal experience. 

This PR adds a mechanism to truncate all string metric attributes to 1024 characters before exporting them to GCP, preventing these errors while preserving the core telemetry functionality.

## Details

- Implemented `truncateAttributes`, `processDataPoint`, `processMetric`, and `processScopeMetric` functions in `packages/core/src/telemetry/gcp-exporters.ts` to traverse the OpenTelemetry `ResourceMetrics` object.
- The `GcpMetricExporter.export` method now intercepts the metrics and truncates any string attribute that exceeds 1024 characters.
- Added comprehensive unit tests in `packages/core/src/telemetry/gcp-exporters.test.ts` to ensure attributes are properly truncated and that undefined properties are handled defensively.
- **Privacy Note:** The traces used to debug this issue were anonymized (replacing real emails, names, and specific rollout data with placeholders like `user@example.com`) to protect user privacy in the public bug report.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #27728

## How to Validate

1. Run `gemini-cli` with a prompt that requires extensive reasoning and forces a large output context (e.g., `-p "..." --format json`).
2. Verify that the terminal is no longer flooded with GCP monitoring exporter errors or Node.js stack traces.
3. Run unit tests for the core package: `npm test -w @google/gemini-cli-core -- src/telemetry/gcp-exporters.test.ts`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
