### PR TITLE
security: gate PRT label workflows on same-repository pull_request_ta…

### DIFF
--- a/.github/workflows/pr-rate-limiter.yaml
+++ b/.github/workflows/pr-rate-limiter.yaml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   limit:
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: 'gemini-cli-ubuntu-16-core'
     permissions:
       contents: 'read'

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   size-label:
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Run size labeler'


### PR DESCRIPTION
## Summary

`pr-size-labeler.yml` and `pr-rate-limiter.yaml` run on `pull_request_target` for external fork PRs and mutate PR labels/comments with `GITHUB_TOKEN` write access.

This PR adds a same-repository guard so automated PRT label/rate-limit jobs skip external fork PRs. `workflow_dispatch` is preserved.

## Details

**Before:** Untrusted fork PRs trigger PRT label/rate-limit automation with pull-request write in base repo context.

**After:** Only same-repo `pull_request_target` paths run; manual `workflow_dispatch` unchanged.

**Change:** Two coordinated `if:` guards in:
- `.github/workflows/pr-rate-limiter.yaml`
- `.github/workflows/pr-size-labeler.yml`

No live exploit performed against production. Static analysis / least-privilege hardening aligned with existing `eval-pr.yml` fork-guard patterns in this repo.

## Related

Proactive security hardening for Google OSS Patch Rewards (REPORT-015). Distinct from workflow_run/E2E chain fixes — this targets PRT label automation only.