### PR TITLE
security: gate chained E2E on same-repository checkout for workflow_run

### DIFF
--- a/.github/workflows/chained_e2e.yml
+++ b/.github/workflows/chained_e2e.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
       github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+      && needs.parse_run_context.outputs.repository == github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -188,6 +189,7 @@ jobs:
     runs-on: 'macos-latest-large'
     if: |
       github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+      && needs.parse_run_context.outputs.repository == github.repository
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -228,6 +230,7 @@ jobs:
       - 'parse_run_context'
     if: |
       github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+      && needs.parse_run_context.outputs.repository == github.repository
     runs-on: 'gemini-cli-windows-16-core'
     steps:
       - name: 'Checkout'
@@ -311,6 +314,7 @@ jobs:
     runs-on: 'gemini-cli-ubuntu-16-core'
     if: |
       github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+      && needs.parse_run_context.outputs.repository == github.repository
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955' # ratchet:actions/checkout@v5
@@ -362,6 +366,7 @@ jobs:
     name: 'E2E'
     if: |
       github.repository == 'google-gemini/gemini-cli' && always() && (needs.merge_queue_skipper.result !='success' || needs.merge_queue_skipper.outputs.skip != 'true')
+      && needs.parse_run_context.outputs.repository == github.repository
     needs:
       - 'e2e_linux'
       - 'e2e_mac'


### PR DESCRIPTION
Fork PR `workflow_run` chains can supply attacker-controlled `repository` + `sha` via artifact metadata while `GEMINI_API_KEY` is mounted in `chained_e2e.yml` jobs.

This PR skips Linux/macOS/Windows/evals jobs that checkout `parse_run_context.outputs.repository` when that repository is **not** `github.repository`.

**Before:** External fork can influence checkout ref/repo in jobs with `GEMINI_API_KEY`.
**After:** Only same-repo workflow_run / dispatch paths run secret-backed E2E.