### PR TITLE
fix(core): recover sessions with a corrupt or missing metadata line

### DIFF
--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -341,6 +341,31 @@ describe('ChatRecordingService', () => {
       expect(conversation?.messages).toHaveLength(1);
       expect(conversation?.messages[0].id).toBe('msg-1');
     });
+
+    it('recovers a session whose metadata line is corrupt by deriving the id from the file name', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'session-corrupt-meta.jsonl');
+
+      // A truncated/corrupt first metadata line (its parse error is swallowed),
+      // followed by a valid user message on its own line.
+      const corruptMetadataLine = '{"sessionId":"abc","projec';
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'user',
+        content: 'hello world',
+      });
+      fs.writeFileSync(sessionFile, `${corruptMetadataLine}\n${messageLine}\n`);
+
+      const conversation = await loadConversationRecord(sessionFile);
+
+      // Before the fix the unparseable metadata line left no session identity,
+      // so the loader returned null and the whole conversation disappeared.
+      expect(conversation).not.toBeNull();
+      expect(conversation?.sessionId).toBe('session-corrupt-meta');
+      expect(conversation?.messages).toHaveLength(1);
+      expect(conversation?.messages[0].id).toBe('msg-1');
+    });
   });
 
   describe('recordMessage', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -310,6 +310,39 @@ describe('ChatRecordingService', () => {
     });
   });
 
+  describe('loadConversationRecord projectHash robustness', () => {
+    it('loads a JSONL session whose metadata line is missing projectHash', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'session-no-project-hash.jsonl');
+
+      // Valid multi-line JSONL: an identity line that omits `projectHash`,
+      // followed by a real user message on its own line.
+      const metadataLine = JSON.stringify({
+        sessionId: 'session-without-hash',
+        startTime: '2026-01-01T00:00:00.000Z',
+        lastUpdated: '2026-01-01T00:00:00.000Z',
+      });
+      const messageLine = JSON.stringify({
+        id: 'msg-1',
+        type: 'user',
+        content: 'hello world',
+      });
+      fs.writeFileSync(sessionFile, `${metadataLine}\n${messageLine}\n`);
+
+      const conversation = await loadConversationRecord(sessionFile);
+
+      // Before the fix the loader fell back to the legacy whole-file
+      // JSON.parse, which throws on multi-line JSONL and returns null —
+      // hiding a real session just because one metadata field was absent.
+      expect(conversation).not.toBeNull();
+      expect(conversation?.sessionId).toBe('session-without-hash');
+      expect(conversation?.projectHash).toBe('');
+      expect(conversation?.messages).toHaveLength(1);
+      expect(conversation?.messages[0].id).toBe('msg-1');
+    });
+  });
+
   describe('recordMessage', () => {
     beforeEach(async () => {
       await chatRecordingService.initialize();

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -90,10 +90,11 @@ function isMetadataUpdateRecord(
 function isPartialMetadataRecord(
   record: unknown,
 ): record is PartialMetadataRecord {
-  return (
-    isStringProperty(record, 'sessionId') &&
-    isStringProperty(record, 'projectHash')
-  );
+  // The metadata/identity line is identified by its `sessionId`. `projectHash`
+  // is optional here: requiring it would leave a sessionId-only metadata line
+  // unrecognized, dropping the session identity and making the whole session
+  // unloadable (see loadConversationRecord's legacy fallback).
+  return isStringProperty(record, 'sessionId');
 }
 
 function isTextPart(part: unknown): part is { text: string } {
@@ -345,7 +346,13 @@ export async function loadConversationRecord(
       }
     }
 
-    if (!metadata.sessionId || !metadata.projectHash) {
+    // A missing `projectHash` must not make an otherwise-valid JSONL session
+    // unloadable. The legacy fallback parses the entire file with a single
+    // `JSON.parse`, which always throws on multi-line JSONL and returns null —
+    // so requiring `projectHash` here silently hides real sessions. Only fall
+    // back when we recovered no session identity at all; `projectHash` is
+    // useful metadata but optional for loading (defaulted below).
+    if (!metadata.sessionId) {
       return await parseLegacyRecordFallback(filePath, options);
     }
 
@@ -375,7 +382,7 @@ export async function loadConversationRecord(
 
     return {
       sessionId: metadata.sessionId,
-      projectHash: metadata.projectHash,
+      projectHash: metadata.projectHash ?? '',
       startTime: metadata.startTime || new Date().toISOString(),
       lastUpdated: metadata.lastUpdated || new Date().toISOString(),
       summary: metadata.summary,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -353,7 +353,19 @@ export async function loadConversationRecord(
     // back when we recovered no session identity at all; `projectHash` is
     // useful metadata but optional for loading (defaulted below).
     if (!metadata.sessionId) {
-      return await parseLegacyRecordFallback(filePath, options);
+      // The metadata/identity line can be missing or corrupt — its per-line
+      // parse error is swallowed in the loop above. Don't discard an entire
+      // conversation just because its first line is unreadable: if we still
+      // recovered message records, derive a stable session id from the file
+      // name so the session stays listable/resumable instead of vanishing.
+      const recoveredMessages = options?.metadataOnly
+        ? messageIds.length
+        : messagesMap.size;
+      if (recoveredMessages > 0) {
+        metadata.sessionId = path.basename(filePath, '.jsonl');
+      } else {
+        return await parseLegacyRecordFallback(filePath, options);
+      }
     }
 
     const loadedMessages = Array.from(messagesMap.values());

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -130,7 +130,7 @@ export interface MetadataUpdateRecord {
 
 export interface PartialMetadataRecord {
   sessionId: string;
-  projectHash: string;
+  projectHash?: string;
   startTime?: string;
   lastUpdated?: string;
   summary?: string;


### PR DESCRIPTION
> **Draft — builds on #27904.** This branch is stacked on the #27275 fix, so the diff currently includes that change too. Please review/merge #27904 first; I'll rebase this onto `main` (leaving only the recovery logic) and mark it ready once #27904 lands.

## Summary

Fixes #27276.

The JSONL reader swallows per-line parse errors — including on the first metadata/identity line. If that line is truncated or malformed, no `sessionId` is recovered, so the loader returns `null` and discards every valid message record that followed. A whole conversation silently disappears from the session list because of one unreadable line.

## Fix

When no session identity was recovered but valid message records exist, derive a stable session id from the file name (`path.basename(filePath, '.jsonl')`) instead of giving up. The conversation stays listable and resumable. If there are no recoverable records either, the legacy fallback path is preserved.

This complements #27275/#27904 (which makes `projectHash` optional for loading); together they make session loading resilient to missing/corrupt metadata.

## Testing

- Added a regression test: a session file with a truncated first metadata line plus a valid message line now loads (id derived from the file name) instead of returning `null`. Verified it **fails before** this change and **passes after**.
- `npx vitest run src/services/chatRecordingService.test.ts` → 52 passed.
- `eslint` (touched files) and `npm run typecheck` (packages/core) clean.