### PR TITLE
test(a2a-server): migrate process.env to vi.stubEnv() per GEMINI.md conventions

### DIFF
--- a/packages/a2a-server/src/commands/init.test.ts
+++ b/packages/a2a-server/src/commands/init.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InitCommand } from './init.js';
 import {
   performInit,
@@ -60,7 +60,7 @@ describe('InitCommand', () => {
   const mockWorkspacePath = path.resolve('/tmp');
 
   beforeEach(() => {
-    process.env['CODER_AGENT_WORKSPACE_PATH'] = mockWorkspacePath;
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', mockWorkspacePath);
     eventBus = {
       publish: vi.fn(),
     } as unknown as ExecutionEventBus;
@@ -78,6 +78,10 @@ describe('InitCommand', () => {
     mockExecute = vi.fn();
     vi.spyOn(mockExecutorInstance, 'execute').mockImplementation(mockExecute);
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('has requiresWorkspace set to true', () => {

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -130,6 +130,7 @@ describe('E2E Tests', () => {
   );
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
@@ -1059,7 +1060,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockCommand);
 
-      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'test-command', args: [] });
@@ -1079,7 +1080,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
-      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });
@@ -1101,7 +1102,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
-      process.env['CODER_AGENT_WORKSPACE_PATH'] = '/tmp/test-workspace';
+      vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '/tmp/test-workspace');
       const response = await request(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });


### PR DESCRIPTION
Fixes #19826

Replaced direct \process.env\ modifications with \i.stubEnv()\ and \i.unstubAllEnvs()\ in \packages/a2a-server/src/commands/init.test.ts\ and \packages/a2a-server/src/http/app.test.ts\, following the guidelines in GEMINI.md.