### PR TITLE
fix(core): make read_background_output delay abort-aware

### DIFF
--- a/packages/core/src/tools/shellBackgroundTools.test.ts
+++ b/packages/core/src/tools/shellBackgroundTools.test.ts
@@ -331,4 +331,29 @@ describe('Background Tools', () => {
 
     fs.unlinkSync(logPath);
   });
+
+  it('read_background_output should abort the delay_ms wait when the signal is aborted', async () => {
+    const invocation = readTool.build({ pid: 12345, delay_ms: 60_000 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+
+    const controller = new AbortController();
+    const promise = invocation.execute({ abortSignal: controller.signal });
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('read_background_output should reject immediately when the signal is already aborted', async () => {
+    const invocation = readTool.build({ pid: 12345, delay_ms: 60_000 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      invocation.execute({ abortSignal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
 });

--- a/packages/core/src/tools/shellBackgroundTools.ts
+++ b/packages/core/src/tools/shellBackgroundTools.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
 import { ShellExecutionService } from '../services/shellExecutionService.js';
 import {
   BaseDeclarativeTool,
@@ -130,11 +131,15 @@ class ReadBackgroundOutputInvocation extends BaseToolInvocation<
     return `Reading output for background process ${this.params.pid}`;
   }
 
-  async execute({ abortSignal: _signal }: ExecuteOptions): Promise<ToolResult> {
+  async execute({ abortSignal }: ExecuteOptions): Promise<ToolResult> {
     const pid = this.params.pid;
 
     if (this.params.delay_ms && this.params.delay_ms > 0) {
-      await new Promise((resolve) => setTimeout(resolve, this.params.delay_ms));
+      // Abort-aware delay: rejects with an AbortError when the user cancels,
+      // which the tool executor converts into a Cancelled result. Without
+      // this, cancellation would leave the scheduler blocked until the
+      // timer fires.
+      await delay(this.params.delay_ms, undefined, { signal: abortSignal });
     }
 
     // Verify process belongs to this session to prevent reading logs of processes from other sessions/users


### PR DESCRIPTION
## Summary

Pressing ESC to cancel a `read_background_output` call marked it as cancelled
in the UI, but the spinner kept spinning and new prompts were queued. The
tool's optional `delay_ms` sleep used a plain `setTimeout` that ignored the
abort signal, so the underlying tool promise kept the scheduler's executing
slot occupied until the timer fired.

## Details

- `ReadBackgroundOutputInvocation.execute` now uses the abortable
  `setTimeout` from `node:timers/promises`, passing the execution
  `abortSignal`.
- On cancellation the pending delay rejects immediately with an
  `AbortError`, which `tool-executor.ts` already converts into a
  `Cancelled` result via its `isAbortError` handling — no executor changes
  needed.
- Added unit tests covering abort-during-delay and an already-aborted
  signal.

## Related Issues

Fixes #18007

## How to Validate

1. Run `npm test -w @google/gemini-cli-core -- src/tools/shellBackgroundTools.test.ts`
   — all 12 tests pass, including the two new abort cases.
2. Manual: start a background shell command, have the agent call
   `read_background_output` with a large `delay_ms` (e.g. 30000), press ESC.
   The spinner stops immediately and the next prompt is accepted without
   queueing.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
