### PR TITLE
Fix MCP header encoding for non-ASCII values

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2225,6 +2225,26 @@ describe('mcp-client', () => {
           vi.unstubAllGlobals();
         }
       });
+
+      it('encodes non-ByteString header values for httpUrl transports', async () => {
+        const transport = await createTransport(
+          'test-server',
+          {
+            httpUrl: 'http://test-server',
+            headers: { 'X-Custom': 'mąka' },
+          },
+          false,
+          MOCK_CONTEXT,
+        );
+
+        const headers = (unwrap(transport) as TestableTransport)._requestInit
+          ?.headers;
+
+        expect(() => new Headers(headers)).not.toThrow();
+        expect(headers?.['X-Custom']).toBe(
+          Buffer.from('mąka', 'utf8').toString('latin1'),
+        );
+      });
     });
 
     describe('should connect via url', () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -1002,11 +1002,33 @@ function createTransportRequestInit(
   }
 
   return {
-    headers: {
+    headers: encodeHeaderValuesForFetch({
       ...expandedHeaders,
       ...headers,
-    },
+    }),
   };
+}
+
+function encodeHeaderValuesForFetch(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [
+      key,
+      isByteString(value)
+        ? value
+        : Buffer.from(value, 'utf8').toString('latin1'),
+    ]),
+  );
+}
+
+function isByteString(value: string): boolean {
+  for (const char of value) {
+    if (char.codePointAt(0)! > 255) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -1673,10 +1695,10 @@ function createSSETransportWithAuth(
   config: MCPServerConfig,
   accessToken?: string | null,
 ): SSEClientTransport {
-  const headers = {
+  const headers = encodeHeaderValuesForFetch({
     ...config.headers,
     ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-  };
+  });
 
   const options: SSEClientTransportOptions = {};
   if (Object.keys(headers).length > 0) {


### PR DESCRIPTION
## Summary

Fixes #25668.

MCP HTTP transports now encode configured header values that cannot be passed to Fetch as `ByteString` values. This prevents discovery from failing when a configured header contains Unicode text such as `mąka`.

## Changes

- Normalize MCP transport header values before they are passed into Fetch-backed transports.
- Preserve existing values that are already valid `ByteString` values.
- Encode only non-`ByteString` values as UTF-8 bytes represented in Latin-1, which keeps Fetch `Headers` validation from throwing while preserving the intended bytes.
- Add a regression test for an `httpUrl` MCP server configured with a non-ASCII header value.

## Verification

```sh
npm exec prettier -- --check packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts
npm exec --workspace @google/gemini-cli-core -- vitest run src/tools/mcp-client.test.ts
npm run typecheck --workspace @google/gemini-cli-core
npm exec eslint -- packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts
```
