### PR TITLE
fix(core): decode response body using charset from Content-Type header

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -1196,5 +1196,60 @@ describe('WebFetchTool', () => {
         '[Content truncated due to size limit]',
       );
     });
+
+    it('should decode response using charset from Content-Type header', async () => {
+      // 0xE9 is 'é' in ISO-8859-1/Latin-1 but is invalid UTF-8 on its own.
+      const latin1Bytes = Buffer.from([
+        0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0xe9,
+      ]); // "Hello é" in Latin-1
+      mockFetch('https://example.com/latin1', {
+        status: 200,
+        headers: new Headers({
+          'content-type': 'text/plain; charset=iso-8859-1',
+        }),
+        arrayBuffer: () =>
+          Promise.resolve(
+            latin1Bytes.buffer.slice(
+              latin1Bytes.byteOffset,
+              latin1Bytes.byteOffset + latin1Bytes.byteLength,
+            ),
+          ),
+      });
+
+      const tool = new WebFetchTool(mockConfig, bus);
+      const invocation = tool.build({ url: 'https://example.com/latin1' });
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(result.llmContent).toContain('Hello é');
+    });
+
+    it('should fall back to UTF-8 for unrecognised charset', async () => {
+      const utf8Bytes = Buffer.from('Hello', 'utf8');
+      mockFetch('https://example.com/unknown-charset', {
+        status: 200,
+        headers: new Headers({
+          'content-type': 'text/plain; charset=x-not-a-real-charset',
+        }),
+        arrayBuffer: () =>
+          Promise.resolve(
+            utf8Bytes.buffer.slice(
+              utf8Bytes.byteOffset,
+              utf8Bytes.byteOffset + utf8Bytes.byteLength,
+            ),
+          ),
+      });
+
+      const tool = new WebFetchTool(mockConfig, bus);
+      const invocation = tool.build({
+        url: 'https://example.com/unknown-charset',
+      });
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(result.llmContent).toContain('Hello');
+    });
   });
 });

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -1225,6 +1225,33 @@ describe('WebFetchTool', () => {
       expect(result.llmContent).toContain('Hello é');
     });
 
