### PR TITLE
ci(dependabot): enable cooldown period for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - 'joshualitt'
+    cooldown:
+      default-days: 7
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

Introduce a 7-day cooldown period for the `npm` package ecosystem in Dependabot configuration.

## Details

This configuration utilizes the `cooldown` block under the Dependabot version updates. By delaying routine npm updates by 7 days, we align with the community recommendation to allow sufficient time for security reviewers, registry maintainers, and automated systems to detect and pull malicious or heavily broken packages before they are automatically proposed in a PR.

*Routine updates will wait for 7 days after publication. Security-related hotfixes and CVE updates are not subject to cooldowns and will still be opened immediately.*

## Related Issues

None.

## How to Validate

We can validate the syntax of `.github/dependabot.yml` by running:
```bash
npm run format && npm run lint:all
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
