### PR TITLE
fix(cli): prevent path traversal vulnerabilities during skill install…

### DIFF
--- a/packages/cli/src/utils/skillUtils.test.ts
+++ b/packages/cli/src/utils/skillUtils.test.ts
@@ -267,5 +267,136 @@ describe('skillUtils', () => {
       const exists = await fs.stat(skillDir).catch(() => null);
       expect(exists).toBeNull();
     });
+
+    it('should prevent path traversal in fallback uninstallation (e.g. sibling directories)', async () => {
+      const skillsDir = path.join(tempDir, '.gemini/skills');
+      await fs.mkdir(skillsDir, { recursive: true });
+
+      const siblingDir = path.join(tempDir, '.gemini/skills-attacker');
+      await fs.mkdir(siblingDir, { recursive: true });
+
+      // Attempt to uninstall the sibling directory using path traversal
+      const result = await uninstallSkill('../skills-attacker', 'user');
+      expect(result).toBeNull();
+
+      // Verify sibling directory is NOT deleted
+      const exists = await fs.stat(siblingDir).catch(() => null);
+      expect(exists).not.toBeNull();
+    });
+
+    it('should prevent path traversal in fallback uninstallation with dot or dot dot', async () => {
+      expect(await uninstallSkill('..', 'user')).toBeNull();
+      expect(await uninstallSkill('.', 'user')).toBeNull();
+      expect(await uninstallSkill('', 'user')).toBeNull();
+    });
+  });
+
+  describe('path traversal prevention', () => {
+    it('should throw error during installation if skill name is dot dot or dot', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: ..\ndescription: exploit\n---\nbody',
+      );
+
+      await expect(
+        installSkill(mockSkillSourceDir, 'workspace', undefined, () => {}),
+      ).rejects.toThrow('Invalid skill name: Path traversal detected.');
+    });
+
+    it('should throw error during linking if skill name is dot dot or dot', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: ..\ndescription: exploit\n---\nbody',
+      );
+
+      await expect(
+        linkSkill(mockSkillSourceDir, 'workspace', () => {}),
+      ).rejects.toThrow('Invalid skill name: Path traversal detected.');
+    });
+
+    it('should throw error during installation if subpath escapes temp directory', async () => {
+      const skillPath = path.join(projectRoot, 'weather-skill.skill');
+      const exists = await fs.stat(skillPath).catch(() => null);
+      if (!exists) return;
+
+      await expect(
+        installSkill(skillPath, 'workspace', '../escape', () => {}),
+      ).rejects.toThrow('Invalid path: Directory traversal not allowed.');
+    });
+
+    it('should sanitize absolute path names and install them safely within the target directory', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: /tmp/exploit\ndescription: exploit\n---\nbody',
+      );
+
+      const installed = await installSkill(
+        mockSkillSourceDir,
+        'workspace',
+        undefined,
+        () => {},
+      );
+      expect(installed.length).toBe(1);
+      expect(installed[0].name).toBe('-tmp-exploit');
+
+      const destPath = installed[0].location;
+      const resolvedTarget = path.resolve(tempDir, '.gemini/skills');
+      expect(destPath.startsWith(resolvedTarget + path.sep)).toBe(true);
+    });
+
+    it('should sanitize traversal names with spaces and install them safely within the target directory', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: " ../../exploit "\ndescription: exploit\n---\nbody',
+      );
+
+      const installed = await installSkill(
+        mockSkillSourceDir,
+        'workspace',
+        undefined,
+        () => {},
+      );
+      expect(installed.length).toBe(1);
+      expect(installed[0].name).toBe(' ..-..-exploit ');
+
+      const destPath = installed[0].location;
+      const resolvedTarget = path.resolve(tempDir, '.gemini/skills');
+      expect(destPath.startsWith(resolvedTarget + path.sep)).toBe(true);
+    });
+
+    it('should allow installation if skill name starts with double dots but is safe (e.g. ..-foo or ...)', async () => {
+      const mockSkillSourceDir = path.join(tempDir, 'mock-skill-source');
+      const skillSubDir = path.join(mockSkillSourceDir, 'test-skill');
+      await fs.mkdir(skillSubDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillSubDir, 'SKILL.md'),
+        '---\nname: ..-foo\ndescription: safe skill name starting with double dots\n---\nbody',
+      );
+
+      const installed = await installSkill(
+        mockSkillSourceDir,
+        'workspace',
+        undefined,
+        () => {},
+      );
+      expect(installed.length).toBe(1);
+      expect(installed[0].name).toBe('..-foo');
+
+      const destPath = installed[0].location;
+      const resolvedTarget = path.resolve(tempDir, '.gemini/skills');
+      expect(destPath.startsWith(resolvedTarget + path.sep)).toBe(true);
+    });
   });
 });

--- a/packages/cli/src/utils/skillUtils.ts
+++ b/packages/cli/src/utils/skillUtils.ts
@@ -75,6 +75,14 @@ export function renderSkillActionFeedback(
   return `Skill "${skillName}" ${actionVerb} ${preposition} ${s} settings.`;
 }
 
