### PR TITLE
fix(trust): disclose hooks declared in canonical nested shape

### DIFF
--- a/packages/core/src/services/FolderTrustDiscoveryService.test.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.test.ts
@@ -76,6 +76,35 @@ describe('FolderTrustDiscoveryService', () => {
     expect(results.settings).not.toContain('hooks');
   });
 
+  it('should discover hooks declared in the canonical nested shape', async () => {
+    // The execution engine (HookRegistry.processHookDefinition) only runs hooks
+    // whose command lives in the inner HookDefinition.hooks[] array. The trust
+    // dialog must disclose that same shape, otherwise a hook can execute without
+    // ever being shown to the user before they trust the folder.
+    const geminiDir = path.join(tempDir, GEMINI_DIR);
+    await fs.mkdir(geminiDir, { recursive: true });
+
+    const settings = {
+      ui: { hideBanner: true },
+      hooks: {
+        SessionStart: [
+          {
+            matcher: '',
+            hooks: [{ type: 'command', command: 'nested-hook-command' }],
+          },
+        ],
+      },
+    };
+    await fs.writeFile(
+      path.join(geminiDir, 'settings.json'),
+      JSON.stringify(settings),
+    );
+
+    const results = await FolderTrustDiscoveryService.discover(tempDir);
+
+    expect(results.hooks).toContain('nested-hook-command');
+  });
+
   it('should flag security warnings for sensitive settings', async () => {
     const geminiDir = path.join(tempDir, GEMINI_DIR);
     await fs.mkdir(geminiDir, { recursive: true });

--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -162,11 +162,22 @@ export class FolderTrustDiscoveryService {
         const hooks = new Set<string>();
         for (const event of Object.values(hooksConfig)) {
           if (!Array.isArray(event)) continue;
-          for (const hook of event) {
-            // eslint-disable-next-line no-restricted-syntax
-            if (this.isRecord(hook) && typeof hook['command'] === 'string') {
-              hooks.add(hook['command']);
+          for (const definition of event) {
+            if (!this.isRecord(definition)) continue;
+            // Canonical shape: the command lives on the inner HookConfig array
+            // (HookDefinition.hooks). This is the shape the execution engine
+            // actually runs, so it must be the shape the trust dialog discloses.
+            const inner = definition['hooks'];
+            if (Array.isArray(inner)) {
+              for (const hook of inner) {
+                if (!this.isRecord(hook)) continue;
+                const command = hook['command'];
+                if (typeof command === 'string') hooks.add(command);
+              }
             }
+            // Flat shorthand: command directly on the definition object.
+            const flatCommand = definition['command'];
+            if (typeof flatCommand === 'string') hooks.add(flatCommand);
           }
         }
         results.hooks = Array.from(hooks);


### PR DESCRIPTION
## Summary

The folder-trust dialog enumerates hook commands so the user can see what a `SessionStart`/`BeforeTool` hook will run **before** they trust the folder. The discovery parser only reads `command` off the **outer** `HookDefinition` — i.e. the flat shorthand `{ type, command }`. But the **canonical** shape puts the command on the inner `HookDefinition.hooks[]` array, and that nested shape is the **only** one the execution engine (`HookRegistry.processHookDefinition`) actually runs.

The two paths read mutually exclusive shapes, so disclosure is **anti-correlated with execution**:

| Hook shape | Trust dialog | Actually runs |
|---|---|---|
| flat `{ type, command }` | ✅ shown | ❌ discarded (`processHookDefinition` requires `definition.hooks` to be an array) |
| nested `{ hooks: [{ type, command }] }` | ❌ **not shown** | ✅ **runs** |

Net effect: a hook written in the canonical nested shape **executes on a single `Trust folder` click but is never displayed in the trust dialog**, while a flat hook is displayed but never runs.

## Root cause

`packages/core/src/services/FolderTrustDiscoveryService.ts` iterated each `HookDefinition` and read `hook['command']` directly — always `undefined` for canonical hooks, because `command` lives on the inner `HookConfig` (`packages/core/src/hooks/types.ts`):

```ts
export interface CommandHookConfig { type: HookType.Command; command: string; /* ... */ } // command here
export interface HookDefinition { matcher?: string; sequential?: boolean; hooks: HookConfig[]; } // not here
```

With `results.hooks` empty, the `Hooks` group is dropped from the dialog (`FolderTrustDialog.tsx` filters empty groups), and `hooks` is also excluded from the `Setting overrides` list — so a `settings.json` containing `{ ui, hooks }` renders only `Setting overrides (1): - ui`.

## Fix

Descend into `HookDefinition.hooks[]` and read the inner `HookConfig.command` (the shape the engine runs), while keeping the flat shorthand for completeness. The dialog now discloses the same hook commands the engine will execute.

## Test

The existing test happened to use the flat shorthand (`hooks: { BeforeTool: [{ command: 'test-hook' }] }`), which is why this was never caught. Added a regression test that declares a hook in the canonical nested shape and asserts it is discovered.

```
✓ src/services/FolderTrustDiscoveryService.test.ts (9 tests)
```

`eslint --max-warnings 0` and `prettier --check` pass on the changed files.

## Related

Reported behavior in #27901.
