### PR TITLE
fix(cli): make useLogger follow the active session ID after /clear

### DIFF
--- a/packages/cli/src/ui/hooks/useLogger.test.tsx
+++ b/packages/cli/src/ui/hooks/useLogger.test.tsx
@@ -53,4 +53,33 @@ describe('useLogger', () => {
     expect(result.current).not.toBeNull();
     expect(Logger).toHaveBeenCalledWith('active-session-id', mockStorage);
   });
+
+  it('should re-create the logger when the session ID changes (e.g. after /clear)', async () => {
+    const getSessionId = vi.fn().mockReturnValue('old-session-id');
+    const config = {
+      getSessionId,
+      storage: mockStorage,
+    } as unknown as Config;
+
+    const { rerender } = await renderHook(() => useLogger(config));
+
+    await act(async () => {
+      deferredInit.resolve();
+    });
+    expect(Logger).toHaveBeenLastCalledWith('old-session-id', mockStorage);
+
+    // Simulate /clear: a new session ID becomes active on the same config
+    // object, followed by a re-render.
+    getSessionId.mockReturnValue('new-session-id');
+    await act(async () => {
+      rerender();
+    });
+    await act(async () => {
+      deferredInit.resolve();
+    });
+
+    // Before the fix the effect only depended on the (unchanged) config object,
+    // so the logger kept the stale session ID.
+    expect(Logger).toHaveBeenLastCalledWith('new-session-id', mockStorage);
+  });
 });

--- a/packages/cli/src/ui/hooks/useLogger.ts
+++ b/packages/cli/src/ui/hooks/useLogger.ts
@@ -12,9 +12,14 @@ import { Logger, type Config } from '@google/gemini-cli-core';
  */
 export const useLogger = (config: Config): Logger | null => {
   const [logger, setLogger] = useState<Logger | null>(null);
+  // Depend on the session id value, not just the (stable) config object, so the
+  // logger follows the active session. `/clear` mints a new session id on the
+  // same config instance; without this the logger keeps writing under the old
+  // id and logs disagree with the current chat session.
+  const sessionId = config.getSessionId();
 
   useEffect(() => {
-    const newLogger = new Logger(config.getSessionId(), config.storage);
+    const newLogger = new Logger(sessionId, config.storage);
 
     /**
      * Start async initialization, no need to await. Using await slows down the
@@ -25,7 +30,7 @@ export const useLogger = (config: Config): Logger | null => {
       .initialize()
       .then(() => setLogger(newLogger))
       .catch(() => {});
-  }, [config]);
+  }, [config, sessionId]);
 
   return logger;
 };


### PR DESCRIPTION
## Summary

Fixes #27280.

`useLogger()` builds the `Logger` from `config.getSessionId()`, but its effect dependency array is only `[config]`. `/clear` mints a **new** session ID on the **same** `config` object (`resetNewSessionState`), so the dependency never changes and the effect never re-runs. The logger keeps writing under the old session ID, so the log files disagree with the current chat session — misleading when debugging.

## Fix

Read the session ID into a value and include it in the dependency array, so the logger is re-created with the new ID whenever the active session changes (after `/clear`, or any future session reset). Minimal change; the happy path (no session change) is unaffected.

## Testing

- Extended `useLogger.test.tsx` with a test that changes the session ID and re-renders, asserting the logger is re-created with the new ID. Verified it **fails before** this change (logger keeps the stale ID) and **passes after**.
- `npx vitest run src/ui/hooks/useLogger.test.tsx` → 2 passed.
- `eslint` (incl. react-hooks/exhaustive-deps) and `npm run typecheck` (packages/cli) clean.