### PR TITLE
fix(core): improve SKILL.md frontmatter parsing robustness

### DIFF
--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -286,4 +286,123 @@ description: Test sanitization
       'https://antigravity.google/docs/cli-getting-started',
     );
   });
+
+  it('should parse skill with long single-line description and punctuation', async () => {
+    const skillDir = path.join(testRootDir, 'test-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---
+name: test-skill
+description: A single line description that is relatively long and contains some punctuation.
+---
+# Test Skill
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('test-skill');
+    expect(skills[0].description).toBe(
+      'A single line description that is relatively long and contains some punctuation.',
+    );
+  });
+
+  it('should handle UTF-8 BOM in SKILL.md', async () => {
+    const skillDir = path.join(testRootDir, 'bom-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `\uFEFF---\nname: bom-skill\ndescription: A skill with a BOM\n---\n# Instructions\nBody\n`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('bom-skill');
+  });
+
+  it('should handle trailing spaces after frontmatter markers', async () => {
+    const skillDir = path.join(testRootDir, 'space-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    await fs.writeFile(
+      skillFile,
+      `---  \nname: space-skill\ndescription: A skill with trailing spaces\n--- \n# Instructions\nBody\n`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('space-skill');
+  });
+
+  it('should handle space before colon and case-insensitivity in simple parser', async () => {
+    const skillDir = path.join(testRootDir, 'simple-parser-robustness');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    // Forces YAML failure with unquoted colon, triggers simple parser
+    await fs.writeFile(
+      skillFile,
+      `---
+Name : robust-name
+DESCRIPTION : robust:description
+---
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('robust-name');
+    expect(skills[0].description).toBe('robust:description');
+  });
+
+  it('should not swallow other keys into description in simple parser', async () => {
+    const skillDir = path.join(testRootDir, 'simple-parser-swallow');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    // Forces YAML failure, triggers simple parser
+    await fs.writeFile(
+      skillFile,
+      `---
+description: A long description: with a colon
+  name: my-skill
+---
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-skill');
+    expect(skills[0].description).toBe('A long description: with a colon');
+  });
+
+  it('should not treat "Note:" as a new key in multi-line description in simple parser', async () => {
+    const skillDir = path.join(testRootDir, 'simple-parser-note');
+    await fs.mkdir(skillDir, { recursive: true });
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    // Forces YAML failure, triggers simple parser
+    await fs.writeFile(
+      skillFile,
+      `---
+name: note-skill
+description: This is a description
+  Note: This should be part of the description
+---
+`,
+    );
+
+    const skills = await loadSkillsFromDir(testRootDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('note-skill');
+    expect(skills[0].description).toBe(
+      'This is a description Note: This should be part of the description',
+    );
+  });
 });

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -32,7 +32,7 @@ export interface SkillDefinition {
 }
 
 export const FRONTMATTER_REGEX =
-  /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?/;
+  /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n([\s\S]*))?/;
 
 /**
  * Parses frontmatter content using YAML with a fallback to simple key-value parsing.
@@ -46,8 +46,11 @@ export function parseFrontmatter(
     if (parsed && typeof parsed === 'object') {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const { name, description } = parsed as Record<string, unknown>;
-      if (typeof name === 'string' && typeof description === 'string') {
-        return { name, description };
+      if (name !== undefined && description !== undefined) {
+        const finalName = name === null ? '' : String(name).trim();
+        const finalDesc =
+          description === null ? '' : String(description).trim();
+        return { name: finalName, description: finalDesc };
       }
     }
   } catch (yamlError) {
@@ -74,23 +77,27 @@ function parseSimpleFrontmatter(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Match "name:" at the start of the line (optional whitespace)
-    const nameMatch = line.match(/^\s*name:\s*(.*)$/);
+    // Match "name:" at the start of the line (optional whitespace, case-insensitive, optional space before colon)
+    const nameMatch = line.match(/^\s*name\s*:\s*(.*)$/i);
     if (nameMatch) {
       name = nameMatch[1].trim();
       continue;
     }
 
-    // Match "description:" at the start of the line (optional whitespace)
-    const descMatch = line.match(/^\s*description:\s*(.*)$/);
+    // Match "description:" at the start of the line (optional whitespace, case-insensitive, optional space before colon)
+    const descMatch = line.match(/^\s*description\s*:\s*(.*)$/i);
     if (descMatch) {
       const descLines = [descMatch[1].trim()];
 
       // Check for multi-line description (indented continuation lines)
       while (i + 1 < lines.length) {
         const nextLine = lines[i + 1];
-        // If next line is indented, it's a continuation of the description
-        if (nextLine.match(/^[ \t]+\S/)) {
+        // If next line is indented, it's a continuation of the description,
+        // UNLESS it looks like another known key (e.g. "name:")
+        if (
+          nextLine.match(/^[ \t]+\S/) &&
+          !nextLine.match(/^\s*(name|description)\s*:/i)
+        ) {
           descLines.push(nextLine.trim());
           i++;
         } else {
@@ -104,7 +111,23 @@ function parseSimpleFrontmatter(
   }
 
   if (name !== undefined && description !== undefined) {
-    return { name, description };
+    let finalName = name.trim();
+    if (
+      (finalName.startsWith('"') && finalName.endsWith('"')) ||
+      (finalName.startsWith("'") && finalName.endsWith("'"))
+    ) {
+      finalName = finalName.substring(1, finalName.length - 1).trim();
+    }
+
+    let finalDesc = description.trim();
+    if (
+      (finalDesc.startsWith('"') && finalDesc.endsWith('"')) ||
+      (finalDesc.startsWith("'") && finalDesc.endsWith("'"))
+    ) {
+      finalDesc = finalDesc.substring(1, finalDesc.length - 1).trim();
+    }
+
+    return { name: finalName, description: finalDesc };
   }
   return null;
 }


### PR DESCRIPTION
This PR resolves **Issue #25693**: improves parsing robustness of \SKILL.md\ frontmatter blocks by:
- Adding support for UTF-8 Byte Order Mark (BOM) at the start of the file.
- Ignoring trailing tabs/spaces on frontmatter markers.
- Normalizing non-string YAML values to strings.
- Stripping surrounding quotes.
- Making the fallback simple parser case-insensitive, spacing-tolerant, and preventing key swallowing.