### PR TITLE
ci: use internal environment for scheduled nightly releases (#27865)

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -39,7 +39,7 @@ jobs:
   release:
     if: "github.repository == 'google-gemini/gemini-cli'"
     needs: ['build-mac']
-    environment: "${{ github.event.inputs.environment || 'prod' }}"
+    environment: "${{ github.event_name == 'schedule' && 'internal' || github.event.inputs.environment || 'prod' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       contents: 'write'


### PR DESCRIPTION
## Summary

Fixes the nightly release workflow stall by using an unprotected environment for scheduled runs.

## Details

Nightly releases were stalling because they defaulted to the `prod` environment, which requires manual approval from the `Gemini CLI AskMode Approvers` team. Scheduled runs (cron) cannot be manually approved, causing the workflow to hang indefinitely.

This PR updates `.github/workflows/release-nightly.yml` to use the `internal` environment (which has no protection rules) for scheduled triggers. Manual `workflow_dispatch` runs will still use the user-provided environment (defaulting to `prod`).

## Related Issues

Fixes #27865

## How to Validate

1. Trigger a dry-run with `environment=prod`: It should wait for manual approval.
1. Trigger a dry-run with `environment=dev`: It should proceed without approval.
1. The next scheduled nightly run should now proceed automatically.

I have already verified this behavior with dry-runs:

- `prod` (waiting): https://github.com/google-gemini/gemini-cli/actions/runs/27530241524
- `dev` (proceeding): https://github.com/google-gemini/gemini-cli/actions/runs/27530241470

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) - N/A (CI/CD change)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
