### PR TITLE
fix(vscode-ide-companion): register all activate() disposables

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { activate } from './extension.js';
+import { activate, deactivate } from './extension.js';
 import {
   IDE_DEFINITIONS,
   detectIdeFromEnv,
@@ -26,6 +26,7 @@ vi.mock('vscode', () => ({
   window: {
     createOutputChannel: vi.fn(() => ({
       appendLine: vi.fn(),
+      dispose: vi.fn(),
     })),
     showInformationMessage: vi.fn(),
     createTerminal: vi.fn(() => ({
@@ -79,6 +80,12 @@ describe('activate', () => {
     vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(
       undefined,
     );
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ extensions: [{ versions: [{ version: '1.1.0' }] }] }],
+      }),
+    } as Response);
     context = {
       subscriptions: [],
       environmentVariableCollection: {
@@ -99,7 +106,8 @@ describe('activate', () => {
     } as unknown as vscode.ExtensionContext;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await deactivate();
     vi.restoreAllMocks();
   });
 
@@ -129,6 +137,46 @@ describe('activate', () => {
   it('should register a handler for onDidGrantWorkspaceTrust', async () => {
     await activate(context);
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
+  });
+
+  it('should push every activation disposable into context.subscriptions', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      statusText: 'Not Found',
+    } as Response);
+
+    const pushedDisposables: vscode.Disposable[] = [];
+    const trackDisposable = <T extends vscode.Disposable>(disposable: T): T => {
+      pushedDisposables.push(disposable);
+      return disposable;
+    };
+
+    vi.mocked(vscode.workspace.onDidCloseTextDocument).mockImplementation(() =>
+      trackDisposable({ dispose: vi.fn() }),
+    );
+    vi.mocked(
+      vscode.workspace.registerTextDocumentContentProvider,
+    ).mockImplementation(() => trackDisposable({ dispose: vi.fn() }));
+    vi.mocked(vscode.commands.registerCommand).mockImplementation(() =>
+      trackDisposable({ dispose: vi.fn() }),
+    );
+    vi.mocked(vscode.workspace.onDidChangeWorkspaceFolders).mockImplementation(
+      () => trackDisposable({ dispose: vi.fn() }),
+    );
+    vi.mocked(vscode.workspace.onDidGrantWorkspaceTrust).mockImplementation(
+      () => trackDisposable({ dispose: vi.fn() }),
+    );
+
+    await activate(context);
+
+    expect(vscode.commands.registerCommand).toHaveBeenCalledWith(
+      'gemini.diff.accept',
+      expect.any(Function),
+    );
+    expect(vscode.workspace.onDidChangeWorkspaceFolders).toHaveBeenCalled();
+    for (const disposable of pushedDisposables) {
+      expect(context.subscriptions).toContain(disposable);
+    }
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

Fixes a resource leak in the VS Code IDE companion where two activation disposables were never added to `context.subscriptions`.

Fixes #27790

## Problem

In `packages/vscode-ide-companion/src/extension.ts`, two `context.subscriptions.push(...)` calls wrapped pairs of registrations in extra parentheses. That turns each pair into a **comma expression**, so both operands run but only the **last** value is passed to `push()`.

Affected registrations:

| Group | Registered | Never pushed to `context.subscriptions` |
|---|---|---|
| Diff commands | `gemini.diff.accept`, `gemini.diff.cancel` | `gemini.diff.accept` |
| Workspace listeners | `onDidChangeWorkspaceFolders`, `onDidGrantWorkspaceTrust` | `onDidChangeWorkspaceFolders` |

On extension reload/update, the leaked `gemini.diff.accept` command stays registered and re-activation throws `command 'gemini.diff.accept' already exists`. The leaked workspace-folder listener keeps calling `ideServer.syncEnvVars()` after the server has been stopped.

## Root cause

```ts
// Before: comma expression — only the second disposable is pushed
(vscode.commands.registerCommand('gemini.diff.accept', ...),
 vscode.commands.registerCommand('gemini.diff.cancel', ...)),
```

## Fix

Remove the grouping parentheses so each registration is a separate argument to `context.subscriptions.push()`:

- `gemini.diff.accept` and `gemini.diff.cancel` are both tracked
- `onDidChangeWorkspaceFolders` and `onDidGrantWorkspaceTrust` are both tracked

No behavior change to command or listener logic — only subscription bookkeeping.

## Testing

Added `should push every activation disposable into context.subscriptions` in `extension.test.ts`. The test tracks every mocked disposable and asserts it appears in `context.subscriptions`.

```bash
cd packages/vscode-ide-companion && npx vitest run src/extension.test.ts
# 12 passed
```