### PR TITLE
fix(core): preserve newlines when truncating multi-line text

### DIFF
--- a/packages/core/src/utils/textUtils.test.ts
+++ b/packages/core/src/utils/textUtils.test.ts
@@ -143,6 +143,11 @@ describe('truncateString', () => {
     // Truncating combinedChar (len 2) at maxLength 2: fits perfectly.
     expect(truncateString(combinedChar, 2, '')).toBe(combinedChar);
   });
+
+  it('preserves newlines in multi-line input', () => {
+    const str = 'line1\nline2\nline3\nline4\nline5';
+    expect(truncateString(str, 12, '')).toBe('line1\nline2\n');
+  });
 });
 
 describe('safeTemplateReplace', () => {

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -115,8 +115,10 @@ export function truncateString(
   // This regex matches a "Grapheme Cluster" manually:
   // 1. A surrogate pair OR a single character...
   // 2. Followed by any number of "Combining Marks" (\p{M})
-  // 'u' flag is required for Unicode property escapes
-  const graphemeRegex = /(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|.)\p{M}*/gu;
+  // 'u' flag is required for Unicode property escapes.
+  // 's' (dotAll) flag lets '.' match line terminators so newlines are
+  // treated as their own grapheme and preserved instead of being dropped.
+  const graphemeRegex = /(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|.)\p{M}*/gsu;
 
   let truncatedStr = '';
   let match: RegExpExecArray | null;


### PR DESCRIPTION
## Summary

`truncateString` silently deletes every newline (and other line terminator) from multi-line input. The grapheme regex it iterates with uses `.` without the dotAll flag, so `\n`, `\r`, ` ` and ` ` never match a grapheme cluster and get skipped over by the global `exec` loop. The result is that a truncated block of shell output, web-fetch page text, or telemetry log collapses into a single line.

## Details

The regex at `packages/core/src/utils/textUtils.ts` was:

```
/(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|.)\p{M}*/gu
```

`.` does not match line terminators without the `s` flag, so newlines are neither counted toward `maxLength` nor copied into the output. Adding the `s` (dotAll) flag makes each newline its own grapheme, so it is counted and preserved like any other character. This is the only change; surrogate-pair and combining-mark handling is untouched.

Every caller truncates multi-line text where dropping newlines is wrong: background shell output (`shellExecutionService`), fetched page content (`web-fetch`), and telemetry attributes (`trace`/`semantic`).

## How to Validate

```
npm ci
npx vitest run packages/core/src/utils/textUtils.test.ts
```

Added a regression test in `truncateString`:

```
truncateString('line1\nline2\nline3\nline4\nline5', 12, '')
```

Before: `'line1line2li'` (newlines gone). After: `'line1\nline2\n'`.

All 50 tests in `textUtils.test.ts` pass, plus the `trace` and `web-fetch` suites (78 tests) that exercise the callers. Lint is clean.
