### PR TITLE
docs: document read_file 20MB file size limit

### DIFF
--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -25,6 +25,10 @@ Reads and returns the content of a specific file. Supports text, images, audio,
 and PDF.
 
 - **Tool name:** `read_file`
+- Note: Files larger than 20 MB are not supported by read_file.
+   Attempting to read a file larger than this limit will result in:
+
+   File size exceeds the 20MB limit.
 - **Arguments:**
   - `file_path` (string, required): Path to the file.
   - `offset` (number, optional): Start line for text files (0-based).


### PR DESCRIPTION
## Summary
Document the 20MB file size limit enforced by the `read_file` tool.

The limit is currently implemented in code but not documented, which can cause confusion when users encounter the error:

`File size exceeds the 20MB limit.`

## Changes

* Added documentation for the 20MB `read_file` size limit in `docs/tools/file-system.md`.
* Included the error message returned when the limit is exceeded.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
