### PR TITLE
fix(core): strip line/range suffix from at-command paths to avoid CLI hang

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -101,11 +101,12 @@ Slash commands provide meta-level control over the CLI itself.
 
 ### `/clear`
 
-- **Description:** Clear the terminal screen, including the visible session
-  history and scrollback within the CLI. The underlying session data (for
-  history recall) might be preserved depending on the exact implementation, but
-  the visual display is cleared.
-- **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
+- **Description:** Clear the terminal screen and reset the active chat context.
+  Running `/clear` starts a new conversation session, clears all message history
+  from the context, clears steering hints, and closes any persistent browser
+  sessions. This is equivalent to `/new`.
+- **Keyboard shortcut:** Press **Ctrl+L** at any time to clear the terminal
+  screen and reset the active chat context.
 
 ### `/commands`
 

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -1143,7 +1143,7 @@ export class Session {
           // If it's an absolute path that is authorized (e.g. added via readOnlyPaths),
           // read it directly to avoid ReadManyFilesTool absolute path resolution issues.
           if (
-            (path.isAbsolute(pathName) ||
+            (path.isAbsolute(absolutePath) ||
               !isWithinRoot(
                 absolutePath,
                 this.context.config.getTargetDir(),
@@ -1216,13 +1216,15 @@ export class Session {
               ? resolved.stats
               : await fs.stat(absolutePath);
             if (stats.isDirectory()) {
-              currentPathSpec = pathName.endsWith('/')
-                ? `${pathName}**`
-                : `${pathName}/**`;
+              const baseSpec = resolved ? resolved.relativePath : pathName;
+              currentPathSpec = baseSpec.endsWith('/')
+                ? `${baseSpec}**`
+                : `${baseSpec}/**`;
               this.debug(
                 `Path ${pathName} resolved to directory, using glob: ${currentPathSpec}`,
               );
             } else {
+              currentPathSpec = resolved ? resolved.relativePath : pathName;
               this.debug(
                 `Path ${pathName} resolved to file: ${currentPathSpec}`,
               );

--- a/packages/core/src/utils/atCommandUtils.test.ts
+++ b/packages/core/src/utils/atCommandUtils.test.ts
@@ -449,4 +449,141 @@ describe('atCommandUtils', () => {
       expect.stringContaining('Reason: FORBIDDEN_ZONE'),
     );
   });
+
+  describe('line and range suffix stripping', () => {
+    const mockStats = {
+      isDirectory: () => false,
+      isFile: () => true,
+    };
+
+    beforeEach(() => {
+      vi.mocked(fsPromises.stat).mockResolvedValue(
+        mockStats as unknown as Stats,
+      );
+    });
+
+    it('should strip line suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:12',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':12');
+      }
+    });
+
+    it('should strip line range suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:12-20',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':12-20');
+      }
+    });
+
+    it('should strip line:column suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:12:5',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':12:5');
+      }
+    });
+
+    it('should strip line:column range suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:12:5-15:20',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':12:5-15:20');
+      }
+    });
+
+    it('should strip L prefix line suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:L12',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':L12');
+      }
+    });
+
+    it('should strip L prefix line range suffix and resolve correctly', async () => {
+      const result = await resolveAtCommandPath(
+        'file.ts:L12-L20',
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':L12-L20');
+      }
+    });
+
+    it('should handle Windows absolute path with suffix correctly', async () => {
+      const absPathWithSuffix = 'C:\\mock\\root\\file.ts:12-20';
+      const cleanAbsPath = 'C:\\mock\\root\\file.ts';
+      (mockConfig['validatePathAccess'] as Mock).mockReturnValue(null);
+      (mockWorkspaceContext['getDirectories'] as Mock).mockReturnValue([
+        'C:\\mock\\root',
+      ]);
+
+      vi.mocked(fsPromises.stat).mockImplementation(async (p) => {
+        if (p === cleanAbsPath) {
+          return mockStats as unknown as Stats;
+        }
+        throw new Error('ENOENT');
+      });
+
+      const result = await resolveAtCommandPath(
+        absPathWithSuffix,
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.absolutePath).toBe(cleanAbsPath);
+        expect(result.resolved.relativePath).toBe('file.ts');
+        expect(result.resolved.lineSuffix).toBe(':12-20');
+      }
+    });
+
+    it('should not confuse a Windows drive letter with a suffix', async () => {
+      const winDrivePath = 'C:\\file.ts';
+      (mockConfig['validatePathAccess'] as Mock).mockReturnValue(null);
+      (mockWorkspaceContext['getDirectories'] as Mock).mockReturnValue([
+        'C:\\',
+      ]);
+
+      vi.mocked(fsPromises.stat).mockImplementation(async (p) => {
+        if (p === winDrivePath) {
+          return mockStats as unknown as Stats;
+        }
+        throw new Error('ENOENT');
+      });
+
+      const result = await resolveAtCommandPath(
+        winDrivePath,
+        mockConfig as unknown as Config,
+      );
+      expect(result.status).toBe('resolved');
+      if (result.status === 'resolved') {
+        expect(result.resolved.absolutePath).toBe(winDrivePath);
+        expect(result.resolved.lineSuffix).toBeUndefined();
+      }
+    });
+  });
 });