+function isPathTraversal(relative: string): boolean {
+  return (
+    relative === '..' ||
+    relative.startsWith('..' + path.sep) ||
+    path.isAbsolute(relative)
+  );
+}
+
 /**
  * Central logic for installing a skill from a remote URL or local path.
  */
@@ -132,11 +140,12 @@ export async function installSkill(
     sourcePath = path.resolve(sourcePath);
 
     // Quick security check to prevent directory traversal out of temp dir when cloning
-    if (
-      tempDirToClean &&
-      !sourcePath.startsWith(path.resolve(tempDirToClean))
-    ) {
-      throw new Error('Invalid path: Directory traversal not allowed.');
+    if (tempDirToClean) {
+      const resolvedTemp = path.resolve(tempDirToClean);
+      const relative = path.relative(resolvedTemp, sourcePath);
+      if (isPathTraversal(relative)) {
+        throw new Error('Invalid path: Directory traversal not allowed.');
+      }
     }
 
     onLog(`Searching for skills in ${sourcePath}...`);
@@ -159,14 +168,20 @@ export async function installSkill(
       throw new Error('Skill installation cancelled by user.');
     }
 
-    await fs.mkdir(targetDir, { recursive: true });
+    const resolvedTarget = path.resolve(targetDir);
+    await fs.mkdir(resolvedTarget, { recursive: true });
 
     const installedSkills: Array<{ name: string; location: string }> = [];
 
     for (const skill of skills) {
       const skillName = skill.name;
       const skillDir = path.dirname(skill.location);
-      const destPath = path.join(targetDir, skillName);
+      const destPath = path.resolve(resolvedTarget, skillName);
+
+      const relative = path.relative(resolvedTarget, destPath);
+      if (isPathTraversal(relative) || relative === '') {
+        throw new Error('Invalid skill name: Path traversal detected.');
+      }
 
       const exists = await fs.stat(destPath).catch(() => null);
       if (exists) {
@@ -231,14 +246,20 @@ export async function linkSkill(
     throw new Error('Skill linking cancelled by user.');
   }
 
-  await fs.mkdir(targetDir, { recursive: true });
+  const resolvedTarget = path.resolve(targetDir);
+  await fs.mkdir(resolvedTarget, { recursive: true });
 
   const linkedSkills: Array<{ name: string; location: string }> = [];
 
   for (const skill of skills) {
     const skillName = skill.name;
     const skillSourceDir = path.dirname(skill.location);
-    const destPath = path.join(targetDir, skillName);
+    const destPath = path.resolve(resolvedTarget, skillName);
+
+    const relative = path.relative(resolvedTarget, destPath);
+    if (isPathTraversal(relative) || relative === '') {
+      throw new Error('Invalid skill name: Path traversal detected.');
+    }
 
     const exists = await fs.lstat(destPath).catch(() => null);
     if (exists) {
@@ -275,18 +296,21 @@ export async function uninstallSkill(
       ? storage.getProjectSkillsDir()
       : Storage.getUserSkillsDir();
 
+  const resolvedTarget = path.resolve(targetDir);
+
   // Load all skills in the target directory to find the one with the matching name
-  const discoveredSkills = await loadSkillsFromDir(targetDir);
+  const discoveredSkills = await loadSkillsFromDir(resolvedTarget);
   const skillToUninstall = discoveredSkills.find((s) => s.name === name);
 
   if (!skillToUninstall) {
     // Fallback: Check if a directory with the given name exists.
     // This maintains backward compatibility for cases where the metadata might be missing or corrupted
     // but the directory name matches the user's request.
-    const skillPath = path.resolve(targetDir, name);
+    const skillPath = path.resolve(resolvedTarget, name);
 
     // Security check: ensure the resolved path is within the target directory to prevent path traversal
-    if (!skillPath.startsWith(path.resolve(targetDir))) {
+    const relative = path.relative(resolvedTarget, skillPath);
+    if (isPathTraversal(relative) || relative === '') {
       return null;
     }
 
@@ -300,7 +324,12 @@ export async function uninstallSkill(
     return { location: skillPath };
   }
 
-  const skillDir = path.dirname(skillToUninstall.location);
+  const skillDir = path.resolve(path.dirname(skillToUninstall.location));
+  const relative = path.relative(resolvedTarget, skillDir);
+  if (isPathTraversal(relative) || relative === '') {
+    return null;
+  }
+
   await fs.rm(skillDir, { recursive: true, force: true });
   return { location: skillDir };
 }

--- a/packages/cli/src/utils/skillUtils.ts
+++ b/packages/cli/src/utils/skillUtils.ts
@@ -83,6 +83,10 @@ function isPathTraversal(relative: string): boolean {
   );
 }
 
+function isInvalidSubpath(relative: string): boolean {
+  return relative === '' || isPathTraversal(relative);
+}
+
 /**
  * Central logic for installing a skill from a remote URL or local path.
  */
@@ -179,11 +183,11 @@ export async function installSkill(
       const destPath = path.resolve(resolvedTarget, skillName);
 
       const relative = path.relative(resolvedTarget, destPath);
-      if (isPathTraversal(relative) || relative === '') {
+      if (isInvalidSubpath(relative)) {
         throw new Error('Invalid skill name: Path traversal detected.');
       }
 
-      const exists = await fs.stat(destPath).catch(() => null);
+      const exists = await fs.lstat(destPath).catch(() => null);
       if (exists) {
         onLog(`Skill "${skillName}" already exists. Overwriting...`);
         await fs.rm(destPath, { recursive: true, force: true });
@@ -257,7 +261,7 @@ export async function linkSkill(
     const destPath = path.resolve(resolvedTarget, skillName);
 
     const relative = path.relative(resolvedTarget, destPath);
-    if (isPathTraversal(relative) || relative === '') {
+    if (isInvalidSubpath(relative)) {
       throw new Error('Invalid skill name: Path traversal detected.');
     }
 
@@ -310,7 +314,7 @@ export async function uninstallSkill(
 
     // Security check: ensure the resolved path is within the target directory to prevent path traversal
     const relative = path.relative(resolvedTarget, skillPath);
-    if (isPathTraversal(relative) || relative === '') {
+    if (isInvalidSubpath(relative)) {
       return null;
     }
 
@@ -326,7 +330,7 @@ export async function uninstallSkill(
 
   const skillDir = path.resolve(path.dirname(skillToUninstall.location));
   const relative = path.relative(resolvedTarget, skillDir);
-  if (isPathTraversal(relative) || relative === '') {
+  if (isInvalidSubpath(relative)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

This PR addresses and fully mitigates three path traversal vulnerabilities within the agent skill management subsystem (`installSkill`, `linkSkill`, and `uninstallSkill`).

## Details

### Vulnerability Context
1. **Frontmatter Path Traversal (Install & Link):** The CLI parser parses the `name` field from the frontmatter of `SKILL.md`. Malicious or un-sanitized skill packages could specify `..` or `.`, causing the installation directory `destPath` (`path.join(targetDir, name)`) to resolve to the parent directory `.gemini` or another directory outside `.gemini/skills`, potentially overwriting existing user config/data.
2. **Subpath Escape from Temporary Folders:** When cloning remote skills or extracting `.skill` zip files, a subpath parameter is supplied. If this subpath used traversal sequences (e.g. `../escape`), it allowed operations to escape the temporary cloning directory.
3. **Fallback Uninstallation Traversal:** When a skill's metadata was missing or corrupted, a fallback method identified the directory using the user-provided name. If the user passed `../skills-attacker`, it resolved to `/Users/ompatel/.gemini/skills-attacker`. Because a simple prefix match `startsWith(targetDir)` was used, it would match `/Users/ompatel/.gemini/skills` (missing the separator), allowing sibling directory deletion.

### Fixes Implemented
- **Robust Path Validation with `path.relative`:** Completely avoided simple string boundary checks (`startsWith` + `path.sep`), which can be fragile or subject to platform-specific edge cases (e.g. Windows drive roots, trailing slashes, or casing differences).
- **Escape Validation (`installSkill` / `linkSkill`):** Added a check based on `path.relative` to ensure skill installation destinations reside strictly inside the resolved skills directory:
  ```typescript
  const relative = path.relative(resolvedTarget, destPath);
  if (relative.startsWith('..') || path.isAbsolute(relative) || relative === '') {
    throw new Error('Invalid skill name: Path traversal detected.');
  }
  ```
- **Subpath Escape Mitigation:** Ensured that `sourcePath` when cloning/extracting resides within `resolvedTemp` by validating:
  ```typescript
  const relative = path.relative(resolvedTemp, sourcePath);
  if (relative.startsWith('..') || path.isAbsolute(relative)) {
    throw new Error('Invalid path: Directory traversal not allowed.');
  }
  ```
- **Uninstall Validation:** Updated the fallback uninstallation directory resolver and loaded metadata-based skill directory resolver to validate directories using `path.relative` checks before removing them from disk.

## Related Issues

Resolves the Cloud VRP security bug regarding path traversal during skill installation.

## How to Validate

### Automated Regression Suite
Run the updated and new unit tests testing path traversal edge cases:
```bash
npm test -w @google/gemini-cli -- src/utils/skillUtils.test.ts
```

### Manual Penetration Validation
1. **Malicious Skill Installation:**
   Create a test skill with name `..` in frontmatter, and execute:
   ```bash
   GEMINI_CLI_HOME=./temp-sandbox node packages/cli/dist/index.js skills install <exploit-dir> --scope user --consent
   ```
   **Expected Result:** Command fails with `Invalid skill name: Path traversal detected.` and no files are written to `./temp-sandbox/.gemini/`.

2. **Malicious Sibling Directory Deletion:**
   Create a sibling directory `./temp-sandbox/.gemini/skills-attacker` and attempt:
   ```bash
   GEMINI_CLI_HOME=./temp-sandbox node packages/cli/dist/index.js skills uninstall ../skills-attacker --scope user
   ```
   **Expected Result:** Command reports the skill is not installed, and the sibling directory is **not** deleted.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
