### PR TITLE
fix(cli): skip background session cleanup when listing sessions

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -666,10 +666,17 @@ export async function main() {
       registerCleanup(consolePatcher.cleanup);
     }
 
-    // Launch cleanup expired sessions as a background task
-    cleanupExpiredSessions(config, settings.merged).catch((e) => {
-      debugLogger.error('Failed to cleanup expired sessions:', e);
-    });
+    // Launch cleanup of expired sessions as a background task. Skip it when the
+    // run only reads or mutates the session list (--list-sessions /
+    // --delete-session): this unawaited cleanup deletes files in the same
+    // directory that listSessions scans, so running both at once makes the
+    // result depend on timing (a file can exist during readdir, then disappear
+    // before readFile).
+    if (!config.getListSessions() && !config.getDeleteSession()) {
+      cleanupExpiredSessions(config, settings.merged).catch((e) => {
+        debugLogger.error('Failed to cleanup expired sessions:', e);
+      });
+    }
 
     if (config.getListExtensions()) {
       debugLogger.log('Installed extensions:');

--- a/packages/cli/src/gemini_cleanup.test.tsx
+++ b/packages/cli/src/gemini_cleanup.test.tsx
@@ -169,6 +169,11 @@ vi.mock('./utils/readStdin.js', () => ({
   readStdin: vi.fn().mockResolvedValue(''),
 }));
 
+vi.mock('./utils/sessions.js', () => ({
+  listSessions: vi.fn().mockResolvedValue(undefined),
+  deleteSession: vi.fn().mockResolvedValue(undefined),
+}));
+
 const { cleanupMockState } = vi.hoisted(() => ({
   cleanupMockState: { shouldThrow: false, called: false },
 }));
@@ -419,6 +424,61 @@ describe('gemini.tsx main function cleanup', () => {
       .mocked(registerCleanup)
       .mock.calls.map((call) => call[0]);
     expect(registeredFunctions).toContain(capturedCleanup!);
+  });
+
+  it('should not run background session cleanup when listing sessions', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { listSessions } = await import('./utils/sessions.js');
+    const { ConsolePatcher } = await import('./ui/utils/ConsolePatcher.js');
+
+    cleanupMockState.called = false;
+    cleanupMockState.shouldThrow = false;
+
+    vi.mocked(ConsolePatcher).mockImplementation(
+      () =>
+        ({
+          patch: vi.fn(),
+          cleanup: vi.fn(),
+        }) as unknown as InstanceType<typeof ConsolePatcher>,
+    );
+
+    class ExitError extends Error {}
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new ExitError();
+    });
+
+    vi.mocked(loadSettings).mockReturnValue({
+      merged: { advanced: {}, security: { auth: {} }, ui: {} },
+      workspace: { settings: {} },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      errors: [],
+    } as unknown as ReturnType<typeof loadSettings>);
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      promptInteractive: false,
+    } as unknown as Awaited<ReturnType<typeof parseArguments>>);
+
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      buildMockConfig({
+        getListSessions: vi.fn(() => true),
+      }),
+    );
+
+    try {
+      await main();
+    } catch (e) {
+      if (!(e instanceof ExitError)) throw e;
+    }
+
+    // --list-sessions reads the session directory; the background cleanup task
+    // deletes files in that same directory, so running both concurrently makes
+    // the printed list depend on timing. Cleanup must be skipped while listing.
+    expect(cleanupMockState.called).toBe(false);
+    expect(vi.mocked(listSessions)).toHaveBeenCalled();
   });
 
   function buildMockConfig(overrides: Partial<Config> = {}): Config {


### PR DESCRIPTION
## Summary

Fixes #27273.

On startup, `cleanupExpiredSessions()` is launched as an **unawaited** background task. A few lines later, `--list-sessions` reads the same session directory via `listSessions()`. Because cleanup runs concurrently, it can delete files while listing is scanning them: a file can exist during `readdir` and then disappear before `readFile`, so the list shown to the user depends on timing rather than a stable snapshot.

## Fix

Skip the background cleanup when the run only reads or mutates the session list (`--list-sessions` / `--delete-session`). The list/delete commands then operate on a stable directory, and cleanup still runs as before on normal interactive/non-interactive startups.

This is the minimal version of the issue author's suggested options (skip cleanup for `--list-sessions`), with no added startup latency.

## Testing

- Added a test in `gemini_cleanup.test.tsx` asserting that the cleanup task is **not** invoked when `--list-sessions` is set (and `listSessions` still runs). Verified it **fails before** this change and **passes after**.
- `npx vitest run src/gemini_cleanup.test.tsx` → 4 passed (1 pre-existing skip).
- `eslint` (touched files) and `npm run typecheck` (packages/cli) clean.