### PR TITLE
feat(cli): add native drag-and-drop and Cmd+V clipboard image pasting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,8 +449,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -1536,7 +1535,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -2244,7 +2242,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -2425,7 +2422,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2475,7 +2471,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2826,7 +2821,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
       "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2861,7 +2855,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1"
@@ -2917,7 +2910,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -4170,7 +4162,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4444,7 +4435,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5220,7 +5210,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7332,8 +7321,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7918,7 +7906,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8529,7 +8516,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9799,7 +9785,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10062,7 +10047,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.6.9.tgz",
       "integrity": "sha512-RL9sSiLQZECnjbmBwjIHOp8yVGdWF7C/uifg7ISv/e+F3nLNsfl7FdUFQs8iZARFMJAYxMFpxW6OW+HSt9drwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "ansi-styles": "^6.2.3",
@@ -13838,7 +13822,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13849,7 +13832,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16004,7 +15986,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16227,8 +16208,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -16236,7 +16216,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16402,7 +16381,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16470,7 +16448,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -16890,7 +16867,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17461,7 +17437,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17474,7 +17449,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -18128,7 +18102,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18652,7 +18625,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -619,6 +619,7 @@ export const AppContainer = (props: AppContainerProps) => {
     stdin,
     setRawMode,
     escapePastedPaths: true,
+    targetDir: config.getTargetDir(),
     shellModeActive,
     getPreferredEditor,
   });

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -67,6 +67,8 @@ import {
   clipboardHasImage,
   saveClipboardImage,
   cleanupOldClipboardImages,
+  readClipboardText,
+  writeClipboardText,
 } from '../utils/clipboardUtils.js';
 import {
   isAutoExecutableCommand,
@@ -263,6 +265,48 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       windowMs: DOUBLE_TAB_CLEAN_UI_TOGGLE_WINDOW_MS,
     });
   const [showEscapePrompt, setShowEscapePrompt] = useState(false);
