### PR TITLE
fix: scope flash model names per auth type for Vertex AI and Gateway backends

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4379,25 +4379,14 @@ describe('hasGemini35FlashGAAccess model setting', () => {
     expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash-preview');
   });
 
-  it('should set DEFAULT_GEMINI_FLASH_MODEL and PREVIEW_GEMINI_FLASH_MODEL to gemini-3.5-flash if hasGemini35FlashGAAccess returns true and authType is not USE_GEMINI', () => {
+  it('should set DEFAULT_GEMINI_FLASH_MODEL to gemini-3.5-flash and PREVIEW_GEMINI_FLASH_MODEL to gemini-3-flash-preview if hasGemini35FlashGAAccess returns true and authType is USE_VERTEX_AI', () => {
     const config = new Config(baseParams);
-    config['contentGeneratorConfig'] = { authType: AuthType.LOGIN_WITH_GOOGLE };
+    config['contentGeneratorConfig'] = { authType: AuthType.USE_VERTEX_AI };
 
-    // Set experiment to return true for GEMINI_3_5_FLASH_GA_LAUNCHED
-    config.setExperiments({
-      experimentIds: [],
-      flags: {
-        [ExperimentFlags.GEMINI_3_5_FLASH_GA_LAUNCHED]: {
-          boolValue: true,
-        },
-      },
-    });
-
-    // Call the method
     const result = config.hasGemini35FlashGAAccess();
     expect(result).toBe(true);
 
     expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('gemini-3.5-flash');
-    expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3.5-flash');
+    expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash-preview');
   });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4389,4 +4389,24 @@ describe('hasGemini35FlashGAAccess model setting', () => {
     expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('gemini-3.5-flash');
     expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash-preview');
   });
+
+  it('should set DEFAULT_GEMINI_FLASH_MODEL and PREVIEW_GEMINI_FLASH_MODEL to gemini-3-flash if hasGemini35FlashGAAccess returns true and authType is not USE_GEMINI or USE_VERTEX_AI', () => {
+    const config = new Config(baseParams);
+    config['contentGeneratorConfig'] = { authType: AuthType.LOGIN_WITH_GOOGLE };
+
+    config.setExperiments({
+      experimentIds: [],
+      flags: {
+        [ExperimentFlags.GEMINI_3_5_FLASH_GA_LAUNCHED]: {
+          boolValue: true,
+        },
+      },
+    });
+
+    const result = config.hasGemini35FlashGAAccess();
+    expect(result).toBe(true);
+
+    expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('gemini-3-flash');
+    expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash');
+  });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4384,7 +4384,7 @@ describe('hasGemini35FlashGAAccess model setting', () => {
     expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash-preview');
   });
 
-  it('should set DEFAULT_GEMINI_FLASH_MODEL to gemini-3.5-flash and PREVIEW_GEMINI_FLASH_MODEL to gemini-3-flash-preview if hasGemini35FlashGAAccess returns true and authType is USE_VERTEX_AI', () => {
+  it('should set DEFAULT_GEMINI_FLASH_MODEL and PREVIEW_GEMINI_FLASH_MODEL to gemini-3.5-flash if hasGemini35FlashGAAccess returns true and authType is USE_VERTEX_AI', () => {
     const config = new Config(baseParams);
     config['contentGeneratorConfig'] = { authType: AuthType.USE_VERTEX_AI };
 
@@ -4392,7 +4392,7 @@ describe('hasGemini35FlashGAAccess model setting', () => {
     expect(result).toBe(true);
 
     expect(DEFAULT_GEMINI_FLASH_MODEL).toBe('gemini-3.5-flash');
-    expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3-flash-preview');
+    expect(PREVIEW_GEMINI_FLASH_MODEL).toBe('gemini-3.5-flash');
   });
 
   it('should set DEFAULT_GEMINI_FLASH_MODEL and PREVIEW_GEMINI_FLASH_MODEL to gemini-3-flash if hasGemini35FlashGAAccess returns true and authType is not USE_GEMINI or USE_VERTEX_AI', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -70,6 +70,7 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
   PREVIEW_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
+  setFlashModels,
 } from './models.js';
 import { Storage } from './storage.js';
 import type { AgentLoopContext } from './agent-loop-context.js';
@@ -4356,6 +4357,10 @@ describe('hasGemini35FlashGAAccess model setting', () => {
     model: 'test-model',
     cwd: '.',
   };
+
+  afterEach(() => {
+    setFlashModels('gemini-3-flash-preview', 'gemini-2.5-flash');
+  });
 
   it('should set DEFAULT_GEMINI_FLASH_MODEL to gemini-3.5-flash and PREVIEW_GEMINI_FLASH_MODEL to gemini-3-flash-preview if hasGemini35FlashGAAccess returns true and authType is USE_GEMINI', () => {
     const config = new Config(baseParams);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3561,13 +3561,7 @@ export class Config implements McpContext, AgentLoopContext {
     // Used to set default flash models based on access
     // TODO: Remove once the experiment for 3_5 flash rollut can be cleaned up.
     if (hasAccess) {
-      // Gemini API key users should have the ability to manually select the
-      // old preview flash model.
-      if (authType === AuthType.USE_GEMINI) {
-        setFlashModels('gemini-3-flash-preview', 'gemini-3.5-flash');
-      } else {
-        setFlashModels('gemini-3.5-flash', 'gemini-3.5-flash');
-      }
+      setFlashModels('gemini-3-flash-preview', 'gemini-3.5-flash');
     } else {
       setFlashModels('gemini-3-flash-preview', 'gemini-2.5-flash');
     }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3561,11 +3561,10 @@ export class Config implements McpContext, AgentLoopContext {
     // Used to set default flash models based on access
     // TODO: Remove once the experiment for 3_5 flash rollut can be cleaned up.
     if (hasAccess) {
-      if (
-        authType === AuthType.USE_GEMINI ||
-        authType === AuthType.USE_VERTEX_AI
-      ) {
+      if (authType === AuthType.USE_GEMINI) {
         setFlashModels('gemini-3-flash-preview', 'gemini-3.5-flash');
+      } else if (authType === AuthType.USE_VERTEX_AI) {
+        setFlashModels('gemini-3.5-flash', 'gemini-3.5-flash');
       } else {
         setFlashModels('gemini-3-flash', 'gemini-3-flash');
       }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3561,7 +3561,14 @@ export class Config implements McpContext, AgentLoopContext {
     // Used to set default flash models based on access
     // TODO: Remove once the experiment for 3_5 flash rollut can be cleaned up.
     if (hasAccess) {
-      setFlashModels('gemini-3-flash-preview', 'gemini-3.5-flash');
+      if (
+        authType === AuthType.USE_GEMINI ||
+        authType === AuthType.USE_VERTEX_AI
+      ) {
+        setFlashModels('gemini-3-flash-preview', 'gemini-3.5-flash');
+      } else {
+        setFlashModels('gemini-3-flash', 'gemini-3-flash');
+      }
     } else {
       setFlashModels('gemini-3-flash-preview', 'gemini-2.5-flash');
     }


### PR DESCRIPTION
## Summary

Fixes #27759

The `hasGemini35FlashGAAccess()` method previously applied the same flash model names to all non-AI-Studio backends. This caused issues because different backends resolve model names differently:

- **Vertex AI** accepts `gemini-3.5-flash` but not the older `gemini-3-flash` alias, which results in a `ModelNotFoundError`
- **Gateway / `LOGIN_WITH_GOOGLE`** may not accept `gemini-3.5-flash` directly and needs the `gemini-3-flash` alias

### Fix

Split the `else` branch into explicit cases per auth type:

| Auth type | Preview model | Default model |
|---|---|---|
| `USE_GEMINI` (AI Studio) | `gemini-3-flash-preview` | `gemini-3.5-flash` |
| `USE_VERTEX_AI` | `gemini-3.5-flash` | `gemini-3.5-flash` |
| Other (Gateway) | `gemini-3-flash` | `gemini-3-flash` |

Also adds `afterEach` cleanup in the test suite to reset flash model globals between tests, preventing cross-test contamination.

## Test plan

- [x] Added dedicated test for `USE_VERTEX_AI` auth type asserting both models are `gemini-3.5-flash`
- [x] Updated existing non-`USE_GEMINI` test to use `LOGIN_WITH_GOOGLE` and assert `gemini-3-flash` for both models
- [x] Added `afterEach` to reset model globals between tests
- [x] All `hasGemini35FlashGAAccess` config tests pass