### PR TITLE
fix(cli): reset slash-command conflict dedupe when conflicts reappear

### DIFF
--- a/packages/cli/src/services/SlashCommandConflictHandler.test.ts
+++ b/packages/cli/src/services/SlashCommandConflictHandler.test.ts
@@ -173,6 +173,33 @@ describe('SlashCommandConflictHandler', () => {
     expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
   });
 
+  it('should re-notify a conflict if it disappears and then reappears', () => {
+    const conflict = {
+      name: 'deploy',
+      renamedTo: 'firebase.deploy',
+      loserExtensionName: 'firebase',
+      loserKind: CommandKind.EXTENSION_FILE,
+      winnerKind: CommandKind.BUILT_IN,
+    };
+
+    // 1. Conflict occurs -> user notified
+    simulateEvent([conflict]);
+    vi.advanceTimersByTime(600);
+    expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(1);
+
+    vi.mocked(coreEvents.emitFeedback).mockClear();
+
+    // 2. Conflict disappears (resolved) -> notifier updates state
+    simulateEvent([]);
+    vi.advanceTimersByTime(600);
+    expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
+
+    // 3. Conflict occurs again -> user is notified again
+    simulateEvent([conflict]);
+    vi.advanceTimersByTime(600);
+    expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(1);
+  });
+
   it('should display a descriptive message for a skill conflict', () => {
     simulateEvent([
       {

--- a/packages/cli/src/services/SlashCommandConflictHandler.ts
+++ b/packages/cli/src/services/SlashCommandConflictHandler.ts
@@ -40,17 +40,22 @@ export class SlashCommandConflictHandler {
   }
 
   private handleConflicts(payload: SlashCommandConflictsPayload) {
-    const newConflicts = payload.conflicts.filter((c) => {
+    const currentKeys = new Set<string>();
+    const newConflicts: SlashCommandConflict[] = [];
+
+    for (const c of payload.conflicts) {
       // Use a unique key to prevent duplicate notifications for the same conflict
       const sourceId =
         c.loserExtensionName || c.loserMcpServerName || c.loserKind;
       const key = `${c.name}:${sourceId}:${c.renamedTo}`;
-      if (this.notifiedConflicts.has(key)) {
-        return false;
+      currentKeys.add(key);
+
+      if (!this.notifiedConflicts.has(key)) {
+        newConflicts.push(c);
       }
-      this.notifiedConflicts.add(key);
-      return true;
-    });
+    }
+
+    this.notifiedConflicts = currentKeys;
 
     if (newConflicts.length > 0) {
       this.pendingConflicts.push(...newConflicts);


### PR DESCRIPTION
Fixes #24333

### Description
This PR fixes the slash-command conflict notifier deduplication bug where a conflict that has been resolved (and disappears) is not re-notified if it subsequently reappears.

### Changes
- Updated \handleConflicts\ in \SlashCommandConflictHandler\ to rebuild the \
otifiedConflicts\ set based on the active conflicts in the current payload. This ensures that when a conflict is resolved and no longer active, its key is removed from \
otifiedConflicts\, allowing it to be re-notified if it reappears in a later reload.
- Added a unit test in \SlashCommandConflictHandler.test.ts\ to verify the resolve-then-reappear behavior.