### PR TITLE
fix(core): cap pending tool responses

### DIFF
--- a/packages/core/src/context/toolOutputMaskingService.ts
+++ b/packages/core/src/context/toolOutputMaskingService.ts
@@ -20,6 +20,7 @@ import {
   EXIT_PLAN_MODE_TOOL_NAME,
 } from '../tools/tool-names.js';
 import { ToolOutputMaskingEvent } from '../telemetry/types.js';
+import type { ToolOutputMaskingConfig } from './types.js';
 
 // Tool output masking defaults
 export const DEFAULT_TOOL_PROTECTION_THRESHOLD = 50000;
@@ -68,12 +69,16 @@ export class ToolOutputMaskingService {
   async mask(
     history: readonly Content[],
     config: Config,
+    overrides?: Partial<ToolOutputMaskingConfig>,
   ): Promise<MaskingResult> {
     if (history.length === 0) {
       return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
     }
 
-    const maskingConfig = await config.getToolOutputMaskingConfig();
+    const maskingConfig = {
+      ...(await config.getToolOutputMaskingConfig()),
+      ...overrides,
+    };
     let cumulativeToolTokens = 0;
     let protectionBoundaryReached = false;
     let totalPrunableTokens = 0;

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1548,6 +1548,89 @@ ${JSON.stringify(
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
+    it('should mask a pending tool response before the overflow check', async () => {
+      vi.mocked(tokenLimit).mockReturnValue(1000);
+
+      const lastPromptTokenCount = 900;
+      const mockChat: Partial<GeminiChat> = {
+        getLastPromptTokenCount: vi.fn().mockReturnValue(lastPromptTokenCount),
+        setTools: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      vi.spyOn(client, 'tryCompressChat').mockResolvedValue({
+        originalTokenCount: lastPromptTokenCount,
+        newTokenCount: lastPromptTokenCount,
+        compressionStatus: CompressionStatus.NOOP,
+      });
+
+      const maskedPart: Part = {
+        functionResponse: {
+          name: 'run_shell_command',
+          id: 'call-1',
+          response: {
+            output:
+              '<tool_output_masked>\nshort preview\n</tool_output_masked>',
+          },
+        },
+      };
+
+      const maskSpy = vi
+        .spyOn(client['toolOutputMaskingService'], 'mask')
+        .mockImplementation(async (history, _config, overrides) => {
+          if (overrides?.protectLatestTurn === false) {
+            return {
+              newHistory: [{ role: 'user', parts: [maskedPart] }],
+              maskedCount: 1,
+              tokensSaved: 250000,
+            };
+          }
+
+          return {
+            newHistory: history,
+            maskedCount: 0,
+            tokensSaved: 0,
+          };
+        });
+
+      mockTurnRunFn.mockImplementation(async function* () {});
+
+      const request: Part[] = [
+        {
+          functionResponse: {
+            name: 'run_shell_command',
+            id: 'call-1',
+            response: { output: 'x'.repeat(1_000_000) },
+          },
+        },
+      ];
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          request,
+          new AbortController().signal,
+          'prompt-id-large-tool-response',
+        ),
+      );
+
+      expect(events).not.toContainEqual(
+        expect.objectContaining({
+          type: GeminiEventType.ContextWindowWillOverflow,
+        }),
+      );
+      expect(maskSpy).toHaveBeenCalledWith(
+        expect.any(Array),
+        mockConfig,
+        expect.objectContaining({
+          protectionThresholdTokens: 0,
+          protectLatestTurn: false,
+        }),
+      );
+      expect(mockTurnRunFn).toHaveBeenCalled();
+      expect(mockTurnRunFn.mock.calls[0][1]).toEqual([maskedPart]);
+    });
+
     it("should use the sticky model's token limit for the overflow check", async () => {
       // Arrange
       const STICKY_MODEL = 'gemini-1.5-flash';

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -698,6 +698,17 @@ export class GeminiClient {
 
     await this.tryMaskToolOutputs(this.getHistory());
 
+    const maskedPendingContent = await this.maskPendingToolResponse(request);
+    if (maskedPendingContent) {
+      request = maskedPendingContent.parts || [];
+      if (apiHistoryOverride && apiHistoryOverride.length > 0) {
+        apiHistoryOverride = [
+          ...apiHistoryOverride.slice(0, -1),
+          maskedPendingContent,
+        ];
+      }
+    }
+
     // Estimate tokens. For text-only requests, we estimate based on character length.
     // For requests with non-text parts (like images, tools), we use the countTokens API.
     const estimatedRequestTokenCount = await calculateRequestTokenCount(
@@ -1262,6 +1273,34 @@ export class GeminiClient {
     if (result.maskedCount > 0) {
       this.getChat().setHistory(result.newHistory);
     }
+  }
+
+  /**
+   * Bounds the tool response that is about to be sent right now.
+   *
+   * History masking intentionally protects the latest turn so the model keeps
+   * recent context. That does not help when the current request is itself a
+   * huge functionResponse; in that case we need to offload it before token
+   * estimation and before Turn.run sends it to the model.
+   */
+  private async maskPendingToolResponse(
+    request: PartListUnion,
+  ): Promise<Content | undefined> {
+    const pendingContent = createUserContent(request);
+    if (!pendingContent.parts?.some((part) => part.functionResponse)) {
+      return undefined;
+    }
+
+    const result = await this.toolOutputMaskingService.mask(
+      [pendingContent],
+      this.config,
+      {
+        protectionThresholdTokens: 0,
+        protectLatestTurn: false,
+      },
+    );
+
+    return result.maskedCount > 0 ? result.newHistory[0] : undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #27738.

A very large tool result can currently be the *pending* `functionResponse` for the next model turn. The existing history masking protects the latest turn by design, so it does not help in that path: token estimation and `Turn.run()` still see the full tool output.

This change reuses the existing `ToolOutputMaskingService` for the pending request before the overflow check and before the request is handed to the model. The normal history-masking behavior stays unchanged; only this pending-request call disables latest-turn protection and starts pruning immediately. The context-management `apiHistoryOverride` path is updated to use the same masked pending content.

This is intentionally narrower than the broader shell streaming / memory work in #20406. It keeps the full output offloaded by the existing masking service and only bounds what reaches the model request.

## Validation

- `npm test --workspace @google/gemini-cli-core -- client.test.ts`
- `npm test --workspace @google/gemini-cli-core -- toolOutputMaskingService.test.ts`
- `npx prettier --write packages/core/src/context/toolOutputMaskingService.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts`
- `npx eslint packages/core/src/context/toolOutputMaskingService.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts --max-warnings 0`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run build --workspace @google/gemini-cli-core`
- `git diff --check`
