### PR TITLE
fix(core): never let shell exit results hang on the output drain (#25166)

### DIFF
--- a/packages/core/src/services/shellExecutionService.drain.test.ts
+++ b/packages/core/src/services/shellExecutionService.drain.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for the post-exit output drain watchdog (#25166).
+ *
+ * These tests mock the headless terminal so the xterm write callback is
+ * under test control, which is how the stuck state reproduces: the exit
+ * result is gated on the output processing chain, and a write callback
+ * that never fires used to leave the execution unresolved forever, with
+ * the UI stuck showing the shell as awaiting input.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  ShellExecutionService,
+  DRAIN_STALL_TIMEOUT_MS,
+  type ShellExecutionConfig,
+} from './shellExecutionService.js';
+import { NoopSandboxManager } from './sandboxManager.js';
+import { ExecutionLifecycleService } from './executionLifecycleService.js';
+
+// Hoisted Mocks
+const mockPtySpawn = vi.hoisted(() => vi.fn());
+const mockIsBinary = vi.hoisted(() => vi.fn());
+const mockPlatform = vi.hoisted(() => vi.fn());
+const mockHomedir = vi.hoisted(() => vi.fn());
+const mockGetPty = vi.hoisted(() => vi.fn());
+const mockSerializeTerminalToObject = vi.hoisted(() => vi.fn());
+const mockResolveExecutable = vi.hoisted(() => vi.fn());
+const mockDebugLogger = vi.hoisted(() => ({
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+/**
+ * Controllable headless terminal: write callbacks are queued instead of
+ * fired, so each test decides when (or whether) a chunk finishes draining.
+ */
+const terminalState = vi.hoisted(() => ({
+  pendingWriteCallbacks: [] as Array<() => void>,
+}));
+
+vi.mock('@xterm/headless', () => {
+  class MockTerminal {
+    buffer = {
+      active: {
+        viewportY: 0,
+        baseY: 0,
+        cursorY: 0,
+        length: 0,
+        getLine: () => undefined,
+      },
+    };
+    scrollToTop = vi.fn();
+    onScroll = vi.fn();
+    resize = vi.fn();
+    scrollLines = vi.fn();
+    dispose = vi.fn();
+    write = vi.fn((_data: string, cb?: () => void) => {
+      if (cb) {
+        terminalState.pendingWriteCallbacks.push(cb);
+      }
+    });
+  }
+  return {
+    default: { Terminal: MockTerminal },
+    Terminal: MockTerminal,
+  };
+});
+
+vi.mock('../config/storage.js', () => ({
+  Storage: {
+    getGlobalTempDir: vi.fn().mockReturnValue('/mock/temp'),
+  },
+}));
+vi.mock('../utils/debugLogger.js', () => ({
+  debugLogger: mockDebugLogger,
+}));
+vi.mock('../utils/shell-utils.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/shell-utils.js')>();
+  return {
+    ...actual,
+    resolveExecutable: mockResolveExecutable,
+  };
+});
+vi.mock('../utils/textUtils.js', () => ({
+  isBinary: mockIsBinary,
+}));
+vi.mock('node:os', () => ({
+  default: {
+    platform: mockPlatform,
+    homedir: mockHomedir,
+    constants: { signals: { SIGTERM: 15, SIGKILL: 9 } },
+  },
+  platform: mockPlatform,
+  homedir: mockHomedir,
+  constants: { signals: { SIGTERM: 15, SIGKILL: 9 } },
+}));
+vi.mock('../utils/getPty.js', () => ({
+  getPty: mockGetPty,
+}));
+vi.mock('../utils/terminalSerializer.js', () => ({
+  serializeTerminalToObject: (
+    _terminal: unknown,
+    ...args: [number | undefined, number | undefined]
+  ) => mockSerializeTerminalToObject(...args),
+  convertColorToHex: () => '#000000',
+  ColorMode: { DEFAULT: 0, PALETTE: 1, RGB: 2 },
+}));
+
+const shellExecutionConfig: ShellExecutionConfig = {
+  sessionId: 'default',
+  terminalWidth: 80,
+  terminalHeight: 24,
+  pager: 'cat',
+  showColor: false,
+  disableDynamicLineTrimming: true,
+  sanitizationConfig: {
+    enableEnvironmentVariableRedaction: false,
+    allowedEnvironmentVariables: [],
+    blockedEnvironmentVariables: [],
+  },
+  sandboxManager: new NoopSandboxManager(),
+};
+
+describe('ShellExecutionService drain watchdog', () => {
+  let mockPtyProcess: {
+    pid: number;
+    kill: ReturnType<typeof vi.fn>;
+    onData: ReturnType<typeof vi.fn>;
+    onExit: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+    resize: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    ExecutionLifecycleService.resetForTest();
+    ShellExecutionService.resetForTest();
+    terminalState.pendingWriteCallbacks.length = 0;
+    mockSerializeTerminalToObject.mockReturnValue([]);
+    mockIsBinary.mockReturnValue(false);
+    mockPlatform.mockReturnValue('linux');
+    mockResolveExecutable.mockImplementation((exe: string) => exe);
+    mockGetPty.mockResolvedValue({
+      module: { spawn: mockPtySpawn },
+      name: 'mock-pty',
+    });
+
+    mockPtyProcess = {
+      pid: 12345,
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      destroy: vi.fn(),
+    };
+    mockPtySpawn.mockReturnValue(mockPtyProcess);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const startExecution = async (command: string) => {
+    const handle = await ShellExecutionService.execute(
+      command,
+      '/test/dir',
+      vi.fn(),
+      new AbortController().signal,
+      true,
+      shellExecutionConfig,
+    );
+    // Let the microtask that registers onData/onExit run.
+    await vi.advanceTimersByTimeAsync(0);
+    return handle;
+  };
+
+  const emitData = (chunk: string) => {
+    mockPtyProcess.onData.mock.calls[0][0](chunk);
+  };
+
+  const emitExit = (exitCode = 0) => {
+    mockPtyProcess.onExit.mock.calls[0][0]({ exitCode, signal: null });
+  };
+
+  it('finalizes the execution when a write callback is never invoked', async () => {
+    const handle = await startExecution('echo hello');
+
+    emitData('hello\r\n'); // its write callback is intentionally never fired
+    emitExit(0);
+
+    let resolved = false;
+    const resultPromise = handle.result.then((r) => {
+      resolved = true;
+      return r;
+    });
+
+    // Before the watchdog window elapses the execution is still pending.
+    await vi.advanceTimersByTimeAsync(DRAIN_STALL_TIMEOUT_MS / 2);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(DRAIN_STALL_TIMEOUT_MS);
+    const result = await resultPromise;
+
+    expect(resolved).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('drain stalled'),
+    );
+  });
+
+  it('does not cut short a slow drain that keeps making progress', async () => {
+    const handle = await startExecution('big-output');
+
+    emitData('chunk-1');
+    emitData('chunk-2');
+    emitData('chunk-3');
+    emitExit(0);
+
+    let resolved = false;
+    void handle.result.then(() => {
+      resolved = true;
+    });
+
+    // Each chunk settles slower than the poll cadence but faster than the
+    // stall window; total drain time exceeds the window. Progress must
+    // keep the watchdog from firing.
+    const step = DRAIN_STALL_TIMEOUT_MS * 0.75;
+    for (let i = 0; i < 3; i++) {
+      await vi.advanceTimersByTimeAsync(step);
+      expect(resolved).toBe(false);
+      terminalState.pendingWriteCallbacks.shift()?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    const result = await handle.result;
+    expect(result.exitCode).toBe(0);
+    expect(mockDebugLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('drain stalled'),
+    );
+  });
+
+  it('does not start a watchdog when there is nothing left to drain', async () => {
+    const handle = await startExecution('true');
+
+    emitExit(0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const result = await handle.result;
+    expect(result.exitCode).toBe(0);
+    expect(mockDebugLogger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -19,6 +19,7 @@ import type { Readable } from 'node:stream';
 import { type ChildProcess } from 'node:child_process';
 import {
   ShellExecutionService,
+  DRAIN_STALL_TIMEOUT_MS,
   type ShellOutputEvent,
   type ShellExecutionConfig,
 } from './shellExecutionService.js';
@@ -1342,6 +1343,85 @@ describe('ShellExecutionService child_process fallback', () => {
     const result = await handle.result;
     return { result, handle, abortController };
   };
+
+  describe('Post-exit drain watchdog', () => {
+    // 'close' waits for the stdio pipes to end; a grandchild that
+    // inherited them (common on Windows) keeps 'close' from ever firing
+    // even though the shell already exited — the same stuck-result family
+    // as #25166, through the fallback path.
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const startExecution = async () => {
+      const handle = await ShellExecutionService.execute(
+        'spawns-a-daemon',
+        '/test/dir',
+        onOutputEventMock,
+        new AbortController().signal,
+        true,
+        shellExecutionConfig,
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      return handle;
+    };
+
+    it('finalizes when close never fires after exit', async () => {
+      vi.useFakeTimers();
+      const handle = await startExecution();
+
+      mockChildProcess.stdout?.emit('data', Buffer.from('hello\n'));
+      mockChildProcess.emit('exit', 0, null);
+      // No 'close': the pipes are held open by a grandchild.
+
+      await vi.advanceTimersByTimeAsync(DRAIN_STALL_TIMEOUT_MS + 500);
+      const result = await handle.result;
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('hello');
+      expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('stdio drain stalled'),
+      );
+    });
+
+    it('caps the wait when a grandchild keeps writing through the pipes', async () => {
+      vi.useFakeTimers();
+      const handle = await startExecution();
+
+      mockChildProcess.emit('exit', 0, null);
+
+      let resolved = false;
+      void handle.result.then(() => {
+        resolved = true;
+      });
+
+      // Keep the streams busy: the idle window never elapses, but the
+      // hard cap (10s) must still end the wait.
+      for (let i = 0; i < 9; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+        mockChildProcess.stdout?.emit('data', Buffer.from(`tick ${i}\n`));
+      }
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1500);
+      const result = await handle.result;
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('lets a prompt close win without logging a warning', async () => {
+      vi.useFakeTimers();
+      const handle = await startExecution();
+
+      mockChildProcess.emit('exit', 0, null);
+      mockChildProcess.emit('close', 0, null);
+      await vi.advanceTimersByTimeAsync(DRAIN_STALL_TIMEOUT_MS * 2);
+
+      const result = await handle.result;
+      expect(result.exitCode).toBe(0);
+      expect(mockDebugLogger.warn).not.toHaveBeenCalled();
+    });
+  });
 
   describe('Successful Execution', () => {
     it('should execute a command and capture stdout and stderr', async () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1247,6 +1247,47 @@ describe('ShellExecutionService', () => {
       expect(destroySpy).toHaveBeenCalled();
     });
   });
+
+  describe('Exit finalization resilience', () => {
+    // Regression tests for the "shell stuck in Awaiting input after the
+    // command completes" family (#25166): the exit result is gated on the
+    // output processing chain, so a chunk that throws anywhere in the
+    // rendering pipeline must never leave the execution unresolved.
+
+    it('resolves the result even if rendering throws while processing output', async () => {
+      mockSerializeTerminalToObject.mockImplementation(() => {
+        throw new Error('serializer boom');
+      });
+
+      const { result } = await simulateExecution('echo hello', (pty) => {
+        pty.onData.mock.calls[0][0]('hello\r\n');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output.trim()).toBe('hello');
+      // The serialized snapshot is lost, but the execution must not hang.
+      expect(result.ansiOutput).toBeUndefined();
+      expect(mockDebugLogger.warn).toHaveBeenCalled();
+    });
+
+    it('resolves the result even if a chunk throws before reaching the terminal', async () => {
+      mockIsBinary.mockImplementation(() => {
+        throw new Error('sniff boom');
+      });
+
+      const { result } = await simulateExecution('echo hello', (pty) => {
+        pty.onData.mock.calls[0][0]('hello\r\n');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Error while processing shell output chunk'),
+        expect.any(Error),
+      );
+    });
+  });
 });
 
 describe('ShellExecutionService child_process fallback', () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -65,6 +65,15 @@ export const GEMINI_CLI_IDENTIFICATION_ENV_VAR_VALUE = '1';
 // we capture significant output from long-running commands.
 export const SCROLLBACK_LIMIT = 300000;
 
+// After the process exits, the result still waits for queued output to
+// drain through the headless terminal. That drain is bounded by an idle
+// watchdog: if no chunk settles for a full window, the chain is considered
+// stuck (e.g. a swallowed terminal write callback) and the execution
+// finalizes with the output buffered so far. Progress resets the window,
+// so a slow but advancing drain is never cut short.
+export const DRAIN_STALL_TIMEOUT_MS = 2000;
+const DRAIN_STALL_POLL_MS = 250;
+
 const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
 const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
 
@@ -1050,6 +1059,14 @@ export class ShellExecutionService {
       const error: Error | null = null;
       let exited = false;
 
+      // Updated every time an output chunk settles so the post-exit drain
+      // watchdog only fires when the chain is stuck, never while it is
+      // slow but advancing.
+      let lastDrainActivityAt = Date.now();
+      const markDrainActivity = () => {
+        lastDrainActivityAt = Date.now();
+      };
+
       let isStreamingRawContent = true;
       const MAX_SNIFF_SIZE = 4096;
       let sniffedBytes = 0;
@@ -1251,6 +1268,9 @@ export class ShellExecutionService {
               }
             }),
         );
+        // Feed the post-exit drain watchdog: every settled chunk is
+        // progress, whether it drained cleanly or failed.
+        void processingChain.then(markDrainActivity, markDrainActivity);
       };
 
       ptyProcess.onData((data: string) => {
@@ -1272,12 +1292,17 @@ export class ShellExecutionService {
           // so it must run exactly once on every exit, no matter how the
           // drain race below settles.
           let finalized = false;
+          let drainWatchdog: NodeJS.Timeout | undefined;
 
           const finalize = () => {
             if (finalized) {
               return;
             }
             finalized = true;
+            if (drainWatchdog) {
+              clearInterval(drainWatchdog);
+              drainWatchdog = undefined;
+            }
             // Nothing below may prevent the result from reaching the caller:
             // a failure in the rendering pipeline must degrade output, not
             // hang the execution.
@@ -1384,9 +1409,31 @@ export class ShellExecutionService {
             });
           });
 
-           
-          Promise.race([processingComplete, abortFired]).then(
-            () => {
+          // Bound the drain with an idle watchdog: if no chunk settles for
+          // a full window after exit, the chain is stuck and the exit
+          // result must win. finalize() clears the interval.
+          markDrainActivity();
+          const drainStalled = new Promise<'drain-stalled'>((res) => {
+            drainWatchdog = setInterval(() => {
+              if (Date.now() - lastDrainActivityAt >= DRAIN_STALL_TIMEOUT_MS) {
+                res('drain-stalled');
+              }
+            }, DRAIN_STALL_POLL_MS);
+            drainWatchdog.unref?.();
+          });
+
+          void Promise.race([
+            processingComplete,
+            abortFired,
+            drainStalled,
+          ]).then(
+            (outcome) => {
+              if (outcome === 'drain-stalled') {
+                debugLogger.warn(
+                  `Shell output drain stalled after exit (pid ${ptyPid}); ` +
+                    `finalizing with the output buffered so far.`,
+                );
+              }
               finalize();
             },
             () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1153,8 +1153,18 @@ export class ShellExecutionService {
         }
 
         renderTimeout = setTimeout(() => {
-          renderFn();
-          renderTimeout = null;
+          // A deferred render runs outside any caller's try/catch; a throw
+          // here would surface as an uncaught exception and kill the CLI.
+          try {
+            renderFn();
+          } catch (err) {
+            debugLogger.warn(
+              `Deferred render failed for shell execution (pid ${ptyPid}):`,
+              err,
+            );
+          } finally {
+            renderTimeout = null;
+          }
         }, 68);
       };
 
@@ -1168,54 +1178,75 @@ export class ShellExecutionService {
         processingChain = processingChain.then(
           () =>
             new Promise<void>((resolveChunk) => {
-              if (!decoder) {
-                decoder = new TextDecoder('utf-8');
-              }
+              // A chunk that throws must settle rather than poison the
+              // chain: finalize() races against this chain on exit, and an
+              // unsettled link would block the exit result forever.
+              try {
+                if (!decoder) {
+                  decoder = new TextDecoder('utf-8');
+                }
 
-              if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-                sniffChunks.push(data);
-              } else if (!isStreamingRawContent) {
-                binaryBytesReceived += data.length;
-              }
+                if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
+                  sniffChunks.push(data);
+                } else if (!isStreamingRawContent) {
+                  binaryBytesReceived += data.length;
+                }
 
-              if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
-                const sniffBuffer = Buffer.concat(sniffChunks);
-                sniffedBytes = sniffBuffer.length;
+                if (isStreamingRawContent && sniffedBytes < MAX_SNIFF_SIZE) {
+                  const sniffBuffer = Buffer.concat(sniffChunks);
+                  sniffedBytes = sniffBuffer.length;
 
-                if (isBinary(sniffBuffer, 512, true)) {
-                  isStreamingRawContent = false;
-                  binaryBytesReceived = sniffBuffer.length;
-                  const event: ShellOutputEvent = { type: 'binary_detected' };
+                  if (isBinary(sniffBuffer, 512, true)) {
+                    isStreamingRawContent = false;
+                    binaryBytesReceived = sniffBuffer.length;
+                    const event: ShellOutputEvent = { type: 'binary_detected' };
+                    onOutputEvent(event);
+                    ExecutionLifecycleService.emitEvent(ptyPid, event);
+                  }
+                }
+
+                if (isStreamingRawContent) {
+                  const decodedChunk = decoder.decode(data, { stream: true });
+                  if (decodedChunk.length === 0) {
+                    resolveChunk();
+                    return;
+                  }
+
+                  if (ShellExecutionService.backgroundLogPids.has(ptyPid)) {
+                    ShellExecutionService.syncBackgroundLog(
+                      ptyPid,
+                      decodedChunk,
+                    );
+                  }
+
+                  isWriting = true;
+                  headlessTerminal.write(decodedChunk, () => {
+                    // A throw inside render() must not leave this chunk
+                    // unsettled: the exit result is gated on the chain
+                    // draining.
+                    try {
+                      render();
+                    } finally {
+                      isWriting = false;
+                      resolveChunk();
+                    }
+                  });
+                } else {
+                  const totalBytes = binaryBytesReceived;
+                  const event: ShellOutputEvent = {
+                    type: 'binary_progress',
+                    bytesReceived: totalBytes,
+                  };
                   onOutputEvent(event);
                   ExecutionLifecycleService.emitEvent(ptyPid, event);
-                }
-              }
-
-              if (isStreamingRawContent) {
-                const decodedChunk = decoder.decode(data, { stream: true });
-                if (decodedChunk.length === 0) {
                   resolveChunk();
-                  return;
                 }
-
-                if (ShellExecutionService.backgroundLogPids.has(ptyPid)) {
-                  ShellExecutionService.syncBackgroundLog(ptyPid, decodedChunk);
-                }
-
-                isWriting = true;
-                headlessTerminal.write(decodedChunk, () => {
-                  render();
-                  isWriting = false;
-                  resolveChunk();
-                });
-              } else {
-                const totalBytes = binaryBytesReceived;
-                const event: ShellOutputEvent = {
-                  type: 'binary_progress',
-                  bytesReceived: totalBytes,
-                };
-                onOutputEvent(event);
-                ExecutionLifecycleService.emitEvent(ptyPid, event);
+              } catch (err) {
+                debugLogger.warn(
+                  `Error while processing shell output chunk (pid ${ptyPid}):`,
+                  err,
+                );
+                isWriting = false;
                 resolveChunk();
               }
             }),
@@ -1237,8 +1268,27 @@ export class ShellExecutionService {
           // its buffer contents, then disposed to free memory.
           ShellExecutionService.destroyPtyProcess(ptyProcess);
 
+          // finalize() is the only path that resolves the execution result,
+          // so it must run exactly once on every exit, no matter how the
+          // drain race below settles.
+          let finalized = false;
+
           const finalize = () => {
-            render(true);
+            if (finalized) {
+              return;
+            }
+            finalized = true;
+            // Nothing below may prevent the result from reaching the caller:
+            // a failure in the rendering pipeline must degrade output, not
+            // hang the execution.
+            try {
+              render(true);
+            } catch (err) {
+              debugLogger.warn(
+                `Final render failed for shell execution (pid ${ptyPid}):`,
+                err,
+              );
+            }
             cmdCleanup?.();
 
             const event: ShellOutputEvent = {
@@ -1259,17 +1309,33 @@ export class ShellExecutionService {
             }
             onOutputEvent(event);
 
-            const endLine = headlessTerminal.buffer.active.length;
-            const startLine = Math.max(
-              0,
-              endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
-            );
-            const ansiOutputSnapshot = serializeTerminalToObject(
-              headlessTerminal,
-              startLine,
-              endLine,
-            );
-            const finalOutput = getFullBufferText(headlessTerminal);
+            let ansiOutputSnapshot: AnsiOutput | undefined;
+            try {
+              const endLine = headlessTerminal.buffer.active.length;
+              const startLine = Math.max(
+                0,
+                endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
+              );
+              ansiOutputSnapshot = serializeTerminalToObject(
+                headlessTerminal,
+                startLine,
+                endLine,
+              );
+            } catch (err) {
+              debugLogger.warn(
+                `Failed to serialize final shell output (pid ${ptyPid}):`,
+                err,
+              );
+            }
+            let finalOutput = '';
+            try {
+              finalOutput = getFullBufferText(headlessTerminal);
+            } catch (err) {
+              debugLogger.warn(
+                `Failed to extract final shell output (pid ${ptyPid}):`,
+                err,
+              );
+            }
 
             // Dispose the headless terminal to free scrollback buffers.
             // This must happen after getFullBufferText() extracts the output.
@@ -1302,7 +1368,12 @@ export class ShellExecutionService {
             return;
           }
 
-          const processingComplete = processingChain.then(() => 'processed');
+          // A rejected chunk counts as drained: the exit result must never
+          // be blocked on the rendering pipeline failing.
+          const processingComplete = processingChain.then(
+            () => 'processed' as const,
+            () => 'processed' as const,
+          );
           const abortFired = new Promise<'aborted'>((res) => {
             if (abortSignal.aborted) {
               res('aborted');
@@ -1313,10 +1384,15 @@ export class ShellExecutionService {
             });
           });
 
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          Promise.race([processingComplete, abortFired]).then(() => {
-            finalize();
-          });
+           
+          Promise.race([processingComplete, abortFired]).then(
+            () => {
+              finalize();
+            },
+            () => {
+              finalize();
+            },
+          );
         },
       );
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -74,6 +74,13 @@ export const SCROLLBACK_LIMIT = 300000;
 export const DRAIN_STALL_TIMEOUT_MS = 2000;
 const DRAIN_STALL_POLL_MS = 250;
 
+// In the child_process fallback the post-exit wait is for the stdio
+// 'close' event, and data may keep arriving from a live grandchild that
+// inherited the pipes rather than from a finite queue — so on top of the
+// idle window there is a hard cap: a process that keeps writing through
+// inherited pipes must not hold the exit result hostage indefinitely.
+export const POST_EXIT_DRAIN_CAP_MS = 10_000;
+
 const BASH_SHOPT_OPTIONS = 'promptvars nullglob extglob nocaseglob dotglob';
 const BASH_SHOPT_GUARD = `shopt -u ${BASH_SHOPT_OPTIONS};`;
 
@@ -664,12 +671,22 @@ export class ShellExecutionService {
       let stderrDecoder: TextDecoder | null = null;
       let error: Error | null = null;
       let exited = false;
+      let finalized = false;
+      let closeWatchdog: NodeJS.Timeout | undefined;
+      // Updated on every output chunk so the post-exit watchdog only fires
+      // when the streams go silent, not while a grandchild is still
+      // writing through the inherited pipes.
+      let lastDrainActivityAt = performance.now();
+      const markDrainActivity = () => {
+        lastDrainActivityAt = performance.now();
+      };
 
       let isStreamingRawContent = true;
       const MAX_SNIFF_SIZE = 4096;
       let sniffedBytes = 0;
 
       const handleOutput = (data: Buffer, stream: 'stdout' | 'stderr') => {
+        markDrainActivity();
         if (!stdoutDecoder || !stderrDecoder) {
           stdoutDecoder = new TextDecoder('utf-8');
           stderrDecoder = new TextDecoder('utf-8');
@@ -743,6 +760,14 @@ export class ShellExecutionService {
         code: number | null,
         signal: NodeJS.Signals | null,
       ) => {
+        if (finalized) {
+          return;
+        }
+        finalized = true;
+        if (closeWatchdog) {
+          clearInterval(closeWatchdog);
+          closeWatchdog = undefined;
+        }
         cleanup();
         cmdCleanup?.();
 
@@ -824,6 +849,33 @@ export class ShellExecutionService {
 
       child.on('close', (code, signal) => {
         handleExit(code, signal);
+      });
+
+      // 'close' waits for the stdio streams to end, which never happens if
+      // a grandchild inherited the pipes and outlives the shell (common on
+      // Windows). 'exit' still fires, so from there the wait for 'close'
+      // is bounded: stream activity resets an idle window (to capture the
+      // trailing flush), and a hard cap covers grandchildren that keep
+      // writing indefinitely.
+      child.on('exit', (code, signal) => {
+        if (finalized || closeWatchdog) {
+          return;
+        }
+        const exitedAt = performance.now();
+        markDrainActivity();
+        closeWatchdog = setInterval(() => {
+          const now = performance.now();
+          const stalled = now - lastDrainActivityAt >= DRAIN_STALL_TIMEOUT_MS;
+          const capped = now - exitedAt >= POST_EXIT_DRAIN_CAP_MS;
+          if (stalled || capped) {
+            debugLogger.warn(
+              `Shell stdio drain stalled after exit (pid ${child.pid}); ` +
+                `finalizing with the output received so far.`,
+            );
+            handleExit(code, signal);
+          }
+        }, DRAIN_STALL_POLL_MS);
+        closeWatchdog.unref?.();
       });
 
       function cleanup() {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1061,10 +1061,11 @@ export class ShellExecutionService {
 
       // Updated every time an output chunk settles so the post-exit drain
       // watchdog only fires when the chain is stuck, never while it is
-      // slow but advancing.
-      let lastDrainActivityAt = Date.now();
+      // slow but advancing. Uses the monotonic clock: wall-clock (Date.now)
+      // adjustments, e.g. NTP, must not fire or delay the watchdog.
+      let lastDrainActivityAt = performance.now();
       const markDrainActivity = () => {
-        lastDrainActivityAt = Date.now();
+        lastDrainActivityAt = performance.now();
       };
 
       let isStreamingRawContent = true;
@@ -1415,7 +1416,10 @@ export class ShellExecutionService {
           markDrainActivity();
           const drainStalled = new Promise<'drain-stalled'>((res) => {
             drainWatchdog = setInterval(() => {
-              if (Date.now() - lastDrainActivityAt >= DRAIN_STALL_TIMEOUT_MS) {
+              if (
+                performance.now() - lastDrainActivityAt >=
+                DRAIN_STALL_TIMEOUT_MS
+              ) {
                 res('drain-stalled');
               }
             }, DRAIN_STALL_POLL_MS);


### PR DESCRIPTION
## TLDR

Shell commands could complete while the CLI stayed stuck showing the shell as awaiting input (#25166). The exit result of a PTY execution is gated on the output-processing chain, and that gate had no error handling and no bound: a single chunk that threw anywhere in the rendering pipeline — or whose xterm write callback was never invoked — left the execution unresolved forever. The tool call then never left `executing`, so `activeBackgroundExecutionId` stayed set and the UI kept reporting an active shell after the process had already exited.

## Failure chain

1. `useShellInactivityStatus` shows the awaiting/focus state while `activePtyId` is set.
2. For model-initiated commands, `activePtyId` derives from the executing tool call (`useGeminiStream.ts`): it clears only when the tool's result promise settles.
3. That promise settles only in `finalize()` inside `ptyProcess.onExit` (`shellExecutionService.ts`), which ran exclusively through:
   ```ts
   Promise.race([processingChain.then(() => 'processed'), abortFired]).then(() => {
     finalize();
   });
   ```
4. Three structural holes:
   - a rejected `processingChain` rejects the race, and with no rejection handler `finalize()` never runs (the CLI's global `unhandledRejection` handler logs and continues, so this manifests as a silent hang, not a crash);
   - a chunk whose `headlessTerminal.write` callback never fires (xterm swallows callbacks on disposed/paused terminals; Windows ConPTY keeps flushing data after exit while the PTY is destroyed immediately on exit) leaves the chain pending forever, and no timeout existed;
   - `finalize()` itself could throw (`render(true)`, final serialization), skipping `completeWithResult`.

## What changed

**Commit 1 — pure correctness, no behavior change on the happy path:**
- every output-chunk link settles even if it throws (try/catch around the chunk executor, try/finally around the write callback), with a debug log instead of a poisoned chain;
- the drain race treats a rejected chain as drained and calls `finalize()` on both race outcomes;
- `finalize()` is idempotent and throw-proof end to end: a failure while rendering or serializing the final buffer degrades the captured output instead of hanging the execution;
- the deferred (debounced) render is guarded: it runs in a 68ms timer outside any caller's try/catch, so a throw there was an *uncaught exception that kills the whole CLI* — a sibling failure mode of the same unguarded rendering pipeline, surfaced by the regression tests for this change.

**Commit 2 — bounded drain (idle watchdog):**
- after exit, if no chunk settles for a full `DRAIN_STALL_TIMEOUT_MS` window (2s, polled at 250ms, `unref`'d and cleared on finalize), the execution finalizes with the output buffered so far and logs a warning. The watchdog is idle-based — every settled chunk resets the window — so a slow but advancing drain (large final bursts against a 300k-line scrollback) is never cut short; only a genuinely stuck chain trips it.

**Commit 3 — monotonic clock (review feedback):**
- the watchdog measures elapsed time with `performance.now()` so wall-clock adjustments (NTP, VM migration) can neither fire it prematurely nor delay it; `Date.now()` remains only where genuine wall-clock timestamps are wanted.

**Commit 4 — same guarantee for the `child_process` fallback:**
- the fallback finalized only on `close`, which waits for the stdio pipes to end; a grandchild that inherits the pipes and outlives the shell (common on Windows) keeps `close` from ever firing even though `exit` was emitted — the same stuck-result family through the non-PTY path. From `exit`, the wait for `close` is now bounded the same way: stream activity resets the idle window (capturing the trailing flush), and a hard cap (`POST_EXIT_DRAIN_CAP_MS`, 10s) covers grandchildren that keep writing indefinitely. A prompt `close` still wins with no behavior change.

The exit result now always reaches the scheduler on both execution paths; in the worst pathological case the trailing output is degraded, never the exit code, and the stall is logged for diagnosis.

## Tests

- `shellExecutionService.test.ts` (existing harness, real headless terminal):
  - rendering throws while processing output → result still resolves with the exit code and the buffer-extracted output;
  - a chunk throws before reaching the terminal → result still resolves, warning logged.
- `shellExecutionService.drain.test.ts` (new, controllable terminal mock):
  - a write callback that is never invoked → watchdog finalizes after the stall window, warning logged;
  - a slow drain that keeps making progress past the stall window in total time → never cut short, no warning;
  - nothing left to drain → resolves immediately, no watchdog side effects.
- `child_process` fallback (existing harness):
  - `exit` fires but `close` never does (pipes held by a grandchild) → finalizes after the idle window with the output received, warning logged;
  - a grandchild keeps writing through the pipes → the hard cap ends the wait;
  - a prompt `close` → unchanged behavior, no warning.
- Red/green: every hang-scenario test above times out against the unfixed code and passes with this change.

## Known boundary (intentionally out of scope)

- If `node-pty` never emits `onExit`, nothing in this file can recover — the watchdog lives inside the exit handler. Recovering from that would require process-liveness polling, and the codebase itself documents `process.kill(pid, 0)` returning false negatives for ConPTY-managed wrappers on Windows — a liveness watchdog built on that signal could finalize healthy long-running sessions. That variant, if it exists in the wild, needs separate evidence first.

Fixes #25166