### PR TITLE
fix(core): keep recreated session files loadable after deletion

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -310,6 +310,40 @@ describe('ChatRecordingService', () => {
     });
   });
 
+  describe('appendRecord file recovery', () => {
+    it('rewrites metadata when the session file was deleted mid-session', async () => {
+      await chatRecordingService.initialize();
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'first',
+        model: 'm',
+      });
+
+      const sessionFile = chatRecordingService.getConversationFilePath()!;
+      expect(fs.existsSync(sessionFile)).toBe(true);
+
+      // Simulate session cleanup (or a manual delete) removing the file while
+      // the recorder is still alive.
+      fs.unlinkSync(sessionFile);
+      expect(fs.existsSync(sessionFile)).toBe(false);
+
+      // Recording another message recreates the file.
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'second',
+        model: 'm',
+      });
+
+      // Before the fix the recreated file held only message records and no
+      // metadata line, so loadConversationRecord returned null. It should now
+      // be recoverable as a valid session.
+      const conversation = await loadConversationRecord(sessionFile);
+      expect(conversation).not.toBeNull();
+      expect(conversation?.sessionId).toBe('test-session-id');
+      expect(conversation?.messages.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('recordMessage', () => {
     beforeEach(async () => {
       await chatRecordingService.initialize();

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -336,11 +336,14 @@ describe('ChatRecordingService', () => {
 
       // Before the fix the recreated file held only message records and no
       // metadata line, so loadConversationRecord returned null. It should now
-      // be recoverable as a valid session.
+      // be recoverable as a valid session, and the prior message ("first")
+      // must not be lost when the file is rebuilt.
       const conversation = await loadConversationRecord(sessionFile);
       expect(conversation).not.toBeNull();
       expect(conversation?.sessionId).toBe('test-session-id');
-      expect(conversation?.messages.length).toBeGreaterThan(0);
+      const contents = conversation?.messages.map((m) => m.content);
+      expect(contents).toContain('first');
+      expect(contents).toContain('second');
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -558,14 +558,15 @@ export class ChatRecordingService {
       // Re-write the metadata from the in-memory conversation first so the
       // recreated file remains a valid, loadable session.
       if (this.cachedConversation && !fs.existsSync(this.conversationFile)) {
-        const metadata: Partial<ConversationRecord> = {
-          ...this.cachedConversation,
-        };
-        delete metadata.messages;
-        fs.appendFileSync(
-          this.conversationFile,
-          JSON.stringify(metadata) + '\n',
-        );
+        // Rebuild the full session from memory — the metadata line followed by
+        // every message held in `cachedConversation` — so recreating the file
+        // doesn't silently drop the prior conversation history. The record that
+        // triggered this append is written immediately below.
+        const { messages, ...metadata } = this.cachedConversation;
+        const rebuilt = [metadata, ...messages]
+          .map((entry) => JSON.stringify(entry) + '\n')
+          .join('');
+        fs.appendFileSync(this.conversationFile, rebuilt);
       }
       const line = JSON.stringify(record) + '\n';
       fs.appendFileSync(this.conversationFile, line);

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -550,8 +550,24 @@ export class ChatRecordingService {
   private appendRecord(record: unknown): void {
     if (!this.conversationFile) return;
     try {
-      const line = JSON.stringify(record) + '\n';
       fs.mkdirSync(path.dirname(this.conversationFile), { recursive: true });
+      // If the session file was removed while the process is still running
+      // (e.g. by session cleanup or a manual delete), appendFileSync would
+      // recreate it containing only this record — with no leading metadata
+      // line — producing a file that loadConversationRecord can never parse.
+      // Re-write the metadata from the in-memory conversation first so the
+      // recreated file remains a valid, loadable session.
+      if (this.cachedConversation && !fs.existsSync(this.conversationFile)) {
+        const metadata: Partial<ConversationRecord> = {
+          ...this.cachedConversation,
+        };
+        delete metadata.messages;
+        fs.appendFileSync(
+          this.conversationFile,
+          JSON.stringify(metadata) + '\n',
+        );
+      }
+      const line = JSON.stringify(record) + '\n';
       fs.appendFileSync(this.conversationFile, line);
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOSPC') {


### PR DESCRIPTION
## Summary

Fixes #27279.

`appendRecord()` guards only on `this.conversationFile` being non-null — it never checks whether the file still exists on disk. If session cleanup (or a manual delete) removes the session file while the process is still running, the next `fs.appendFileSync()` recreates it containing **only** the record being appended, with no leading metadata line. The recreated file then has message records but no `sessionId`, so `loadConversationRecord()` can never load it: a zombie session that `list`/`resume` silently ignore.

## Fix

Before appending, if the file is gone but the recorder still holds the in-memory `cachedConversation`, re-write the conversation's metadata line first, then append the record. The recreated file stays a valid, loadable session.

- The check is a single `fs.existsSync` per append and only does extra work in the (rare) deletion case.
- It does not fire during initial metadata creation (`cachedConversation` is not yet set) or normal appends (the file exists), so the happy path is unchanged.

## Testing

- Added a regression test in `chatRecordingService.test.ts`: initialize a session, record a message, delete the file mid-session, record another message, then load it. Verified it **fails before** this change (loader returns `null`) and **passes after**.
- `npx vitest run src/services/chatRecordingService.test.ts` → 51 passed.
- `eslint` (touched files) and `npm run typecheck` (packages/core) clean.