### PR TITLE
feat(cli): add 'models' command to list available Gemini models

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -18,6 +18,7 @@ and parameters.
 | `gemini update`                    | Update to latest version           | `gemini update`                                              |
 | `gemini extensions`                | Manage extensions                  | See [Extensions Management](#extensions-management)          |
 | `gemini mcp`                       | Configure MCP servers              | See [MCP Server Management](#mcp-server-management)          |
+| `gemini models`                    | List available models              | `gemini models`                                              |
 
 ### Positional arguments
 
@@ -73,6 +74,18 @@ These commands are available within the interactive REPL.
 
 The `--model` (or `-m`) flag lets you specify which Gemini model to use. You can
 use either model aliases (user-friendly names) or concrete model names.
+
+To see the full list of available models and their capabilities, run:
+
+```bash
+gemini models
+```
+
+For machine-readable output, use:
+
+```bash
+gemini models --output-format json
+```
 
 ### Model aliases
 

--- a/packages/cli/src/commands/models.test.ts
+++ b/packages/cli/src/commands/models.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  coreEvents,
+  ModelConfigService,
+  tokenLimit,
+} from '@google/gemini-cli-core';
+import { handleModelsList, modelsCommand } from './models.js';
+import { loadSettings, type LoadedSettings } from '../config/settings.js';
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const { mockCoreDebugLogger } = await import(
+    '../test-utils/mockDebugLogger.js'
+  );
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  const mocked = mockCoreDebugLogger(actual, { stripAnsi: false });
+  return {
+    ...mocked,
+    getErrorMessage: vi.fn((e) => (e as Error).message),
+    tokenLimit: vi.fn(),
+  };
+});
+
+vi.mock('../config/settings.js');
+vi.mock('./utils.js', () => ({
+  exitCli: vi.fn(),
+}));
+
+describe('models command', () => {
+  const mockLoadSettings = vi.mocked(loadSettings);
+  const mockTokenLimit = vi.mocked(tokenLimit);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockLoadSettings.mockReturnValue({
+      merged: {},
+    } as unknown as LoadedSettings);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleModelsList', () => {
+    it('should list available models in text format', async () => {
+      const mockModels: ReturnType<
+        ModelConfigService['getAvailableModelOptions']
+      > = [
+        {
+          modelId: 'model-1',
+          name: 'Model 1',
+          description: 'Desc 1',
+          tier: 'pro',
+        },
+        {
+          modelId: 'model-2',
+          name: 'Model 2',
+          description: 'Desc 2',
+          tier: 'flash',
+        },
+      ];
+
+      vi.spyOn(
+        ModelConfigService.prototype,
+        'getAvailableModelOptions',
+      ).mockReturnValue(mockModels);
+      mockTokenLimit.mockReturnValue(1000000);
+
+      await handleModelsList();
+
+      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Available Gemini Models:',
+      );
+      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        'Model 1 (model-1)',
+      );
+      // Depending on locale, this might be 1,000,000 or 1.000.000
+      // We can check if it contains "1" and "000" and "000"
+      const call = vi
+        .mocked(coreEvents.emitConsoleLog)
+        .mock.calls.find((c) => String(c[1]).includes('Context Window:'));
+      expect(call?.[1]).toMatch(/Context Window: 1.*000.*000 tokens/);
+    });
+
+    it('should list available models in JSON format', async () => {
+      const mockModels: ReturnType<
+        ModelConfigService['getAvailableModelOptions']
+      > = [
+        {
+          modelId: 'model-1',
+          name: 'Model 1',
+          description: 'Desc 1',
+          tier: 'pro',
+        },
+      ];
+
+      vi.spyOn(
+        ModelConfigService.prototype,
+        'getAvailableModelOptions',
+      ).mockReturnValue(mockModels);
+      mockTokenLimit.mockReturnValue(1000000);
+
+      await handleModelsList({ outputFormat: 'json' });
+
+      const expectedJson = JSON.stringify(
+        [
+          {
+            modelId: 'model-1',
+            displayName: 'Model 1',
+            description: 'Desc 1',
+            contextWindow: 1000000,
+            tier: 'pro',
+          },
+        ],
+        null,
+        2,
+      );
+
+      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
+        'log',
+        expectedJson,
+      );
+    });
+
+    it('should log an error and exit on failure', async () => {
+      const mockProcessExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('Exit');
+        }) as unknown as (code?: string | number | null | undefined) => never);
+      vi.spyOn(
+        ModelConfigService.prototype,
+        'getAvailableModelOptions',
+      ).mockImplementation(() => {
+        throw new Error('Test Error');
+      });
+
+      try {
+        await handleModelsList();
+      } catch (e) {
+        if ((e as Error).message !== 'Exit') throw e;
+      }
+
+      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
+        'error',
+        'Test Error',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      mockProcessExit.mockRestore();
+    });
+  });
+
+  describe('modelsCommand', () => {
+    it('should have correct command and describe', () => {
+      expect(modelsCommand.command).toBe('models');
+      expect(modelsCommand.describe).toBe(
+        'Lists available Gemini models in a structured format.',
+      );
+    });
+  });
+});

