### PR TITLE
fix(web-fetch): prevent SSRF via DNS hostnames and redirects

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,10 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import {
+  isPrivateIp,
+  safeFetchFollowingRedirects,
+} from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -294,7 +297,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
 
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
+        const res = await safeFetchFollowingRedirects(url, URL_FETCH_TIMEOUT_MS, {
           signal,
           headers: {
             'User-Agent': USER_AGENT,
@@ -633,14 +636,18 @@ ${aggregatedContent}
     try {
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-            signal,
-            headers: {
-              Accept:
-                'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
-              'User-Agent': USER_AGENT,
+          const res = await safeFetchFollowingRedirects(
+            url,
+            URL_FETCH_TIMEOUT_MS,
+            {
+              signal,
+              headers: {
+                Accept:
+                  'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
+                'User-Agent': USER_AGENT,
+              },
             },
-          });
+          );
           return res;
         },
         {

--- a/packages/core/src/utils/fetch.ssrf.test.ts
+++ b/packages/core/src/utils/fetch.ssrf.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as dnsPromises from 'node:dns/promises';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  assertUrlIsPublic,
+  safeFetchFollowingRedirects,
+  PrivateIpError,
+} from './fetch.js';
+
+describe('assertUrlIsPublic', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    'http://127.0.0.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://10.0.0.5/',
+    'http://192.168.1.1/',
+    'http://localhost/',
+  ])('rejects the literal private or loopback address %s', async (url) => {
+    await expect(assertUrlIsPublic(url)).rejects.toBeInstanceOf(PrivateIpError);
+  });
+
+  it('rejects a hostname that resolves to a private address', async () => {
+    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
+      { address: '169.254.169.254', family: 4 },
+    ] as never);
+    await expect(
+      assertUrlIsPublic('http://metadata.internal.example/'),
+    ).rejects.toBeInstanceOf(PrivateIpError);
+  });
+
+  it('rejects a hostname that resolves to the gcp metadata address', async () => {
+    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
+      { address: '169.254.169.254', family: 4 },
+    ] as never);
+    await expect(
+      assertUrlIsPublic('http://metadata.google.internal/'),
+    ).rejects.toBeInstanceOf(PrivateIpError);
+  });
+
+  it('allows a hostname that resolves to a public address', async () => {
+    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+    ] as never);
+    await expect(
+      assertUrlIsPublic('http://example.test/'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('safeFetchFollowingRedirects', () => {
+  let internal: http.Server;
+  let internalUrl: string;
+
+  beforeEach(async () => {
+    internal = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('INTERNAL_SECRET');
+    });
+    await new Promise<void>((resolve) =>
+      internal.listen(0, '127.0.0.1', resolve),
+    );
+    internalUrl = `http://127.0.0.1:${(internal.address() as AddressInfo).port}/`;
+  });
+
+  afterEach(() => {
+    internal.close();
+    vi.restoreAllMocks();
+  });
+
+  it('refuses to fetch a private target so the internal body is never read', async () => {
+    await expect(
+      safeFetchFollowingRedirects(internalUrl, 5000),
+    ).rejects.toBeInstanceOf(PrivateIpError);
+  });
+});

