### PR TITLE
fix(core): remove leading space in camelToSpace for capitalized keys

### DIFF
--- a/packages/core/src/utils/markdownUtils.test.ts
+++ b/packages/core/src/utils/markdownUtils.test.ts
@@ -29,6 +29,13 @@ describe('markdownUtils', () => {
       );
     });
 
+    it('should not add a leading space for keys starting with an uppercase letter', () => {
+      const data = { Id: 1, HTTPStatus: 'OK' };
+      expect(jsonToMarkdown(data)).toBe(
+        '- **Id**: 1\n- **H T T P Status**: OK',
+      );
+    });
+
     it('should handle empty structures', () => {
       expect(jsonToMarkdown([])).toBe('[]');
       expect(jsonToMarkdown({})).toBe('{}');

--- a/packages/core/src/utils/markdownUtils.ts
+++ b/packages/core/src/utils/markdownUtils.ts
@@ -9,8 +9,8 @@
  * e.g., "camelCaseString" -> "Camel Case String"
  */
 function camelToSpace(text: string): string {
-  const result = text.replace(/([A-Z])/g, ' $1');
-  return result.charAt(0).toUpperCase() + result.slice(1).trim();
+  const result = text.replace(/([A-Z])/g, ' $1').trim();
+  return result.charAt(0).toUpperCase() + result.slice(1);
 }
 
 /**


### PR DESCRIPTION
camelToSpace inserted a space before every uppercase letter, including the first character of keys that already start with an uppercase letter (e.g. "Id", "HTTPStatus"). The trailing .trim() only applied to result.slice(1), so the inserted leading space survived, producing " Id" instead of "Id". This breaks markdown bold rendering for any JSON tool result containing capitalized keys (e.g. "- ** Id**: 123"), which is common for fields like Id, ID, URL, etc.

Trim the full result before splitting off the first character.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
