### PR TITLE
fix(core): respect .gitignore and .geminiignore in session_context directory tree

### DIFF
--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -36,6 +36,11 @@ describe('getDirectoryContextString', () => {
         getDirectories: vi.fn().mockReturnValue(['/test/dir']),
       }),
       getFileService: vi.fn(),
+      getFileFilteringOptions: vi.fn().mockReturnValue({
+        respectGitIgnore: true,
+        respectGeminiIgnore: true,
+        customIgnoreFilePaths: [],
+      }),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/tmp/project-temp'),
       } as unknown as Storage,
@@ -88,6 +93,11 @@ describe('getEnvironmentContext', () => {
         getDirectories: vi.fn().mockReturnValue(['/test/dir']),
       }),
       getFileService: vi.fn(),
+      getFileFilteringOptions: vi.fn().mockReturnValue({
+        respectGitIgnore: true,
+        respectGeminiIgnore: true,
+        customIgnoreFilePaths: [],
+      }),
       getIncludeDirectoryTree: vi.fn().mockReturnValue(true),
       getEnvironmentMemory: vi.fn().mockReturnValue('Mock Environment Memory'),
       getSessionMemory: vi.fn().mockReturnValue('Mock Session Memory'),
@@ -121,6 +131,11 @@ describe('getEnvironmentContext', () => {
     expect(context).toContain('</session_context>');
     expect(getFolderStructure).toHaveBeenCalledWith('/test/dir', {
       fileService: undefined,
+      fileFilteringOptions: {
+        respectGitIgnore: true,
+        respectGeminiIgnore: true,
+        customIgnoreFilePaths: [],
+      },
     });
   });
 

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -27,6 +27,7 @@ export async function getDirectoryContextString(
     workspaceDirectories.map((dir) =>
       getFolderStructure(dir, {
         fileService: config.getFileService(),
+        fileFilteringOptions: config.getFileFilteringOptions(),
       }),
     ),
   );


### PR DESCRIPTION
## Summary

Ensures the `<session_context>` directory tree honors the same ignore rules as the rest of the CLI.

Fixes #27787

## Problem

`getDirectoryContextString()` builds the folder tree shown inside `<session_context>`. It calls `getFolderStructure()` with only `fileService`, but **does not pass** `fileFilteringOptions` from config.

`getFolderStructure()` only applies `.gitignore` / `.geminiignore` filtering when both are available:

1. `fileService.shouldIgnoreFile()` / `shouldIgnoreDirectory()`
2. Matching `fileFilteringOptions.respectGitIgnore` / `respectGeminiIgnore` flags

Without (2), ignored paths can still appear in the session bootstrap context — wasting tokens and potentially leaking files the user intentionally excluded.

## Root cause

```ts
// Before
getFolderStructure(dir, {
  fileService: config.getFileService(),
});
```

Other tools (`ls`, `glob`, `read-many-files`, etc.) already pass `config.getFileFilteringOptions()`. Session context generation was the missing call site.

## Fix

Pass the configured filtering options alongside the file service:

```ts
getFolderStructure(dir, {
  fileService: config.getFileService(),
  fileFilteringOptions: config.getFileFilteringOptions(),
});
```

This aligns session context generation with the ignore behavior used elsewhere in core.

## Testing

Updated `environmentContext.test.ts` expectations and mocked `getFileFilteringOptions()`.

```bash
cd packages/core && npx vitest run src/utils/environmentContext.test.ts
# 8 passed
```