--- a/packages/core/src/utils/fetch.ssrf.test.ts
+++ b/packages/core/src/utils/fetch.ssrf.test.ts
@@ -9,12 +9,31 @@ import * as dnsPromises from 'node:dns/promises';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import {
+  applyRedirect,
   assertUrlIsPublic,
   safeFetchFollowingRedirects,
   PrivateIpError,
 } from './fetch.js';
 
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+type MockLookup = (
+  hostname: string,
+) => Promise<Array<{ address: string; family: number }>>;
+
+function mockResolvedAddress(address: string): void {
+  vi.mocked(dnsPromises.lookup as unknown as MockLookup).mockImplementation(
+    async () => [{ address, family: 4 }],
+  );
+}
+
 describe('assertUrlIsPublic', () => {
+  beforeEach(() => {
+    mockResolvedAddress('93.184.216.34');
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -30,30 +49,94 @@ describe('assertUrlIsPublic', () => {
   });
 
   it('rejects a hostname that resolves to a private address', async () => {
-    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
-      { address: '169.254.169.254', family: 4 },
-    ] as never);
+    mockResolvedAddress('169.254.169.254');
     await expect(
       assertUrlIsPublic('http://metadata.internal.example/'),
     ).rejects.toBeInstanceOf(PrivateIpError);
   });
 
   it('rejects a hostname that resolves to the gcp metadata address', async () => {
-    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
-      { address: '169.254.169.254', family: 4 },
-    ] as never);
+    mockResolvedAddress('169.254.169.254');
     await expect(
       assertUrlIsPublic('http://metadata.google.internal/'),
     ).rejects.toBeInstanceOf(PrivateIpError);
   });
 
   it('allows a hostname that resolves to a public address', async () => {
-    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue([
-      { address: '93.184.216.34', family: 4 },
-    ] as never);
+    mockResolvedAddress('93.184.216.34');
     await expect(
       assertUrlIsPublic('http://example.test/'),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('applyRedirect', () => {
+  it.each(['gopher://evil/', 'file:///etc/passwd', 'ftp://evil/'])(
+    'rejects a redirect to the non http protocol %s',
+    (location) => {
+      expect(() =>
+        applyRedirect('https://a.example/', 302, location, {}),
+      ).toThrow();
+    },
+  );
+
+  it('strips credential headers on a cross origin redirect', () => {
+    const { nextOptions } = applyRedirect(
+      'https://a.example/',
+      302,
+      'https://b.example/',
+      {
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'session=secret',
+          'user-agent': 'gemini',
+        },
+      },
+    );
+    const headers = new Headers(nextOptions.headers);
+    expect(headers.get('authorization')).toBeNull();
+    expect(headers.get('cookie')).toBeNull();
+    expect(headers.get('user-agent')).toBe('gemini');
+  });
+
+  it('keeps headers on a same origin redirect', () => {
+    const { nextOptions } = applyRedirect(
+      'https://a.example/one',
+      302,
+      'https://a.example/two',
+      { headers: { authorization: 'Bearer secret' } },
+    );
+    const headers = new Headers(nextOptions.headers);
+    expect(headers.get('authorization')).toBe('Bearer secret');
+  });
+
+  it('downgrades a 303 to GET and drops the body and content headers', () => {
+    const { nextOptions } = applyRedirect(
+      'https://a.example/',
+      303,
+      'https://a.example/next',
+      {
+        method: 'POST',
+        body: 'payload',
+        headers: { 'content-type': 'application/json', 'content-length': '7' },
+      },
+    );
+    expect(nextOptions.method).toBe('GET');
+    expect(nextOptions.body).toBeUndefined();
+    const headers = new Headers(nextOptions.headers);
+    expect(headers.get('content-type')).toBeNull();
+    expect(headers.get('content-length')).toBeNull();
+  });
+
+  it('downgrades a 302 POST to GET', () => {
+    const { nextOptions } = applyRedirect(
+      'https://a.example/',
+      302,
+      'https://a.example/next',
+      { method: 'POST', body: 'payload' },
+    );
+    expect(nextOptions.method).toBe('GET');
+    expect(nextOptions.body).toBeUndefined();
   });
 });
 
@@ -62,6 +145,7 @@ describe('safeFetchFollowingRedirects', () => {
   let internalUrl: string;
 
   beforeEach(async () => {
+    mockResolvedAddress('93.184.216.34');
     internal = http.createServer((_req, res) => {
       res.writeHead(200, { 'content-type': 'text/plain' });
       res.end('INTERNAL_SECRET');

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -229,6 +229,62 @@ export async function fetchWithTimeout(
   }
 }
 
+const MAX_SAFE_REDIRECTS = 5;
+
+/**
+ * Throws PrivateIpError if the url targets a private, loopback, link local, or
+ * otherwise non public address. It checks both the literal hostname and the
+ * address the hostname resolves to, so it stops IP literals such as
+ * 169.254.169.254 and hostnames such as metadata.google.internal that resolve
+ * to a private address.
+ */
+export async function assertUrlIsPublic(url: string): Promise<void> {
+  if (isPrivateIp(url)) {
+    throw new PrivateIpError(
+      `Access to private or internal address ${url} is blocked`,
+    );
+  }
+  if (await isPrivateIpAsync(url)) {
+    throw new PrivateIpError(
+      `Host ${url} resolves to a private or internal address and is blocked`,
+    );
+  }
+}
+
+/**
+ * Fetches a url while enforcing the SSRF guard on the initial request and on
+ * every redirect hop. Redirects are followed manually so the resolved target
+ * of each hop is validated before the connection is made. Use this for any
+ * fetch whose url can be influenced by untrusted content.
+ */
+export async function safeFetchFollowingRedirects(
+  url: string,
+  timeout: number,
+  options?: RequestInit,
+): Promise<Response> {
+  let currentUrl = url;
+  for (let hop = 0; hop <= MAX_SAFE_REDIRECTS; hop++) {
+    await assertUrlIsPublic(currentUrl);
+    const response = await fetchWithTimeout(currentUrl, timeout, {
+      ...options,
+      redirect: 'manual',
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return response;
+      }
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+    return response;
+  }
+  throw new FetchError(
+    `Too many redirects while fetching ${url}`,
+    'ETOOMANYREDIRECTS',
+  );
+}
+
 export function setGlobalProxy(proxy: string) {
   const trimmedProxy = proxy.trim();
   currentProxy = trimmedProxy;

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -251,6 +251,71 @@ export async function assertUrlIsPublic(url: string): Promise<void> {
   }
 }
 
+// Credential carrying headers that must not be forwarded to a different origin
+// during a redirect.
+const SENSITIVE_HEADERS = [
+  'authorization',
+  'cookie',
+  'cookie2',
+  'proxy-authorization',
+];
+
+/**
+ * Computes the next url and request options for a redirect hop. It rejects any
+ * redirect target that is not http or https, strips credential carrying headers
+ * when the redirect crosses to a different origin, and downgrades the method to
+ * GET while removing the body for 303 responses and for non GET or HEAD 301 and
+ * 302 responses, following RFC 9110.
+ */
+export function applyRedirect(
+  currentUrl: string,
+  status: number,
+  location: string,
+  options: RequestInit,
+): { nextUrl: string; nextOptions: RequestInit } {
+  const nextUrl = new URL(location, currentUrl);
+  if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+    throw new FetchError(
+      `Unsupported redirect protocol ${nextUrl.protocol}`,
+      'EUNSUPPORTEDPROTOCOL',
+    );
+  }
+
+  let nextOptions: RequestInit = { ...options };
+
+  const currentUrlObj = new URL(currentUrl);
+  const isCrossOrigin =
+    currentUrlObj.protocol !== nextUrl.protocol ||
+    currentUrlObj.host !== nextUrl.host;
+  if (isCrossOrigin && nextOptions.headers) {
+    const headers = new Headers(nextOptions.headers);
+    for (const name of SENSITIVE_HEADERS) {
+      headers.delete(name);
+    }
+    nextOptions = { ...nextOptions, headers };
+  }
+
+  const method = (nextOptions.method ?? 'GET').toUpperCase();
+  if (
+    status === 303 ||
+    ((status === 301 || status === 302) &&
+      method !== 'GET' &&
+      method !== 'HEAD')
+  ) {
+    const headers = new Headers(nextOptions.headers ?? {});
+    headers.delete('content-type');
+    headers.delete('content-length');
+    nextOptions = {
+      ...nextOptions,
+      method: 'GET',
+      body: undefined,
+      headers,
+    };
+  }
+
+  return { nextUrl: nextUrl.toString(), nextOptions };
+}
+
 /**
  * Fetches a url while enforcing the SSRF guard on the initial request and on
  * every redirect hop. Redirects are followed manually so the resolved target
@@ -263,22 +328,34 @@ export async function safeFetchFollowingRedirects(
   options?: RequestInit,
 ): Promise<Response> {
   let currentUrl = url;
+  let currentOptions: RequestInit = { ...options };
+
   for (let hop = 0; hop <= MAX_SAFE_REDIRECTS; hop++) {
     await assertUrlIsPublic(currentUrl);
     const response = await fetchWithTimeout(currentUrl, timeout, {
-      ...options,
+      ...currentOptions,
       redirect: 'manual',
     });
-    if (response.status >= 300 && response.status < 400) {
-      const location = response.headers.get('location');
-      if (!location) {
-        return response;
-      }
-      currentUrl = new URL(location, currentUrl).toString();
-      continue;
+
+    if (response.status < 300 || response.status >= 400) {
+      return response;
     }
-    return response;
+
+    const location = response.headers.get('location');
+    if (!location) {
+      return response;
+    }
+
+    const next = applyRedirect(
+      currentUrl,
+      response.status,
+      location,
+      currentOptions,
+    );
+    currentUrl = next.nextUrl;
+    currentOptions = next.nextOptions;
   }
+
   throw new FetchError(
     `Too many redirects while fetching ${url}`,
     'ETOOMANYREDIRECTS',


### PR DESCRIPTION
## What this fixes

The `web_fetch` tool guards outbound requests with `isBlockedHost`
(`packages/core/src/tools/web-fetch.ts`), which inspects only the hostname
string of the entry url and delegates to the synchronous `isPrivateIp`. Two
gaps let a request reach a private or internal target:

1. Hostname bypass. `isPrivateIp` returns false for anything that is not an IP
   literal, so a DNS hostname that resolves to a private or link local address
   passes the guard. Examples are `metadata.google.internal`, an attacker owned
   domain whose A record points to `169.254.169.254` or `127.0.0.1`, and
   wildcard resolvers such as `169.254.169.254.nip.io`.
2. Redirect bypass. The guard runs only on the entry url. The fetch then follows
   HTTP redirects with the default behaviour and no revalidation, so an allowed
   host can redirect to an internal address.

In both cases the internal response body is returned to the caller, so the
attacker reads internal or cloud metadata content. On a Google Cloud host this
includes the service account token at
`http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token`.

The repository already contains `isPrivateIpAsync`, which resolves the hostname
and checks the address, but `web_fetch` never used it.

## The change

Add `assertUrlIsPublic` and `safeFetchFollowingRedirects` to
`packages/core/src/utils/fetch.ts`.

1. `assertUrlIsPublic` rejects a url whose literal hostname is private or
   loopback, and whose resolved address is private or link local, reusing the
   existing `isPrivateIp` and `isPrivateIpAsync`.
2. `safeFetchFollowingRedirects` follows redirects manually with
   `redirect: 'manual'` and calls `assertUrlIsPublic` on the initial url and on
   every redirect hop before connecting, so a hostname that resolves inward and
   a redirect that points inward are both refused. It caps the redirect chain.

`web_fetch` now uses `safeFetchFollowingRedirects` for both fallback fetch
paths. The existing synchronous `isBlockedHost` pre check is kept as a fast
first filter.

## Test cases

Added `packages/core/src/utils/fetch.ssrf.test.ts`:

1. `assertUrlIsPublic` rejects literal private and loopback addresses:
   `127.0.0.1`, `169.254.169.254`, `10.0.0.5`, `192.168.1.1`, `localhost`.
2. `assertUrlIsPublic` rejects a hostname that resolves to a private address
   (dns lookup mocked), including `metadata.google.internal` resolving to
   `169.254.169.254`.
3. `assertUrlIsPublic` allows a hostname that resolves to a public address.
4. `safeFetchFollowingRedirects` refuses a private target, so the internal body
   is never read.

Manual end to end check that the redirect hop is revalidated. With a local
internal server holding a secret and a redirector that points at it, a fetch
that passes the entry check is still refused when the redirect target resolves
to a private address, and the secret is never returned.

## Suggested follow up

For full protection against DNS rebinding between the check and the connection,
the validated address can be pinned at connect time with a custom dispatcher.
This change closes the reported bypasses without that larger refactor.

## Security

This addresses a Server Side Request Forgery issue (CWE 918). This was reported
to the Google Bug Hunters program.

## Checklist

1. Fix scoped to the `web_fetch` fetch paths.
2. Unit tests added.
3. Reuses existing `isPrivateIpAsync` rather than introducing a parallel check.
