### PR TITLE
fix(core): bound web search tool latency

### DIFF
--- a/packages/core/src/tools/web-search.test.ts
+++ b/packages/core/src/tools/web-search.test.ts
@@ -53,6 +53,7 @@ describe('WebSearchTool', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -149,6 +150,36 @@ describe('WebSearchTool', () => {
       expect(result.llmContent).toContain('Error:');
       expect(result.llmContent).toContain('API Failure');
       expect(result.returnDisplay).toBe('Error performing web search.');
+    });
+
+    it('should abort slow web searches after the tool timeout', async () => {
+      vi.useFakeTimers();
+      const params: WebSearchToolParams = { query: 'slow query' };
+      let receivedSignal: AbortSignal | undefined;
+
+      (mockGeminiClient.generateContent as Mock).mockImplementation(
+        (_modelConfig, _contents, signal: AbortSignal): Promise<never> => {
+          receivedSignal = signal;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => {
+              const error = new Error('aborted');
+              error.name = 'AbortError';
+              reject(error);
+            });
+          });
+        },
+      );
+
+      const invocation = tool.build(params);
+      const resultPromise = invocation.execute({ abortSignal });
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      const result = await resultPromise;
+
+      expect(receivedSignal?.aborted).toBe(true);
+      expect(result.error?.type).toBe(ToolErrorType.WEB_SEARCH_FAILED);
+      expect(result.llmContent).toContain('Web search timed out');
+      expect(result.returnDisplay).toBe('Search timed out.');
     });
 
     it('should correctly format results with sources and citations', async () => {

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -25,6 +25,8 @@ import { resolveToolDeclaration } from './definitions/resolver.js';
 import { LlmRole } from '../telemetry/llmRole.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 
+const WEB_SEARCH_TIMEOUT_MS = 2 * 60 * 1000;
+
 interface GroundingChunkWeb {
   uri?: string;
   title?: string;
@@ -67,6 +69,40 @@ export interface WebSearchToolResult extends ToolResult {
     : GroundingChunkItem[];
 }
 
+function createTimedSignal(signal: AbortSignal): {
+  signal: AbortSignal;
+  didTimeout: () => boolean;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  let didTimeout = false;
+
+  const abortFromParent = () => {
+    controller.abort(signal.reason);
+  };
+
+  const timeoutId = setTimeout(() => {
+    didTimeout = true;
+    controller.abort(
+      new Error(`Web search timed out after ${WEB_SEARCH_TIMEOUT_MS / 1000}s`),
+    );
+  }, WEB_SEARCH_TIMEOUT_MS);
+
+  signal.addEventListener('abort', abortFromParent, { once: true });
+  if (signal.aborted) {
+    abortFromParent();
+  }
+
+  return {
+    signal: controller.signal,
+    didTimeout: () => didTimeout,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener('abort', abortFromParent);
+    },
+  };
+}
+
 class WebSearchToolInvocation extends BaseToolInvocation<
   WebSearchToolParams,
   WebSearchToolResult
@@ -89,12 +125,13 @@ class WebSearchToolInvocation extends BaseToolInvocation<
     abortSignal: signal,
   }: ExecuteOptions): Promise<WebSearchToolResult> {
     const geminiClient = this.context.geminiClient;
+    const timedSignal = createTimedSignal(signal);
 
     try {
       const response = await geminiClient.generateContent(
         { model: 'web-search' },
         [{ role: 'user', parts: [{ text: this.params.query }] }],
-        signal,
+        timedSignal.signal,
         LlmRole.UTILITY_TOOL,
       );
 
@@ -178,6 +215,20 @@ class WebSearchToolInvocation extends BaseToolInvocation<
         sources,
       };
     } catch (error: unknown) {
+      if (timedSignal.didTimeout()) {
+        const errorMessage = `Web search timed out after ${
+          WEB_SEARCH_TIMEOUT_MS / 1000
+        }s for query "${this.params.query}"`;
+        debugLogger.warn(errorMessage, error);
+        return {
+          llmContent: `Error: ${errorMessage}`,
+          returnDisplay: 'Search timed out.',
+          error: {
+            message: errorMessage,
+            type: ToolErrorType.WEB_SEARCH_FAILED,
+          },
+        };
+      }
       if (isAbortError(error)) {
         return {
           llmContent: 'Web search was cancelled.',
@@ -196,6 +247,8 @@ class WebSearchToolInvocation extends BaseToolInvocation<
           type: ToolErrorType.WEB_SEARCH_FAILED,
         },
       };
+    } finally {
+      timedSignal.cleanup();
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a 120s local timeout around the `google_web_search` utility call
- abort the underlying `generateContent` request when the timeout fires
- return a clear tool error so the agent can recover instead of waiting forever

Fixes #27890

## To verify
- `npx prettier --check packages/core/src/tools/web-search.ts packages/core/src/tools/web-search.test.ts`
- `npx eslint packages/core/src/tools/web-search.ts packages/core/src/tools/web-search.test.ts --max-warnings 0`
- `npm run typecheck --workspace=@google/gemini-cli-core -- --pretty false`
- `npm run test --workspace=@google/gemini-cli-core -- web-search.test.ts`