+    it('should strip quotes from charset value (charset="iso-8859-1")', async () => {
+      const latin1Bytes = Buffer.from([0x63, 0x61, 0x66, 0xe9]); // "café" in Latin-1
+      mockFetch('https://example.com/quoted-charset', {
+        status: 200,
+        headers: new Headers({
+          'content-type': 'text/plain; charset="iso-8859-1"',
+        }),
+        arrayBuffer: () =>
+          Promise.resolve(
+            latin1Bytes.buffer.slice(
+              latin1Bytes.byteOffset,
+              latin1Bytes.byteOffset + latin1Bytes.byteLength,
+            ),
+          ),
+      });
+
+      const tool = new WebFetchTool(mockConfig, bus);
+      const invocation = tool.build({
+        url: 'https://example.com/quoted-charset',
+      });
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(result.llmContent).toContain('café');
+    });
+
     it('should fall back to UTF-8 for unrecognised charset', async () => {
       const utf8Bytes = Buffer.from('Hello', 'utf8');
       mockFetch('https://example.com/unknown-charset', {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -56,8 +56,9 @@ const hostRequestHistory = new LRUCache<string, number[]>(1000);
  * charset is not recognised by the platform's TextDecoder.
  */
 function decodeBody(buffer: Buffer, contentType: string): string {
-  const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
-  const charset = charsetMatch?.[1] ?? 'utf-8';
+  const charsetMatch = contentType.match(/charset\s*=\s*([^\s;]+)/i);
+  let charset = charsetMatch?.[1] ?? 'utf-8';
+  charset = charset.replace(/^['"]|['"]$/g, '');
   try {
     return new TextDecoder(charset).decode(buffer);
   } catch {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -57,7 +57,8 @@ const hostRequestHistory = new LRUCache<string, number[]>(1000);
  */
 function decodeBody(buffer: Buffer, contentType: string): string {
   const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
-  const charset = charsetMatch?.[1] ?? 'utf-8';
+  // Strip optional surrounding quotes per RFC 7231 (charset="gbk" or charset='utf-8')
+  const charset = charsetMatch?.[1].replace(/^["']|["']$/g, '') ?? 'utf-8';
   try {
     return new TextDecoder(charset).decode(buffer);
   } catch {

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -50,6 +50,21 @@ const RATE_LIMIT_WINDOW_MS = 60000; // 1 minute
 const MAX_REQUESTS_PER_WINDOW = 10;
 const hostRequestHistory = new LRUCache<string, number[]>(1000);
 
+/**
+ * Decodes a response buffer using the charset declared in the Content-Type
+ * header, falling back to UTF-8 when none is specified or the declared
+ * charset is not recognised by the platform's TextDecoder.
+ */
+function decodeBody(buffer: Buffer, contentType: string): string {
+  const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
+  const charset = charsetMatch?.[1] ?? 'utf-8';
+  try {
+    return new TextDecoder(charset).decode(buffer);
+  } catch {
+    return new TextDecoder('utf-8').decode(buffer);
+  }
+}
+
 function checkRateLimit(url: string): {
   allowed: boolean;
   waitTimeMs?: number;
@@ -321,8 +336,8 @@ class WebFetchToolInvocation extends BaseToolInvocation<
       response,
       MAX_EXPERIMENTAL_FETCH_SIZE,
     );
-    const rawContent = bodyBuffer.toString('utf8');
     const contentType = response.headers.get('content-type') || '';
+    const rawContent = decodeBody(bodyBuffer, contentType);
     let textContent: string;
 
     // Only use html-to-text if content type is HTML, or if no content type is provided (assume HTML)
@@ -659,7 +674,7 @@ ${aggregatedContent}
       );
 
       if (status >= 400) {
-        let rawResponseText = bodyBuffer.toString('utf8');
+        let rawResponseText = decodeBody(bodyBuffer, contentType);
         if (!this.context.config.isContextManagementEnabled()) {
           rawResponseText = truncateString(
             rawResponseText,
@@ -689,7 +704,7 @@ Response: ${rawResponseText}`;
         lowContentType.includes('text/plain') ||
         lowContentType.includes('application/json')
       ) {
-        let text = bodyBuffer.toString('utf8');
+        let text = decodeBody(bodyBuffer, contentType);
         if (!this.context.config.isContextManagementEnabled()) {
           text = truncateString(text, MAX_CONTENT_LENGTH, TRUNCATION_WARNING);
         }
@@ -700,7 +715,7 @@ Response: ${rawResponseText}`;
       }
 
       if (lowContentType.includes('text/html')) {
-        const html = bodyBuffer.toString('utf8');
+        const html = decodeBody(bodyBuffer, contentType);
         let textContent = convert(html, {
           wordwrap: false,
           selectors: [
@@ -738,7 +753,7 @@ Response: ${rawResponseText}`;
       }
 
       // Fallback for unknown types - try as text
-      let text = bodyBuffer.toString('utf8');
+      let text = decodeBody(bodyBuffer, contentType);
       if (!this.context.config.isContextManagementEnabled()) {
         text = truncateString(text, MAX_CONTENT_LENGTH, TRUNCATION_WARNING);
       }


### PR DESCRIPTION
## Summary

`web-fetch` always decoded response bodies with `bodyBuffer.toString('utf8')`, ignoring the `charset` parameter in the `Content-Type` header. Pages served with `charset=gbk`, `charset=iso-8859-1`, or other non-UTF-8 encodings (common on Chinese, Japanese, and legacy sites) returned garbled output.

## Details

Five text-decoding paths in `packages/core/src/tools/web-fetch.ts` all hardcoded `'utf8'`:
- Line 324 (legacy fetch path)
- Lines 662, 692, 703, 741 (experimental fetch path)

Added a `decodeBody(buffer, contentType)` helper that parses the `charset` parameter from `Content-Type` and delegates to `TextDecoder`, which handles the full range of IANA-registered encodings available in Node ≥ 20's bundled ICU data (the minimum required Node version for this project). Falls back to UTF-8 if no charset is declared or if the declared charset is not recognised.

The binary `bodyBuffer.toString('base64')` path for images/PDFs is left unchanged.

In the legacy fetch path, the `contentType` read was also moved above the buffer decode so both paths follow the same read-then-decode order.

## Related Issues

Fixes #27980

## How to Validate

1. Stand up a local HTTP server that serves `Content-Type: text/plain; charset=iso-8859-1` with a response body containing `0xE9` (`é` in Latin-1).
2. Run `gemini-cli` with experimental fetch enabled and fetch that URL.
3. Before this fix: the output shows `�` or garbled bytes. After: `é`.

The added unit tests cover this path directly without needing a live server:
```
npx vitest run packages/core/src/tools/web-fetch.test.ts
# 64 passed
```

## Pre-Merge Checklist

- [x] Tests pass (`npx vitest run packages/core/src/tools/web-fetch.test.ts`)
- [x] New tests added for charset decoding (iso-8859-1) and unknown-charset fallback
- [x] No new dependencies introduced (uses built-in `TextDecoder`)
- [x] Binary paths (image/PDF base64) left unchanged