### PR TITLE
fix: keep array tool results out of structuredContent

### DIFF
--- a/packages/core/src/tools/mcp-compliance-transport.test.ts
+++ b/packages/core/src/tools/mcp-compliance-transport.test.ts
@@ -69,6 +69,34 @@ describe('McpComplianceTransport', () => {
     );
   });
 
+  it('should NOT use JSON arrays as structuredContent', async () => {
+    const mockTransport = createMockTransport();
+    const complianceTransport = new McpComplianceTransport(mockTransport);
+    const onMessage = vi.fn();
+    complianceTransport.onmessage = onMessage;
+
+    const rawResponse: JSONRPCMessage = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([{ summary: 'standup' }]),
+          },
+        ],
+      },
+    };
+
+    mockTransport.onmessage!(rawResponse);
+
+    const fixedResponse = onMessage.mock.calls[0][0];
+    expect(fixedResponse.result.structuredContent).toBeUndefined();
+    expect(fixedResponse.result.content[0].text).toBe(
+      JSON.stringify([{ summary: 'standup' }]),
+    );
+  });
+
   it('should NOT modify already compliant responses', async () => {
     const mockTransport = createMockTransport();
     const complianceTransport = new McpComplianceTransport(mockTransport);

--- a/packages/core/src/tools/mcp-compliance-transport.ts
+++ b/packages/core/src/tools/mcp-compliance-transport.ts
@@ -11,6 +11,10 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js';
 import { EventEmitter } from 'node:events';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * A wrapper transport that intercepts messages from MCP servers and fixes
  * non-compliant responses.
@@ -87,11 +91,11 @@ export class McpComplianceTransport extends EventEmitter implements Transport {
       if (firstItem.type === 'text' && typeof firstItem.text === 'string') {
         try {
           // Attempt to parse the text as JSON
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const parsed = JSON.parse(firstItem.text);
-          // If successful, populate structuredContent
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          result.structuredContent = parsed;
+          const parsed: unknown = JSON.parse(firstItem.text);
+          if (isRecord(parsed)) {
+            // If successful, populate structuredContent
+            result.structuredContent = parsed;
+          }
         } catch {
           // Ignored: Content is likely plain text, not JSON.
         }


### PR DESCRIPTION
## Summary
- keep `McpComplianceTransport` from copying JSON arrays into `structuredContent`
- preserve the original text content for array-valued tool results
- add a regression test for calendar-style JSON array payloads

Fixes #27725.

## Tested
- `npm exec -- vitest run packages/core/src/tools/mcp-compliance-transport.test.ts`
- `npm exec -- prettier --check packages/core/src/tools/mcp-compliance-transport.ts packages/core/src/tools/mcp-compliance-transport.test.ts`
- `npm exec -- eslint packages/core/src/tools/mcp-compliance-transport.ts packages/core/src/tools/mcp-compliance-transport.test.ts --max-warnings 0`
- `git diff --check`

## Also checked
- `npm run typecheck --workspace @google/gemini-cli-core` was attempted locally, but this reused Windows `node_modules` checkout is missing workspace dependencies/generated files such as `@a2a-js/sdk`, `fdir`, and `generated/git-commit.js`, so the full package typecheck does not complete in this local environment.
