### PR TITLE
fix(cli): preserve executing subagent tool calls in UI

### DIFF
--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -22,6 +22,8 @@ import {
   CoreToolCallStatus,
   type WaitingToolCall,
   SubagentState,
+  Kind,
+  AGENT_TOOL_NAME,
 } from '@google/gemini-cli-core';
 import { createMockMessageBus } from '@google/gemini-cli-core/src/test-utils/mock-message-bus.js';
 
@@ -530,6 +532,58 @@ describe('useToolScheduler', () => {
     // The subagent list should now be empty because the previously approved tool
     // is gone from the current list, and the new tool doesn't need approval.
     expect(result.current[0]).toHaveLength(0);
+  });
+
+  it('preserves executing subagent tool calls in the UI when they are subagents', async () => {
+    const { result } = await renderHook(() =>
+      useToolScheduler(
+        vi.fn().mockResolvedValue(undefined),
+        mockConfig,
+        () => undefined,
+      ),
+    );
+
+    // 1. Tool call with AGENT_TOOL_NAME
+    const agentNameCall = {
+      status: CoreToolCallStatus.Executing as const,
+      request: {
+        callId: 'call-agent-name',
+        name: AGENT_TOOL_NAME,
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'p1',
+      },
+      tool: createMockTool({ name: AGENT_TOOL_NAME }),
+      invocation: createMockInvocation(),
+      schedulerId: 'subagent-1',
+    } as ExecutingToolCall;
+
+    // 2. Tool call with Kind.Agent
+    const agentKindCall = {
+      status: CoreToolCallStatus.Executing as const,
+      request: {
+        callId: 'call-agent-kind',
+        name: 'custom_agent',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'p1',
+      },
+      tool: createMockTool({ name: 'custom_agent', kind: Kind.Agent }),
+      invocation: createMockInvocation(),
+      schedulerId: 'subagent-1',
+    } as ExecutingToolCall;
+
+    act(() => {
+      void mockMessageBus.publish({
+        type: MessageBusType.TOOL_CALLS_UPDATE,
+        toolCalls: [agentNameCall, agentKindCall],
+        schedulerId: 'subagent-1',
+      } as ToolCallsUpdateMessage);
+    });
+
+    expect(result.current[0]).toHaveLength(2);
+    expect(result.current[0][0].request.callId).toBe('call-agent-name');
+    expect(result.current[0][1].request.callId).toBe('call-agent-kind');
   });
 
   it('adapts success/error status to executing when a tail call is present', async () => {

--- a/packages/cli/src/ui/hooks/useToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.ts
@@ -18,6 +18,7 @@ import {
   type SubagentActivityItem,
   type SubagentActivityMessage,
   AGENT_TOOL_NAME,
+  Kind,
 } from '@google/gemini-cli-core';
 import { useCallback, useState, useMemo, useEffect, useRef } from 'react';
 
@@ -153,6 +154,9 @@ export function useToolScheduler(
           : event.toolCalls.filter(
               (tc) =>
                 tc.status === CoreToolCallStatus.AwaitingApproval ||
+                (tc.status === CoreToolCallStatus.Executing &&
+                  (tc.tool?.kind === Kind.Agent ||
+                    tc.request.name === AGENT_TOOL_NAME)) ||
                 prevCallIds.has(tc.request.callId),
             );
 


### PR DESCRIPTION
Fixes #22589

### Description
This PR fixes an issue where subagent tool calls were not being properly preserved as executing in the UI, leading to them disappearing from the display while still active.

### Changes
- Updated the \useToolScheduler\ hook in \packages/cli/src/ui/hooks/useToolScheduler.ts\ to explicitly retain executing tool calls if they belong to an agent or match the agent tool name.
- Added a corresponding unit test in \packages/cli/src/ui/hooks/useToolScheduler.test.ts\ to verify that executing subagent tool calls are preserved.