### PR TITLE
docs: remove references to deprecated consumer and free tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Learn all about Gemini CLI in our [documentation](https://geminicli.com/docs/).
 
 ## 🚀 Why Gemini CLI?
 
-- **🎯 Free tier**: 60 requests/min and 1,000 requests/day with personal Google
-  account.
 - **🧠 Powerful Gemini 3 models**: Access to improved reasoning and 1M token
   context window.
 - **🔧 Built-in tools**: Google Search grounding, file operations, shell
@@ -149,14 +147,13 @@ Choose the authentication method that best fits your needs:
 
 ### Option 1: Sign in with Google (OAuth login using your Google Account)
 
-**✨ Best for:** Individual developers as well as anyone who has a Gemini Code
-Assist License. (see
+**✨ Best for:** Teams who have a Gemini Code Assist Standard or Enterprise
+License. (see
 [quota limits and terms of service](https://cloud.google.com/gemini/docs/quotas)
 for details)
 
 **Benefits:**
 
-- **Free tier**: 60 requests/min and 1,000 requests/day
 - **Gemini 3 models** with 1M token context window
 - **No API key management** - just sign in with your Google account
 - **Automatic updates** to latest models
@@ -181,7 +178,6 @@ gemini
 
 **Benefits:**
 
-- **Free tier**: 1000 requests/day with Gemini 3 (mix of flash and pro)
 - **Model selection**: Choose specific Gemini models
 - **Usage-based billing**: Upgrade for higher limits when needed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,8 +67,7 @@ To better organize our efforts, we categorize our work into several key feature
 areas. These labels are used on our GitHub Issues to help you filter and find
 initiatives that interest you.
 
-- **Authentication:** Secure user access via API keys, Gemini Code Assist login,
-  etc.
+- **Authentication:** Secure user access via API keys, Vertex AI, etc.
 - **Model:** Support new Gemini models, multi-modality, local execution, and
   performance tuning.
 - **User Experience:** Improve the CLI's usability, performance, interactive

--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -501,8 +501,6 @@ on GitHub.
 
 ## Announcements: v0.22.0 - 2025-12-22
 
-- 🎉**Free Tier + Gemini 3:** Free tier users now all have access to Gemini 3
-  Pro & Flash. Enable in `/settings` by toggling "Preview Features" to `true`.
 - 🎉**Gemini CLI + Colab:** Gemini CLI is now pre-installed. Can be used
   headlessly in notebook cells or interactively in the built-in terminal
   ([pic](https://imgur.com/a/G0Tn7vi))
@@ -524,8 +522,8 @@ on GitHub.
 ## Announcements: v0.21.0 - 2025-12-15
 
 - **⚡️⚡️⚡️ Gemini 3 Flash + Gemini CLI:** Better, faster and cheaper than 2.5
-  Pro - and in some scenarios better than 3 Pro! For paid tiers + free tier
-  users who were on the wait list enable **Preview Features** in `/settings.`
+  Pro - and in some scenarios better than 3 Pro! For paid tiers, enable
+  **Preview Features** in `/settings.`
 - For more information:
   [Gemini 3 Flash is now available in Gemini CLI](https://developers.googleblog.com/gemini-3-flash-is-now-available-in-gemini-cli/).
 - 🎉 Gemini CLI Extensions:
@@ -596,10 +594,6 @@ on GitHub.
   information.
   - Blog:
     [https://allen.hutchison.org/2025/11/26/the-guardrails-of-autonomy/](https://allen.hutchison.org/2025/11/26/the-guardrails-of-autonomy/)
-- **Gemini 3 support for paid:** Gemini 3 support has been rolled out to all API
-  key, Google AI Pro or Google AI Ultra (for individuals, not businesses) and
-  Gemini Code Assist Enterprise users. Enable it via `/settings` and toggling on
-  **Preview Features**.
 - **Updated UI rollback:** We’ve temporarily rolled back our updated UI to give
   it more time to bake. This means for a time you won’t have embedded scrolling
   or mouse support. You can re-enable with `/settings` -> **Use Alternate Screen

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -537,9 +537,6 @@ HTTP header.
 This policy prevents users from logging in with personal Gmail accounts or other
 non-corporate Google accounts.
 
-For detailed instructions, see the Google Workspace Admin Help article on
-[blocking access to consumer accounts](https://support.google.com/a/answer/1668854?hl=en#zippy=%2Cstep-choose-a-web-proxy-server%2Cstep-configure-the-network-to-block-certain-accounts).
-
 The general steps are as follows:
 
 1.  **Intercept Requests**: Configure your web proxy to intercept all requests

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -11,33 +11,16 @@ using the CLI.
 > To compare features and find the right quota for your needs, see our
 > [Plans page](https://geminicli.com/plans/).
 
-For most users, we recommend starting Gemini CLI and logging in with your
-personal Google account.
-
 ## Choose your authentication method <a id="auth-methods"></a>
 
 Select the authentication method that matches your situation in the table below:
 
 | User Type / Scenario                                                   | Recommended Authentication Method                                | Google Cloud Project Required                               |
 | :--------------------------------------------------------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------- |
-| Individual Google accounts                                             | [Sign in with Google](#login-google)                             | No, with exceptions                                         |
 | Organization users with a company, school, or Google Workspace account | [Sign in with Google](#login-google)                             | [Yes](#set-gcp)                                             |
 | AI Studio user with a Gemini API key                                   | [Use Gemini API Key](#gemini-api)                                | No                                                          |
 | Google Cloud Vertex AI user                                            | [Vertex AI](#vertex-ai)                                          | [Yes](#set-gcp)                                             |
 | [Headless mode](#headless)                                             | [Use Gemini API Key](#gemini-api) or<br /> [Vertex AI](#vertex-ai) | No (for Gemini API Key)<br /> [Yes](#set-gcp) (for Vertex AI) |
-
-### What is my Google account type?
-
-- **Individual Google accounts:** Includes all
-  [free tier accounts](../resources/quota-and-pricing.md#free-usage) such as
-  Gemini Code Assist for individuals, as well as paid subscriptions for
-  [Google AI Pro and Ultra](https://gemini.google/subscriptions/).
-
-- **Organization accounts:** Accounts using paid licenses through an
-  organization such as a company, school, or
-  [Google Workspace](https://workspace.google.com/). Includes
-  [Google AI Ultra for Business](https://support.google.com/a/answer/16345165)
-  subscriptions.
 
 ## (Recommended) Sign in with Google <a id="login-google"></a>
 
@@ -45,9 +28,6 @@ If you run Gemini CLI on your local machine, the simplest authentication method
 is logging in with your Google account. This method requires a web browser on a
 machine that can communicate with the terminal running Gemini CLI (for example,
 your local machine).
-
-If you are a **Google AI Pro** or **Google AI Ultra** subscriber, use the Google
-account associated with your subscription.
 
 To authenticate and use Gemini CLI:
 
@@ -63,9 +43,8 @@ To authenticate and use Gemini CLI:
 
 ### Do I need to set my Google Cloud project?
 
-Most individual Google accounts (free and paid) don't require a Google Cloud
-project for authentication. However, you'll need to set a Google Cloud project
-when you meet at least one of the following conditions:
+When using a company, school, or Google Workspace account, you'll need to set 
+a Google Cloud project when you meet at least one of the following conditions:
 
 - You are using a company, school, or Google Workspace account.
 - You are using a Gemini Code Assist license from the Google Developer Program.
@@ -309,15 +288,11 @@ Remove-Item Env:\GOOGLE_API_KEY, Env:\GEMINI_API_KEY -ErrorAction Ignore
 
 ## Set your Google Cloud project <a id="set-gcp"></a>
 
-> [!IMPORTANT]
-> Most individual Google accounts (free and paid) don't require a
-> Google Cloud project for authentication.
-
 When you sign in using your Google account, you may need to configure a Google
 Cloud project for Gemini CLI to use. This applies when you meet at least one of
 the following conditions:
 
-- You are using a Company, School, or Google Workspace account.
+- You are using a company, school, or Google Workspace account.
 - You are using a Gemini Code Assist license from the Google Developer Program.
 - You are using a license from a Gemini Code Assist subscription.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -469,12 +469,6 @@ Slash commands provide meta-level control over the CLI itself.
   - **`nodesc`** or **`nodescriptions`**:
     - **Description:** Hide tool descriptions, showing only the tool names.
 
-### `/upgrade`
-
-- **Description:** Open the Gemini Code Assist upgrade page in your browser.
-  This lets you upgrade your tier for higher usage limits.
-- **Note:** This command is only available when logged in with Google.
-
 ### `/vim`
 
 - **Description:** Toggle vim mode on or off. When vim mode is enabled, the

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -141,45 +141,6 @@ Gemini CLI configuration is stored in two `settings.json` files:
 Refer to [Gemini CLI Configuration](../reference/configuration.md) for more
 details.
 
-## Google AI Pro/Ultra and subscription FAQs
-
-### Where can I learn more about my Google AI Pro or Google AI Ultra subscription?
-
-To learn more about your Google AI Pro or Google AI Ultra subscription, visit
-**Manage subscription** in your [subscription settings](https://one.google.com).
-
-### How do I know if I have higher limits for Google AI Pro or Ultra?
-
-If you're subscribed to Google AI Pro or Ultra, you automatically have higher
-limits to Gemini Code Assist and Gemini CLI. These are shared across Gemini CLI
-and agent mode in the IDE. You can confirm you have higher limits by checking if
-you are still subscribed to Google AI Pro or Ultra in your
-[subscription settings](https://one.google.com).
-
-### What is the privacy policy for using Gemini Code Assist or Gemini CLI if I've subscribed to Google AI Pro or Ultra?
-
-To learn more about your privacy policy and terms of service governed by your
-subscription, visit
-[Gemini Code Assist: Terms of Service and Privacy Policies](https://developers.google.com/gemini-code-assist/resources/privacy-notices).
-
-### I've upgraded to Google AI Pro or Ultra but it still says I am hitting quota limits. Is this a bug?
-
-The higher limits in your Google AI Pro or Ultra subscription are for Gemini 2.5
-across both Gemini 2.5 Pro and Flash. They are shared quota across Gemini CLI
-and agent mode in Gemini Code Assist IDE extensions. You can learn more about
-quota limits for Gemini CLI, Gemini Code Assist and agent mode in Gemini Code
-Assist at
-[Quotas and limits](https://developers.google.com/gemini-code-assist/resources/quotas).
-
-### If I upgrade to higher limits for Gemini CLI and Gemini Code Assist by purchasing a Google AI Pro or Ultra subscription, will Gemini start using my data to improve its machine learning models?
-
-Google does not use your data to improve Google's machine learning models if you
-purchase a paid plan. Note: If you decide to remain on the free version of
-Gemini Code Assist, Gemini Code Assist for individuals, you can also opt out of
-using your data to improve Google's machine learning models. See the
-[Gemini Code Assist for individuals privacy notice](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals)
-for more information.
-
 ## Not seeing your question?
 
 Search the

--- a/docs/resources/quota-and-pricing.md
+++ b/docs/resources/quota-and-pricing.md
@@ -1,8 +1,7 @@
 # Gemini CLI: Quotas and pricing
 
-Gemini CLI offers a generous free tier that covers many individual developers'
-use cases. For enterprise or professional usage, or if you need increased quota,
-several options are available depending on your authentication account type.
+Gemini CLI is designed for professional and enterprise usage. Several options
+are available depending on your authentication account type and project needs.
 
 For a high-level comparison of available subscriptions and to select the right
 quota for your needs, see the [Plans page](https://geminicli.com/plans/).
@@ -14,108 +13,35 @@ when using different authentication methods.
 
 The following table summarizes the available quotas and their respective limits:
 
-| Authentication method | Tier / Subscription             | Maximum requests per user per day |
-| :-------------------- | :------------------------------ | :-------------------------------- |
-| **Google account**    | Gemini Code Assist (Individual) | 1,000 requests                    |
-|                       | Google AI Pro                   | 1,500 requests                    |
-|                       | Google AI Ultra                 | 2,000 requests                    |
-| **Gemini API key**    | Free tier (Unpaid)              | 250 requests                      |
-|                       | Pay-as-you-go (Paid)            | Varies                            |
-| **Vertex AI**         | Express mode (Free)             | Varies                            |
-|                       | Pay-as-you-go (Paid)            | Varies                            |
-| **Google Workspace**  | Code Assist Standard            | 1,500 requests                    |
-|                       | Code Assist Enterprise          | 2,000 requests                    |
-|                       | Workspace AI Ultra              | 2,000 requests                    |
+| Authentication method | Tier / Subscription    | Maximum requests per user per day |
+| :-------------------- | :--------------------- | :-------------------------------- |
+| **Gemini API key**    | Pay-as-you-go (Paid)   | Varies                            |
+| **Vertex AI**         | Pay-as-you-go (Paid)   | Varies                            |
+| **Google Workspace**  | Code Assist Standard   | 1,500 requests                    |
+|                       | Code Assist Enterprise | 2,000 requests                    |
+|                       | Workspace AI Ultra     | 2,000 requests                    |
 
-Generally, there are three categories to choose from:
+Generally, there are two categories to choose from:
 
-- Free Usage: Ideal for experimentation and light use.
-- Paid Tier (fixed price): For individual developers or enterprises who need
-  more generous daily quotas and predictable costs.
+- Paid Tier (fixed price): For teams who need generous daily quotas and
+  predictable costs.
 - Pay-As-You-Go: The most flexible option for professional use, long-running
   tasks, or when you need full control over your usage.
 
 Requests are limited per user per minute and are subject to the availability of
 the service in times of high demand.
 
-## Free usage
-
-Access to Gemini CLI begins with a generous free tier, perfect for
-experimentation and light use.
-
-Your free usage is governed by the following limits, which depend on your
-authorization type.
-
-### Log in with Google (Gemini Code Assist for individuals)
-
-For users who authenticate by using their Google account to access Gemini Code
-Assist for individuals. This includes:
-
-- 1000 maximum model requests / user / day
-- Model requests will be made across the Gemini model family as determined by
-  Gemini CLI.
-
-Learn more at
-[Gemini Code Assist for Individuals Limits](https://developers.google.com/gemini-code-assist/resources/quotas#quotas-for-agent-mode-gemini-cli).
-
-### Log in with Gemini API Key (unpaid)
-
-If you are using a Gemini API key, you can also benefit from a free tier. This
-includes:
-
-- 250 maximum model requests / user / day
-- Model requests to Flash model only.
-
-Learn more at
-[Gemini API Rate Limits](https://ai.google.dev/gemini-api/docs/rate-limits).
-
-### Log in with Vertex AI (Express Mode)
-
-Vertex AI offers an Express Mode without the need to enable billing. This
-includes:
-
-- 90 days before you need to enable billing.
-- Quotas and models are specific to your account and their limits vary.
-
-Learn more at
-[Vertex AI Express Mode Limits](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview#quotas).
-
 ## Paid tier: Higher limits for a fixed cost
 
-If you use up your initial number of requests, you can continue to benefit from
-Gemini CLI by upgrading to one of the following subscriptions:
-
-### Individuals
-
-These tiers apply when you sign in with a personal account. To verify whether
-you're on a personal account, visit
-[Google One](https://one.google.com/about/plans?hl=en-US&g1_landing_page=0):
-
-- If you are on a personal account, you will see your personal dashboard.
-- If you are not on a personal account, you will see: "You're currently signed
-  in to your Google Workspace Account."
-
-**Supported tiers:** _- Tiers not listed above, including Google AI Plus, are
-not supported._
-
-- [Google AI Pro and AI Ultra](https://gemini.google/subscriptions/). This is
-  recommended for individual developers. Quotas and pricing are based on a fixed
-  price subscription.
-
-  For predictable costs, you can log in with Google.
-
-  Learn more at
-  [Gemini Code Assist Quotas and Limits](https://developers.google.com/gemini-code-assist/resources/quotas)
+Several fixed-price subscriptions are available for teams and organizations:
 
 ### Through your organization
 
 These tiers are applicable when you are signing in with a Google Workspace
 account.
 
-- To verify your account type, visit
-  [the Google One page](https://one.google.com/about/plans?hl=en-US&g1_landing_page=0).
 - You are on a workspace account if you see the message "You're currently signed
-  in to your Google Workspace Account".
+  in to your Google Workspace Account" when accessing Google services.
 
 **Supported tiers:** _- Tiers not listed above, including Workspace AI
 Standard/Plus and AI Expanded, are not supported._

--- a/docs/resources/tos-privacy.md
+++ b/docs/resources/tos-privacy.md
@@ -33,20 +33,11 @@ Google’s services with Gemini CLI. Supported authentication methods include:
 The Terms of Service and Privacy Notices applicable to the aforementioned Google
 services are set forth in the table below.
 
-If you log in with your Google account and you do not already have a Gemini Code
-Assist account associated with your Google account, you will be directed to the
-sign up flow for Gemini Code Assist for individuals. If your Google account is
-managed by your organization, your administrator may not permit access to Gemini
-Code Assist for individuals. See the
-[Gemini Code Assist for individuals FAQs](https://developers.google.com/gemini-code-assist/resources/faqs)
-for further information.
-
-| Authentication Method    | Service(s)                   | Terms of Service                                                                                        | Privacy Notice                                                                                |
-| :----------------------- | :--------------------------- | :------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
-| Google Account           | Gemini Code Assist services  | [Terms of Service](https://developers.google.com/gemini-code-assist/resources/privacy-notices)          | [Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices) |
-| Gemini Developer API Key | Gemini API - Unpaid Services | [Gemini API Terms of Service - Unpaid Services](https://ai.google.dev/gemini-api/terms#unpaid-services) | [Google Privacy Policy](https://policies.google.com/privacy)                                  |
-| Gemini Developer API Key | Gemini API - Paid Services   | [Gemini API Terms of Service - Paid Services](https://ai.google.dev/gemini-api/terms#paid-services)     | [Google Privacy Policy](https://policies.google.com/privacy)                                  |
-| Vertex AI GenAI API Key  | Vertex AI GenAI API          | [Google Cloud Platform Terms of Service](https://cloud.google.com/terms/service-terms/)                 | [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)            |
+| Authentication Method    | Service(s)                  | Terms of Service                                                                                    | Privacy Notice                                                                                |
+| :----------------------- | :-------------------------- | :-------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| Google Account           | Gemini Code Assist services | [Terms of Service](https://developers.google.com/gemini-code-assist/resources/privacy-notices)      | [Privacy Notices](https://developers.google.com/gemini-code-assist/resources/privacy-notices) |
+| Gemini Developer API Key | Gemini API - Paid Services  | [Gemini API Terms of Service - Paid Services](https://ai.google.dev/gemini-api/terms#paid-services) | [Google Privacy Policy](https://policies.google.com/privacy)                                  |
+| Vertex AI GenAI API Key  | Vertex AI GenAI API         | [Google Cloud Platform Terms of Service](https://cloud.google.com/terms/service-terms/)             | [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)            |
 
 ## 1. If you have signed in with your Google account to Gemini Code Assist
 
@@ -54,21 +45,9 @@ For users who use their Google account to access
 [Gemini Code Assist](https://codeassist.google), these Terms of Service and
 Privacy Notice documents apply:
 
-- Gemini Code Assist for individuals:
-  [Google Terms of Service](https://policies.google.com/terms) and
-  [Gemini Code Assist for individuals Privacy Notice](https://developers.google.com/gemini-code-assist/resources/privacy-notice-gemini-code-assist-individuals).
-- Gemini Code Assist with Google AI Pro or Ultra subscription:
-  [Google Terms of Service](https://policies.google.com/terms),
-  [Google One Additional Terms of Service](https://one.google.com/terms-of-service)
-  and [Google Privacy Policy\*](https://policies.google.com/privacy).
 - Gemini Code Assist Standard and Enterprise editions:
   [Google Cloud Platform Terms of Service](https://cloud.google.com/terms) and
   [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice).
-
-_\* If your account is also associated with an active subscription to Gemini
-Code Assist Standard or Enterprise edition, the terms and privacy policy of
-Gemini Code Assist Standard or Enterprise edition will apply to all your use of
-Gemini Code Assist._
 
 ## 2. If you have signed in with a Gemini API key to the Gemini Developer API
 
@@ -77,12 +56,7 @@ If you are using a Gemini API key for authentication with the
 Service and Privacy Notice documents apply:
 
 - Terms of Service: Your use of Gemini CLI is governed by the
-  [Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms). These
-  terms may differ depending on whether you are using an unpaid or paid service:
-  - For unpaid services, refer to the
-    [Gemini API Terms of Service - Unpaid Services](https://ai.google.dev/gemini-api/terms#unpaid-services).
-  - For paid services, refer to the
-    [Gemini API Terms of Service - Paid Services](https://ai.google.dev/gemini-api/terms#paid-services).
+  [Gemini API Terms of Service - Paid Services](https://ai.google.dev/gemini-api/terms#paid-services).
 - Privacy Notice: The collection and use of your data is described in the
   [Google Privacy Policy](https://policies.google.com/privacy).
 

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -12,38 +12,19 @@ topics on:
 
 - **Error:
   `You must be a named user on your organization's Gemini Code Assist Standard edition subscription to use this service. Please contact your administrator to request an entitlement to Gemini Code Assist Standard edition.`**
-  - **Cause:** This error might occur if Gemini CLI detects the
-    `GOOGLE_CLOUD_PROJECT` or `GOOGLE_CLOUD_PROJECT_ID` environment variable is
-    defined. Setting these variables forces an organization subscription check.
-    This might be an issue if you are using an individual Google account not
-    linked to an organizational subscription.
+  - **Cause:** This error occurs if Gemini CLI detects that you are not
+    authorized under an organizational subscription.
 
   - **Solution:**
-    - **Individual Users:** Unset the `GOOGLE_CLOUD_PROJECT` and
-      `GOOGLE_CLOUD_PROJECT_ID` environment variables. Check and remove these
-      variables from your shell configuration files (for example, `.bashrc`,
-      `.zshrc`) and any `.env` files. If this doesn't resolve the issue, try
-      using a different Google account.
-
     - **Organizational Users:** Contact your Google Cloud administrator to be
       added to your organization's Gemini Code Assist subscription.
 
 - **Error:
   `Failed to sign in. Message: Your current account is not eligible... because it is not currently available in your location.`**
   - **Cause:** Gemini CLI does not currently support your location. For a full
-    list of supported locations, see the following pages:
-    - Gemini Code Assist for individuals:
-      [Available locations](https://developers.google.com/gemini-code-assist/resources/available-locations#americas)
-
-- **Error: `Failed to sign in. Message: Request contains an invalid argument`**
-  - **Cause:** Users with Google Workspace accounts or Google Cloud accounts
-    associated with their Gmail accounts may not be able to activate the free
-    tier of the Google Code Assist plan.
-  - **Solution:** For Google Cloud accounts, you can work around this by setting
-    `GOOGLE_CLOUD_PROJECT` to your project ID. Alternatively, you can obtain the
-    Gemini API key from
-    [Google AI Studio](http://aistudio.google.com/app/apikey), which also
-    includes a separate free tier.
+    list of supported locations, see the
+    [Gemini Code Assist available locations](https://developers.google.com/gemini-code-assist/resources/available-locations#americas)
+    page.
 
 - **Error: `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` or
   `unable to get local issuer certificate`**


### PR DESCRIPTION
## Summary

This PR removes all references to the deprecated consumer account tiers and the free tier for individual developers. According to recent news, these services (including Gemini Code Assist for individuals, Google AI Pro/Ultra, and the unpaid Free Tier) will stop serving requests on June 18, 2026.

## Details

All mentions of the following have been removed or rewritten to reflect only supported Standard, Enterprise, and Paid API tiers:
- Free Tier quota and pricing information.
- Google account (Individual) authentication guidance.
- Google AI Pro and AI Ultra subscription details.
- References to consumer-tier privacy notices and terms of service.
- The `/upgrade` command from the documentation.

## Related Issues

Fixes #27998
Related to the deprecation announced for June 18, 2026.

## How to Validate

1. Review the modified documentation files:
   - `README.md`
   - `ROADMAP.md`
   - `docs/changelogs/index.md`
   - `docs/cli/enterprise.md`
   - `docs/get-started/authentication.mdx`
   - `docs/reference/commands.md`
   - `docs/resources/faq.md`
   - `docs/resources/quota-and-pricing.md`
   - `docs/resources/tos-privacy.md`
   - `docs/resources/troubleshooting.md`
2. Run a global search for "Free tier" or "Google One" in the `docs` and root directories to ensure no lingering references remain.
3. Run `npm run lint` to ensure no formatting or link issues were introduced.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) - N/A for documentation changes
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run (lint)
