### PR TITLE
fix(cli): honor custom theme border.default when terminal reports OSC 11 background

### DIFF
--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -331,6 +331,24 @@ describe('ThemeManager', () => {
       expect(semanticColors.background.primary).toBe(darkTerminalBg);
     });
 
+    it('should preserve explicit custom border colors when terminal background is set', () => {
+      themeManager.loadCustomThemes({
+        ZedClean: {
+          name: 'ZedClean',
+          type: 'custom',
+          background: { primary: '#282c34' },
+          border: { default: '#282c34' },
+          text: { primary: '#abb2bf', secondary: '#5c6370' },
+        },
+      });
+      themeManager.setActiveTheme('ZedClean');
+      themeManager.setTerminalBackground('#282c34');
+
+      const semanticColors = themeManager.getSemanticColors();
+      expect(semanticColors.border.default).toBe('#282c34');
+      expect(themeManager.getColors().DarkGray).toBe('#282c34');
+    });
+
     it('should NOT override background for custom theme when incompatible', () => {
       themeManager.loadCustomThemes({
         MyLight: {

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -52,6 +52,25 @@ export interface ThemeDisplay {
 
 export const DEFAULT_THEME: Theme = DefaultDark;
 
+function hasUserSpecifiedBorderColor(customThemeConfig: CustomTheme): boolean {
+  return (
+    customThemeConfig.border?.default !== undefined ||
+    customThemeConfig.DarkGray !== undefined
+  );
+}
+
+function buildCustomThemeConfig(
+  customThemeConfig: CustomTheme,
+  name: string,
+): CustomTheme {
+  return {
+    ...DEFAULT_THEME.colors,
+    ...customThemeConfig,
+    name,
+    type: 'custom',
+  };
+}
+
 class ThemeManager {
   private readonly availableThemes: Theme[];
   private activeTheme: Theme;
@@ -140,15 +159,16 @@ class ThemeManager {
         if (validation.warning) {
           debugLogger.warn(`Theme "${name}": ${validation.warning}`);
         }
-        const themeWithDefaults: CustomTheme = {
-          ...DEFAULT_THEME.colors,
-          ...customThemeConfig,
-          name: customThemeConfig.name || name,
-          type: 'custom',
-        };
+        const themeWithDefaults = buildCustomThemeConfig(
+          customThemeConfig,
+          customThemeConfig.name || name,
+        );
 
         try {
-          const theme = createCustomTheme(themeWithDefaults);
+          const theme = createCustomTheme(themeWithDefaults, {
+            hasExplicitBorderColor:
+              hasUserSpecifiedBorderColor(customThemeConfig),
+          });
           this.settingsThemes.set(name, theme);
         } catch (error) {
           debugLogger.warn(`Failed to load custom theme "${name}":`, error);
@@ -196,15 +216,16 @@ class ThemeManager {
         if (validation.warning) {
           debugLogger.warn(`Theme "${namespacedName}": ${validation.warning}`);
         }
-        const themeWithDefaults: CustomTheme = {
-          ...DEFAULT_THEME.colors,
-          ...customThemeConfig,
-          name: namespacedName,
-          type: 'custom',
-        };
+        const themeWithDefaults = buildCustomThemeConfig(
+          customThemeConfig,
+          namespacedName,
+        );
 
         try {
-          const theme = createCustomTheme(themeWithDefaults);
+          const theme = createCustomTheme(themeWithDefaults, {
+            hasExplicitBorderColor:
+              hasUserSpecifiedBorderColor(customThemeConfig),
+          });
           this.extensionThemes.set(namespacedName, theme);
         } catch (error) {
           debugLogger.warn(
@@ -365,11 +386,13 @@ class ThemeManager {
       this.cachedColors = {
         ...colors,
         Background: this.terminalBackground,
-        DarkGray: interpolateColor(
-          this.terminalBackground,
-          colors.Gray,
-          DEFAULT_BORDER_OPACITY,
-        ),
+        DarkGray: activeTheme.hasExplicitBorderColor
+          ? colors.DarkGray
+          : interpolateColor(
+              this.terminalBackground,
+              colors.Gray,
+              DEFAULT_BORDER_OPACITY,
+            ),
         InputBackground: interpolateColor(
           this.terminalBackground,
           colors.Gray,
@@ -598,14 +621,14 @@ class ThemeManager {
       }
 
       // 4. Create and cache the theme.
-      const themeWithDefaults: CustomTheme = {
-        ...DEFAULT_THEME.colors,
-        ...customThemeConfig,
-        name: customThemeConfig.name || canonicalPath,
-        type: 'custom',
-      };
+      const themeWithDefaults = buildCustomThemeConfig(
+        customThemeConfig,
+        customThemeConfig.name || canonicalPath,
+      );
 
-      const theme = createCustomTheme(themeWithDefaults);
+      const theme = createCustomTheme(themeWithDefaults, {
+        hasExplicitBorderColor: hasUserSpecifiedBorderColor(customThemeConfig),
+      });
       this.fileThemes.set(canonicalPath, theme); // Cache by canonical path
       return theme;
     } catch (error) {

--- a/packages/cli/src/ui/themes/theme.test.ts
+++ b/packages/cli/src/ui/themes/theme.test.ts
@@ -84,6 +84,26 @@ describe('createCustomTheme', () => {
     // Interpolate between #000000 and #cccccc -> #525252
     expect(theme.colors.DarkGray).toBe('#525252');
   });
+
+  it('should use border.default when DarkGray is not provided', () => {
+    const theme = createCustomTheme({
+      ...baseTheme,
+      border: {
+        default: '#282c34',
+      },
+    });
+    expect(theme.colors.DarkGray).toBe('#282c34');
+    expect(theme.semanticColors.border.default).toBe('#282c34');
+    expect(theme.hasExplicitBorderColor).toBe(true);
+  });
+
+  it('should mark hasExplicitBorderColor when DarkGray is provided', () => {
+    const theme = createCustomTheme({
+      ...baseTheme,
+      DarkGray: '#123456',
+    });
+    expect(theme.hasExplicitBorderColor).toBe(true);
+  });
 });
 
 describe('validateCustomTheme', () => {

--- a/packages/cli/src/ui/themes/theme.ts
+++ b/packages/cli/src/ui/themes/theme.ts
@@ -272,6 +272,7 @@ export class Theme {
     rawMappings: Record<string, CSSProperties>,
     readonly colors: ColorsTheme,
     semanticColors?: SemanticColors,
+    readonly hasExplicitBorderColor: boolean = false,
   ) {
     this.semanticColors = semanticColors ?? {
       text: {
@@ -391,7 +392,18 @@ export class Theme {
  * @param customTheme The custom theme configuration.
  * @returns A new Theme instance.
  */
-export function createCustomTheme(customTheme: CustomTheme): Theme {
+export function createCustomTheme(
+  customTheme: CustomTheme,
+  options?: { hasExplicitBorderColor?: boolean },
+): Theme {
+  const explicitBorderDefault = customTheme.border?.default
+    ? (resolveColor(customTheme.border.default) ?? customTheme.border.default)
+    : undefined;
+  const hasExplicitBorderColor =
+    options?.hasExplicitBorderColor ??
+    (customTheme.border?.default !== undefined ||
+      customTheme.DarkGray !== undefined);
+
   const colors: ColorsTheme = {
     type: 'custom',
     Background: customTheme.background?.primary ?? customTheme.Background ?? '',
@@ -410,6 +422,7 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
     Comment: customTheme.ui?.comment ?? customTheme.Comment ?? '',
     Gray: customTheme.text?.secondary ?? customTheme.Gray ?? '',
     DarkGray:
+      explicitBorderDefault ??
       customTheme.DarkGray ??
       interpolateColor(
         customTheme.background?.primary ?? customTheme.Background ?? '',
@@ -595,7 +608,7 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
       },
     },
     border: {
-      default: colors.DarkGray,
+      default: explicitBorderDefault ?? customTheme.DarkGray ?? colors.DarkGray,
     },
     ui: {
       comment: customTheme.ui?.comment ?? colors.Comment,
@@ -618,6 +631,7 @@ export function createCustomTheme(customTheme: CustomTheme): Theme {
     rawMappings,
     colors,
     semanticColors,
+    hasExplicitBorderColor,
   );
 }
 


### PR DESCRIPTION
## Summary

Makes documented custom theme border colors actually apply, including on terminals that report background color via OSC 11.

Fixes #27786

## Problem

`docs/cli/themes.md` documents `border.default` (and `border.focused`), but two code paths prevented custom border colors from sticking:

1. **`createCustomTheme()` ignored `border.default`** — `semanticColors.border.default` always came from computed `DarkGray`.
2. **`ThemeManager.getColors()` always recomputed `DarkGray`** when OSC 11 background was detected, even if the user explicitly configured border colors. That override flowed into `getSemanticColors()` via `border.default`.

Additionally, when loading settings themes, `DEFAULT_THEME.colors` is merged in first. That injects a default `DarkGray` which previously took precedence over a user-provided `border.default`.

## Root cause

```ts
// border.default never read
DarkGray: customTheme.DarkGray ?? interpolateColor(...)

// terminal background always wins
DarkGray: interpolateColor(terminalBackground, colors.Gray, DEFAULT_BORDER_OPACITY)
```

## Fix

1. **`createCustomTheme()`**
   - Resolve `border.default` and use it before fallback interpolation.
   - Prefer `border.default` over merged-in default `DarkGray`.
   - Track whether the **user** explicitly configured border colors.

2. **`ThemeManager`**
   - Detect user-specified border config before default merge (`border.default` or `DarkGray` in the raw settings entry).
   - Pass `hasExplicitBorderColor` into `createCustomTheme()`.
   - Skip terminal-background recomputation of `DarkGray` when the user explicitly set border colors.

3. **Tests**
   - `border.default` maps to `colors.DarkGray` and `semanticColors.border.default`.
   - Custom theme with `border.default: '#282c34'` keeps that color after `setTerminalBackground('#282c34')`.

## Testing

```bash
cd packages/cli && npx vitest run src/ui/themes/theme.test.ts src/ui/themes/theme-manager.test.ts
# 41 passed
```