### PR TITLE
fix(cli): prevent infinite loop in ghost text wrapping when inputWidth is narrower than a codepoint

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -5387,6 +5387,43 @@ describe('InputPrompt', () => {
     });
   });
 
+  describe('ghost text wrapping', () => {
+    it('does not freeze when ghost text contains wide chars and inputWidth is narrow', async () => {
+      // Regression test for issue #19985: when inputWidth (1) is smaller than a
+      // wide character's rendered width (2 for emoji), the inner for-loop
+      // consumed nothing and splitIndex stayed 0, so cpSlice(word, 0) returned
+      // the full word unchanged, causing an infinite while loop.
+      props.inputWidth = 1;
+      props.suggestionsWidth = 1;
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        promptCompletion: {
+          text: '😀',
+          accept: vi.fn(),
+          clear: vi.fn(),
+          isLoading: false,
+          isActive: true,
+          markSelected: vi.fn(),
+        },
+      });
+      mockBuffer.text = '';
+      mockBuffer.lines = [''];
+      mockBuffer.cursor = [0, 0];
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} />,
+        { uiActions },
+      );
+
+      // If the infinite-loop bug is present this waitFor will time out; with
+      // the fix the component renders immediately.
+      await waitFor(() => {
+        expect(lastFrame()).toBeDefined();
+      });
+      unmount();
+    });
+  });
+
   describe('terminal buffer rendering', () => {
     it('does not clip the last char of a visual line whose width equals inputWidth', async () => {
       const fullLine = '1234567890'; // 10 chars, exactly props.inputWidth

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1515,6 +1515,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 partWidth += charWidth;
                 splitIndex = i + 1;
               }
+              // When inputWidth is narrower than a single codepoint, nothing
+              // fits and splitIndex stays 0, causing an infinite loop. Force-
+              // advance by one codepoint so the loop always terminates.
+              if (splitIndex === 0 && wordCP.length > 0) {
+                part = wordCP[0];
+                splitIndex = 1;
+              }
               additionalLines.push(part);
               wordToProcess = cpSlice(wordToProcess, splitIndex);
             }


### PR DESCRIPTION
## Summary

Fixes #19985 — the CLI freezes when an `@filename:line` completion is active and the terminal is too narrow to display a wide character (e.g. an emoji rendered at width 2 in a 1-column window).

**Root cause:** `getGhostTextLines` in `InputPrompt.tsx` contains a `while (stringWidth(wordToProcess) > inputWidth)` loop that splits an oversized word into lines. An inner `for`-loop scans codepoints and advances `splitIndex` only when `partWidth + charWidth <= inputWidth`. When `inputWidth` is 0 — or smaller than a single codepoint's rendered width — no codepoint ever fits, so `splitIndex` stays `0`. `cpSlice(wordToProcess, 0)` then returns the full word unchanged, and the outer `while` loops forever, freezing the renderer.

**Fix:** After the inner scan, if `splitIndex` is still `0` and the word is non-empty, force-advance by one codepoint. This guarantees the loop always makes progress and terminates.

```ts
// When inputWidth is narrower than a single codepoint, nothing
// fits and splitIndex stays 0, causing an infinite loop. Force-
// advance by one codepoint so the loop always terminates.
if (splitIndex === 0 && wordCP.length > 0) {
  part = wordCP[0];
  splitIndex = 1;
}
```

## Test plan

- [ ] Added regression test `does not freeze when ghost text contains wide chars and inputWidth is narrow` in `InputPrompt.test.tsx`: sets `inputWidth=1` with an emoji ghost text (`😀`, width 2), which would have hung the test runner before this fix
- [ ] `pnpm test` in `packages/cli` — existing suite passes