### PR TITLE
Fix/pending tools and trust overrides

### DIFF
--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -22,6 +22,7 @@ vi.mock('../config/config.js', () => ({
     getCheckpointingEnabled: () => false,
   }),
   loadEnvironment: vi.fn(),
+  setIsTrusted: vi.fn().mockReturnValue(false),
   setTargetDir: vi.fn().mockReturnValue('/tmp'),
 }));
 

--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -62,6 +62,8 @@ vi.mock('./task.js', () => {
     scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
     waitForPendingTools: vi.fn().mockResolvedValue(undefined),
     getAndClearCompletedTools: vi.fn().mockReturnValue([]),
+    hasPendingTools: vi.fn().mockReturnValue(false),
+    getPendingToolsCount: vi.fn().mockReturnValue(0),
     addToolResponsesToHistory: vi.fn(),
     sendCompletedToolsToLlm: vi.fn().mockImplementation(async function* () {}),
     cancelPendingTools: vi.fn(),

--- a/packages/a2a-server/src/agent/executor.test.ts
+++ b/packages/a2a-server/src/agent/executor.test.ts
@@ -63,8 +63,12 @@ vi.mock('./task.js', () => {
     scheduleToolCalls: vi.fn().mockResolvedValue(undefined),
     waitForPendingTools: vi.fn().mockResolvedValue(undefined),
     getAndClearCompletedTools: vi.fn().mockReturnValue([]),
-    hasPendingTools: vi.fn().mockReturnValue(false),
-    getPendingToolsCount: vi.fn().mockReturnValue(0),
+    get hasPendingTools() {
+      return false;
+    },
+    get pendingToolsCount() {
+      return 0;
+    },
     addToolResponsesToHistory: vi.fn(),
     sendCompletedToolsToLlm: vi.fn().mockImplementation(async function* () {}),
     cancelPendingTools: vi.fn(),
@@ -247,5 +251,53 @@ describe('CoderAgentExecutor', () => {
 
     expect(executor.getTask(taskId)).toBeUndefined();
     expect(wrapper.task.dispose).toHaveBeenCalled();
+  });
+
+  it('should yield the turn and transition to input-required if tools are pending', async () => {
+    const taskId = 'test-task-pending-tools';
+    const contextId = 'test-context';
+
+    const mockSocket = new EventEmitter();
+    (requestStorage.getStore as Mock).mockReturnValue({
+      req: { socket: mockSocket },
+    });
+
+    // Pre-create the task to safely modify its mocked methods before execution
+    const wrapper = await executor.createTask(
+      taskId,
+      contextId,
+      undefined,
+      mockEventBus,
+    );
+    const hasPendingToolsSpy = vi
+      .spyOn(wrapper.task, 'hasPendingTools', 'get')
+      .mockReturnValue(true);
+    vi.spyOn(wrapper.task, 'pendingToolsCount', 'get').mockReturnValue(1);
+
+    const requestContext = {
+      userMessage: {
+        messageId: 'msg-1',
+        taskId,
+        contextId,
+        parts: [{ kind: 'confirmation', callId: '1', outcome: 'proceed' }],
+        metadata: {
+          coderAgent: { kind: 'agent-settings', workspacePath: '/tmp' },
+        },
+      },
+    } as unknown as RequestContext;
+
+    await executor.execute(requestContext, mockEventBus);
+
+    // Assert that the executor yielded the turn correctly without further progression
+    expect(hasPendingToolsSpy).toHaveBeenCalled();
+    expect(wrapper.task.getAndClearCompletedTools).not.toHaveBeenCalled();
+    expect(wrapper.task.sendCompletedToolsToLlm).not.toHaveBeenCalled();
+    expect(wrapper.task.setTaskStateAndPublishUpdate).toHaveBeenCalledWith(
+      'input-required',
+      expect.any(Object),
+      undefined,
+      undefined,
+      true,
+    );
   });
 });

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -546,9 +546,9 @@ export class CoderAgentExecutor implements AgentExecutor {
 
         if (abortSignal.aborted) throw new Error('Execution aborted');
 
-        if (currentTask.hasPendingTools()) {
+        if (currentTask.hasPendingTools) {
           logger.info(
-            `[CoderAgentExecutor] Task ${taskId}: There are still ${currentTask.getPendingToolsCount()} pending tools waiting for approval. Yielding to user.`,
+            `[CoderAgentExecutor] Task ${taskId}: There are still ${currentTask.pendingToolsCount} pending tools waiting for approval. Yielding to user.`,
           );
           agentTurnActive = false;
         } else {

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -98,8 +98,8 @@ export class CoderAgentExecutor implements AgentExecutor {
     taskId: string,
   ): Promise<Config> {
     const workspaceRoot = setTargetDir(agentSettings);
-    const isTrusted = setIsTrusted(agentSettings);
     loadEnvironment(); // Will override any global env with workspace envs
+    const isTrusted = setIsTrusted(agentSettings);
     const settings = loadSettings(workspaceRoot, isTrusted);
     const extensions = loadExtensions(workspaceRoot);
     return loadConfig(

--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -31,7 +31,12 @@ import {
   getContextIdFromMetadata,
   getAgentSettingsFromMetadata,
 } from '../types.js';
-import { loadConfig, loadEnvironment, setTargetDir } from '../config/config.js';
+import {
+  loadConfig,
+  loadEnvironment,
+  setIsTrusted,
+  setTargetDir,
+} from '../config/config.js';
 import { loadSettings } from '../config/settings.js';
 import { loadExtensions } from '../config/extension.js';
 import { Task } from './task.js';
@@ -93,7 +98,7 @@ export class CoderAgentExecutor implements AgentExecutor {
     taskId: string,
   ): Promise<Config> {
     const workspaceRoot = setTargetDir(agentSettings);
-    const isTrusted = agentSettings.isTrusted ?? false;
+    const isTrusted = setIsTrusted(agentSettings);
     loadEnvironment(); // Will override any global env with workspace envs
     const settings = loadSettings(workspaceRoot, isTrusted);
     const extensions = loadExtensions(workspaceRoot);
@@ -541,42 +546,49 @@ export class CoderAgentExecutor implements AgentExecutor {
 
         if (abortSignal.aborted) throw new Error('Execution aborted');
 
-        const completedTools = currentTask.getAndClearCompletedTools();
-
-        if (completedTools.length > 0) {
-          // If all completed tool calls were canceled, manually add them to history and set state to input-required, final:true
-          if (completedTools.every((tool) => tool.status === 'cancelled')) {
-            logger.info(
-              `[CoderAgentExecutor] Task ${taskId}: All tool calls were cancelled. Updating history and ending agent turn.`,
-            );
-            currentTask.addToolResponsesToHistory(completedTools);
-            agentTurnActive = false;
-            const stateChange: StateChange = {
-              kind: CoderAgentEvent.StateChangeEvent,
-            };
-            currentTask.setTaskStateAndPublishUpdate(
-              'input-required',
-              stateChange,
-              undefined,
-              undefined,
-              true,
-            );
-          } else {
-            logger.info(
-              `[CoderAgentExecutor] Task ${taskId}: Found ${completedTools.length} completed tool calls. Sending results back to LLM.`,
-            );
-
-            agentEvents = currentTask.sendCompletedToolsToLlm(
-              completedTools,
-              abortSignal,
-            );
-            // Continue the loop to process the LLM response to the tool results.
-          }
-        } else {
+        if (currentTask.hasPendingTools()) {
           logger.info(
-            `[CoderAgentExecutor] Task ${taskId}: No more tool calls to process. Ending agent turn.`,
+            `[CoderAgentExecutor] Task ${taskId}: There are still ${currentTask.getPendingToolsCount()} pending tools waiting for approval. Yielding to user.`,
           );
           agentTurnActive = false;
+        } else {
+          const completedTools = currentTask.getAndClearCompletedTools();
+
+          if (completedTools.length > 0) {
+            // If all completed tool calls were canceled, manually add them to history and set state to input-required, final:true
+            if (completedTools.every((tool) => tool.status === 'cancelled')) {
+              logger.info(
+                `[CoderAgentExecutor] Task ${taskId}: All tool calls were cancelled. Updating history and ending agent turn.`,
+              );
+              currentTask.addToolResponsesToHistory(completedTools);
+              agentTurnActive = false;
+              const stateChange: StateChange = {
+                kind: CoderAgentEvent.StateChangeEvent,
+              };
+              currentTask.setTaskStateAndPublishUpdate(
+                'input-required',
+                stateChange,
+                undefined,
+                undefined,
+                true,
+              );
+            } else {
+              logger.info(
+                `[CoderAgentExecutor] Task ${taskId}: Found ${completedTools.length} completed tool calls. Sending results back to LLM.`,
+              );
+
+              agentEvents = currentTask.sendCompletedToolsToLlm(
+                completedTools,
+                abortSignal,
+              );
+              // Continue the loop to process the LLM response to the tool results.
+            }
+          } else {
+            logger.info(
+              `[CoderAgentExecutor] Task ${taskId}: No more tool calls to process. Ending agent turn.`,
+            );
+            agentTurnActive = false;
+          }
         }
       }
 

--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -652,12 +652,12 @@ describe('Task', () => {
           mockEventBus,
         );
 
-        expect(task.hasPendingTools()).toBe(false);
-        expect(task.getPendingToolsCount()).toBe(0);
+        expect(task.hasPendingTools).toBe(false);
+        expect(task.pendingToolsCount).toBe(0);
 
         task['_registerToolCall']('tool-1', 'scheduled');
-        expect(task.hasPendingTools()).toBe(true);
-        expect(task.getPendingToolsCount()).toBe(1);
+        expect(task.hasPendingTools).toBe(true);
+        expect(task.pendingToolsCount).toBe(1);
       });
     });
   });

--- a/packages/a2a-server/src/agent/task.test.ts
+++ b/packages/a2a-server/src/agent/task.test.ts
@@ -631,6 +631,35 @@ describe('Task', () => {
 
       expect(handleEventDrivenToolCallSpy).toHaveBeenCalled();
     });
+
+    describe('Pending Tools state', () => {
+      it('should correctly report pending tools presence and count', () => {
+        const mockConfig = createMockConfig();
+        const mockEventBus: ExecutionEventBus = {
+          publish: vi.fn(),
+          on: vi.fn(),
+          off: vi.fn(),
+          once: vi.fn(),
+          removeAllListeners: vi.fn(),
+          finished: vi.fn(),
+        };
+
+        // @ts-expect-error - Calling private constructor
+        const task = new Task(
+          'task-id',
+          'context-id',
+          mockConfig as Config,
+          mockEventBus,
+        );
+
+        expect(task.hasPendingTools()).toBe(false);
+        expect(task.getPendingToolsCount()).toBe(0);
+
+        task['_registerToolCall']('tool-1', 'scheduled');
+        expect(task.hasPendingTools()).toBe(true);
+        expect(task.getPendingToolsCount()).toBe(1);
+      });
+    });
   });
 
   describe('Serialization and Mapping', () => {

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -137,6 +137,14 @@ export class Task {
     );
   }
 
+  hasPendingTools(): boolean {
+    return this.pendingToolCalls.size > 0;
+  }
+
+  getPendingToolsCount(): number {
+    return this.pendingToolCalls.size;
+  }
+
   static async create(
     id: string,
     contextId: string,

--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -137,11 +137,11 @@ export class Task {
     );
   }
 
-  hasPendingTools(): boolean {
+  get hasPendingTools(): boolean {
     return this.pendingToolCalls.size > 0;
   }
 
-  getPendingToolsCount(): number {
+  get pendingToolsCount(): number {
     return this.pendingToolCalls.size;
   }
 

--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
-import { loadConfig, setIsTrusted } from './config.js';
+import { loadConfig } from './config.js';
 import type { Settings } from './settings.js';
 import {
   type ExtensionLoader,
@@ -615,23 +615,30 @@ describe('loadConfig', () => {
 });
 
 describe('setIsTrusted', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it('should return true when GEMINI_FOLDER_TRUST env var is true', () => {
+  it('should return true when GEMINI_FOLDER_TRUST env var is true', async () => {
     vi.stubEnv('GEMINI_FOLDER_TRUST', 'true');
+    const { setIsTrusted } = await import('./config.js');
     expect(setIsTrusted(undefined)).toBe(true);
     expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(true);
   });
 
-  it('should return false when GEMINI_FOLDER_TRUST env var is false', () => {
+  it('should return false when GEMINI_FOLDER_TRUST env var is false', async () => {
     vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+    const { setIsTrusted } = await import('./config.js');
     expect(setIsTrusted(undefined)).toBe(false);
     expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(false);
   });
 
-  it('should fallback to agentSettings.isTrusted if env var is undefined', () => {
+  it('should fallback to agentSettings.isTrusted if env var is undefined', async () => {
+    const { setIsTrusted } = await import('./config.js');
     expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(true);
     expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(false);
     expect(setIsTrusted(undefined)).toBe(false);

--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
-import { loadConfig } from './config.js';
+import { loadConfig, setIsTrusted } from './config.js';
 import type { Settings } from './settings.js';
 import {
   type ExtensionLoader,
@@ -23,6 +23,7 @@ import {
   PRIORITY_YOLO_ALLOW_ALL,
   createPolicyEngineConfig,
 } from '@google/gemini-cli-core';
+import type { AgentSettings } from '../types.js';
 
 // Mock dependencies
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -610,5 +611,23 @@ describe('loadConfig', () => {
         );
       });
     });
+  });
+});
+
+describe('setIsTrusted', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should return true when GEMINI_FOLDER_TRUST env var is true', () => {
+    vi.stubEnv('GEMINI_FOLDER_TRUST', 'true');
+    expect(setIsTrusted(undefined)).toBe(true);
+  });
+
+  it('should fallback to agentSettings.isTrusted if env var is not true', () => {
+    vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+    expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(true);
+    expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(false);
+    expect(setIsTrusted(undefined)).toBe(false);
   });
 });

--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -622,10 +622,16 @@ describe('setIsTrusted', () => {
   it('should return true when GEMINI_FOLDER_TRUST env var is true', () => {
     vi.stubEnv('GEMINI_FOLDER_TRUST', 'true');
     expect(setIsTrusted(undefined)).toBe(true);
+    expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(true);
   });
 
-  it('should fallback to agentSettings.isTrusted if env var is not true', () => {
+  it('should return false when GEMINI_FOLDER_TRUST env var is false', () => {
     vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+    expect(setIsTrusted(undefined)).toBe(false);
+    expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(false);
+  });
+
+  it('should fallback to agentSettings.isTrusted if env var is undefined', () => {
     expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(true);
     expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(false);
     expect(setIsTrusted(undefined)).toBe(false);

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -182,6 +182,14 @@ export async function loadConfig(
   return config;
 }
 
+export function setIsTrusted(
+  agentSettings: AgentSettings | undefined,
+): boolean {
+  return (
+    process.env['GEMINI_FOLDER_TRUST'] === 'true' || !!agentSettings?.isTrusted
+  );
+}
+
 export function setTargetDir(agentSettings: AgentSettings | undefined): string {
   const originalCWD = process.cwd();
   const targetDir =

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -185,9 +185,10 @@ export async function loadConfig(
 export function setIsTrusted(
   agentSettings: AgentSettings | undefined,
 ): boolean {
-  return (
-    process.env['GEMINI_FOLDER_TRUST'] === 'true' || !!agentSettings?.isTrusted
-  );
+  if (process.env['GEMINI_FOLDER_TRUST'] !== undefined) {
+    return process.env['GEMINI_FOLDER_TRUST'] === 'true';
+  }
+  return !!agentSettings?.isTrusted;
 }
 
 export function setTargetDir(agentSettings: AgentSettings | undefined): string {

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -34,6 +34,8 @@ import { logger } from '../utils/logger.js';
 import type { Settings } from './settings.js';
 import { type AgentSettings, CoderAgentEvent } from '../types.js';
 
+const INITIAL_FOLDER_TRUST = process.env['GEMINI_FOLDER_TRUST'];
+
 export async function loadConfig(
   settings: Settings,
   extensionLoader: ExtensionLoader,
@@ -185,8 +187,8 @@ export async function loadConfig(
 export function setIsTrusted(
   agentSettings: AgentSettings | undefined,
 ): boolean {
-  if (process.env['GEMINI_FOLDER_TRUST'] !== undefined) {
-    return process.env['GEMINI_FOLDER_TRUST'] === 'true';
+  if (INITIAL_FOLDER_TRUST !== undefined) {
+    return INITIAL_FOLDER_TRUST === 'true';
   }
   return !!agentSettings?.isTrusted;
 }

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -26,7 +26,10 @@ import {
   type ScheduledToolCall,
 } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
-import { UPDATE_TOPIC_TOOL_NAME } from '../tools/tool-names.js';
+import {
+  UPDATE_TOPIC_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+} from '../tools/tool-names.js';
 import { PolicyDecision, type ApprovalMode } from '../policy/types.js';
 import {
   ToolConfirmationOutcome,
@@ -548,7 +551,10 @@ export class Scheduler {
 
   private _isParallelizable(request: ToolCallRequestInfo): boolean {
     // update_topic tool is forced as sequential call
-    if (request.name === UPDATE_TOPIC_TOOL_NAME) {
+    if (
+      request.name === UPDATE_TOPIC_TOOL_NAME ||
+      request.name === WRITE_FILE_TOOL_NAME
+    ) {
       return false;
     }
     if (request.args) {

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -27,9 +27,8 @@ import {
 } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import {
-  EDIT_TOOL_NAME,
   UPDATE_TOPIC_TOOL_NAME,
-  WRITE_FILE_TOOL_NAME,
+  EDIT_TOOL_NAMES,
 } from '../tools/tool-names.js';
 import { PolicyDecision, type ApprovalMode } from '../policy/types.js';
 import {
@@ -554,8 +553,7 @@ export class Scheduler {
     // update_topic tool is forced as sequential call
     if (
       request.name === UPDATE_TOPIC_TOOL_NAME ||
-      request.name === WRITE_FILE_TOOL_NAME ||
-      request.name === EDIT_TOOL_NAME
+      EDIT_TOOL_NAMES.has(request.name)
     ) {
       return false;
     }

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -27,6 +27,7 @@ import {
 } from './types.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import {
+  EDIT_TOOL_NAME,
   UPDATE_TOPIC_TOOL_NAME,
   WRITE_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
@@ -553,7 +554,8 @@ export class Scheduler {
     // update_topic tool is forced as sequential call
     if (
       request.name === UPDATE_TOPIC_TOOL_NAME ||
-      request.name === WRITE_FILE_TOOL_NAME
+      request.name === WRITE_FILE_TOOL_NAME ||
+      request.name === EDIT_TOOL_NAME
     ) {
       return false;
     }

--- a/packages/core/src/scheduler/scheduler_parallel.test.ts
+++ b/packages/core/src/scheduler/scheduler_parallel.test.ts
@@ -82,6 +82,7 @@ import {
 import {
   UPDATE_TOPIC_TOOL_NAME,
   WRITE_FILE_TOOL_NAME,
+  EDIT_TOOL_NAME,
 } from '../tools/tool-names.js';
 import { GeminiCliOperation } from '../telemetry/constants.js';
 import type { EditorType } from '../utils/editor.js';
@@ -164,6 +165,12 @@ describe('Scheduler Parallel Execution', () => {
     isReadOnly: false,
     build: vi.fn(),
   } as unknown as AnyDeclarativeTool;
+  const editTool = {
+    name: EDIT_TOOL_NAME,
+    kind: Kind.Execute,
+    isReadOnly: false,
+    build: vi.fn(),
+  } as unknown as AnyDeclarativeTool;
   const agentTool1 = {
     name: 'agent-tool-1',
     kind: Kind.Agent,
@@ -207,6 +214,7 @@ describe('Scheduler Parallel Execution', () => {
         if (name === 'agent-tool-2') return agentTool2;
         if (name === UPDATE_TOPIC_TOOL_NAME) return topicTool;
         if (name === WRITE_FILE_TOOL_NAME) return writeTool;
+        if (name === EDIT_TOOL_NAME) return editTool;
         return undefined;
       }),
       getAllToolNames: vi
@@ -219,6 +227,7 @@ describe('Scheduler Parallel Execution', () => {
           'agent-tool-2',
           UPDATE_TOPIC_TOOL_NAME,
           WRITE_FILE_TOOL_NAME,
+          EDIT_TOOL_NAME,
         ]),
     } as unknown as Mocked<ToolRegistry>;
 
@@ -339,6 +348,9 @@ describe('Scheduler Parallel Execution', () => {
       mockInvocation as unknown as AnyToolInvocation,
     );
     vi.mocked(writeTool.build).mockReturnValue(
+      mockInvocation as unknown as AnyToolInvocation,
+    );
+    vi.mocked(editTool.build).mockReturnValue(
       mockInvocation as unknown as AnyToolInvocation,
     );
     vi.mocked(agentTool1.build).mockReturnValue(
@@ -637,5 +649,37 @@ describe('Scheduler Parallel Execution', () => {
 
     // Even though wait_for_previous is false, WRITE_FILE_TOOL_NAME enforces sequential execution
     expect(executionLog).toEqual(['start-w1', 'end-w1', 'start-w2', 'end-w2']);
+  });
+
+  it('should execute EDIT_TOOL_NAME sequentially even without wait_for_previous', async () => {
+    const executionLog: string[] = [];
+    mockExecutor.execute.mockImplementation(async ({ call }) => {
+      const id = call.request.callId;
+      executionLog.push(`start-${id}`);
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      executionLog.push(`end-${id}`);
+      return {
+        status: 'success',
+        response: { callId: id, responseParts: [] },
+      } as unknown as SuccessfulToolCall;
+    });
+
+    const e1: ToolCallRequestInfo = {
+      callId: 'e1',
+      name: EDIT_TOOL_NAME,
+      args: { path: 'a.txt', wait_for_previous: false },
+      isClientInitiated: false,
+      prompt_id: 'p1',
+      schedulerId: ROOT_SCHEDULER_ID,
+    };
+    const e2: ToolCallRequestInfo = {
+      ...e1,
+      callId: 'e2',
+    };
+
+    await scheduler.schedule([e1, e2], signal);
+
+    // Even though wait_for_previous is false, EDIT_TOOL_NAME enforces sequential execution
+    expect(executionLog).toEqual(['start-e1', 'end-e1', 'start-e2', 'end-e2']);
   });
 });

--- a/packages/core/src/scheduler/scheduler_parallel.test.ts
+++ b/packages/core/src/scheduler/scheduler_parallel.test.ts
@@ -79,7 +79,10 @@ import {
   type Status,
   type ToolCall,
 } from './types.js';
-import { UPDATE_TOPIC_TOOL_NAME } from '../tools/tool-names.js';
+import {
+  UPDATE_TOPIC_TOOL_NAME,
+  WRITE_FILE_TOOL_NAME,
+} from '../tools/tool-names.js';
 import { GeminiCliOperation } from '../telemetry/constants.js';
 import type { EditorType } from '../utils/editor.js';
 
@@ -203,6 +206,7 @@ describe('Scheduler Parallel Execution', () => {
         if (name === 'agent-tool-1') return agentTool1;
         if (name === 'agent-tool-2') return agentTool2;
         if (name === UPDATE_TOPIC_TOOL_NAME) return topicTool;
+        if (name === WRITE_FILE_TOOL_NAME) return writeTool;
         return undefined;
       }),
       getAllToolNames: vi
@@ -214,6 +218,7 @@ describe('Scheduler Parallel Execution', () => {
           'agent-tool-1',
           'agent-tool-2',
           UPDATE_TOPIC_TOOL_NAME,
+          WRITE_FILE_TOOL_NAME,
         ]),
     } as unknown as Mocked<ToolRegistry>;
 
@@ -596,5 +601,41 @@ describe('Scheduler Parallel Execution', () => {
     expect(executionLog[1]).toBe('end-call-topic');
     expect(executionLog.slice(2, 4)).toContain('start-call-1');
     expect(executionLog.slice(2, 4)).toContain('start-call-2');
+  });
+
+  it('should execute WRITE_FILE_TOOL_NAME sequentially even without wait_for_previous', async () => {
+    const executionLog: string[] = [];
+    mockExecutor.execute.mockImplementation(async ({ call }) => {
+      const id = call.request.callId;
+      executionLog.push(`start-${id}`);
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      executionLog.push(`end-${id}`);
+      return {
+        status: 'success',
+        response: { callId: id, responseParts: [] },
+      } as unknown as SuccessfulToolCall;
+    });
+
+    const w1: ToolCallRequestInfo = {
+      callId: 'w1',
+      name: WRITE_FILE_TOOL_NAME,
+      args: { path: 'a.txt', wait_for_previous: false },
+      isClientInitiated: false,
+      prompt_id: 'p1',
+      schedulerId: ROOT_SCHEDULER_ID,
+    };
+    const w2: ToolCallRequestInfo = {
+      callId: 'w2',
+      name: WRITE_FILE_TOOL_NAME,
+      args: { path: 'b.txt', wait_for_previous: false },
+      isClientInitiated: false,
+      prompt_id: 'p1',
+      schedulerId: ROOT_SCHEDULER_ID,
+    };
+
+    await scheduler.schedule([w1, w2], signal);
+
+    // Even though wait_for_previous is false, WRITE_FILE_TOOL_NAME enforces sequential execution
+    expect(executionLog).toEqual(['start-w1', 'end-w1', 'start-w2', 'end-w2']);
   });
 });

--- a/packages/core/src/scheduler/scheduler_parallel.test.ts
+++ b/packages/core/src/scheduler/scheduler_parallel.test.ts
@@ -83,6 +83,7 @@ import {
   UPDATE_TOPIC_TOOL_NAME,
   WRITE_FILE_TOOL_NAME,
   EDIT_TOOL_NAME,
+  EDIT_TOOL_NAMES,
 } from '../tools/tool-names.js';
 import { GeminiCliOperation } from '../telemetry/constants.js';
 import type { EditorType } from '../utils/editor.js';
@@ -615,71 +616,43 @@ describe('Scheduler Parallel Execution', () => {
     expect(executionLog.slice(2, 4)).toContain('start-call-2');
   });
 
-  it('should execute WRITE_FILE_TOOL_NAME sequentially even without wait_for_previous', async () => {
-    const executionLog: string[] = [];
-    mockExecutor.execute.mockImplementation(async ({ call }) => {
-      const id = call.request.callId;
-      executionLog.push(`start-${id}`);
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-      executionLog.push(`end-${id}`);
-      return {
-        status: 'success',
-        response: { callId: id, responseParts: [] },
-      } as unknown as SuccessfulToolCall;
-    });
+  it.each(Array.from(EDIT_TOOL_NAMES))(
+    'should execute %s sequentially even without wait_for_previous',
+    async (toolName) => {
+      const executionLog: string[] = [];
+      mockExecutor.execute.mockImplementation(async ({ call }) => {
+        const id = call.request.callId;
+        executionLog.push(`start-${id}`);
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        executionLog.push(`end-${id}`);
+        return {
+          status: 'success',
+          response: { callId: id, responseParts: [] },
+        } as unknown as SuccessfulToolCall;
+      });
 
-    const w1: ToolCallRequestInfo = {
-      callId: 'w1',
-      name: WRITE_FILE_TOOL_NAME,
-      args: { path: 'a.txt', wait_for_previous: false },
-      isClientInitiated: false,
-      prompt_id: 'p1',
-      schedulerId: ROOT_SCHEDULER_ID,
-    };
-    const w2: ToolCallRequestInfo = {
-      callId: 'w2',
-      name: WRITE_FILE_TOOL_NAME,
-      args: { path: 'b.txt', wait_for_previous: false },
-      isClientInitiated: false,
-      prompt_id: 'p1',
-      schedulerId: ROOT_SCHEDULER_ID,
-    };
+      const e1: ToolCallRequestInfo = {
+        callId: 'e1',
+        name: toolName,
+        args: { path: 'a.txt', wait_for_previous: false },
+        isClientInitiated: false,
+        prompt_id: 'p1',
+        schedulerId: ROOT_SCHEDULER_ID,
+      };
+      const e2: ToolCallRequestInfo = {
+        ...e1,
+        callId: 'e2',
+      };
 
-    await scheduler.schedule([w1, w2], signal);
+      await scheduler.schedule([e1, e2], signal);
 
-    // Even though wait_for_previous is false, WRITE_FILE_TOOL_NAME enforces sequential execution
-    expect(executionLog).toEqual(['start-w1', 'end-w1', 'start-w2', 'end-w2']);
-  });
-
-  it('should execute EDIT_TOOL_NAME sequentially even without wait_for_previous', async () => {
-    const executionLog: string[] = [];
-    mockExecutor.execute.mockImplementation(async ({ call }) => {
-      const id = call.request.callId;
-      executionLog.push(`start-${id}`);
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-      executionLog.push(`end-${id}`);
-      return {
-        status: 'success',
-        response: { callId: id, responseParts: [] },
-      } as unknown as SuccessfulToolCall;
-    });
-
-    const e1: ToolCallRequestInfo = {
-      callId: 'e1',
-      name: EDIT_TOOL_NAME,
-      args: { path: 'a.txt', wait_for_previous: false },
-      isClientInitiated: false,
-      prompt_id: 'p1',
-      schedulerId: ROOT_SCHEDULER_ID,
-    };
-    const e2: ToolCallRequestInfo = {
-      ...e1,
-      callId: 'e2',
-    };
-
-    await scheduler.schedule([e1, e2], signal);
-
-    // Even though wait_for_previous is false, EDIT_TOOL_NAME enforces sequential execution
-    expect(executionLog).toEqual(['start-e1', 'end-e1', 'start-e2', 'end-e2']);
-  });
+      // Even though wait_for_previous is false, EDIT_TOOL_NAMES enforces sequential execution
+      expect(executionLog).toEqual([
+        'start-e1',
+        'end-e1',
+        'start-e2',
+        'end-e2',
+      ]);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

This PR improves the agent's execution stability by preventing premature state progression when the agent is waiting for user tool approvals. It also eliminates race conditions during file modifications by forcing file writes to execute sequentially, and fixes a configuration bug to ensure environment variables correctly override workspace trust settings.

## Details

- **Execution State**: Added `hasPendingTools()` and `getPendingToolsCount()` to the `Task` class. The `CoderAgentExecutor` now uses these to safely pause its execution loop and yield the turn to the user when tool confirmations are pending.
- **Sequential File Writes**: Updated `_isParallelizable` in the scheduler to treat `WRITE_FILE_TOOL_NAME` as non-parallelizable. This ensures multiple file edits requested in a single LLM batch do not conflict with each other.
- **Trust Configuration**: Extracted the trust resolution into a new `setIsTrusted` helper, allowing the `GEMINI_FOLDER_TRUST` environment variable to take precedence over internal agent settings.
- **Testing**: Added comprehensive unit and integration tests across the agent, configuration, and scheduler modules to guarantee these behaviors.

## Related Issues

Fixes b/521342062 # 400 error when using the write file tool
Fixes b/522312717 # The "Untrusted Folder" message appears in chat even when working within a trusted folder.

## How to Validate

1.  Run unit tests for the A2A server:
    ```bash
    npm test -w @google/gemini-cli-a2a-server
    ```
 2. Verify that all 140 tests pass.
 3. Run unit test for core:
    ```bash
    yarn workspace @google/gemini-cli-core build
    yarn test -w @google/gemini-cli-core
    ```
4. Verify that all tests modified in this PR pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ x] Linux
    - [ x] npm run
    - [ ] npx
    - [ ] Docker