### PR TITLE
fix(core): prioritize structured display titles in tool invocation

### DIFF
--- a/packages/core/src/tools/base-tool-invocation.test.ts
+++ b/packages/core/src/tools/base-tool-invocation.test.ts
@@ -132,4 +132,26 @@ describe('BaseToolInvocation', () => {
       // ignore abort error
     }
   });
+
+  describe('getDisplayTitle', () => {
+    it('should return _toolDisplayName if provided', () => {
+      const tool = new TestBaseToolInvocation(
+        {},
+        messageBus,
+        'test-tool',
+        'Test Tool Display Name',
+      );
+      expect(tool.getDisplayTitle()).toBe('Test Tool Display Name');
+    });
+
+    it('should return _toolName if _toolDisplayName is not provided but _toolName is', () => {
+      const tool = new TestBaseToolInvocation({}, messageBus, 'test-tool');
+      expect(tool.getDisplayTitle()).toBe('test-tool');
+    });
+
+    it('should fall back to getDescription() if neither display name nor name is provided', () => {
+      const tool = new TestBaseToolInvocation({}, messageBus);
+      expect(tool.getDisplayTitle()).toBe('test description');
+    });
+  });
 });

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -173,7 +173,7 @@ export abstract class BaseToolInvocation<
   abstract getDescription(): string;
 
   getDisplayTitle(): string {
-    return this.getDescription();
+    return this._toolDisplayName || this._toolName || this.getDescription();
   }
 
   getExplanation(): string {


### PR DESCRIPTION
Fixes #23018

### Description
This PR fixes an issue where structured display titles for tool invocations were not being properly prioritized.

### Changes
- Updated \getDisplayTitle()\ in \packages/core/src/tools/tools.ts\ to prioritize \_toolDisplayName\ if present, then \_toolName\, and fall back to \getDescription()\ otherwise.
- Added unit tests in \packages/core/src/tools/base-tool-invocation.test.ts\ to verify the title priority logic.