### PR TITLE
fix(core): insert skill/agent content literally in system prompt substitutions

### DIFF
--- a/packages/core/src/prompts/utils.test.ts
+++ b/packages/core/src/prompts/utils.test.ts
@@ -312,4 +312,33 @@ describe('applySubstitutions', () => {
     );
     expect(result).toBe('A plain prompt with no variables.');
   });
+
+  it('should insert ${AgentSkills} content literally when it contains $ sequences', () => {
+    const skills = "Run: echo $'a' ; cost $$5 ; use $&";
+    const result = applySubstitutions(
+      'Header.\n${AgentSkills}\nTAIL.',
+      mockConfig,
+      skills,
+    );
+    expect(result).toBe(`Header.\n${skills}\nTAIL.`);
+  });
+
+  it('should insert ${SubAgents} content literally when it contains $ sequences', async () => {
+    const legacySnippets = await import('./snippets.legacy.js');
+    vi.mocked(legacySnippets.renderSubAgents).mockReturnValueOnce(
+      "see $' here",
+    );
+    const result = applySubstitutions('A:${SubAgents}:B', mockConfig, '');
+    expect(result).toBe("A:see $' here:B");
+  });
+
+  it('should insert ${AvailableTools} list literally even with $ in tool names', () => {
+    (mockConfig as unknown as { toolRegistry: ToolRegistry }).toolRegistry = {
+      getAllToolNames: vi.fn().mockReturnValue(['weird$&tool']),
+      getAllTools: vi.fn().mockReturnValue([]),
+    } as unknown as ToolRegistry;
+
+    const result = applySubstitutions('T: ${AvailableTools}', mockConfig, '');
+    expect(result).toBe('T: - weird$&tool');
+  });
 });

--- a/packages/core/src/prompts/utils.ts
+++ b/packages/core/src/prompts/utils.ts
@@ -69,7 +69,7 @@ export function applySubstitutions(
 ): string {
   let result = prompt;
 
-  result = result.replace(/\${AgentSkills}/g, skillsPrompt);
+  result = result.replace(/\${AgentSkills}/g, () => skillsPrompt);
 
   const activeSnippets = isGemini3 ? snippets : legacySnippets;
   const subAgentsContent = activeSnippets.renderSubAgents(
@@ -82,7 +82,7 @@ export function applySubstitutions(
       })),
   );
 
-  result = result.replace(/\${SubAgents}/g, subAgentsContent);
+  result = result.replace(/\${SubAgents}/g, () => subAgentsContent);
 
   const toolRegistry = context.toolRegistry;
   const allToolNames = toolRegistry.getAllToolNames();
@@ -90,7 +90,7 @@ export function applySubstitutions(
     allToolNames.length > 0
       ? allToolNames.map((name) => `- ${name}`).join('\n')
       : 'No tools are currently available.';
-  result = result.replace(/\${AvailableTools}/g, availableToolsList);
+  result = result.replace(/\${AvailableTools}/g, () => availableToolsList);
 
   for (const toolName of allToolNames) {
     const varName = `${toolName}_ToolName`;

--- a/packages/core/src/prompts/utils.ts
+++ b/packages/core/src/prompts/utils.ts
@@ -96,7 +96,7 @@ export function applySubstitutions(
     const varName = `${toolName}_ToolName`;
     result = result.replace(
       new RegExp(`\\\${\\b${varName}\\b}`, 'g'),
-      toolName,
+      () => toolName,
     );
   }
 


### PR DESCRIPTION
## Summary

`applySubstitutions()` in `packages/core/src/prompts/utils.ts` injects
skill / sub-agent / tool content into the system prompt using the **string**
form of `String.prototype.replace`:

```ts
result = result.replace(/\${AgentSkills}/g, skillsPrompt);
// ...same for ${SubAgents} and ${AvailableTools}
```

When the replacement argument is a plain string, JavaScript interprets `$`
replacement patterns inside it (`$$`, `$&`, `` $` ``, `$'`, `$n`). The
`skillsPrompt` / sub-agents content is rendered from user- and
extension-authored skill and agent descriptions (`SKILL.md`, agent `.md`
files), which can legitimately contain shell snippets such as `$'…'`, `$$`, or
`$VAR`. When they do, the substituted system prompt is **silently mangled** —
no error, just a degraded instruction that can subtly worsen model behavior.

The worst case is `$'` (dollar-apostrophe, common in shell), which
`String.replace` treats as "insert everything **after** the match" — so the
entire remainder of the system prompt is spliced in and duplicated.

This runs whenever a custom system-prompt override is in use
(`applySubstitutions` is called from `promptProvider.ts`).

## Details

The fix switches the three substitutions to the **function** form of
`replace`, so the value is inserted literally and `$` sequences are never
treated as replacement patterns:

```ts
result = result.replace(/\${AgentSkills}/g, () => skillsPrompt);
result = result.replace(/\${SubAgents}/g, () => subAgentsContent);
result = result.replace(/\${AvailableTools}/g, () => availableToolsList);
```

This mirrors the pattern the repo already uses for exactly this reason in
`HookRunner.expandCommand` (`packages/core/src/hooks/hookRunner.ts`):
`.replace(/\$GEMINI_PROJECT_DIR/g, () => escapedCwd)`. The change makes
`utils.ts` consistent with that existing in-repo practice.

Platform-independent defect (language-level `String.prototype.replace`
semantics).

## Related Issues

Closes https://github.com/google-gemini/gemini-cli/issues/27993

## How to Validate

```
npm test -w packages/core -- src/prompts/utils.test.ts
```

This PR adds three regression tests to the existing
`describe('applySubstitutions')` block in `utils.test.ts`, asserting that
`$`-containing values are inserted literally for each of the three
placeholders. The pre-existing suite only used alphanumeric replacement
values, so it could not see this bug.

- **Without the fix**, the three new tests fail — e.g. the `${SubAgents}` case
  reports `expected 'A:see :B here:B' to be "A:see $' here:B"` (the prompt tail
  is spliced in by `$'`), and the `${AvailableTools}` case reports
  `expected 'T: - weird${AvailableTools}tool' to be 'T: - weird$&tool'` (`$&`
  re-inserts the matched placeholder). The suite reports `3 failed | 30 passed`.
- **With the fix**, all placeholders receive the literal content and the suite
  reports `33 passed`.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
