### PR TITLE
fix(core): refresh MCP OAuth with stored client ID

### DIFF
--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -1458,6 +1458,49 @@ describe('MCPOAuthProvider', () => {
       );
     });
 
+    it('should refresh with the stored client ID when config has none', async () => {
+      const expiredCredentials = {
+        serverName: 'test-server',
+        token: { ...mockToken, expiresAt: Date.now() - 3600000 },
+        clientId: 'registered-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      const tokenStorage = new MCPOAuthTokenStorage();
+      vi.mocked(tokenStorage.getCredentials).mockResolvedValue(
+        expiredCredentials,
+      );
+      vi.mocked(tokenStorage.isTokenExpired).mockReturnValue(true);
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          ok: true,
+          contentType: 'application/json',
+          text: JSON.stringify(mockTokenResponse),
+          json: mockTokenResponse,
+        }),
+      );
+
+      const authProvider = new MCPOAuthProvider();
+      const result = await authProvider.getValidToken('test-server', {
+        ...mockConfig,
+        clientId: undefined,
+      });
+
+      expect(result).toBe('access_token_123');
+      expect(mockFetch.mock.calls[0][1].body).toContain(
+        'client_id=registered-client-id',
+      );
+      expect(tokenStorage.saveToken).toHaveBeenCalledWith(
+        'test-server',
+        expect.any(Object),
+        'registered-client-id',
+        'https://auth.example.com/token',
+        undefined,
+      );
+      expect(tokenStorage.deleteCredentials).not.toHaveBeenCalled();
+    });
+
     it('should return null when no credentials exist', async () => {
       const tokenStorage = new MCPOAuthTokenStorage();
       vi.mocked(tokenStorage.getCredentials).mockResolvedValue(null);
@@ -1539,6 +1582,51 @@ describe('MCPOAuthProvider', () => {
       );
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getValidTokenWithMetadata', () => {
+    it('should refresh with the stored client ID when config has none', async () => {
+      const expiredCredentials = {
+        serverName: 'test-server',
+        token: { ...mockToken, expiresAt: Date.now() - 3600000 },
+        clientId: 'registered-client-id',
+        tokenUrl: 'https://auth.example.com/token',
+        updatedAt: Date.now(),
+      };
+
+      const tokenStorage = new MCPOAuthTokenStorage();
+      vi.mocked(tokenStorage.getCredentials).mockResolvedValue(
+        expiredCredentials,
+      );
+      vi.mocked(tokenStorage.isTokenExpired).mockReturnValue(true);
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          ok: true,
+          contentType: 'application/json',
+          text: JSON.stringify(mockTokenResponse),
+          json: mockTokenResponse,
+        }),
+      );
+
+      const authProvider = new MCPOAuthProvider();
+      const result = await authProvider.getValidTokenWithMetadata(
+        'test-server',
+        { ...mockConfig, clientId: undefined },
+      );
+
+      expect(result?.accessToken).toBe('access_token_123');
+      expect(mockFetch.mock.calls[0][1].body).toContain(
+        'client_id=registered-client-id',
+      );
+      expect(tokenStorage.saveToken).toHaveBeenCalledWith(
+        'test-server',
+        expect.any(Object),
+        'registered-client-id',
+        'https://auth.example.com/token',
+        undefined,
+      );
+      expect(tokenStorage.deleteCredentials).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -569,14 +569,15 @@ ${authUrl}
     }
 
     // Try to refresh if we have a refresh token
-    if (token.refreshToken && config.clientId && credentials.tokenUrl) {
+    const clientId = config.clientId ?? credentials.clientId;
+    if (token.refreshToken && clientId && credentials.tokenUrl) {
       try {
         debugLogger.log(
           `Refreshing expired token for MCP server: ${serverName}`,
         );
 
         const newTokenResponse = await this.refreshAccessToken(
-          config,
+          { ...config, clientId },
           token.refreshToken,
           credentials.tokenUrl,
           credentials.mcpServerUrl,
@@ -597,7 +598,7 @@ ${authUrl}
         await this.tokenStorage.saveToken(
           serverName,
           newToken,
-          config.clientId,
+          clientId,
           credentials.tokenUrl,
           credentials.mcpServerUrl,
         );
@@ -636,7 +637,7 @@ ${authUrl}
       if (current.refreshToken && clientId && credentials.tokenUrl) {
         try {
           const newTokenResponse = await this.refreshAccessToken(
-            config,
+            { ...config, clientId },
             current.refreshToken,
             credentials.tokenUrl,
             credentials.mcpServerUrl,


### PR DESCRIPTION
## Summary

Fix the MCP OAuth refresh path used after `/mcp auth` when an auto-discovered server has no static `oauth.clientId` in settings.

The CLI already persists the discovered client ID in token metadata, but `getValidTokenWithMetadata()` refreshed with the original server config. For auto-discovered providers that config can still have no client ID, so refresh failed, the freshly stored credentials were deleted, and the restarted MCP connection had no bearer token to attach.

## Details

- Use the stored credential client ID as the effective refresh client ID when the static config does not provide one.
- Preserve that effective client ID when writing refreshed credentials back to storage.
- Add regression coverage for the normal access-token path and the metadata-returning provider path.

This supersedes #27752, which had the same fix but was auto-closed by the repository PR rate limiter while I had seven open PRs.

## Related Issues

Fixes #27745

## How to Validate

Validated on Windows with:

- `npm test --workspace @google/gemini-cli-core -- src/mcp/oauth-provider.test.ts`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm run lint --workspace @google/gemini-cli-core -- --max-warnings 0`
- `git diff --check`

Expected result: the focused OAuth provider suite passes, the core package type-checks and lints, and the patch has no whitespace errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
