### PR TITLE
fix(a2a-server): add missing return after 501 response in GET /tasks/metadata

### DIFF
--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -339,6 +339,7 @@ export async function createApp() {
           error:
             'Listing all task metadata is only supported when using InMemoryTaskStore.',
         });
+        return;
       }
       try {
         const wrappers = agentExecutor.getAllTasks();


### PR DESCRIPTION
Fixes #21729

Added the missing \eturn;\ statement after sending a 501 response in \packages/a2a-server/src/http/app.ts\ to prevent it from falling through to the rest of the endpoint handling, which resulted in \ERR_HTTP_HEADERS_SENT\ and crashed the A2A server.