### PR TITLE
fix(core): skip user agents dir when it resolves to the project agents dir

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -29,6 +29,7 @@ import {
   PREVIEW_GEMINI_MODEL_AUTO,
 } from '../config/models.js';
 import * as tomlLoader from './agentLoader.js';
+import { Storage } from '../config/storage.js';
 import { SimpleExtensionLoader } from '../utils/extensionLoader.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import { ThinkingLevel } from '@google/genai';
@@ -266,6 +267,38 @@ describe('AgentRegistry', () => {
       expect(
         vi.mocked(tomlLoader.loadAgentsFromDirectory),
       ).toHaveBeenCalledTimes(2);
+    });
+
+    it('should load agents only once when project dir and user dir resolve to the same path', async () => {
+      // Simulate running the CLI from the home directory: both the project
+      // agents dir and the user agents dir point to ~/.gemini/agents/.
+      const sharedDir = '/mock/home/.gemini/agents';
+      mockConfig = makeMockedConfig({ enableAgents: true });
+      registry = new TestableAgentRegistry(mockConfig);
+
+      vi.spyOn(mockConfig.storage, 'getProjectAgentsDir').mockReturnValue(
+        sharedDir,
+      );
+      vi.spyOn(Storage, 'getUserAgentsDir').mockReturnValue(sharedDir);
+
+      const agent = { ...MOCK_AGENT_V1, name: 'home-agent' };
+      vi.mocked(tomlLoader.loadAgentsFromDirectory).mockResolvedValue({
+        agents: [agent],
+        errors: [],
+      });
+
+      await registry.initialize();
+
+      // loadAgentsFromDirectory should be called exactly once — not twice —
+      // even though both dirs resolve to the same path.
+      expect(
+        vi.mocked(tomlLoader.loadAgentsFromDirectory),
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(tomlLoader.loadAgentsFromDirectory),
+      ).toHaveBeenCalledWith(sharedDir);
+      // The agent should be registered without a duplicate warning.
+      expect(registry.getDefinition('home-agent')).toBeDefined();
     });
 
     it('should NOT load TOML agents when enableAgents is false', async () => {

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -5,6 +5,7 @@
  */
 
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import { Storage } from '../config/storage.js';
 import { CoreEvent, coreEvents } from '../utils/events.js';
 import type { AgentOverride, Config } from '../config/config.js';
@@ -233,28 +234,41 @@ export class AgentRegistry {
 
     // Load user-level agents: ~/.gemini/agents/
     const userAgentsDir = Storage.getUserAgentsDir();
-    const userAgents = await loadAgentsFromDirectory(userAgentsDir);
-    for (const error of userAgents.errors) {
-      debugLogger.warn(
-        `[AgentRegistry] Error loading user agent: ${error.message}`,
+
+    // When the CLI is run from the home directory, the project agents dir and
+    // the user agents dir resolve to the same physical path. Guard against
+    // loading the same directory twice, which would trigger false-positive
+    // "Duplicate agent name" warnings for every agent defined there.
+    const projectAgentsDir = this.config.storage.getProjectAgentsDir();
+    const projectAgentsWereLoaded = !folderTrustEnabled || isTrustedFolder;
+    const userDirAlreadyLoaded =
+      projectAgentsWereLoaded &&
+      path.resolve(userAgentsDir) === path.resolve(projectAgentsDir);
+
+    if (!userDirAlreadyLoaded) {
+      const userAgents = await loadAgentsFromDirectory(userAgentsDir);
+      for (const error of userAgents.errors) {
+        debugLogger.warn(
+          `[AgentRegistry] Error loading user agent: ${error.message}`,
+        );
+        const msg = `Agent loading error: ${error.message}`;
+        errors?.push(msg);
+        coreEvents.emitFeedback('error', msg);
+      }
+      await Promise.allSettled(
+        userAgents.agents.map(async (agent) => {
+          try {
+            this.ensureRemoteAgentHash(agent);
+            await this.registerAgent(agent, errors);
+          } catch (e) {
+            const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
+            debugLogger.warn(`[AgentRegistry] ${msg}`, e);
+            errors?.push(msg);
+            coreEvents.emitFeedback('error', msg);
+          }
+        }),
       );
-      const msg = `Agent loading error: ${error.message}`;
-      errors?.push(msg);
-      coreEvents.emitFeedback('error', msg);
     }
-    await Promise.allSettled(
-      userAgents.agents.map(async (agent) => {
-        try {
-          this.ensureRemoteAgentHash(agent);
-          await this.registerAgent(agent, errors);
-        } catch (e) {
-          const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
-          debugLogger.warn(`[AgentRegistry] ${msg}`, e);
-          errors?.push(msg);
-          coreEvents.emitFeedback('error', msg);
-        }
-      }),
-    );
 
     // Load agents from extensions
     for (const extension of this.config.getExtensions()) {


### PR DESCRIPTION
## Summary

Eliminates a false-positive \"Duplicate agent name\" warning that appears every time Gemini CLI is launched from the user's home directory.

## Details

When the CLI is run with the workspace set to `~`, the project-level agents directory (`.gemini/agents/` relative to CWD, i.e. `~/.gemini/agents/`) and the user-level agents directory (`~/.gemini/agents/`) resolve to the same physical path. `AgentRegistry.loadAgents` loaded both directories without checking for overlap, causing every agent defined in `~/.gemini/agents/` to be registered twice and triggering the warning on the second registration.

The fix resolves both paths to absolute strings in `loadAgents` and skips the user-level load when the two directories are identical. The path comparison uses `path.resolve` so symlinks and trailing-slash differences don't cause false negatives.

## Related Issues

Fixes #27692

## How to Validate

1. Create an agent definition at `~/.gemini/agents/test-agent.md`.
2. `cd ~` and run `gemini`.
3. **Before:** startup output contains `Duplicate agent name 'test-agent' detected. The later definition will be ignored.`
4. **After:** no duplicate warning; the agent loads once and is available normally.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run