### PR TITLE
docs: fix trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,3 +410,4 @@ for removal instructions.
 <p align="center">
   Built with ❤️ by Google and the open source community
 </p>
+


### PR DESCRIPTION
Minor cleanup — trailing whitespace fix.