--- a/packages/cli/src/commands/models.test.ts
+++ b/packages/cli/src/commands/models.test.ts
@@ -5,11 +5,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import {
-  coreEvents,
-  ModelConfigService,
-  tokenLimit,
-} from '@google/gemini-cli-core';
+import { ModelConfigService, tokenLimit } from '@google/gemini-cli-core';
 import { handleModelsList, modelsCommand } from './models.js';
 import { loadSettings, type LoadedSettings } from '../config/settings.js';
 
@@ -35,12 +31,15 @@ vi.mock('./utils.js', () => ({
 describe('models command', () => {
   const mockLoadSettings = vi.mocked(loadSettings);
   const mockTokenLimit = vi.mocked(tokenLimit);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let consoleLogSpy: any;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     mockLoadSettings.mockReturnValue({
       merged: {},
     } as unknown as LoadedSettings);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -74,20 +73,21 @@ describe('models command', () => {
 
       await handleModelsList();
 
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
-        'Available Gemini Models:',
-      );
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
-        'Model 1 (model-1)',
-      );
+      expect(consoleLogSpy).toHaveBeenCalledWith('Available Gemini Models:');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Model 1 (model-1)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Description: Desc 1');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Tier: pro');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Model 2 (model-2)');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Description: Desc 2');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  Tier: flash');
+
       // Depending on locale, this might be 1,000,000 or 1.000.000
       // We can check if it contains "1" and "000" and "000"
-      const call = vi
-        .mocked(coreEvents.emitConsoleLog)
-        .mock.calls.find((c) => String(c[1]).includes('Context Window:'));
-      expect(call?.[1]).toMatch(/Context Window: 1.*000.*000 tokens/);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = consoleLogSpy.mock.calls.find((c: any) =>
+        String(c[0]).includes('Context Window:'),
+      );
+      expect(call?.[0]).toMatch(/Context Window: 1.*000.*000 tokens/);
     });
 
     it('should list available models in JSON format', async () => {
@@ -124,18 +124,10 @@ describe('models command', () => {
         2,
       );
 
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'log',
-        expectedJson,
-      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(expectedJson);
     });
 
-    it('should log an error and exit on failure', async () => {
-      const mockProcessExit = vi
-        .spyOn(process, 'exit')
-        .mockImplementation((() => {
-          throw new Error('Exit');
-        }) as unknown as (code?: string | number | null | undefined) => never);
+    it('should throw an error on failure', async () => {
       vi.spyOn(
         ModelConfigService.prototype,
         'getAvailableModelOptions',
@@ -143,18 +135,7 @@ describe('models command', () => {
         throw new Error('Test Error');
       });
 
-      try {
-        await handleModelsList();
-      } catch (e) {
-        if ((e as Error).message !== 'Exit') throw e;
-      }
-
-      expect(coreEvents.emitConsoleLog).toHaveBeenCalledWith(
-        'error',
-        'Test Error',
-      );
-      expect(mockProcessExit).toHaveBeenCalledWith(1);
-      mockProcessExit.mockRestore();
+      await expect(handleModelsList()).rejects.toThrow('Test Error');
     });
   });
 

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import {
+  debugLogger,
+  getErrorMessage,
+  ModelConfigService,
+  DEFAULT_MODEL_CONFIGS,
+  tokenLimit,
+} from '@google/gemini-cli-core';
+import { loadSettings } from '../config/settings.js';
+import { exitCli } from './utils.js';
+
+/**
+ * Handles the 'models' command to list available Gemini models.
+ */
+export async function handleModelsList(options?: {
+  outputFormat?: 'text' | 'json';
+}) {
+  try {
+    const workspaceDir = process.cwd();
+    const settings = loadSettings(workspaceDir).merged;
+
+    const modelConfigService = new ModelConfigService(
+      settings.modelConfigs ?? DEFAULT_MODEL_CONFIGS,
+    );
+
+    const context = {
+      hasAccessToPreview: true,
+      useGemini3_1: true,
+      useGemini3_5Flash: true,
+    };
+
+    const models = modelConfigService
+      .getAvailableModelOptions(context)
+      .map((m) => ({
+        modelId: m.modelId,
+        displayName: m.name,
+        description: m.description,
+        contextWindow: tokenLimit(m.modelId),
+        tier: m.tier,
+      }));
+
+    if (options?.outputFormat === 'json') {
+      debugLogger.log(JSON.stringify(models, null, 2));
+    } else {
+      debugLogger.log('Available Gemini Models:');
+      debugLogger.log('');
+      for (const m of models) {
+        debugLogger.log(`${m.displayName} (${m.modelId})`);
+        if (m.description) {
+          debugLogger.log(`  Description: ${m.description}`);
+        }
+        debugLogger.log(
+          `  Context Window: ${m.contextWindow.toLocaleString()} tokens`,
+        );
+        debugLogger.log(`  Tier: ${m.tier}`);
+        debugLogger.log('');
+      }
+    }
+  } catch (error) {
+    debugLogger.error(getErrorMessage(error));
+    process.exit(1);
+  }
+}
+
+export const modelsCommand: CommandModule = {
+  command: 'models',
+  describe: 'Lists available Gemini models in a structured format.',
+  builder: (yargs) =>
+    yargs.option('output-format', {
+      alias: 'o',
+      type: 'string',
+      describe: 'The format of the CLI output.',
+      choices: ['text', 'json'],
+      default: 'text',
+    }),
+  handler: async (argv) => {
+    await handleModelsList({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      outputFormat: argv['output-format'] as 'text' | 'json',
+    });
+    await exitCli();
+  },
+};

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable no-console */
+
 import type { CommandModule } from 'yargs';
 import {
   debugLogger,
-  getErrorMessage,
   ModelConfigService,
   DEFAULT_MODEL_CONFIGS,
   tokenLimit,
@@ -46,25 +47,25 @@ export async function handleModelsList(options?: {
       }));
 
     if (options?.outputFormat === 'json') {
-      debugLogger.log(JSON.stringify(models, null, 2));
+      console.log(JSON.stringify(models, null, 2));
     } else {
-      debugLogger.log('Available Gemini Models:');
-      debugLogger.log('');
+      console.log('Available Gemini Models:');
+      console.log('');
       for (const m of models) {
-        debugLogger.log(`${m.displayName} (${m.modelId})`);
+        console.log(`${m.displayName} (${m.modelId})`);
         if (m.description) {
-          debugLogger.log(`  Description: ${m.description}`);
+          console.log(`  Description: ${m.description}`);
         }
-        debugLogger.log(
+        console.log(
           `  Context Window: ${m.contextWindow.toLocaleString()} tokens`,
         );
-        debugLogger.log(`  Tier: ${m.tier}`);
-        debugLogger.log('');
+        console.log(`  Tier: ${m.tier}`);
+        console.log('');
       }
     }
   } catch (error) {
-    debugLogger.error(getErrorMessage(error));
-    process.exit(1);
+    debugLogger.error('Failed to list models', error);
+    throw error;
   }
 }
 
@@ -80,10 +81,13 @@ export const modelsCommand: CommandModule = {
       default: 'text',
     }),
   handler: async (argv) => {
-    await handleModelsList({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      outputFormat: argv['output-format'] as 'text' | 'json',
-    });
-    await exitCli();
+    try {
+      await handleModelsList({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        outputFormat: argv['output-format'] as 'text' | 'json',
+      });
+    } finally {
+      await exitCli();
+    }
   },
 };

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { execa } from 'execa';
 import { mcpCommand } from '../commands/mcp.js';
 import { extensionsCommand } from '../commands/extensions.js';
