### PR TITLE
fix(cli): throw FatalConfigError instead of process.exit in parseArguments

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -20,6 +20,7 @@ import {
   type MCPServerConfig,
   type GeminiCLIExtension,
   Storage,
+  FatalConfigError,
 } from '@google/gemini-cli-core';
 import { loadCliConfig, parseArguments, type CliArgs } from './config.js';
 import {
@@ -228,7 +229,7 @@ describe('parseArguments', () => {
     });
 
     await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-      'process.exit called',
+      FatalConfigError,
     );
 
     expect(mockConsoleError).toHaveBeenCalledWith(
@@ -279,9 +280,7 @@ describe('parseArguments', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      await expect(parseArguments(settings)).rejects.toThrow(
-        'process.exit called',
-      );
+      await expect(parseArguments(settings)).rejects.toThrow(FatalConfigError);
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining(
           'The --worktree flag is only available when experimental.worktrees is enabled in your settings.',
@@ -327,7 +326,7 @@ describe('parseArguments', () => {
         .mockImplementation(() => {});
 
       await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-        'process.exit called',
+        FatalConfigError,
       );
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -580,7 +579,7 @@ describe('parseArguments', () => {
         .mockImplementation(() => {});
 
       await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-        'process.exit called',
+        FatalConfigError,
       );
 
       expect(mockConsoleError).toHaveBeenCalledWith(
@@ -624,7 +623,7 @@ describe('parseArguments', () => {
       .mockImplementation(() => {});
 
     await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-      'process.exit called',
+      FatalConfigError,
     );
 
     expect(debugErrorSpy).toHaveBeenCalledWith(
@@ -3175,7 +3174,7 @@ describe('Output format', () => {
       .mockImplementation(() => {});
 
     await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-      'process.exit called',
+      FatalConfigError,
     );
     expect(debugErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Invalid values:'),
@@ -3221,7 +3220,7 @@ describe('parseArguments with positional prompt', () => {
       .mockImplementation(() => {});
 
     await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-      'process.exit called',
+      FatalConfigError,
     );
 
     expect(debugErrorSpy).toHaveBeenCalledWith(

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -72,7 +72,6 @@ import type { ExtensionEvents } from '@google/gemini-cli-core/src/utils/extensio
 import { requestConsentNonInteractive } from './extensions/consent.js';
 import { promptForSetting } from './extensions/extensionSettings.js';
 import type { EventEmitter } from 'node:stream';
-import { runExitCleanup } from '../utils/cleanup.js';
 
 export interface CliArgs {
   query: string | undefined;
@@ -519,13 +518,11 @@ export async function parseArguments(
     const msg = getErrorMessage(e);
     debugLogger.error(msg);
     yargsInstance.showHelp();
-    await runExitCleanup();
-    process.exit(1);
+    throw new FatalConfigError(msg);
   }
 
   // Handle help and version flags manually since we disabled exitProcess
   if (result['help'] || result['version']) {
-    await runExitCleanup();
     process.exit(0);
   }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -58,7 +58,6 @@ import {
 
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
-import { runExitCleanup } from '../utils/cleanup.js';
 import { isRecord } from '../utils/settingsUtils.js';
 import { RESUME_LATEST } from '../utils/sessionUtils.js';
 
@@ -82,6 +81,9 @@ export interface CliArgs {
   prompt: string | undefined;
   promptInteractive: string | undefined;
   worktree?: string;
+
+  help?: boolean;
+  version?: boolean;
 
   yolo: boolean | undefined;
   approvalMode: string | undefined;
@@ -520,17 +522,6 @@ export async function parseArguments(
     debugLogger.error(msg);
     yargsInstance.showHelp();
     throw new FatalConfigError(msg);
-  }
-
-  // Handle help and version flags manually since we disabled exitProcess
-  if (result['help'] || result['version']) {
-    if (
-      process.env['VITEST'] !== 'true' &&
-      process.env['GEMINI_CLI_INTEGRATION_TEST'] !== 'true'
-    ) {
-      await runExitCleanup();
-      process.exit(0);
-    }
   }
 
   // Normalize query args: handle both quoted "@path file" and unquoted @path file

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -58,6 +58,7 @@ import {
 
 import { loadSandboxConfig } from './sandboxConfig.js';
 import { resolvePath } from '../utils/resolvePath.js';
+import { runExitCleanup } from '../utils/cleanup.js';
 import { isRecord } from '../utils/settingsUtils.js';
 import { RESUME_LATEST } from '../utils/sessionUtils.js';
 
@@ -523,7 +524,13 @@ export async function parseArguments(
 
   // Handle help and version flags manually since we disabled exitProcess
   if (result['help'] || result['version']) {
-    process.exit(0);
+    if (
+      process.env['VITEST'] !== 'true' &&
+      process.env['GEMINI_CLI_INTEGRATION_TEST'] !== 'true'
+    ) {
+      await runExitCleanup();
+      process.exit(0);
+    }
   }
 
   // Normalize query args: handle both quoted "@path file" and unquoted @path file

--- a/packages/cli/src/config/mutual-exclusivity.test.ts
+++ b/packages/cli/src/config/mutual-exclusivity.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { parseArguments } from './config.js';
 import { createTestMergedSettings } from './settings.js';
+import { FatalConfigError } from '@google/gemini-cli-core';
 
 describe('parseArguments mutual exclusivity', () => {
   afterEach(() => {
@@ -26,12 +27,9 @@ describe('parseArguments mutual exclusivity', () => {
       const mockConsoleError = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
-      vi.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit called');
-      });
 
       await expect(parseArguments(createTestMergedSettings())).rejects.toThrow(
-        'process.exit called',
+        FatalConfigError,
       );
 
       expect(mockConsoleError).toHaveBeenCalledWith(

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -423,6 +423,17 @@ export async function main() {
 
   const argv = await argvPromise;
 
+  if (argv.help || argv.version) {
+    if (
+      process.env['VITEST'] === 'true' ||
+      process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true'
+    ) {
+      return;
+    }
+    await runExitCleanup();
+    process.exit(0);
+  }
+
   const { sessionId, resumedSessionData } = await resolveSessionId(
     argv.resume,
     argv.sessionId,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -425,8 +425,8 @@ export async function main() {
 
   if (argv.help || argv.version) {
     if (
-      process.env['VITEST'] === 'true' ||
-      process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true'
+      process.env['VITEST'] === 'true' &&
+      process.env['GEMINI_CLI_INTEGRATION_TEST'] !== 'true'
     ) {
       return;
     }


### PR DESCRIPTION
Refactored argument parsing to throw FatalConfigError instead of process.exit(1). Moved help/version exit logic to main() to ensure robust execution.

This resolves the issue where E2E tests for `--help`/`--version` would timeout (exit code 42) due to the child process inheriting `VITEST=true` but not being allowed to gracefully `process.exit(0)` after telemetry timers had started. The condition now strictly prevents `process.exit(0)` ONLY during in-memory unit tests (`VITEST=true` AND `!GEMINI_CLI_INTEGRATION_TEST`), allowing actual integration subprocesses to exit cleanly.