+
+  // Background clipboard image watcher to automatically convert copied raw images
+  // into temporary files and write their relative path back to the clipboard.
+  // This allows the user to paste raw images directly into the terminal with Cmd+V!
+  useEffect(() => {
+    if (!focus || shellModeActive) {
+      return;
+    }
+
+    const intervalId = setInterval(async () => {
+      try {
+        if (await clipboardHasImage()) {
+          const currentText = await readClipboardText();
+          // Only process if the clipboard text does not already reference a clipboard image or file path
+          if (
+            !currentText.startsWith('@') ||
+            !currentText.includes('clipboard-')
+          ) {
+            const imagePath = await saveClipboardImage(config.getTargetDir());
+            if (imagePath) {
+              // Clean up old clipboard images
+              cleanupOldClipboardImages(config.getTargetDir()).catch(() => {});
+
+              // Get relative path from current workspace
+              const relativePath = path.relative(
+                config.getTargetDir(),
+                imagePath,
+              );
+              const insertText = `@${relativePath} `;
+
+              // Write the text reference back to the clipboard!
+              await writeClipboardText(insertText);
+            }
+          }
+        }
+      } catch {
+        // Ignore clipboard watcher errors silently
+      }
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [focus, shellModeActive, config]);
   const { handlePress: handleEscPress, resetCount: resetEscapeState } =
     useRepeatedKeyPress({
       windowMs: 500,

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -25,6 +25,11 @@ import {
   getCachedStringWidth,
 } from '../../utils/textUtils.js';
 import { parsePastedPaths } from '../../utils/clipboardUtils.js';
+import {
+  appEvents,
+  AppEvent,
+  TransientMessageType,
+} from '../../../utils/events.js';
 import type { Key } from '../../contexts/KeypressContext.js';
 import { Command } from '../../key/keyMatchers.js';
 import type { VimAction } from './vim-buffer-actions.js';
@@ -769,6 +774,7 @@ interface UseTextBufferProps {
   setRawMode?: (mode: boolean) => void; // For external editor
   onChange?: (text: string) => void; // Callback for when text changes
   escapePastedPaths?: boolean;
+  targetDir?: string;
   shellModeActive?: boolean; // Whether the text buffer is in shell mode
   inputFilter?: (text: string) => string; // Optional filter for input text
   singleLine?: boolean;
@@ -2837,6 +2843,7 @@ export function useTextBuffer({
   setRawMode,
   onChange,
   escapePastedPaths = false,
+  targetDir,
   shellModeActive = false,
   inputFilter,
   singleLine = false,
@@ -2958,9 +2965,24 @@ export function useTextBuffer({
         paste &&
         escapePastedPaths
       ) {
-        const processed = parsePastedPaths(ch.trim());
+        const processed = parsePastedPaths(ch.trim(), targetDir);
         if (processed) {
           textToInsert = processed;
+          // Emit transient toast message for dragging/pasting file
+          const files = (processed.match(/@("[^"]+"|[^ ]+)/g) || []).map((f) =>
+            f.slice(1).replace(/^["']|["']$/g, ''),
+          );
+          if (files.length > 0) {
+            const displayNames = files.map((f) => pathMod.basename(f));
+            const message =
+              displayNames.length === 1
+                ? `Added ${displayNames[0]} to prompt context`
+                : `Added ${displayNames.length} files to prompt context`;
+            appEvents.emit(AppEvent.TransientMessage, {
+              message,
+              type: TransientMessageType.Hint,
+            });
+          }
         }
       }
 
@@ -2980,7 +3002,7 @@ export function useTextBuffer({
         dispatch({ type: 'insert', payload: currentText, isPaste: paste });
       }
     },
-    [shellModeActive, escapePastedPaths],
+    [shellModeActive, escapePastedPaths, targetDir],
   );
 
   const newline = useCallback((): void => {

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -47,6 +47,8 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   return {
     ...actual,
     spawnAsync: vi.fn(),
+    resolveToRealPath: vi.fn((p) => p),
+    isSubpath: vi.fn((parent, child) => child.startsWith(parent)),
     debugLogger: {
       debug: vi.fn(),
       warn: vi.fn(),
@@ -595,6 +597,28 @@ describe('clipboardUtils', () => {
 
         const result = parsePastedPaths('\\\\server\\share\\file.txt');
         expect(result).toBe('@\\\\server\\share\\file.txt ');
+      });
+    });
+
+    describe('with targetDir', () => {
+      it('should resolve path relative to targetDir if within it', () => {
+        const targetDir = '/mock/workspace';
+        const absolutePath = '/mock/workspace/src/image.png';
+        vi.mocked(existsSync).mockImplementation((p) => p === absolutePath);
+        vi.mocked(statSync).mockReturnValue(MOCK_FILE_STATS);
+
+        const result = parsePastedPaths(absolutePath, targetDir);
+        expect(result).toBe('@src/image.png ');
+      });
+
+      it('should keep absolute path if outside of targetDir', () => {
+        const targetDir = '/mock/workspace';
+        const absolutePath = '/mock/image.png';
+        vi.mocked(existsSync).mockImplementation((p) => p === absolutePath);
+        vi.mocked(statSync).mockReturnValue(MOCK_FILE_STATS);
+
+        const result = parsePastedPaths(absolutePath, targetDir);
+        expect(result).toBe('@/mock/image.png ');
       });
     });
   });

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -13,6 +13,8 @@ import {
   spawnAsync,
   escapePath,
   Storage,
+  isSubpath,
+  resolveToRealPath,
 } from '@google/gemini-cli-core';
 
 /**
@@ -508,22 +510,141 @@ function isValidFilePath(p: string): boolean {
  * @param text The pasted text
  * @returns Processed string with @ prefixes or null if any paths are invalid
  */
-export function parsePastedPaths(text: string): string | null {
+export function parsePastedPaths(
+  text: string,
+  targetDir?: string,
+): string | null {
   // First, check if the entire text is a single valid path
   if (isValidFilePath(text)) {
-    return `@${escapePath(text)} `;
+    let finalPath = text;
+    if (targetDir) {
+      try {
+        const resolvedPath = resolveToRealPath(text);
+        const resolvedTarget = resolveToRealPath(targetDir);
+        if (isSubpath(resolvedTarget, resolvedPath)) {
+          finalPath = path.relative(resolvedTarget, resolvedPath);
+        }
+      } catch {
+        // Silently fallback if resolution fails
+      }
+    }
+    return `@${escapePath(finalPath)} `;
   }
 
   const validPaths = [];
   for (const segment of splitDragAndDropPaths(text)) {
-    if (isValidFilePath(segment)) {
-      validPaths.push(`@${escapePath(segment)}`);
-    } else {
+    if (!isValidFilePath(segment)) {
       return null; // If any segment is invalid, return null for the whole string
     }
+    let finalSegment = segment;
+    if (targetDir) {
+      try {
+        const resolvedPath = resolveToRealPath(segment);
+        const resolvedTarget = resolveToRealPath(targetDir);
+        if (isSubpath(resolvedTarget, resolvedPath)) {
+          finalSegment = path.relative(resolvedTarget, resolvedPath);
+        }
+      } catch {
+        // Silently fallback if resolution fails
+      }
+    }
+    validPaths.push(`@${escapePath(finalSegment)}`);
   }
   if (validPaths.length === 0) {
     return null;
   }
   return validPaths.join(' ') + ' ';
+}
+
+export async function readClipboardText(): Promise<string> {
+  if (process.platform === 'darwin') {
+    try {
+      const { stdout } = await spawnAsync('pbpaste', []);
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+  if (process.platform === 'win32') {
+    try {
+      const { stdout } = await spawnAsync('powershell', [
+        '-NoProfile',
+        '-Command',
+        'Get-Clipboard',
+      ]);
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+  if (process.platform === 'linux') {
+    try {
+      const tool = getUserLinuxClipboardTool();
+      if (tool === 'wl-paste') {
+        const { stdout } = await spawnAsync('wl-paste', [
+          '--type',
+          'text/plain',
+        ]);
+        return stdout.trim();
+      }
+      if (tool === 'xclip') {
+        const { stdout } = await spawnAsync('xclip', [
+          '-selection',
+          'clipboard',
+          '-o',
+        ]);
+        return stdout.trim();
+      }
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+export async function writeClipboardText(text: string): Promise<boolean> {
+  if (process.platform === 'darwin') {
+    try {
+      const child = spawn('pbcopy', []);
+      child.stdin?.write(text);
+      child.stdin?.end();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (process.platform === 'win32') {
+    try {
+      const child = spawn('powershell', [
+        '-NoProfile',
+        '-Command',
+        '[Console]::InputEncoding = [System.Text.Encoding]::UTF8; $input | Set-Clipboard',
+      ]);
+      child.stdin?.write(text);
+      child.stdin?.end();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (process.platform === 'linux') {
+    try {
+      const tool = getUserLinuxClipboardTool();
+      if (tool === 'wl-paste') {
+        const child = spawn('wl-copy', []);
+        child.stdin?.write(text);
+        child.stdin?.end();
+        return true;
+      }
+      if (tool === 'xclip') {
+        const child = spawn('xclip', ['-selection', 'clipboard']);
+        child.stdin?.write(text);
+        child.stdin?.end();
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
### What does this PR do?

This PR brings visual multimodal parity to Gemini CLI by adding **first-class terminal drag-and-drop** and native **`Cmd+V` / `Ctrl+V`** clipboard image pasting inside standard terminal emulators.

This addresses the long-standing limitation discussed in closed/stale issues #15532 and #5316, making the workflow incredibly fast and polished.

### Detailed Changes:
1. **Background Clipboard Image Synchronizer:**
   - Implemented a background observer loop inside `InputPrompt.tsx` that polls the clipboard for raw image buffers (e.g. screenshots).
   - When a new raw image is detected, it automatically saves it to the secure local project temporary directory (`~/.gemini/tmp/gemini-cli/images/clipboard-xxx.png`) and writes the workspace-relative path text (`@.gemini-clipboard/clipboard-xxx.png `) back to the system clipboard.
   - This makes standard **`Cmd+V`** paste the file reference natively!
2. **Workspace-Relative Path Resolution:**
   - Updated `parsePastedPaths` in `clipboardUtils.ts` to accept an optional `targetDir` parameter.
   - If a dropped/pasted file path is inside the active workspace, it automatically resolves to a clean relative path (e.g., `@src/image.png`) instead of a long absolute path.
3. **Pasting / Drop Status Toast:**
   - Updated the `text-buffer.ts` input handler to pass the active workspace directory and emit a clean, non-intrusive status toast (e.g. `Added logo.png to prompt context`) when files are dropped or pasted.
4. **Unit Tests:**
   - Added robust tests inside `clipboardUtils.test.ts` verifying path resolution both inside and outside of the workspace directory.

Closes #27855