### PR TITLE
feat(core): Support GDC air-gapped Service Identity after auth library update

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -491,13 +491,13 @@ describe('createContentGenerator', () => {
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        googleAuthOptions: {
-          clientOptions: {
-            transporterOptions: {
+        googleAuthOptions: expect.objectContaining({
+          clientOptions: expect.objectContaining({
+            transporterOptions: expect.objectContaining({
               agent: expect.any(HttpsProxyAgent),
-            },
-          },
-        },
+            }),
+          }),
+        }),
       }),
     );
   });
@@ -527,13 +527,13 @@ describe('createContentGenerator', () => {
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        googleAuthOptions: {
-          clientOptions: {
-            transporterOptions: {
+        googleAuthOptions: expect.objectContaining({
+          clientOptions: expect.objectContaining({
+            transporterOptions: expect.objectContaining({
               agent: expect.any(HttpsProxyAgent),
-            },
-          },
-        },
+            }),
+          }),
+        }),
       }),
     );
   });
@@ -565,13 +565,13 @@ describe('createContentGenerator', () => {
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        googleAuthOptions: {
-          clientOptions: {
-            transporterOptions: {
+        googleAuthOptions: expect.objectContaining({
+          clientOptions: expect.objectContaining({
+            transporterOptions: expect.objectContaining({
               agent: expect.any(HttpProxyAgent),
-            },
-          },
-        },
+            }),
+          }),
+        }),
       }),
     );
   });
@@ -601,13 +601,13 @@ describe('createContentGenerator', () => {
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        googleAuthOptions: {
-          clientOptions: {
-            transporterOptions: {
+        googleAuthOptions: expect.objectContaining({
+          clientOptions: expect.objectContaining({
+            transporterOptions: expect.objectContaining({
               agent: expect.any(HttpsProxyAgent),
-            },
-          },
-        },
+            }),
+          }),
+        }),
       }),
     );
   });
@@ -981,6 +981,38 @@ describe('createContentGenerator', () => {
         vertexai: true,
         httpOptions: expect.objectContaining({
           baseUrl: 'https://vertex.test.local',
+        }),
+      }),
+    );
+  });
+
+  it('should inject apiEndpoint into googleAuthOptions.clientOptions when GOOGLE_VERTEX_BASE_URL is set', async () => {
+    const mockConfig = {
+      getModel: vi.fn().mockReturnValue('gemini-pro'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+      getUsageStatisticsEnabled: () => false,
+      getClientName: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const mockGenerator = {
+      models: {},
+    } as unknown as GoogleGenAI;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    vi.stubEnv('GOOGLE_VERTEX_BASE_URL', 'https://vertex.test.local');
+
+    await createContentGenerator(
+      {
+        authType: AuthType.USE_VERTEX_AI,
+      },
+      mockConfig,
+    );
+
+    expect(GoogleGenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        googleAuthOptions: expect.objectContaining({
+          clientOptions: expect.objectContaining({
+            apiEndpoint: 'https://vertex.test.local',
+          }),
         }),
       }),
     );

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -358,7 +358,6 @@ export async function createContentGenerator(
         : undefined;
       const useVertex =
         config.vertexai ?? config.authType === AuthType.USE_VERTEX_AI;
-      const vertexEndpoint = process.env['GOOGLE_VERTEX_BASE_URL'];
       const googleGenAI = new GoogleGenAI({
         apiKey:
           config.authType === AuthType.GATEWAY
@@ -370,15 +369,15 @@ export async function createContentGenerator(
         httpOptions,
         ...(apiVersionEnv && { apiVersion: apiVersionEnv }),
         // Merge proxy and GDCH endpoint into googleAuthOptions if either exists
-        ...((proxyAgent || (useVertex && vertexEndpoint)) && {
+        ...((proxyAgent || (useVertex && baseUrl)) && {
           googleAuthOptions: {
             clientOptions: {
               ...(proxyAgent && {
                 transporterOptions: { agent: proxyAgent },
               }),
               ...(useVertex &&
-                vertexEndpoint && {
-                  apiEndpoint: vertexEndpoint,
+                baseUrl && {
+                  apiEndpoint: baseUrl,
                 }),
             },
           },

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -356,7 +356,9 @@ export async function createContentGenerator(
           ? new HttpProxyAgent(proxyUrl)
           : new HttpsProxyAgent(proxyUrl)
         : undefined;
-
+      const useVertex =
+        config.vertexai ?? config.authType === AuthType.USE_VERTEX_AI;
+      const vertexEndpoint = process.env['GOOGLE_VERTEX_BASE_URL'];
       const googleGenAI = new GoogleGenAI({
         apiKey:
           config.authType === AuthType.GATEWAY
@@ -367,10 +369,17 @@ export async function createContentGenerator(
         vertexai: config.vertexai ?? config.authType === AuthType.USE_VERTEX_AI,
         httpOptions,
         ...(apiVersionEnv && { apiVersion: apiVersionEnv }),
-        ...(proxyAgent && {
+        // Merge proxy and GDCH endpoint into googleAuthOptions if either exists
+        ...((proxyAgent || (useVertex && vertexEndpoint)) && {
           googleAuthOptions: {
             clientOptions: {
-              transporterOptions: { agent: proxyAgent },
+              ...(proxyAgent && {
+                transporterOptions: { agent: proxyAgent },
+              }),
+              ...(useVertex &&
+                vertexEndpoint && {
+                  apiEndpoint: vertexEndpoint,
+                }),
             },
           },
         }),


### PR DESCRIPTION
## Summary

Adds support for GDCH air-gapped service identity token exchange. The underlying `google-auth-library` was recently updated to v10.7.0 in `google-cloud-node` [PR](https://github.com/googleapis/google-cloud-node/pull/8428) which introduced support for this. This PR properly passes the `apiEndpoint` to `googleAuthOptions.clientOptions` when `GOOGLE_VERTEX_BASE_URL` is set, allowing the auth library to correctly perform STS token exchange in GDCH environments.

## Details

The logic wraps `apiEndpoint` appropriately in `clientOptions` inside `googleAuthOptions`. A new test case has also been added to `contentGenerator.test.ts` to assert that `apiEndpoint` is correctly populated.

## Related Issues
Fixes #27917 

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

1. Run the test suite for core: `npm test -w @google/gemini-cli-core -- src/core/contentGenerator.test.ts`
2. Test manually by setting `GOOGLE_VERTEX_BASE_URL` and verifying if the generated GoogleAuth instance includes the `apiEndpoint`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
