### PR TITLE
ci: validate workflow_run origin before consuming the E2E artifact (fixes fork artifact poisoning)

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -43,7 +43,21 @@ jobs:
 
   download_repo_name:
     runs-on: 'gemini-cli-ubuntu-16-core'
-    if: "github.repository == 'google-gemini/gemini-cli' && (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run')"
+    # For `workflow_run`, only consume the repo_name/head_sha artifact when the
+    # triggering run came from this repository. The triggering `Trigger E2E`
+    # run executes on `pull_request` (including forks) and writes the PR head
+    # `repo.full_name` and `sha` into the artifact; without this guard a fork PR
+    # poisons the artifact and the secret-bearing jobs below check out and run
+    # the fork's code (npm ci / postinstall) with GEMINI_API_KEY,
+    # GEMINI_CLI_ROBOT_GITHUB_PAT, and write-all GITHUB_TOKEN in scope.
+    # `github.repository` is always this repo here (workflow_run runs in the base
+    # context), so it does not validate the artifact's origin; check the
+    # triggering run's head_repository instead.
+    if: >-
+      github.repository == 'google-gemini/gemini-cli' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.head_repository.full_name == github.repository))
     outputs:
       repo_name: '${{ steps.output-repo-name.outputs.repo_name }}'
       head_sha: '${{ steps.output-repo-name.outputs.head_sha }}'


### PR DESCRIPTION
## Summary

The chained E2E pipeline is vulnerable to **`workflow_run` artifact poisoning**, allowing a fork PR to run attacker-controlled code with repository secrets.

- `trigger_e2e.yml` runs on `pull_request` (including forks) and writes the PR head `repo.full_name` and `sha` into the `repo_name` artifact.
- `chained_e2e.yml` runs on `workflow_run` (base-repo context, full secret access). `download_repo_name` downloads that artifact and the downstream jobs (`e2e_linux`, `e2e_mac`, `e2e_windows`, `evals`) `actions/checkout` the artifact's `repository`/`sha` and run `npm ci` (executing `postinstall`), `npm run build`, and tests with `GEMINI_API_KEY`, `GEMINI_CLI_ROBOT_GITHUB_PAT`, and `permissions: write-all` in scope.

A fork can therefore put its own repo + SHA into the artifact and have the privileged workflow execute its code with those secrets. The existing `github.repository == 'google-gemini/gemini-cli'` guard is always true under `workflow_run` (it runs in the base context) and does not validate the artifact's origin.

This is the [`workflow_run` artifact-poisoning pattern](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) documented by GitHub Security Lab.

## Fix

Gate artifact consumption (`download_repo_name`) on the triggering run's `head_repository` being this repository:

```yaml
if: >-
  github.repository == 'google-gemini/gemini-cli' &&
  (github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'workflow_run' &&
  github.event.workflow_run.head_repository.full_name == github.repository))
```

For a fork-triggered run this skips the artifact download, so `parse_run_context` falls back to `github.repository`/base `sha` and the E2E jobs no longer check out or execute fork code with secrets. Same-repo PRs and `workflow_dispatch` are unaffected.

## Note on fork E2E

This change intentionally stops the secret-bearing E2E jobs from running **fork** code. If you want to keep E2E coverage for fork PRs, the safe pattern is to gate it behind a human-applied label (or a deployment environment with required reviewers) before checking out fork code with secrets — similar to how other Google repos (e.g. `protocolbuffers/protobuf`) require a "safe for tests" label on fork PRs. Happy to follow up with that if preferred.

Resolves #27940