### PR TITLE
fix(mcp): scope resource resolution to prevent cross-server URI confusion

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -915,5 +915,86 @@ describe('McpClientManager', () => {
       const result = manager.findResourceByUri('non-existent');
       expect(result).toBeUndefined();
     });
+
+    it('should fail closed when multiple servers expose the same URI', () => {
+      const resourceFromServerA = {
+        uri: 'test://shared-resource',
+        name: 'Trusted Resource',
+        serverName: 'server-a',
+      };
+      const resourceFromServerB = {
+        uri: 'test://shared-resource',
+        name: 'Malicious Resource',
+        serverName: 'server-b',
+      };
+      const mockResourceRegistry = {
+        getAllResources: vi
+          .fn()
+          .mockReturnValue([resourceFromServerA, resourceFromServerB]),
+        findResourceByUri: vi.fn().mockReturnValue(undefined),
+      };
+      mockConfig.getResourceRegistry.mockReturnValue(
+        mockResourceRegistry as unknown as ResourceRegistry,
+      );
+
+      const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+
+      const result = manager.findResourceByUri('test://shared-resource');
+      expect(result).toBeUndefined();
+    });
+
+    it('should still resolve a direct URI match when only one server exposes it', () => {
+      const resource = {
+        uri: 'test://unique-resource',
+        name: 'Resource',
+        serverName: 'server-a',
+      };
+      const mockResourceRegistry = {
+        getAllResources: vi.fn().mockReturnValue([resource]),
+        findResourceByUri: vi.fn().mockReturnValue(undefined),
+      };
+      mockConfig.getResourceRegistry.mockReturnValue(
+        mockResourceRegistry as unknown as ResourceRegistry,
+      );
+
+      const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+
+      const result = manager.findResourceByUri('test://unique-resource');
+      expect(result).toBe(resource);
+    });
+
+    it('should not be affected by collisions on a different URI', () => {
+      const resourceA = {
+        uri: 'test://resource-a',
+        name: 'Resource A',
+        serverName: 'server-a',
+      };
+      const resourceB1 = {
+        uri: 'test://shared-resource',
+        name: 'Shared 1',
+        serverName: 'server-b',
+      };
+      const resourceB2 = {
+        uri: 'test://shared-resource',
+        name: 'Shared 2',
+        serverName: 'server-c',
+      };
+      const mockResourceRegistry = {
+        getAllResources: vi
+          .fn()
+          .mockReturnValue([resourceA, resourceB1, resourceB2]),
+        findResourceByUri: vi.fn().mockReturnValue(undefined),
+      };
+      mockConfig.getResourceRegistry.mockReturnValue(
+        mockResourceRegistry as unknown as ResourceRegistry,
+      );
+
+      const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+
+      expect(manager.findResourceByUri('test://resource-a')).toBe(resourceA);
+      expect(
+        manager.findResourceByUri('test://shared-resource'),
+      ).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -181,10 +181,23 @@ export class McpClientManager {
       return qualifiedMatch;
     }
 
-    // Try direct URI match
-    return this.mainResourceRegistry
+    // Try direct URI match. Only resolve if exactly one server exposes this
+    // URI - if multiple servers collide on the same URI, resolving silently
+    // to the first match would let one server shadow another's resource, so
+    // fail closed instead.
+    const directMatches = this.mainResourceRegistry
       .getAllResources()
-      .find((r) => r.uri === uri);
+      .filter((r) => r.uri === uri);
+    if (directMatches.length > 1) {
+      const servers = directMatches.map((r) => r.serverName).join(', ');
+      this.emitDiagnostic(
+        'warning',
+        `Resource URI collision detected for "${uri}" across multiple servers (${servers}). ` +
+          `Resolution disabled to prevent cross-server shadowing.`,
+      );
+      return undefined;
+    }
+    return directMatches.length === 1 ? directMatches[0] : undefined;
   }
 
   getAllResources(): MCPResource[] {

--- a/packages/core/src/tools/read-mcp-resource.test.ts
+++ b/packages/core/src/tools/read-mcp-resource.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { ReadMcpResourceTool } from './read-mcp-resource.js';
 import { ToolErrorType } from './tool-error.js';
+import { ToolConfirmationOutcome } from './tools.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 
@@ -190,5 +191,54 @@ describe('ReadMcpResourceTool', () => {
 
     expect(result.error?.type).toBe(ToolErrorType.MCP_TOOL_ERROR);
     expect(result.error?.message).toContain('Failed to read resource');
+  });
+
+  describe('getPolicyUpdateOptions', () => {
+    it('should scope the policy update to the resolved server', () => {
+      const uri = 'protocol://resource';
+      const serverName = 'test-server';
+
+      mockMcpManager.findResourceByUri.mockReturnValue({
+        uri,
+        serverName,
+        name: 'Test Resource',
+      });
+
+      const invocation = (
+        tool as unknown as {
+          createInvocation: (params: Record<string, unknown>) => {
+            getPolicyUpdateOptions: (
+              outcome: ToolConfirmationOutcome,
+            ) => { mcpName?: string } | undefined;
+          };
+        }
+      ).createInvocation({ uri });
+
+      expect(
+        invocation.getPolicyUpdateOptions(
+          ToolConfirmationOutcome.ProceedAlways,
+        ),
+      ).toEqual({ mcpName: serverName });
+    });
+
+    it('should return undefined when no resource was resolved', () => {
+      mockMcpManager.findResourceByUri.mockReturnValue(undefined);
+
+      const invocation = (
+        tool as unknown as {
+          createInvocation: (params: Record<string, unknown>) => {
+            getPolicyUpdateOptions: (
+              outcome: ToolConfirmationOutcome,
+            ) => { mcpName?: string } | undefined;
+          };
+        }
+      ).createInvocation({ uri: 'uri' });
+
+      expect(
+        invocation.getPolicyUpdateOptions(
+          ToolConfirmationOutcome.ProceedAlways,
+        ),
+      ).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/tools/read-mcp-resource.ts
+++ b/packages/core/src/tools/read-mcp-resource.ts
@@ -10,6 +10,8 @@ import {
   Kind,
   type ToolResult,
   type ExecuteOptions,
+  type ToolConfirmationOutcome,
+  type PolicyUpdateOptions,
 } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { READ_MCP_RESOURCE_TOOL_NAME } from './tool-names.js';
@@ -78,6 +80,14 @@ class ReadMcpResourceToolInvocation extends BaseToolInvocation<
     return `Read MCP resource: ${this.params.uri}`;
   }
 
+  override getPolicyUpdateOptions(
+    _outcome: ToolConfirmationOutcome,
+  ): PolicyUpdateOptions | undefined {
+    return this.resource?.serverName
+      ? { mcpName: this.resource.serverName }
+      : undefined;
+  }
+
   async execute({
     abortSignal: _abortSignal,
   }: ExecuteOptions): Promise<ToolResult> {
@@ -105,7 +115,12 @@ class ReadMcpResourceToolInvocation extends BaseToolInvocation<
       };
     }
 
-    const resource = mcpManager.findResourceByUri(uri);
+    // Use the resource resolved at construction time (this.resource) rather than
+    // re-resolving via findResourceByUri(). Re-resolving could return a different
+    // server's resource if the registry state changed between construction and
+    // execution, which would bypass the server-scoped policy set by
+    // getPolicyUpdateOptions() and create a TOCTOU scoping inconsistency.
+    const resource = this.resource;
     if (!resource) {
       const errorMessage = `Resource not found for URI: ${uri}`;
       return {


### PR DESCRIPTION
An unscoped `findResourceByUri` fallback returned the first cross-server match on a colliding URI, letting a second connected MCP server silently shadow a trusted server's resource. Resolution now fails closed when more than one server exposes the same URI, and the `read_mcp_resource` Always-Allow approval is scoped to the server that actually resolved.

## Summary

`McpClientManager.findResourceByUri` fell back to scanning all discovered resources for a direct URI match and returned the first hit, with no server scoping. If a second, lower-trust server exposed a resource at a URI colliding with a trusted server's, `read_mcp_resource` could read and return content from the wrong server — with no indication to the user or the model. gemini-cli already namespaces MCP *tools* per server; this brings *resources* in line.

## Details

- `packages/core/src/tools/mcp-client-manager.ts` the direct-URI fallback now collects all matching resources and resolves **only** when exactly one server exposes the URI; if two or more servers collide on the same URI it fails closed (returns `undefined`) instead of silently picking the first.
- `packages/core/src/tools/read-mcp-resource.ts` -`ReadMcpResourceToolInvocation` now overrides `getPolicyUpdateOptions` to return `{ mcpName: resolvedServerName }`, so an "Always Allow" approval is scoped to the resolving server instead of blanket-approving `read_mcp_resource` for every MCP server.
- Regression tests added for both behaviors.

## Related Issues

Reported via Google OSS VRP - Issue **524559480**.

## How to Validate
npm run test --workspace packages/core -- mcp-client-manager read-mcp-resource

Expected: a cross-server URI collision resolves to `undefined`; a single-server match still resolves; an unrelated URI is unaffected by a collision elsewhere; `getPolicyUpdateOptions` returns `{ mcpName }` when a resource resolved and `undefined` otherwise. The two added test files pass 48/48 locally.

## Follow-ups (out of scope here)
- Rework the `resource-registry.ts` qualified-lookup parser (it splits on the first colon, which collides with URI schemes).
- Expose an optional `serverName` parameter on the `read_mcp_resource` schema so reads can be explicitly bound to a server.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests
- [x] Noted breaking changes (none)
- [ ] Validated on required platforms/methods (Linux: npm run — local `npm run preflight` clean; two pre-existing `packages/cli` failures are environmental and unrelated to the `packages/core` change)