### PR TITLE
fix(cli): don't offer to resume a session that wasn't saved

### DIFF
--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -261,5 +261,46 @@ describe('<SessionSummaryDisplay />', () => {
       expect(output).toContain('was not saved');
       unmount();
     });
+
+    it('still shows how to remove the worktree when the session was not saved', async () => {
+      useSessionStatsMock.mockReturnValue({
+        stats: {
+          sessionId: 'test-session',
+          sessionStartTime: new Date(),
+          metrics: emptyMetrics,
+          lastPromptTokenCount: 0,
+          promptCount: 5,
+        },
+        getPromptCount: () => 5,
+        startNewPrompt: vi.fn(),
+      } as unknown as ReturnType<typeof SessionContext.useSessionStats>);
+
+      vi.mocked(useConfig).mockReturnValue({
+        getWorktreeSettings: () => ({
+          name: 'foo-bar',
+          path: '/path/to/foo-bar',
+          baseSha: 'base-sha',
+        }),
+        getGeminiClient: () => ({
+          getChatRecordingService: () => ({
+            getConversationFilePath: () => null,
+          }),
+        }),
+      } as never);
+
+      const { lastFrame, waitUntilReady, unmount } = await renderWithProviders(
+        <SessionSummaryDisplay duration="1h 23m 45s" />,
+        { width: 100 },
+      );
+      await waitUntilReady();
+      const output = lastFrame();
+
+      // The worktree exists on disk even though the session wasn't saved, so
+      // the removal instruction must still be shown — but not a resume command.
+      expect(output).not.toContain('gemini --resume');
+      expect(output).toContain('was not saved');
+      expect(output).toContain('git worktree remove /path/to/foo-bar');
+      unmount();
+    });
   });
 });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.test.tsx
@@ -66,6 +66,11 @@ const renderWithMockedStats = async (
 
   vi.mocked(useConfig).mockReturnValue({
     getWorktreeSettings: () => worktreeSettings,
+    getGeminiClient: () => ({
+      getChatRecordingService: () => ({
+        getConversationFilePath: () => '/tmp/session.jsonl',
+      }),
+    }),
   } as never);
 
   const result = await renderWithProviders(
@@ -217,6 +222,43 @@ describe('<SessionSummaryDisplay />', () => {
       expect(output).toContain(
         'To remove manually: git worktree remove /path/to/foo-bar',
       );
+      unmount();
+    });
+  });
+
+  describe('Recording disabled', () => {
+    it('does not offer to resume when the session was not saved', async () => {
+      useSessionStatsMock.mockReturnValue({
+        stats: {
+          sessionId: 'test-session',
+          sessionStartTime: new Date(),
+          metrics: emptyMetrics,
+          lastPromptTokenCount: 0,
+          promptCount: 5,
+        },
+        getPromptCount: () => 5,
+        startNewPrompt: vi.fn(),
+      } as unknown as ReturnType<typeof SessionContext.useSessionStats>);
+
+      // Recorder is present but has no active file => recording was disabled.
+      vi.mocked(useConfig).mockReturnValue({
+        getWorktreeSettings: () => undefined,
+        getGeminiClient: () => ({
+          getChatRecordingService: () => ({
+            getConversationFilePath: () => null,
+          }),
+        }),
+      } as never);
+
+      const { lastFrame, waitUntilReady, unmount } = await renderWithProviders(
+        <SessionSummaryDisplay duration="1h 23m 45s" />,
+        { width: 100 },
+      );
+      await waitUntilReady();
+      const output = lastFrame();
+
+      expect(output).not.toContain('gemini --resume');
+      expect(output).toContain('was not saved');
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -27,6 +27,13 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
 
   const worktreeSettings = config.getWorktreeSettings();
 
+  // If the recorder is present but has no active file (e.g. recording was
+  // disabled by a disk-full error), the session was not saved — don't print a
+  // misleading resume command. If we can't tell, keep the resume hint.
+  const recordingService = config.getGeminiClient()?.getChatRecordingService();
+  const sessionNotSaved =
+    recordingService != null && !recordingService.getConversationFilePath();
+
   const escapedSessionId = escapeShellArg(stats.sessionId, shell);
   const footerSessionId =
     isWindows() &&
@@ -34,9 +41,11 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
     !escapedSessionId.startsWith("'")
       ? `"${escapedSessionId}"`
       : escapedSessionId;
-  let footer = `To resume this session: gemini --resume ${footerSessionId}`;
+  let footer = sessionNotSaved
+    ? 'This session was not saved and cannot be resumed.'
+    : `To resume this session: gemini --resume ${footerSessionId}`;
 
-  if (worktreeSettings) {
+  if (worktreeSettings && !sessionNotSaved) {
     footer =
       `To resume work in this worktree: cd ${escapeShellArg(worktreeSettings.path, shell)} && gemini --resume ${footerSessionId}\n` +
       `To remove manually: git worktree remove ${escapeShellArg(worktreeSettings.path, shell)}`;

--- a/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/SessionSummaryDisplay.tsx
@@ -45,10 +45,13 @@ export const SessionSummaryDisplay: React.FC<SessionSummaryDisplayProps> = ({
     ? 'This session was not saved and cannot be resumed.'
     : `To resume this session: gemini --resume ${footerSessionId}`;
 
-  if (worktreeSettings && !sessionNotSaved) {
-    footer =
-      `To resume work in this worktree: cd ${escapeShellArg(worktreeSettings.path, shell)} && gemini --resume ${footerSessionId}\n` +
-      `To remove manually: git worktree remove ${escapeShellArg(worktreeSettings.path, shell)}`;
+  if (worktreeSettings) {
+    // The worktree exists on disk regardless of whether the session was saved,
+    // so always show how to remove it — but only offer to resume when saved.
+    const removeManually = `To remove manually: git worktree remove ${escapeShellArg(worktreeSettings.path, shell)}`;
+    footer = sessionNotSaved
+      ? `${footer}\n${removeManually}`
+      : `To resume work in this worktree: cd ${escapeShellArg(worktreeSettings.path, shell)} && gemini --resume ${footerSessionId}\n${removeManually}`;
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixes #27277 (the user-facing half).

When a write hits `ENOSPC`, the chat recorder disables itself (`conversationFile` set to `null`) and stops saving — but the runtime session id still exists, so the exit summary kept printing:

> To resume this session: gemini --resume &lt;id&gt;

…for a session that was never written to disk. Running that command then fails, and the user has no indication their conversation wasn't saved.

## Fix

In `SessionSummaryDisplay`, if the recorder is present but has no active conversation file, show that the session was not saved instead of a resume command. When the recorder state can't be determined, the resume hint is unchanged (no regression).

Scoped to the misleading exit summary — the surgical, clearly-correct part of the issue. (I left the broader "surface a live warning mid-session" idea out, as it's a separate UX decision.)

## Testing

- Added a test asserting the footer omits `gemini --resume` and states the session "was not saved" when the recorder has no file. Verified it **fails before** this change and **passes after**; all existing `SessionSummaryDisplay` tests (incl. the snapshot) still pass (7 total).
- `eslint` (touched files) and `npm run typecheck` (packages/cli) clean.