### PR TITLE
fix(vscode-ide-companion): add missing activate() Disposables

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { activate } from './extension.js';
+import { activate, deactivate } from './extension.js';
 import {
   IDE_DEFINITIONS,
   detectIdeFromEnv,
@@ -26,6 +26,7 @@ vi.mock('vscode', () => ({
   window: {
     createOutputChannel: vi.fn(() => ({
       appendLine: vi.fn(),
+      dispose: vi.fn(),
     })),
     showInformationMessage: vi.fn(),
     createTerminal: vi.fn(() => ({
@@ -114,7 +115,8 @@ describe('activate', () => {
     } as unknown as vscode.ExtensionContext;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await deactivate();
     vi.restoreAllMocks();
   });
 

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -43,16 +43,31 @@ vi.mock('vscode', () => ({
   },
   workspace: {
     workspaceFolders: [],
-    onDidCloseTextDocument: vi.fn(),
-    registerTextDocumentContentProvider: vi.fn(),
-    onDidChangeWorkspaceFolders: vi.fn(),
-    onDidGrantWorkspaceTrust: vi.fn(),
+    onDidCloseTextDocument: vi.fn(() => ({
+      __id: 'onDidCloseTextDocument',
+      dispose: vi.fn(),
+    })),
+    registerTextDocumentContentProvider: vi.fn(() => ({
+      __id: 'registerTextDocumentContentProvider',
+      dispose: vi.fn(),
+    })),
+    onDidChangeWorkspaceFolders: vi.fn(() => ({
+      __id: 'onDidChangeWorkspaceFolders',
+      dispose: vi.fn(),
+    })),
+    onDidGrantWorkspaceTrust: vi.fn(() => ({
+      __id: 'onDidGrantWorkspaceTrust',
+      dispose: vi.fn(),
+    })),
     getConfiguration: vi.fn(() => ({
       get: vi.fn(),
     })),
   },
   commands: {
-    registerCommand: vi.fn(),
+    registerCommand: vi.fn((command: string) => ({
+      __id: command,
+      dispose: vi.fn(),
+    })),
     executeCommand: vi.fn(),
   },
   Uri: {
@@ -129,6 +144,17 @@ describe('activate', () => {
   it('should register a handler for onDidGrantWorkspaceTrust', async () => {
     await activate(context);
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
+  });
+
+  it('adds every registered disposable to context.subscriptions', async () => {
+    await activate(context);
+    const ids = context.subscriptions.map(
+      (d) => (d as unknown as { __id?: string }).__id,
+    );
+    expect(ids).toContain('gemini.diff.accept');
+    expect(ids).toContain('gemini.diff.cancel');
+    expect(ids).toContain('onDidChangeWorkspaceFolders');
+    expect(ids).toContain('onDidGrantWorkspaceTrust');
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

`activate()` in the VS Code companion extension wraps two groups of
registrations in an extra pair of parentheses, which turns each group into a
JavaScript **comma expression** instead of separate arguments to
`context.subscriptions.push(...)`. A comma expression evaluates both operands
but yields only the last one, so the **first** registration in each group runs
but its `Disposable` is never pushed onto `context.subscriptions` — and is
therefore never disposed on deactivation.

Two Disposables leak today:

- the `gemini.diff.accept` command, and
- the `onDidChangeWorkspaceFolders` listener.

Impact:

- On deactivation/reload within the same extension host (e.g. an extension
  update), `gemini.diff.accept` stays registered. Re-activation then throws
  `command 'gemini.diff.accept' already exists`.
- The `onDidChangeWorkspaceFolders` listener is never torn down, so a stale
  listener keeps calling `ideServer.syncEnvVars()` against an `IDEServer` that
  has already been stopped.

## Details

The two offending groups in `packages/vscode-ide-companion/src/extension.ts`:

```ts
// group 1
(vscode.commands.registerCommand('gemini.diff.accept', ...),
 vscode.commands.registerCommand('gemini.diff.cancel', ...)),

// group 2
(vscode.workspace.onDidChangeWorkspaceFolders(...),
 vscode.workspace.onDidGrantWorkspaceTrust(...)),
```

The surrounding registrations in the same two `push()` calls already use the
flat one-argument-per-Disposable style, which is what makes the two
parenthesized groups stand out as unintended. The fix removes the stray `(` / `)`
around each group so every registration is its own argument to `push()`.

This is a platform-independent defect (JavaScript comma-operator semantics),
present since the companion extension was introduced.

## Related Issues

Closes #27790

## How to Validate

```
npm test -w packages/vscode-ide-companion -- src/extension.test.ts
```

This PR adds a regression test, `adds every registered disposable to
context.subscriptions`, to `extension.test.ts`. The existing `vscode` mock
returned `undefined` from `registerCommand` / the workspace listeners, which is
why the leak was invisible to the suite; the mock now returns a tagged
`Disposable` so the test can assert what actually lands in
`context.subscriptions`.

- Without the fix, the new test fails — `context.subscriptions` is missing
  `gemini.diff.accept` and `onDidChangeWorkspaceFolders`
  (`expected [ 'onDidCloseTextDocument', …(5) ] to include 'gemini.diff.accept'`);
  the suite reports `1 failed | 11 passed`.
- With the fix, all four registrations (`gemini.diff.accept`,
  `gemini.diff.cancel`, `onDidChangeWorkspaceFolders`,
  `onDidGrantWorkspaceTrust`) are present and the suite reports `12 passed`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
