### PR TITLE
fix(web-fetch): resolve DNS before SSRF guard to block hostname-to-private-IP bypass

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -27,6 +27,7 @@ import {
   type ToolConfirmationResponse,
 } from '../confirmation-bus/types.js';
 import { randomUUID } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
 import {
   logWebFetchFallbackAttempt,
   WebFetchFallbackAttemptEvent,
@@ -52,13 +53,15 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
   return {
     ...actual,
     fetchWithTimeout: vi.fn(),
-    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
+    resolveAndValidateDns: vi.fn().mockResolvedValue(['8.8.8.8']),
   };
 });
 
 vi.mock('node:crypto', () => ({
   randomUUID: vi.fn(),
 }));
+
+vi.mock('node:dns/promises');
 
 /**
  * Helper to mock fetchWithTimeout with URL matching.
@@ -67,7 +70,16 @@ const mockFetch = (url: string, response: Partial<Response> | Error) =>
   vi
     .spyOn(fetchUtils, 'fetchWithTimeout')
     .mockImplementation(async (actualUrl) => {
-      if (actualUrl !== url) {
+      let pinnedUrlStr = url;
+      try {
+        const u = new URL(url);
+        u.hostname = '8.8.8.8';
+        pinnedUrlStr = u.toString();
+      } catch {
+        // ignore error
+      }
+
+      if (actualUrl !== url && actualUrl !== pinnedUrlStr) {
         throw new Error(
           `Unexpected fetch URL: expected "${url}", got "${actualUrl}"`,
         );
@@ -270,6 +282,10 @@ describe('WebFetchTool', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(lookup).mockResolvedValue([
+      { address: '8.8.8.8', family: 4 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
     bus = createMockMessageBus();
     getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
     mockConfig = {
@@ -376,7 +392,9 @@ describe('WebFetchTool', () => {
 
   describe('execute', () => {
     it('should return WEB_FETCH_PROCESSING_ERROR on rate limit exceeded', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValue({
         candidates: [{ content: { parts: [{ text: 'response' }] } }],
       });
@@ -400,7 +418,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip rate-limited URLs but fetch others', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
 
       const tool = new WebFetchTool(mockConfig, bus);
       const params = {
@@ -439,8 +459,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip private or local URLs but fetch others and log telemetry', async () => {
-      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
-        async (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+        async (url) => (url === 'https://private.com/' ? [] : ['8.8.8.8']),
       );
 
       const tool = new WebFetchTool(mockConfig, bus);
@@ -475,7 +495,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should fallback to all public URLs if primary fails', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
 
       // Primary fetch fails
       mockGenerateContent.mockRejectedValueOnce(new Error('primary fail'));
@@ -511,8 +533,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should NOT include private URLs in fallback', async () => {
-      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
-        async (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+        async (url) => (url === 'https://private.com/' ? [] : ['8.8.8.8']),
       );
 
       // Primary fetch fails
@@ -542,7 +564,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should return WEB_FETCH_FALLBACK_FAILED on total failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockRejectedValue(new Error('primary fail'));
       mockFetch('https://public.ip/', new Error('fallback fetch failed'));
       const tool = new WebFetchTool(mockConfig, bus);
@@ -555,7 +579,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should log telemetry when falling back due to primary fetch failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       // Mock primary fetch to return empty response, triggering fallback
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
@@ -587,7 +613,9 @@ describe('WebFetchTool', () => {
   describe('execute (fallback)', () => {
     beforeEach(() => {
       // Force fallback by mocking primary fetch to fail
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
       });
@@ -925,7 +953,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should execute normally after confirmation approval', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValue({
         candidates: [
           {
@@ -959,7 +989,9 @@ describe('WebFetchTool', () => {
   describe('execute (experimental)', () => {
     beforeEach(() => {
       vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(true);
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
     });
 
     it('should perform direct fetch and return text for plain text content', async () => {
@@ -980,7 +1012,7 @@ describe('WebFetchTool', () => {
       expect(result.llmContent).toBe(content);
       expect(result.returnDisplay).toContain('Fetched text/plain content');
       expect(fetchUtils.fetchWithTimeout).toHaveBeenCalledWith(
-        'https://example.com/',
+        'https://8.8.8.8/',
         expect.any(Number),
         expect.objectContaining({
           headers: expect.objectContaining({
@@ -1136,7 +1168,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should block private IP (experimental)', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([]);
       const tool = new WebFetchTool(mockConfig, bus);
       const invocation = tool['createInvocation'](
         { url: 'http://localhost' },
@@ -1178,7 +1210,7 @@ describe('WebFetchTool', () => {
         {
           label: '127.0.0.1.nip.io (nip.io loopback bypass)',
           url: 'http://127.0.0.1.nip.io',
-          // DNS resolves to 127.0.0.1 — mocked via isPrivateIpAsync
+          // DNS resolves to 127.0.0.1 — mocked via resolveAndValidateDns
           dnsPrivate: true,
         },
         {
@@ -1188,7 +1220,7 @@ describe('WebFetchTool', () => {
         },
       ])('should block $label', async ({ url, dnsPrivate }) => {
         if (dnsPrivate) {
-          vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+          vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([]);
         }
         const tool = new WebFetchTool(mockConfig, bus);
         const invocation = tool['createInvocation']({ url }, bus);
@@ -1205,7 +1237,9 @@ describe('WebFetchTool', () => {
       });
 
       it('should allow a public URL (https://google.com)', async () => {
-        vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+        vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+          '8.8.8.8',
+        ]);
         const content = 'Google homepage';
         mockFetch('https://google.com/', {
           status: 200,
@@ -1227,8 +1261,8 @@ describe('WebFetchTool', () => {
         // Override the outer beforeEach that enables experimental mode
         vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(false);
         // Simulate DNS resolving the hostname to a private IP
-        vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(async (url) =>
-          url.includes('127.0.0.1.nip.io'),
+        vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+          async (url) => (url.includes('127.0.0.1.nip.io') ? [] : ['8.8.8.8']),
         );
 
         const tool = new WebFetchTool(mockConfig, bus);

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -52,7 +52,7 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
   return {
     ...actual,
     fetchWithTimeout: vi.fn(),
-    isPrivateIp: vi.fn(),
+    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
   };
 });
 
@@ -376,7 +376,7 @@ describe('WebFetchTool', () => {
 
   describe('execute', () => {
     it('should return WEB_FETCH_PROCESSING_ERROR on rate limit exceeded', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [{ content: { parts: [{ text: 'response' }] } }],
       });
@@ -400,7 +400,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip rate-limited URLs but fetch others', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
 
       const tool = new WebFetchTool(mockConfig, bus);
       const params = {
@@ -439,8 +439,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip private or local URLs but fetch others and log telemetry', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
+        async (url) => url === 'https://private.com/',
       );
 
       const tool = new WebFetchTool(mockConfig, bus);
@@ -475,7 +475,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should fallback to all public URLs if primary fails', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
 
       // Primary fetch fails
       mockGenerateContent.mockRejectedValueOnce(new Error('primary fail'));
@@ -511,8 +511,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should NOT include private URLs in fallback', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
+        async (url) => url === 'https://private.com/',
       );
 
       // Primary fetch fails
@@ -542,7 +542,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should return WEB_FETCH_FALLBACK_FAILED on total failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockRejectedValue(new Error('primary fail'));
       mockFetch('https://public.ip/', new Error('fallback fetch failed'));
       const tool = new WebFetchTool(mockConfig, bus);
@@ -555,7 +555,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should log telemetry when falling back due to primary fetch failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       // Mock primary fetch to return empty response, triggering fallback
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
@@ -587,7 +587,7 @@ describe('WebFetchTool', () => {
   describe('execute (fallback)', () => {
     beforeEach(() => {
       // Force fallback by mocking primary fetch to fail
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
       });
@@ -925,7 +925,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should execute normally after confirmation approval', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [
           {
@@ -959,7 +959,7 @@ describe('WebFetchTool', () => {
   describe('execute (experimental)', () => {
     beforeEach(() => {
       vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(true);
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
     });
 
     it('should perform direct fetch and return text for plain text content', async () => {
@@ -1136,7 +1136,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should block private IP (experimental)', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(true);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
       const tool = new WebFetchTool(mockConfig, bus);
       const invocation = tool['createInvocation'](
         { url: 'http://localhost' },
@@ -1150,6 +1150,99 @@ describe('WebFetchTool', () => {
         'Error: Access to blocked or private host http://localhost/ is not allowed.',
       );
       expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_PROCESSING_ERROR);
+    });
+
+    describe('SSRF guard — DNS hostname-to-private-IP bypass (CVE-class)', () => {
+      it.each([
+        {
+          label: 'localhost (literal name)',
+          url: 'http://localhost',
+          // caught by explicit loopback check, no DNS mock needed
+          dnsPrivate: false,
+        },
+        {
+          label: '127.0.0.1 (IPv4 loopback literal)',
+          url: 'http://127.0.0.1',
+          dnsPrivate: false,
+        },
+        {
+          label: '::1 (IPv6 loopback literal)',
+          url: 'http://[::1]',
+          dnsPrivate: false,
+        },
+        {
+          label: '0.0.0.0 (unspecified literal)',
+          url: 'http://0.0.0.0',
+          dnsPrivate: false,
+        },
+        {
+          label: '127.0.0.1.nip.io (nip.io loopback bypass)',
+          url: 'http://127.0.0.1.nip.io',
+          // DNS resolves to 127.0.0.1 — mocked via isPrivateIpAsync
+          dnsPrivate: true,
+        },
+        {
+          label: '169.254.169.254.nip.io (cloud metadata bypass)',
+          url: 'http://169.254.169.254.nip.io',
+          dnsPrivate: true,
+        },
+      ])('should block $label', async ({ url, dnsPrivate }) => {
+        if (dnsPrivate) {
+          vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+        }
+        const tool = new WebFetchTool(mockConfig, bus);
+        const invocation = tool['createInvocation']({ url }, bus);
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error?.type).toBe(
+          ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        );
+        expect(result.llmContent).toContain(
+          'Access to blocked or private host',
+        );
+      });
+
+      it('should allow a public URL (https://google.com)', async () => {
+        vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+        const content = 'Google homepage';
+        mockFetch('https://google.com/', {
+          status: 200,
+          headers: new Headers({ 'content-type': 'text/plain' }),
+          text: () => Promise.resolve(content),
+        });
+
+        const tool = new WebFetchTool(mockConfig, bus);
+        const invocation = tool.build({ url: 'https://google.com' });
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.llmContent).toBe(content);
+      });
+
+      it('should block nip.io bypass in standard (non-experimental) mode', async () => {
+        // Override the outer beforeEach that enables experimental mode
+        vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(false);
+        // Simulate DNS resolving the hostname to a private IP
+        vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(async (url) =>
+          url.includes('127.0.0.1.nip.io'),
+        );
+
+        const tool = new WebFetchTool(mockConfig, bus);
+        const params = { prompt: 'fetch http://127.0.0.1.nip.io/secret' };
+        const invocation = tool.build(params);
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error?.type).toBe(
+          ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        );
+        expect(result.llmContent).toContain('[Blocked Host]');
+      });
     });
 
     it('should bypass truncation if isContextManagementEnabled is true', async () => {

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -52,7 +52,7 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
   return {
     ...actual,
     fetchWithTimeout: vi.fn(),
-    isPrivateIp: vi.fn(),
+    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
   };
 });
 
@@ -376,7 +376,7 @@ describe('WebFetchTool', () => {
 
   describe('execute', () => {
     it('should return WEB_FETCH_PROCESSING_ERROR on rate limit exceeded', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [{ content: { parts: [{ text: 'response' }] } }],
       });
@@ -400,7 +400,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip rate-limited URLs but fetch others', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
 
       const tool = new WebFetchTool(mockConfig, bus);
       const params = {
@@ -439,8 +439,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip private or local URLs but fetch others and log telemetry', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
+        async (url) => url === 'https://private.com/',
       );
 
       const tool = new WebFetchTool(mockConfig, bus);
@@ -475,7 +475,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should fallback to all public URLs if primary fails', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
 
       // Primary fetch fails
       mockGenerateContent.mockRejectedValueOnce(new Error('primary fail'));
@@ -513,8 +513,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should NOT include private URLs in fallback', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
+        async (url) => url === 'https://private.com/',
       );
 
       // Primary fetch fails
@@ -546,7 +546,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should return WEB_FETCH_FALLBACK_FAILED on total failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockRejectedValue(new Error('primary fail'));
       mockFetch('https://public.ip/', new Error('fallback fetch failed'));
       const tool = new WebFetchTool(mockConfig, bus);
@@ -559,7 +559,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should log telemetry when falling back due to primary fetch failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       // Mock primary fetch to return empty response, triggering fallback
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
@@ -591,7 +591,7 @@ describe('WebFetchTool', () => {
   describe('execute (fallback)', () => {
     beforeEach(() => {
       // Force fallback by mocking primary fetch to fail
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
       });
@@ -929,7 +929,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should execute normally after confirmation approval', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [
           {
@@ -963,7 +963,7 @@ describe('WebFetchTool', () => {
   describe('execute (experimental)', () => {
     beforeEach(() => {
       vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(true);
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
     });
 
     it('should perform direct fetch and return text for plain text content', async () => {
@@ -1142,7 +1142,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should block private IP (experimental)', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(true);
+      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
       const tool = new WebFetchTool(mockConfig, bus);
       const invocation = tool['createInvocation'](
         { url: 'http://localhost' },
@@ -1156,6 +1156,99 @@ describe('WebFetchTool', () => {
         'Error: Access to blocked or private host http://localhost/ is not allowed.',
       );
       expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_PROCESSING_ERROR);
+    });
+
+    describe('SSRF guard — DNS hostname-to-private-IP bypass (CVE-class)', () => {
+      it.each([
+        {
+          label: 'localhost (literal name)',
+          url: 'http://localhost',
+          // caught by explicit loopback check, no DNS mock needed
+          dnsPrivate: false,
+        },
+        {
+          label: '127.0.0.1 (IPv4 loopback literal)',
+          url: 'http://127.0.0.1',
+          dnsPrivate: false,
+        },
+        {
+          label: '::1 (IPv6 loopback literal)',
+          url: 'http://[::1]',
+          dnsPrivate: false,
+        },
+        {
+          label: '0.0.0.0 (unspecified literal)',
+          url: 'http://0.0.0.0',
+          dnsPrivate: false,
+        },
+        {
+          label: '127.0.0.1.nip.io (nip.io loopback bypass)',
+          url: 'http://127.0.0.1.nip.io',
+          // DNS resolves to 127.0.0.1 — mocked via isPrivateIpAsync
+          dnsPrivate: true,
+        },
+        {
+          label: '169.254.169.254.nip.io (cloud metadata bypass)',
+          url: 'http://169.254.169.254.nip.io',
+          dnsPrivate: true,
+        },
+      ])('should block $label', async ({ url, dnsPrivate }) => {
+        if (dnsPrivate) {
+          vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+        }
+        const tool = new WebFetchTool(mockConfig, bus);
+        const invocation = tool['createInvocation']({ url }, bus);
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error?.type).toBe(
+          ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        );
+        expect(result.llmContent).toContain(
+          'Access to blocked or private host',
+        );
+      });
+
+      it('should allow a public URL (https://google.com)', async () => {
+        vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+        const content = 'Google homepage';
+        mockFetch('https://google.com/', {
+          status: 200,
+          headers: new Headers({ 'content-type': 'text/plain' }),
+          text: () => Promise.resolve(content),
+        });
+
+        const tool = new WebFetchTool(mockConfig, bus);
+        const invocation = tool.build({ url: 'https://google.com' });
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.llmContent).toBe(content);
+      });
+
+      it('should block nip.io bypass in standard (non-experimental) mode', async () => {
+        // Override the outer beforeEach that enables experimental mode
+        vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(false);
+        // Simulate DNS resolving the hostname to a private IP
+        vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(async (url) =>
+          url.includes('127.0.0.1.nip.io'),
+        );
+
+        const tool = new WebFetchTool(mockConfig, bus);
+        const params = { prompt: 'fetch http://127.0.0.1.nip.io/secret' };
+        const invocation = tool.build(params);
+        const result = await invocation.execute({
+          abortSignal: new AbortController().signal,
+        });
+
+        expect(result.error?.type).toBe(
+          ToolErrorType.WEB_FETCH_PROCESSING_ERROR,
+        );
+        expect(result.llmContent).toContain('[Blocked Host]');
+      });
     });
 
     it('should bypass truncation if isContextManagementEnabled is true', async () => {

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -27,6 +27,7 @@ import {
   type ToolConfirmationResponse,
 } from '../confirmation-bus/types.js';
 import { randomUUID } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
 import {
   logWebFetchFallbackAttempt,
   WebFetchFallbackAttemptEvent,
@@ -52,13 +53,15 @@ vi.mock('../utils/fetch.js', async (importOriginal) => {
   return {
     ...actual,
     fetchWithTimeout: vi.fn(),
-    isPrivateIpAsync: vi.fn().mockResolvedValue(false),
+    resolveAndValidateDns: vi.fn().mockResolvedValue(['8.8.8.8']),
   };
 });
 
 vi.mock('node:crypto', () => ({
   randomUUID: vi.fn(),
 }));
+
+vi.mock('node:dns/promises');
 
 /**
  * Helper to mock fetchWithTimeout with URL matching.
@@ -67,7 +70,16 @@ const mockFetch = (url: string, response: Partial<Response> | Error) =>
   vi
     .spyOn(fetchUtils, 'fetchWithTimeout')
     .mockImplementation(async (actualUrl) => {
-      if (actualUrl !== url) {
+      let pinnedUrlStr = url;
+      try {
+        const u = new URL(url);
+        u.hostname = '8.8.8.8';
+        pinnedUrlStr = u.toString();
+      } catch {
+        // ignore error
+      }
+
+      if (actualUrl !== url && actualUrl !== pinnedUrlStr) {
         throw new Error(
           `Unexpected fetch URL: expected "${url}", got "${actualUrl}"`,
         );
@@ -270,6 +282,10 @@ describe('WebFetchTool', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(lookup).mockResolvedValue([
+      { address: '8.8.8.8', family: 4 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
     bus = createMockMessageBus();
     getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
     mockConfig = {
@@ -376,7 +392,9 @@ describe('WebFetchTool', () => {
 
   describe('execute', () => {
     it('should return WEB_FETCH_PROCESSING_ERROR on rate limit exceeded', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValue({
         candidates: [{ content: { parts: [{ text: 'response' }] } }],
       });
@@ -400,7 +418,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip rate-limited URLs but fetch others', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
 
       const tool = new WebFetchTool(mockConfig, bus);
       const params = {
@@ -439,8 +459,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip private or local URLs but fetch others and log telemetry', async () => {
-      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
-        async (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+        async (url) => (url === 'https://private.com/' ? [] : ['8.8.8.8']),
       );
 
       const tool = new WebFetchTool(mockConfig, bus);
@@ -475,7 +495,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should fallback to all public URLs if primary fails', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
 
       // Primary fetch fails
       mockGenerateContent.mockRejectedValueOnce(new Error('primary fail'));
@@ -513,8 +535,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should NOT include private URLs in fallback', async () => {
-      vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(
-        async (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+        async (url) => (url === 'https://private.com/' ? [] : ['8.8.8.8']),
       );
 
       // Primary fetch fails
@@ -546,7 +568,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should return WEB_FETCH_FALLBACK_FAILED on total failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockRejectedValue(new Error('primary fail'));
       mockFetch('https://public.ip/', new Error('fallback fetch failed'));
       const tool = new WebFetchTool(mockConfig, bus);
@@ -559,7 +583,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should log telemetry when falling back due to primary fetch failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       // Mock primary fetch to return empty response, triggering fallback
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
@@ -591,7 +617,9 @@ describe('WebFetchTool', () => {
   describe('execute (fallback)', () => {
     beforeEach(() => {
       // Force fallback by mocking primary fetch to fail
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
       });
@@ -929,7 +957,9 @@ describe('WebFetchTool', () => {
     });
 
     it('should execute normally after confirmation approval', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
       mockGenerateContent.mockResolvedValue({
         candidates: [
           {
@@ -963,7 +993,9 @@ describe('WebFetchTool', () => {
   describe('execute (experimental)', () => {
     beforeEach(() => {
       vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(true);
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+        '8.8.8.8',
+      ]);
     });
 
     it('should perform direct fetch and return text for plain text content', async () => {
@@ -986,7 +1018,7 @@ describe('WebFetchTool', () => {
       );
       expect(result.returnDisplay).toContain('Fetched text/plain content');
       expect(fetchUtils.fetchWithTimeout).toHaveBeenCalledWith(
-        'https://example.com/',
+        'https://8.8.8.8/',
         expect.any(Number),
         expect.objectContaining({
           headers: expect.objectContaining({
@@ -1142,7 +1174,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should block private IP (experimental)', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+      vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([]);
       const tool = new WebFetchTool(mockConfig, bus);
       const invocation = tool['createInvocation'](
         { url: 'http://localhost' },
@@ -1184,7 +1216,7 @@ describe('WebFetchTool', () => {
         {
           label: '127.0.0.1.nip.io (nip.io loopback bypass)',
           url: 'http://127.0.0.1.nip.io',
-          // DNS resolves to 127.0.0.1 — mocked via isPrivateIpAsync
+          // DNS resolves to 127.0.0.1 — mocked via resolveAndValidateDns
           dnsPrivate: true,
         },
         {
@@ -1194,7 +1226,7 @@ describe('WebFetchTool', () => {
         },
       ])('should block $label', async ({ url, dnsPrivate }) => {
         if (dnsPrivate) {
-          vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(true);
+          vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([]);
         }
         const tool = new WebFetchTool(mockConfig, bus);
         const invocation = tool['createInvocation']({ url }, bus);
@@ -1211,7 +1243,9 @@ describe('WebFetchTool', () => {
       });
 
       it('should allow a public URL (https://google.com)', async () => {
-        vi.spyOn(fetchUtils, 'isPrivateIpAsync').mockResolvedValue(false);
+        vi.spyOn(fetchUtils, 'resolveAndValidateDns').mockResolvedValue([
+          '8.8.8.8',
+        ]);
         const content = 'Google homepage';
         mockFetch('https://google.com/', {
           status: 200,
@@ -1233,8 +1267,8 @@ describe('WebFetchTool', () => {
         // Override the outer beforeEach that enables experimental mode
         vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(false);
         // Simulate DNS resolving the hostname to a private IP
-        vi.mocked(fetchUtils.isPrivateIpAsync).mockImplementation(async (url) =>
-          url.includes('127.0.0.1.nip.io'),
+        vi.mocked(fetchUtils.resolveAndValidateDns).mockImplementation(
+          async (url) => (url.includes('127.0.0.1.nip.io') ? [] : ['8.8.8.8']),
         );
 
         const tool = new WebFetchTool(mockConfig, bus);

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,11 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import {
+  fetchWithTimeout,
+  isLoopbackHost,
+  isPrivateIpAsync,
+} from '../utils/fetch.js';
 import { truncateString, wrapUntrusted } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -267,14 +271,24 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     );
   }
 
-  private isBlockedHost(urlStr: string): boolean {
+  private async isBlockedHost(urlStr: string): Promise<boolean> {
     try {
       const url = new URL(urlStr);
       const hostname = url.hostname.toLowerCase();
-      if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      // Block loopback and unspecified addresses by literal name/IP without DNS
+      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0)
+      if (isLoopbackHost(hostname) || hostname === '0.0.0.0') {
         return true;
       }
-      return isPrivateIp(urlStr);
+      // Resolve DNS to catch hostname-to-private-IP bypasses such as
+      // 127.0.0.1.nip.io, 169.254.169.254.nip.io, or attacker-controlled DNS
+      try {
+        return await isPrivateIpAsync(urlStr);
+      } catch {
+        // DNS resolution failed — deny by default to avoid SSRF via
+        // unresolvable or ambiguous hostnames
+        return true;
+      }
     } catch {
       return true;
     }
@@ -285,7 +299,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
@@ -350,16 +364,16 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     return textContent;
   }
 
-  private filterAndValidateUrls(urls: string[]): {
+  private async filterAndValidateUrls(urls: string[]): Promise<{
     toFetch: string[];
     skipped: string[];
-  } {
+  }> {
     const uniqueUrls = [...new Set(urls.map(normalizeUrl))];
     const toFetch: string[] = [];
     const skipped: string[] = [];
 
     for (const url of uniqueUrls) {
-      if (this.isBlockedHost(url)) {
+      if (await this.isBlockedHost(url)) {
         debugLogger.warn(
           `[WebFetchTool] Skipped private or local host: ${url}`,
         );
@@ -615,7 +629,7 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -769,7 +783,7 @@ Response: ${rawResponseText}`;
     const userPrompt = this.params.prompt!;
     const { validUrls } = parsePrompt(userPrompt);
 
-    const { toFetch, skipped } = this.filterAndValidateUrls(validUrls);
+    const { toFetch, skipped } = await this.filterAndValidateUrls(validUrls);
 
     // If everything was skipped, fail early
     if (toFetch.length === 0 && skipped.length > 0) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -22,7 +22,7 @@ import { getResponseText } from '../utils/partUtils.js';
 import {
   fetchWithTimeout,
   isLoopbackHost,
-  isPrivateIpAsync,
+  resolveAndValidateDns,
 } from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
@@ -271,26 +271,34 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     );
   }
 
-  private async isBlockedHost(urlStr: string): Promise<boolean> {
+  private async isBlockedHost(urlStr: string): Promise<string | null> {
     try {
       const url = new URL(urlStr);
       const hostname = url.hostname.toLowerCase();
       // Block loopback and unspecified addresses by literal name/IP without DNS
-      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0)
-      if (isLoopbackHost(hostname) || hostname === '0.0.0.0') {
-        return true;
+      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0, [::])
+      if (
+        isLoopbackHost(hostname) ||
+        hostname === '0.0.0.0' ||
+        hostname === '[::]'
+      ) {
+        return null;
       }
       // Resolve DNS to catch hostname-to-private-IP bypasses such as
       // 127.0.0.1.nip.io, 169.254.169.254.nip.io, or attacker-controlled DNS
       try {
-        return await isPrivateIpAsync(urlStr);
+        const safeIps = await resolveAndValidateDns(urlStr);
+        if (safeIps.length === 0) {
+          return null;
+        }
+        return safeIps[0];
       } catch {
         // DNS resolution failed — deny by default to avoid SSRF via
         // unresolvable or ambiguous hostnames
-        return true;
+        return null;
       }
     } catch {
-      return true;
+      return null;
     }
   }
 
@@ -299,21 +307,31 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (await this.isBlockedHost(url)) {
+    const pinnedIp = await this.isBlockedHost(url);
+    if (!pinnedIp) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
       );
     }
 
+    const urlWithIp = new URL(url);
+    const originalHostname = urlWithIp.hostname;
+    urlWithIp.hostname = pinnedIp;
+
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-          signal,
-          headers: {
-            'User-Agent': USER_AGENT,
+        const res = await fetchWithTimeout(
+          urlWithIp.toString(),
+          URL_FETCH_TIMEOUT_MS,
+          {
+            signal,
+            headers: {
+              'User-Agent': USER_AGENT,
+              Host: originalHostname,
+            },
           },
-        });
+        );
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -373,7 +391,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     const skipped: string[] = [];
 
     for (const url of uniqueUrls) {
-      if (await this.isBlockedHost(url)) {
+      if (!(await this.isBlockedHost(url))) {
         debugLogger.warn(
           `[WebFetchTool] Skipped private or local host: ${url}`,
         );
@@ -629,7 +647,8 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (await this.isBlockedHost(url)) {
+    const pinnedIp = await this.isBlockedHost(url);
+    if (!pinnedIp) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -645,16 +664,25 @@ ${aggregatedContent}
     }
 
     try {
+      const urlWithIp = new URL(url);
+      const originalHostname = urlWithIp.hostname;
+      urlWithIp.hostname = pinnedIp;
+
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-            signal,
-            headers: {
-              Accept:
-                'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
-              'User-Agent': USER_AGENT,
+          const res = await fetchWithTimeout(
+            urlWithIp.toString(),
+            URL_FETCH_TIMEOUT_MS,
+            {
+              signal,
+              headers: {
+                Accept:
+                  'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
+                'User-Agent': USER_AGENT,
+                Host: originalHostname,
+              },
             },
-          });
+          );
           return res;
         },
         {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -19,7 +19,11 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolErrorType } from './tool-error.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { getResponseText } from '../utils/partUtils.js';
-import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
+import {
+  fetchWithTimeout,
+  isLoopbackHost,
+  isPrivateIpAsync,
+} from '../utils/fetch.js';
 import { truncateString } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
 import {
@@ -267,14 +271,24 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     );
   }
 
-  private isBlockedHost(urlStr: string): boolean {
+  private async isBlockedHost(urlStr: string): Promise<boolean> {
     try {
       const url = new URL(urlStr);
       const hostname = url.hostname.toLowerCase();
-      if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      // Block loopback and unspecified addresses by literal name/IP without DNS
+      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0)
+      if (isLoopbackHost(hostname) || hostname === '0.0.0.0') {
         return true;
       }
-      return isPrivateIp(urlStr);
+      // Resolve DNS to catch hostname-to-private-IP bypasses such as
+      // 127.0.0.1.nip.io, 169.254.169.254.nip.io, or attacker-controlled DNS
+      try {
+        return await isPrivateIpAsync(urlStr);
+      } catch {
+        // DNS resolution failed — deny by default to avoid SSRF via
+        // unresolvable or ambiguous hostnames
+        return true;
+      }
     } catch {
       return true;
     }
@@ -285,7 +299,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
@@ -350,16 +364,16 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     return textContent;
   }
 
-  private filterAndValidateUrls(urls: string[]): {
+  private async filterAndValidateUrls(urls: string[]): Promise<{
     toFetch: string[];
     skipped: string[];
-  } {
+  }> {
     const uniqueUrls = [...new Set(urls.map(normalizeUrl))];
     const toFetch: string[] = [];
     const skipped: string[] = [];
 
     for (const url of uniqueUrls) {
-      if (this.isBlockedHost(url)) {
+      if (await this.isBlockedHost(url)) {
         debugLogger.warn(
           `[WebFetchTool] Skipped private or local host: ${url}`,
         );
@@ -615,7 +629,7 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -769,7 +783,7 @@ Response: ${rawResponseText}`;
     const userPrompt = this.params.prompt!;
     const { validUrls } = parsePrompt(userPrompt);
 
-    const { toFetch, skipped } = this.filterAndValidateUrls(validUrls);
+    const { toFetch, skipped } = await this.filterAndValidateUrls(validUrls);
 
     // If everything was skipped, fail early
     if (toFetch.length === 0 && skipped.length > 0) {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -22,7 +22,7 @@ import { getResponseText } from '../utils/partUtils.js';
 import {
   fetchWithTimeout,
   isLoopbackHost,
-  isPrivateIpAsync,
+  resolveAndValidateDns,
 } from '../utils/fetch.js';
 import { truncateString, wrapUntrusted } from '../utils/textUtils.js';
 import { convert } from 'html-to-text';
@@ -271,26 +271,34 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     );
   }
 
-  private async isBlockedHost(urlStr: string): Promise<boolean> {
+  private async isBlockedHost(urlStr: string): Promise<string | null> {
     try {
       const url = new URL(urlStr);
       const hostname = url.hostname.toLowerCase();
       // Block loopback and unspecified addresses by literal name/IP without DNS
-      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0)
-      if (isLoopbackHost(hostname) || hostname === '0.0.0.0') {
-        return true;
+      // (covers localhost, 127.0.0.1, ::1, [::1], 0.0.0.0, [::])
+      if (
+        isLoopbackHost(hostname) ||
+        hostname === '0.0.0.0' ||
+        hostname === '[::]'
+      ) {
+        return null;
       }
       // Resolve DNS to catch hostname-to-private-IP bypasses such as
       // 127.0.0.1.nip.io, 169.254.169.254.nip.io, or attacker-controlled DNS
       try {
-        return await isPrivateIpAsync(urlStr);
+        const safeIps = await resolveAndValidateDns(urlStr);
+        if (safeIps.length === 0) {
+          return null;
+        }
+        return safeIps[0];
       } catch {
         // DNS resolution failed — deny by default to avoid SSRF via
         // unresolvable or ambiguous hostnames
-        return true;
+        return null;
       }
     } catch {
-      return true;
+      return null;
     }
   }
 
@@ -299,21 +307,31 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (await this.isBlockedHost(url)) {
+    const pinnedIp = await this.isBlockedHost(url);
+    if (!pinnedIp) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
       );
     }
 
+    const urlWithIp = new URL(url);
+    const originalHostname = urlWithIp.hostname;
+    urlWithIp.hostname = pinnedIp;
+
     const response = await retryWithBackoff(
       async () => {
-        const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-          signal,
-          headers: {
-            'User-Agent': USER_AGENT,
+        const res = await fetchWithTimeout(
+          urlWithIp.toString(),
+          URL_FETCH_TIMEOUT_MS,
+          {
+            signal,
+            headers: {
+              'User-Agent': USER_AGENT,
+              Host: originalHostname,
+            },
           },
-        });
+        );
         if (!res.ok) {
           const error = new Error(
             `Request failed with status code ${res.status} ${res.statusText}`,
@@ -373,7 +391,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     const skipped: string[] = [];
 
     for (const url of uniqueUrls) {
-      if (await this.isBlockedHost(url)) {
+      if (!(await this.isBlockedHost(url))) {
         debugLogger.warn(
           `[WebFetchTool] Skipped private or local host: ${url}`,
         );
@@ -629,7 +647,8 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (await this.isBlockedHost(url)) {
+    const pinnedIp = await this.isBlockedHost(url);
+    if (!pinnedIp) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -645,16 +664,25 @@ ${aggregatedContent}
     }
 
     try {
+      const urlWithIp = new URL(url);
+      const originalHostname = urlWithIp.hostname;
+      urlWithIp.hostname = pinnedIp;
+
       const response = await retryWithBackoff(
         async () => {
-          const res = await fetchWithTimeout(url, URL_FETCH_TIMEOUT_MS, {
-            signal,
-            headers: {
-              Accept:
-                'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
-              'User-Agent': USER_AGENT,
+          const res = await fetchWithTimeout(
+            urlWithIp.toString(),
+            URL_FETCH_TIMEOUT_MS,
+            {
+              signal,
+              headers: {
+                Accept:
+                  'text/markdown, text/plain;q=0.9, application/json;q=0.9, text/html;q=0.8, application/pdf;q=0.7, video/*;q=0.7, */*;q=0.5',
+                'User-Agent': USER_AGENT,
+                Host: originalHostname,
+              },
             },
