### PR TITLE
docs: clarify GEMINI_CLI_HOME settings path

### DIFF
--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -223,7 +223,9 @@ directory.
 By default, Gemini CLI stores configuration and history in `~/.gemini`. You can
 use the `GEMINI_CLI_HOME` environment variable to point to a unique directory
 for a specific user or job. The CLI will create a `.gemini` folder inside the
-specified path.
+specified path. When you provide your own settings file, place it in that
+generated directory, for example `$GEMINI_CLI_HOME/.gemini/settings.json` on
+macOS/Linux or `%GEMINI_CLI_HOME%\.gemini\settings.json` on Windows.
 
 **macOS/Linux**
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2434,6 +2434,9 @@ the `advanced.excludedEnvVars` setting in your `settings.json` file.
     storage.
   - By default, this is the user's system home directory. The CLI will create a
     `.gemini` folder inside this directory.
+  - User-level settings are still loaded from a `.gemini` subdirectory. For
+    example, if `GEMINI_CLI_HOME` is set to `/path/to/user/config`, place
+    `settings.json` at `/path/to/user/config/.gemini/settings.json`.
   - Useful for shared compute environments or keeping CLI state isolated.
   - Example: `export GEMINI_CLI_HOME="/path/to/user/config"` (Windows
     PowerShell: `$env:GEMINI_CLI_HOME="C:\path\to\user\config"`)


### PR DESCRIPTION
## Summary
- Clarify that `GEMINI_CLI_HOME` points to the parent directory for user-level state
- Document that user settings should be placed at `$GEMINI_CLI_HOME/.gemini/settings.json`
- Add the same path guidance to the enterprise user isolation docs

Fixes #23622

## Testing
- `npm exec --yes prettier -- --check docs/reference/configuration.md docs/cli/enterprise.md`