### PR TITLE
test: cover AfterAgent wildcard settings

### DIFF
--- a/integration-tests/hooks-agent-flow.test.ts
+++ b/integration-tests/hooks-agent-flow.test.ts
@@ -155,6 +155,56 @@ describe('Hooks Agent Flow', () => {
       expect(afterAgentLog?.hookCall.stdout).toContain('Hello World');
     });
 
+    it('should run AfterAgent from settings defaults with wildcard matcher', async () => {
+      await rig.setup(
+        'should run AfterAgent from settings defaults with wildcard matcher',
+        {
+          fakeResponsesPath: join(
+            import.meta.dirname,
+            'hooks-agent-flow.responses',
+          ),
+        },
+      );
+
+      const markerPath = join(rig.testDir!, 'after-agent-triggered.txt');
+      const escapedMarkerPath = JSON.stringify(markerPath);
+      const hookScript = `
+      const fs = require('fs');
+      fs.writeFileSync(${escapedMarkerPath}, 'Triggered!');
+      console.log('AfterAgent default hook fired');
+      `;
+      const scriptPath = rig.createScript(
+        'after_agent_default_wildcard.cjs',
+        hookScript,
+      );
+
+      rig.setup(
+        'should run AfterAgent from settings defaults with wildcard matcher',
+        {
+          settings: {
+            hooks: {
+              AfterAgent: [
+                {
+                  matcher: '*',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: normalizePath(`node "${scriptPath}"`)!,
+                      timeout: 5000,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      await rig.run({ args: 'Hello validation' });
+
+      expect(rig.readFile('after-agent-triggered.txt')).toBe('Triggered!');
+    });
+
     it('should process clearContext in AfterAgent hook output', async () => {
       rig.setup('should process clearContext in AfterAgent hook output', {
         fakeResponsesPath: join(


### PR DESCRIPTION
## Summary

- Add an integration regression test for `hooks.AfterAgent` configured only through settings defaults.
- Cover the `matcher: "*"` shape reported in #27712.
- Assert the command hook actually runs by checking the marker file written by the hook script.

## Validation

- `npx prettier --check integration-tests/hooks-agent-flow.test.ts`
- `npx eslint integration-tests/hooks-agent-flow.test.ts --max-warnings 0`
- `$env:GEMINI_API_KEY='test-key-not-real'; npm run test:integration:sandbox:none -- hooks-agent-flow.test.ts -t AfterAgent`
- `git diff --check`

The integration test uses fake responses; the `GEMINI_API_KEY` value above is a dummy value required by test startup validation.
