### PR TITLE
Wrap read_mcp_resource output with wrapUntrusted() for consistency with mcp-tool

### DIFF
--- a/packages/core/src/tools/read-mcp-resource.test.ts
+++ b/packages/core/src/tools/read-mcp-resource.test.ts
@@ -9,6 +9,7 @@ import { ReadMcpResourceTool } from './read-mcp-resource.js';
 import { ToolErrorType } from './tool-error.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import { wrapUntrusted } from '../utils/textUtils.js';
 
 describe('ReadMcpResourceTool', () => {
   let tool: ReadMcpResourceTool;
@@ -83,7 +84,7 @@ describe('ReadMcpResourceTool', () => {
     expect(mockMcpManager.getClient).toHaveBeenCalledWith(serverName);
     expect(mockClient.readResource).toHaveBeenCalledWith(uri);
     expect(result).toEqual({
-      llmContent: resourceContent + '\n',
+      llmContent: wrapUntrusted(resourceContent + '\n'),
       returnDisplay: `Successfully read resource "${resourceName}" from server "${serverName}"`,
     });
   });
@@ -124,7 +125,7 @@ describe('ReadMcpResourceTool', () => {
     expect(mockMcpManager.findResourceByUri).toHaveBeenCalledWith(qualifiedUri);
     expect(mockMcpManager.getClient).toHaveBeenCalledWith(serverName);
     expect(mockClient.readResource).toHaveBeenCalledWith(rawUri);
-    expect(result.llmContent).toBe(resourceContent + '\n');
+    expect(result.llmContent).toBe(wrapUntrusted(resourceContent + '\n'));
   });
 
   it('should return error if MCP Client Manager not available', async () => {

--- a/packages/core/src/tools/read-mcp-resource.ts
+++ b/packages/core/src/tools/read-mcp-resource.ts
@@ -17,6 +17,7 @@ import { READ_MCP_RESOURCE_DEFINITION } from './definitions/coreTools.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { ToolErrorType } from './tool-error.js';
 import type { MCPResource } from '../resources/resource-registry.js';
+import { wrapUntrusted } from '../utils/textUtils.js';
 
 export interface ReadMcpResourceParams {
   uri: string;
@@ -149,7 +150,9 @@ class ReadMcpResourceToolInvocation extends BaseToolInvocation<
       }
 
       return {
-        llmContent: contentText || 'No content returned from resource.',
+        llmContent: contentText
+          ? wrapUntrusted(contentText)
+          : 'No content returned from resource.',
         returnDisplay: this.resource
           ? `Successfully read resource "${this.resource.name}" from server "${this.resource.serverName}"`
           : `Successfully read resource: ${uri}`,


### PR DESCRIPTION
Resolves #27983

## What
Wrap the resource text returned by `read_mcp_resource` with `wrapUntrusted()` before it is passed to the model, and update the tests accordingly.

## Why
`ReadMcpResourceToolInvocation` returns MCP-server-supplied resource text directly as `llmContent`, while the sibling MCP path in `mcp-tool.ts` already wraps the same class of content with `wrapUntrusted()` (resource text and text blocks). MCP resource content is third-party / untrusted input, so today `read_mcp_resource` output reaches the model without the untrusted-context signal that every other tool applies. This change makes the two code paths consistent.

## Changes
- `packages/core/src/tools/read-mcp-resource.ts`: import `wrapUntrusted` and wrap non-empty `contentText` (the empty-content fallback message is unchanged).
- `packages/core/src/tools/read-mcp-resource.test.ts`: assertions updated to expect the wrapped output.

## Testing
`npx vitest run src/tools/read-mcp-resource.test.ts` in `packages/core` → 5/5 passing. `prettier --check` and `eslint` are clean on the changed files.

_Prepared with AI assistance; reviewed and tested locally._