+import { modelsCommand } from '../commands/models.js';
 import { skillsCommand } from '../commands/skills.js';
 import { hooksCommand } from '../commands/hooks.js';
 import { gemmaCommand } from '../commands/gemma.js';
@@ -183,6 +184,7 @@ export async function parseArguments(
       const commandModules = [
         mcpCommand,
         extensionsCommand,
+        modelsCommand,
         skillsCommand,
         hooksCommand,
         gemmaCommand,
@@ -273,6 +275,7 @@ export async function parseArguments(
 
   yargsInstance.command(mcpCommand);
   yargsInstance.command(extensionsCommand);
+  yargsInstance.command(modelsCommand);
   yargsInstance.command(skillsCommand);
   yargsInstance.command(hooksCommand);
   yargsInstance.command(gemmaCommand);


### PR DESCRIPTION
## Summary

Adds a new `gemini models` command that allows users to list all available Gemini models, their context window limits, and their respective tiers (Pro, Flash, etc.). Supports both human-readable text and machine-readable JSON output.

## Details

This implementation provides a quick way for developers to discover which models are currently supported and accessible within their environment without leaving the terminal. 
- Integrated with `ModelConfigService` to ensure consistency with the core engine's model resolution logic.
- Added `--output-format` (alias `-o`) flag with `text` (default) and `json` options.
- Includes full unit test coverage for the new command and its options.

## Related Issues

Fixes #27847

## How to Validate

### 1. List models in text format
```bash
gemini models
```
**Output example:**
```text
Available Gemini Models:

Auto (auto)
  Description: Let Gemini CLI decide the best model for the task: gemini-3.1-pro-preview, gemini-3.5-flash
  Context Window: 1.048.576 tokens
  Tier: auto

gemini-3.5-flash (gemini-3.5-flash)
  Context Window: 1.048.576 tokens
  Tier: flash

gemini-3.1-pro-preview (gemini-3.1-pro-preview)
  Context Window: 1.048.576 tokens
  Tier: pro

gemini-3.1-flash-lite (gemini-3.1-flash-lite)
  Context Window: 1.048.576 tokens
  Tier: flash-lite

gemma-4-31b-it (gemma-4-31b-it)
  Context Window: 256.000 tokens
  Tier: custom
```

### 2. List models in JSON format
```bash
gemini models --output-format json
```
**Output example:**
```json
[
  {
    "modelId": "auto",
    "displayName": "Auto",
    "description": "Let Gemini CLI decide the best model for the task: gemini-3.1-pro-preview, gemini-3.5-flash",
    "contextWindow": 1048576,
    "tier": "auto"
  },
  {
    "modelId": "gemini-3.5-flash",
    "displayName": "gemini-3.5-flash",
    "description": "",
    "contextWindow": 1048576,
    "tier": "flash"
  },
  {
    "modelId": "gemini-3.1-pro-preview",
    "displayName": "gemini-3.1-pro-preview",
    "description": "",
    "contextWindow": 1048576,
    "tier": "pro"
  },
  {
    "modelId": "gemma-4-31b-it",
    "displayName": "gemma-4-31b-it",
    "description": "",
    "contextWindow": 256000,
    "tier": "custom"
  }
]
```

### 3. Run unit tests
```bash
npm test -w @google/gemini-cli -- src/commands/models.test.ts
```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [x] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
