### PR TITLE
fix(core): load JSONL sessions when projectHash is missing

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -310,6 +310,39 @@ describe('ChatRecordingService', () => {
     });
   });
 
+  describe('loadConversationRecord projectHash robustness', () => {
+    it('loads a JSONL session whose metadata line is missing projectHash', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'session-no-project-hash.jsonl');
+
+      // Valid multi-line JSONL: an identity line that omits `projectHash`,
+      // followed by a real user message on its own line.
+      const metadataLine = JSON.stringify({
+        sessionId: 'session-without-hash',
+        startTime: '2026-01-01T00:00:00.000Z',
+        lastUpdated: '2026-01-01T00:00:00.000Z',
+      });
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'user',
+        content: 'hello world',
+      });
+      fs.writeFileSync(sessionFile, `${metadataLine}\n${messageLine}\n`);
+
+      const conversation = await loadConversationRecord(sessionFile);
+
+      // Before the fix the loader fell back to the legacy whole-file
+      // JSON.parse, which throws on multi-line JSONL and returns null —
+      // hiding a real session just because one metadata field was absent.
+      expect(conversation).not.toBeNull();
+      expect(conversation?.sessionId).toBe('session-without-hash');
+      expect(conversation?.projectHash).toBe('');
+      expect(conversation?.messages).toHaveLength(1);
+      expect(conversation?.messages[0].id).toBe('msg-1');
+    });
+  });
+
   describe('recordMessage', () => {
     beforeEach(async () => {
       await chatRecordingService.initialize();

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -90,10 +90,11 @@ function isMetadataUpdateRecord(
 function isPartialMetadataRecord(
   record: unknown,
 ): record is PartialMetadataRecord {
-  return (
-    isStringProperty(record, 'sessionId') &&
-    isStringProperty(record, 'projectHash')
-  );
+  // The metadata/identity line is identified by its `sessionId`. `projectHash`
+  // is optional here: requiring it would leave a sessionId-only metadata line
+  // unrecognized, dropping the session identity and making the whole session
+  // unloadable (see loadConversationRecord's legacy fallback).
+  return isStringProperty(record, 'sessionId');
 }
 
 function isTextPart(part: unknown): part is { text: string } {
@@ -345,7 +346,13 @@ export async function loadConversationRecord(
       }
     }
 
-    if (!metadata.sessionId || !metadata.projectHash) {
+    // A missing `projectHash` must not make an otherwise-valid JSONL session
+    // unloadable. The legacy fallback parses the entire file with a single
+    // `JSON.parse`, which always throws on multi-line JSONL and returns null —
+    // so requiring `projectHash` here silently hides real sessions. Only fall
+    // back when we recovered no session identity at all; `projectHash` is
+    // useful metadata but optional for loading (defaulted below).
+    if (!metadata.sessionId) {
       return await parseLegacyRecordFallback(filePath, options);
     }
 
@@ -375,7 +382,7 @@ export async function loadConversationRecord(
 
     return {
       sessionId: metadata.sessionId,
-      projectHash: metadata.projectHash,
+      projectHash: metadata.projectHash ?? '',
       startTime: metadata.startTime || new Date().toISOString(),
       lastUpdated: metadata.lastUpdated || new Date().toISOString(),
       summary: metadata.summary,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -438,7 +438,12 @@ export class ChatRecordingService {
         );
         if (loadedRecord) {
           this.cachedConversation = loadedRecord;
-          this.projectHash = this.cachedConversation.projectHash;
+          // A resumed record may carry an empty/whitespace projectHash (e.g.
+          // older or partial metadata, now tolerated when loading). Don't let
+          // that clobber the active project hash computed in the constructor —
+          // keep the current one so the session stays associated correctly.
+          this.projectHash =
+            this.cachedConversation.projectHash.trim() || this.projectHash;
 
           if (this.conversationFile.endsWith('.json')) {
             this.conversationFile = this.conversationFile + 'l'; // e.g. session-foo.jsonl

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -130,7 +130,7 @@ export interface MetadataUpdateRecord {
 
 export interface PartialMetadataRecord {
   sessionId: string;
-  projectHash: string;
+  projectHash?: string;
   startTime?: string;
   lastUpdated?: string;
   summary?: string;


### PR DESCRIPTION
## Summary

Fixes #27275.

`loadConversationRecord` treated a session record as valid only when **both** `sessionId` and `projectHash` were present. When `projectHash` was missing it fell back to `parseLegacyRecordFallback`, which reads the entire file with a single `JSON.parse(fileContent)`. That call is guaranteed to throw on a modern multi-line **JSONL** file, so the loader returned `null` — and a real session containing messages silently disappeared from `list`/`resume` just because one metadata field was absent.

The identity of a session is its `sessionId`; `projectHash` is secondary metadata. This was enforced in two places, both fixed here:

- `isPartialMetadataRecord` required `projectHash`, so a `sessionId`-only metadata line wasn't even recognized as the identity line.
- The load gate (`if (!metadata.sessionId || !metadata.projectHash)`) routed such sessions into the always-failing legacy parser.

## Changes

- `isPartialMetadataRecord` now identifies the metadata line by `sessionId` alone.
- `PartialMetadataRecord.projectHash` is now optional, matching the runtime reality.
- `loadConversationRecord` falls back to legacy parsing only when no `sessionId` was recovered, and defaults `projectHash` to `''` when absent.

No change to the happy path (records with both fields load exactly as before); the legacy fallback still handles genuinely identity-less files.

## Testing

- Added a regression test in `chatRecordingService.test.ts` that writes a valid multi-line JSONL session whose metadata line omits `projectHash` and asserts it loads with its messages. Verified it **fails before** this change (loader returns `null`) and **passes after**.
- `npx vitest run src/services/chatRecordingService.test.ts` → 51 passed.
- `eslint` (touched files) and `npm run typecheck` (packages/core) both clean.