### PR TITLE
feat(acp): report cached and thought tokens in PromptResponse.usage

### DIFF
--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -274,14 +274,14 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: 'Hi' }],
     });
 
-    // cachedReadTokens is a subset of inputTokens, so totalTokens sums
-    // input + output + thought (1000 + 200 + 50).
+    // cachedReadTokens is a subset of inputTokens, and thoughtTokens is a subset of outputTokens,
+    // so totalTokens is input + output (1000 + 200).
     expect(result.usage).toEqual({
       inputTokens: 1000,
       outputTokens: 200,
       cachedReadTokens: 800,
       thoughtTokens: 50,
-      totalTokens: 1250,
+      totalTokens: 1200,
     });
   });
 

--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -249,6 +249,42 @@ describe('Session', () => {
     expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
+  it('reports token usage in the standard ACP usage field (incl. cached and thought tokens)', async () => {
+    mockSendMessageStream.mockImplementation(() => {
+      async function* gen(): AsyncGenerator<ServerGeminiStreamEvent> {
+        yield { type: GeminiEventType.Content, value: 'Hello' };
+        yield {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: FinishReason.STOP,
+            usageMetadata: {
+              promptTokenCount: 1000,
+              candidatesTokenCount: 200,
+              cachedContentTokenCount: 800,
+              thoughtsTokenCount: 50,
+            },
+          },
+        };
+      }
+      return gen();
+    });
+
+    const result = await session.prompt({
+      sessionId: 'session-1',
+      prompt: [{ type: 'text', text: 'Hi' }],
+    });
+
+    // cachedReadTokens is a subset of inputTokens, so totalTokens sums
+    // input + output + thought (1000 + 200 + 50).
+    expect(result.usage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 200,
+      cachedReadTokens: 800,
+      thoughtTokens: 50,
+      totalTokens: 1250,
+    });
+  });
+
   it('should pass current session information directly onto geminiClient.sendMessageStream', async () => {
     const stream = createMockStream([
       {

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -361,7 +361,21 @@ export class Session {
 
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let totalCachedTokens = 0;
+    let totalThoughtTokens = 0;
     const modelUsageMap = new Map<string, { input: number; output: number }>();
+
+    // Populate the standard ACP `PromptResponse.usage` field so any ACP client
+    // (Zed, OpenHands, etc.) can read token usage — including cached and thought
+    // tokens — without Gemini-specific parsing of `_meta.quota`. This mirrors
+    // the behaviour of Claude Agent ACP and Codex ACP.
+    const buildUsage = (): acp.Usage => ({
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
+      cachedReadTokens: totalCachedTokens,
+      thoughtTokens: totalThoughtTokens,
+      totalTokens: totalInputTokens + totalOutputTokens + totalThoughtTokens,
+    });
 
     let currentParts: Part[] = parts;
     let turnCount = 0;
@@ -372,6 +386,7 @@ export class Session {
       if (maxTurns >= 0 && turnCount > maxTurns) {
         return {
           stopReason: 'max_turn_requests',
+          usage: buildUsage(),
           _meta: {
             quota: {
               token_count: {
@@ -401,6 +416,8 @@ export class Session {
       let turnModelId = this.context.config.getModel();
       let turnInputTokens = 0;
       let turnOutputTokens = 0;
+      let turnCachedTokens = 0;
+      let turnThoughtTokens = 0;
 
       try {
         const responseStream = this.context.geminiClient.sendMessageStream(
@@ -447,6 +464,10 @@ export class Session {
                 turnInputTokens = usage.promptTokenCount ?? turnInputTokens;
                 turnOutputTokens =
                   usage.candidatesTokenCount ?? turnOutputTokens;
+                turnCachedTokens =
+                  usage.cachedContentTokenCount ?? turnCachedTokens;
+                turnThoughtTokens =
+                  usage.thoughtsTokenCount ?? turnThoughtTokens;
               }
               break;
             }
@@ -516,6 +537,7 @@ export class Session {
           // Treat this as a graceful end to the model's turn rather than a crash.
           return {
             stopReason: 'end_turn',
+            usage: buildUsage(),
             _meta: {
               quota: {
                 token_count: {
@@ -544,6 +566,8 @@ export class Session {
 
       totalInputTokens += turnInputTokens;
       totalOutputTokens += turnOutputTokens;
+      totalCachedTokens += turnCachedTokens;
+      totalThoughtTokens += turnThoughtTokens;
 
       if (turnInputTokens > 0 || turnOutputTokens > 0) {
         const existing = modelUsageMap.get(turnModelId) ?? {
@@ -558,6 +582,7 @@ export class Session {
       if (stopReason !== 'end_turn') {
         return {
           stopReason,
+          usage: buildUsage(),
           _meta: {
             quota: {
               token_count: {
@@ -609,6 +634,7 @@ export class Session {
 
     return {
       stopReason: 'end_turn',
+      usage: buildUsage(),
       _meta: {
         quota: {
           token_count: {


### PR DESCRIPTION
## Summary

When running as an ACP server (`gemini --acp`), per-turn token usage only included **input** and **output** tokens. The **cached** and **thought/reasoning** counts were dropped, so ACP clients that estimate cost from token counts treat all input as uncached — overstating cost by ~3× for cache-heavy agentic sessions (the real spend already benefits from caching; only the reporting was wrong).

This populates the standard ACP `PromptResponse.usage` field with cached and thought tokens, aligning Gemini CLI with Claude Agent ACP and Codex ACP.

## Details

`packages/cli/src/acp/acpSession.ts` read only `promptTokenCount` / `candidatesTokenCount` from Gemini's `usageMetadata` and emitted only `input_tokens` / `output_tokens` in the non-standard `_meta.quota.token_count`. `cachedContentTokenCount` and `thoughtsTokenCount` were available (they're already read in `event-translator.ts`, `telemetry/types.ts`, `services/chatRecordingService.ts`) but never forwarded over ACP.

This PR:
- captures `usageMetadata.cachedContentTokenCount` and `usageMetadata.thoughtsTokenCount` per turn and accumulates them;
- populates the standard `PromptResponse.usage` (`inputTokens`, `outputTokens`, `cachedReadTokens`, `thoughtTokens`, `totalTokens`) on every completion path;
- keeps the existing `_meta.quota` payload untouched for backward compatibility.

`cachedReadTokens` is a subset of `inputTokens`, so `totalTokens = input + output + thought`.

## Related Issues

Closes #27985
Related to #24280

## How to Validate

```bash
npm run typecheck --workspace packages/cli
npx vitest run src/acp/acpSession.test.ts   # from packages/cli
npx eslint packages/cli/src/acp/acpSession.ts packages/cli/src/acp/acpSession.test.ts --max-warnings 0
```

A new unit test asserts that a `Finished` event with `cachedContentTokenCount` / `thoughtsTokenCount` is surfaced in `result.usage`. All 29 tests in `acpSession.test.ts` pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (none — additive; `_meta.quota` preserved)
- [x] Validated on required platforms/methods:
  - [x] MacOS — npm run typecheck, vitest, eslint