--- a/packages/core/src/utils/atCommandUtils.ts
+++ b/packages/core/src/utils/atCommandUtils.ts
@@ -17,6 +17,7 @@ export interface ResolvedAtCommandPath {
     isDirectory(): boolean;
     isFile(): boolean;
   };
+  lineSuffix?: string;
 }
 
 /**
@@ -37,20 +38,33 @@ export async function resolveAtCommandPath(
   config: Config,
   onDebugMessage: (msg: string) => void = () => {},
 ): Promise<ResolveAtCommandPathResult> {
-  const pathValidation = validatePath(pathName);
+  // Identify and strip trailing line/range suffix (e.g. :12, :12-20, :12:5, :L12-L20)
+  const suffixRegex = /:(L?\d+(?:-\d+|:\d+)?(?:-L?\d+)?(?::\d+)?)$/i;
+  const match = pathName.match(suffixRegex);
+  const isDriveLetter =
+    /^[a-zA-Z]:/.test(pathName) && match && match.index === 1;
+
+  let cleanPathName = pathName;
+  let lineSuffix: string | undefined = undefined;
+  if (match && match.index !== undefined && !isDriveLetter) {
+    cleanPathName = pathName.substring(0, match.index);
+    lineSuffix = match[0];
+  }
+
+  const pathValidation = validatePath(cleanPathName);
   if (!pathValidation.isValid) {
     // Attempt to extract a real path from the invalid fragment
-    const extractedPath = tryExtractPath(pathName);
-    if (extractedPath && extractedPath !== pathName) {
+    const extractedPath = tryExtractPath(cleanPathName);
+    if (extractedPath && extractedPath !== cleanPathName) {
       onDebugMessage(
-        `Identified invalid path fragment, attempting to extract path: "${extractedPath}" from "${pathName}"`,
+        `Identified invalid path fragment, attempting to extract path: "${extractedPath}" from "${cleanPathName}"`,
       );
       // Recurse once with the extracted path.
       return resolveAtCommandPath(extractedPath, config, onDebugMessage);
     }
 
     onDebugMessage(
-      `Skipping invalid path in @-command: ${pathName}. Reason: ${pathValidation.error}`,
+      `Skipping invalid path in @-command: ${cleanPathName}. Reason: ${pathValidation.error}`,
     );
     return { status: 'invalid', error: pathValidation.error! };
   }
@@ -58,25 +72,25 @@ export async function resolveAtCommandPath(
   const workspaceDirs = config.getWorkspaceContext().getDirectories();
 
   // If it's an absolute path, we only need to check it against authorization once.
-  if (path.isAbsolute(pathName)) {
-    const validationError = config.validatePathAccess(pathName, 'read');
+  if (path.isAbsolute(cleanPathName)) {
+    const validationError = config.validatePathAccess(cleanPathName, 'read');
     if (validationError) {
       onDebugMessage(
-        `Skipping unauthorized absolute path: ${pathName}. Reason: ${validationError}`,
+        `Skipping unauthorized absolute path: ${cleanPathName}. Reason: ${validationError}`,
       );
       return {
         status: 'unauthorized',
-        absolutePath: pathName,
+        absolutePath: cleanPathName,
         error: validationError,
       };
     }
 
     try {
-      const stats = await fs.stat(pathName);
+      const stats = await fs.stat(cleanPathName);
       // Try to find if it's within one of the workspace directories to provide a nice relative path
-      let relativePath = pathName;
+      let relativePath = cleanPathName;
       for (const dir of workspaceDirs) {
-        const rel = path.relative(dir, pathName);
+        const rel = path.relative(dir, cleanPathName);
         if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
           relativePath = rel;
           break;
@@ -86,9 +100,10 @@ export async function resolveAtCommandPath(
       return {
         status: 'resolved',
         resolved: {
-          absolutePath: pathName,
+          absolutePath: cleanPathName,
           relativePath,
           stats,
+          lineSuffix,
         },
       };
     } catch (error) {
@@ -96,7 +111,7 @@ export async function resolveAtCommandPath(
         return { status: 'not_found' };
       }
       onDebugMessage(
-        `Unexpected error stating path ${pathName}: ${getErrorMessage(error)}`,
+        `Unexpected error stating path ${cleanPathName}: ${getErrorMessage(error)}`,
       );
       return { status: 'not_found' };
     }
@@ -106,7 +121,7 @@ export async function resolveAtCommandPath(
   let lastUnauthorized: { absolutePath: string; error: string } | null = null;
 
   for (const dir of workspaceDirs) {
-    const absolutePath = path.resolve(dir, pathName);
+    const absolutePath = path.resolve(dir, cleanPathName);
 
     // Final workspace boundary check using centralized logic
     const validationError = config.validatePathAccess(absolutePath, 'read');
@@ -125,8 +140,9 @@ export async function resolveAtCommandPath(
         status: 'resolved',
         resolved: {
           absolutePath,
-          relativePath: pathName,
+          relativePath: cleanPathName,
           stats,
+          lineSuffix,
         },
       };
     } catch (error) {


### PR DESCRIPTION
This PR resolves two issues:
1. **Issue #19985**: Strips line/range suffixes (e.g., \:12\, \:12-20\, \:12:5\, \:L12\, \:L12-L20\) from at-command paths before executing filesystem and glob operations, preventing hangs/crashes.
2. **Issue #19239**: Updates the \/clear\ command documentation in commands.md to clarify that it resets the active chat session context and starts a new conversation.