### PR TITLE
docs(policy): correct policy tier references

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -134,7 +134,7 @@ The policy engine uses a sophisticated priority system to resolve conflicts when
 multiple rules match a single tool call. The core principle is simple: **the
 rule with the highest priority wins**.
 
-To provide a clear hierarchy, policies are organized into three tiers. Each tier
+To provide a clear hierarchy, policies are organized into five tiers. Each tier
 has a designated number that forms the base of the final priority calculation.
 
 | Tier      | Base | Description                                                                                   |
@@ -161,9 +161,9 @@ This system guarantees that:
 For example:
 
 - A `priority: 50` rule in a Default policy TOML becomes `1.050`.
-- A `priority: 10` rule in a Workspace policy TOML becomes `2.010`.
-- A `priority: 100` rule in a User policy TOML becomes `3.100`.
-- A `priority: 20` rule in an Admin policy TOML becomes `4.020`.
+- A `priority: 10` rule in a Workspace policy TOML becomes `3.010`.
+- A `priority: 100` rule in a User policy TOML becomes `4.100`.
+- A `priority: 20` rule in an Admin policy TOML becomes `5.020`.
 
 ### Approval modes
 
@@ -232,7 +232,7 @@ User, and (if configured) Admin directories.
 
 #### System-wide policies (Admin)
 
-Administrators can enforce system-wide policies (Tier 4) that override all user
+Administrators can enforce system-wide policies (Tier 5) that override all user
 and default settings. These policies can be loaded from standard system
 locations or supplemental paths.
 
@@ -253,7 +253,7 @@ Administrators can also specify supplemental policy paths using:
 - The `--admin-policy` command-line flag.
 - The `adminPolicyPaths` setting in a system settings file.
 
-These supplemental policies are assigned the same **Admin** tier (Base 4) as
+These supplemental policies are assigned the same **Admin** tier (Base 5) as
 policies in standard locations.
 
 **Security Guard**: Supplemental admin policies are **ignored** if any `.toml`

--- a/packages/core/src/policy/toml-loader.ts
+++ b/packages/core/src/policy/toml-loader.ts
@@ -47,8 +47,10 @@ const PolicyRuleSchema = z.object({
   // Priority must be in range [0, 999] to prevent tier overflow.
   // With tier transformation (tier + priority/1000), this ensures:
   // - Tier 1 (default): range [1.000, 1.999]
-  // - Tier 2 (user): range [2.000, 2.999]
-  // - Tier 3 (admin): range [3.000, 3.999]
+  // - Tier 2 (extension): range [2.000, 2.999]
+  // - Tier 3 (workspace): range [3.000, 3.999]
+  // - Tier 4 (user): range [4.000, 4.999]
+  // - Tier 5 (admin): range [5.000, 5.999]
   priority: z
     .number({
       required_error: 'priority is required',
@@ -317,7 +319,7 @@ function transformPriority(priority: number, tier: number): number {
  * 4. Collects detailed error information for any failures
  *
  * @param policyPaths Array of paths (directories or files) to scan for policy files
- * @param getPolicyTier Function to determine tier (1-4) for a path
+ * @param getPolicyTier Function to determine tier (1-5) for a path
  * @returns Object containing successfully parsed rules and any errors encountered
  */
 export async function loadPoliciesFromToml(


### PR DESCRIPTION
Fixes #21681

## Summary
- updates the policy engine docs from three tiers to five tiers
- corrects Workspace/User/Admin priority examples to match tier bases 3/4/5
- updates Admin tier references and the TOML loader tier comments/JSDoc

## Verification
- npx prettier --check docs/reference/policy-engine.md packages/core/src/policy/toml-loader.ts
- rg stale tier patterns in docs/reference/policy-engine.md and packages/core/src/policy/toml-loader.ts
- git diff --check

## Duplicate check
- Existing PRs mentioned in the issue (#21682 and #21946) are closed; no active PR was found for this correction.