-          });
+          );
           return res;
         },
         {

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -29,7 +29,7 @@ vi.mock('node:dns/promises', () => ({
 // Import after mocks are established
 const {
   isPrivateIp,
-  isPrivateIpAsync,
+  resolveAndValidateDns,
   isAddressPrivate,
   fetchWithTimeout,
   setGlobalProxy,
@@ -138,9 +138,9 @@ describe('fetch utils', () => {
     });
   });
 
-  describe('isPrivateIpAsync', () => {
+  describe('resolveAndValidateDns', () => {
     it('should identify private IPs directly', async () => {
-      expect(await isPrivateIpAsync('http://10.0.0.1/')).toBe(true);
+      expect(await resolveAndValidateDns('http://10.0.0.1/')).toEqual([]);
     });
 
     it('should identify domains resolving to private IPs', async () => {
@@ -150,7 +150,7 @@ describe('fetch utils', () => {
           options: LookupAllOptions,
         ) => Promise<LookupAddress[]>,
       ).mockImplementation(async () => [{ address: '10.0.0.1', family: 4 }]);
-      expect(await isPrivateIpAsync('http://malicious.com/')).toBe(true);
+      expect(await resolveAndValidateDns('http://malicious.com/')).toEqual([]);
     });
 
     it('should identify domains resolving to public IPs as non-private', async () => {
@@ -160,18 +160,20 @@ describe('fetch utils', () => {
           options: LookupAllOptions,
         ) => Promise<LookupAddress[]>,
       ).mockImplementation(async () => [{ address: '8.8.8.8', family: 4 }]);
-      expect(await isPrivateIpAsync('http://google.com/')).toBe(false);
+      expect(await resolveAndValidateDns('http://google.com/')).toEqual([
+        '8.8.8.8',
+      ]);
     });
 
-    it('should throw error if DNS resolution fails (fail closed)', async () => {
+    it('should return empty array if DNS resolution fails (fail closed)', async () => {
       vi.mocked(dnsPromises.lookup).mockRejectedValue(new Error('DNS Error'));
-      await expect(isPrivateIpAsync('http://unreachable.com/')).rejects.toThrow(
-        'Failed to verify if URL resolves to private IP',
+      expect(await resolveAndValidateDns('http://unreachable.com/')).toEqual(
+        [],
       );
     });
 
-    it('should return false for invalid URLs instead of throwing verification error', async () => {
-      expect(await isPrivateIpAsync('not-a-url')).toBe(false);
+    it('should return empty array for invalid URLs', async () => {
+      expect(await resolveAndValidateDns('not-a-url')).toEqual([]);
     });
   });
 

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -144,27 +144,25 @@ export function isAddressPrivate(address: string): boolean {
   }
 }
 
-/**
- * Checks if a URL resolves to a private IP address.
- */
-export async function isPrivateIpAsync(url: string): Promise<boolean> {
+export async function resolveAndValidateDns(url: string): Promise<string[]> {
   try {
     const parsedUrl = new URL(url);
     const hostname = parsedUrl.hostname;
 
     if (isLoopbackHost(hostname)) {
-      return false;
+      return [];
     }
 
     const addresses = await lookup(hostname, { all: true });
-    return addresses.some((addr) => isAddressPrivate(addr.address));
+    if (addresses.some((addr) => isAddressPrivate(addr.address))) {
+      return [];
+    }
+    return addresses.map((addr) => addr.address);
   } catch (error) {
     if (error instanceof TypeError) {
-      return false;
+      return [];
     }
-    throw new Error('Failed to verify if URL resolves to private IP', {
-      cause: error,
-    });
+    return []; // Fail closed on DNS errors
   }
 }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `isBlockedHost()` called the synchronous `isPrivateIp()` which uses `ipaddr.isValid()` to test whether the URL's hostname is itself an IP address in a private range. Any non-IP-literal hostname — including wildcard-DNS services like `127.0.0.1.nip.io` or `169.254.169.254.nip.io` — passes `ipaddr.isValid()` as `false`, so `isAddressPrivate()` returns `false` and the guard silently allows the request.
- **Fix**: Make `isBlockedHost()` async and replace the synchronous call with `isPrivateIpAsync()` (already present in `utils/fetch.ts` but unused here), which resolves all DNS addresses and validates each against `isAddressPrivate()`. Fail-closed on DNS errors. Expand the explicit literal blocklist to also cover `::1` / `[::1]` and `0.0.0.0`.

## Bypass vectors (pre-fix)
| Hostname | Reason for bypass |
|---|---|
| `127.0.0.1.nip.io` | Not an IP literal → `ipaddr.isValid()` false → allowed |
| `169.254.169.254.nip.io` | Same; resolves to cloud metadata endpoint |
| `localtest.me` | Any public wildcard-DNS service resolving to private space |
| Attacker-controlled DNS | Hostname resolves to `10.x`, `172.16.x`, `192.168.x`, etc. |

## Impact
An LLM agent processing attacker-controlled content (indirect prompt injection) can be instructed to call `web_fetch` with a crafted hostname. Before this fix:

1. **Loopback service exfiltration** — `http://127.0.0.1.nip.io:<port>/` reaches any service bound to loopback (e.g., local dev servers, internal admin APIs).
2. **Cloud metadata** — `http://169.254.169.254.nip.io/latest/meta-data/` fetches AWS/GCP/Azure instance metadata including IAM credentials when running in CI or cloud environments.
3. **Internal network pivoting** — Any RFC-1918 range reachable from the host can be accessed by pointing an attacker-controlled DNS record to it.
4. **Prompt injection → SSRF chain** — A malicious web page or document returned by a prior tool call can inject a `web_fetch` invocation targeting an internal endpoint, exfiltrating secrets back through the LLM response.

## Fix approach
1. `isBlockedHost()` is now `async`.
2. After blocking known loopback/unspecified literals (`localhost`, `127.0.0.1`, `::1`, `[::1]`, `0.0.0.0`) synchronously, the method calls `isPrivateIpAsync()`, which resolves the hostname via `node:dns/promises` `lookup({ all: true })` and checks every returned address with `isAddressPrivate()`.
3. DNS resolution failure → `return true` (deny by default).
4. All three call sites (`executeFallbackForUrl`, `filterAndValidateUrls`, `executeExperimental`) and the `execute` dispatcher are updated to `await` the guard.

## Tests added
New `describe('SSRF guard — DNS hostname-to-private-IP bypass')` suite covering:
- `localhost` → blocked (explicit literal)
- `127.0.0.1` → blocked (explicit literal)
- `::1` → blocked (explicit literal, new)
- `0.0.0.0` → blocked (explicit literal, new)
- `127.0.0.1.nip.io` → blocked (DNS mock returns private IP)
- `169.254.169.254.nip.io` → blocked (DNS mock returns link-local)
- `https://google.com` → allowed
- Standard (non-experimental) mode path via `filterAndValidateUrls` also covered.

## Security report reference
This vulnerability was reported to **Google Cloud VRP on 2026-06-07** (Issue **#520981635**). A working proof-of-concept was submitted demonstrating end-to-end exfiltration of loopback-only content via `127.0.0.1.nip.io` and the cloud metadata endpoint via `169.254.169.254.nip.io`, both bypassing the existing `isBlockedHost()` guard. This PR is submitted as a **Patch Rewards** contribution to strengthen the report and demonstrate the remediation path.
---