### PR TITLE
fix(theme): honor custom border colors

### DIFF
--- a/packages/cli/src/ui/components/ColorsDisplay.tsx
+++ b/packages/cli/src/ui/components/ColorsDisplay.tsx
@@ -46,6 +46,7 @@ const COLOR_DESCRIPTIONS: Record<string, string> = {
   'background.diff.added': 'Background for added lines in diffs',
   'background.diff.removed': 'Background for removed lines in diffs',
   'border.default': 'Standard border color',
+  'border.focused': 'Border color for focused elements',
   'ui.comment': 'Color for code comments and metadata',
   'ui.symbol': 'Color for technical symbols and UI icons',
   'ui.active': 'Border color for active or running elements',

--- a/packages/cli/src/ui/themes/semantic-tokens.ts
+++ b/packages/cli/src/ui/themes/semantic-tokens.ts
@@ -26,6 +26,7 @@ export interface SemanticColors {
   };
   border: {
     default: string;
+    focused?: string;
   };
   ui: {
     comment: string;

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -331,6 +331,31 @@ describe('ThemeManager', () => {
       expect(semanticColors.background.primary).toBe(darkTerminalBg);
     });
 
+    it('should preserve explicit custom border colors when terminal background is set', () => {
+      themeManager.loadCustomThemes({
+        MyDark: {
+          name: 'MyDark',
+          type: 'custom',
+          Background: '#000000',
+          Foreground: '#ffffff',
+          border: {
+            default: '#282c34',
+            focused: '#61afef',
+          },
+        },
+      });
+      themeManager.setActiveTheme('MyDark');
+      themeManager.setTerminalBackground('#1a1a1a');
+
+      const colors = themeManager.getColors();
+      const semanticColors = themeManager.getSemanticColors();
+
+      expect(colors.Background).toBe('#1a1a1a');
+      expect(colors.DarkGray).toBe('#282c34');
+      expect(semanticColors.border.default).toBe('#282c34');
+      expect(semanticColors.border.focused).toBe('#61afef');
+    });
+
     it('should NOT override background for custom theme when incompatible', () => {
       themeManager.loadCustomThemes({
         MyLight: {

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -365,11 +365,13 @@ class ThemeManager {
       this.cachedColors = {
         ...colors,
         Background: this.terminalBackground,
-        DarkGray: interpolateColor(
-          this.terminalBackground,
-          colors.Gray,
-          DEFAULT_BORDER_OPACITY,
-        ),
+        DarkGray:
+          colors.BorderDefault ??
+          interpolateColor(
+            this.terminalBackground,
+            colors.Gray,
+            DEFAULT_BORDER_OPACITY,
+          ),
         InputBackground: interpolateColor(
           this.terminalBackground,
           colors.Gray,

--- a/packages/cli/src/ui/themes/theme.test.ts
+++ b/packages/cli/src/ui/themes/theme.test.ts
@@ -52,6 +52,23 @@ describe('createCustomTheme', () => {
     expect(theme.colors.DarkGray).toBe('#123456');
   });
 
+  it('should use custom border colors when provided', () => {
+    const theme = createCustomTheme({
+      ...baseTheme,
+      DarkGray: '#123456',
+      border: {
+        default: '#222222',
+        focused: '#abcdef',
+      },
+    });
+
+    expect(theme.colors.DarkGray).toBe('#222222');
+    expect(theme.colors.BorderDefault).toBe('#222222');
+    expect(theme.colors.BorderFocused).toBe('#abcdef');
+    expect(theme.semanticColors.border.default).toBe('#222222');
+    expect(theme.semanticColors.border.focused).toBe('#abcdef');
+  });
+
   it('should interpolate DarkGray when text.secondary is provided but DarkGray is not', () => {
     const customTheme: CustomTheme = {
       type: 'custom',

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -180,6 +180,8 @@ export interface ColorsTheme {
   MessageBackground?: string;
   FocusBackground?: string;
   FocusColor?: string;
+  BorderDefault?: string;
+  BorderFocused?: string;
   GradientColors?: string[];
 }
 
@@ -392,6 +394,9 @@ export class Theme {
  * @returns A new Theme instance.
  */
 export function createCustomTheme(customTheme: CustomTheme): Theme {
+  const explicitBorderDefault =
+    customTheme.border?.default ?? customTheme.DarkGray;
+  const explicitBorderFocused = customTheme.border?.focused;
   const colors: ColorsTheme = {
     type: 'custom',
     Background: customTheme.background?.primary ?? customTheme.Background ?? '',
@@ -410,7 +415,7 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
     Comment: customTheme.ui?.comment ?? customTheme.Comment ?? '',
     Gray: customTheme.text?.secondary ?? customTheme.Gray ?? '',
     DarkGray:
-      customTheme.DarkGray ??
+      explicitBorderDefault ??
       interpolateColor(
         customTheme.background?.primary ?? customTheme.Background ?? '',
         customTheme.text?.secondary ?? customTheme.Gray ?? '',
@@ -432,6 +437,8 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
       DEFAULT_SELECTION_OPACITY,
     ),
     FocusColor: customTheme.ui?.focus ?? customTheme.AccentGreen,
+    BorderDefault: explicitBorderDefault,
+    BorderFocused: explicitBorderFocused,
     GradientColors: customTheme.ui?.gradient ?? customTheme.GradientColors,
   };
 
@@ -595,7 +602,8 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
       },
     },
     border: {
-      default: colors.DarkGray,
+      default: explicitBorderDefault ?? colors.DarkGray,
+      ...(explicitBorderFocused ? { focused: explicitBorderFocused } : {}),
     },
     ui: {
       comment: customTheme.ui?.comment ?? colors.Comment,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -319,6 +319,7 @@ export interface CustomTheme {
   };
   border?: {
     default?: string;
+    focused?: string;
   };
   ui?: {
     comment?: string;


### PR DESCRIPTION
## Summary

Custom themes document `border.default`, and the settings schema also accepts `border.focused`, but the runtime did not carry those values through the theme objects. Terminals that report a background color made this worse by recomputing `DarkGray`, so an explicit custom border color could still be replaced at render time.

This PR wires the documented border colors into the custom theme path and keeps explicit border colors stable when terminal-background detection is active.

## Details

- Adds `border.focused` to the custom theme config type and semantic border tokens.
- Stores explicit custom border colors on the internal `ColorsTheme` so the terminal-background override can tell them apart from interpolated defaults.
- Uses `border.default` as the border/DarkGray color when provided, while preserving the existing interpolation behavior for themes that do not set it.
- Adds regression coverage for both custom theme creation and the terminal-background override path.

## Related Issues

Fixes #27786

## How to Validate

Commands run from the repository root:

```bash
npm run build --workspace=@google/gemini-cli-core
npm run test --workspace=@google/gemini-cli -- src/ui/themes/theme.test.ts src/ui/themes/theme-manager.test.ts
npm run typecheck --workspace=@google/gemini-cli-core
npm run typecheck --workspace=@google/gemini-cli
npx prettier --check packages/cli/src/ui/components/ColorsDisplay.tsx packages/cli/src/ui/themes/semantic-tokens.ts packages/cli/src/ui/themes/theme-manager.test.ts packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme.test.ts packages/cli/src/ui/themes/theme.ts packages/core/src/config/config.ts
npx eslint packages/cli/src/ui/components/ColorsDisplay.tsx packages/cli/src/ui/themes/semantic-tokens.ts packages/cli/src/ui/themes/theme-manager.test.ts packages/cli/src/ui/themes/theme-manager.ts packages/cli/src/ui/themes/theme.test.ts packages/cli/src/ui/themes/theme.ts packages/core/src/config/config.ts --max-warnings 0
git diff --check
```

The first targeted CLI test/typecheck attempt failed before building `@google/gemini-cli-core` because the package references generated `packages/core/dist` declarations. After building the core workspace, the targeted tests and both typecheck commands passed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
