### PR TITLE
docs(model): document customtools auth requirement

### DIFF
--- a/docs/cli/model-routing.md
+++ b/docs/cli/model-routing.md
@@ -26,6 +26,14 @@ policies.
     the CLI will use an available fallback model for the current turn or the
     remainder of the session.
 
+### Authentication-specific model variants
+
+When Gemini 3.1 Pro Preview is available, model routing can use the
+`gemini-3.1-pro-preview-customtools` variant only for Gemini API key
+authentication with a key from Google AI Studio. Other authentication methods,
+including Vertex AI, use `gemini-3.1-pro-preview` for Gemini 3.1 Pro Preview
+routing.
+
 ### Local Model Routing (Experimental)
 
 Gemini CLI supports using a local model for routing decisions. When configured,

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -34,6 +34,11 @@ You can also use the `--model` flag to specify a particular Gemini model on
 startup. For more details, refer to the
 [configuration documentation](../reference/configuration.md).
 
+When Gemini 3.1 Pro Preview is available, the
+`gemini-3.1-pro-preview-customtools` variant is shown only for Gemini API key
+authentication with a key from Google AI Studio. Other authentication methods
+show and resolve to `gemini-3.1-pro-preview`.
+
 Changes to these settings will be applied to all subsequent interactions with
 Gemini CLI.
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -26,6 +26,10 @@ Select the authentication method that matches your situation in the table below:
 | Google Cloud Vertex AI user                                            | [Vertex AI](#vertex-ai)                                          | [Yes](#set-gcp)                                             |
 | [Headless mode](#headless)                                             | [Use Gemini API Key](#gemini-api) or<br /> [Vertex AI](#vertex-ai) | No (for Gemini API Key)<br /> [Yes](#set-gcp) (for Vertex AI) |
 
+Authentication method can also affect model availability. The
+`gemini-3.1-pro-preview-customtools` model variant is available only when
+Gemini CLI is authenticated with a Gemini API key from Google AI Studio.
+
 ### What is my Google account type?
 
 - **Individual Google accounts:** Includes all
@@ -77,6 +81,10 @@ For instructions, see [Set your Google Cloud Project](#set-gcp).
 
 If you don't want to authenticate using your Google account, you can use an API
 key from Google AI Studio.
+
+When Gemini 3.1 Pro Preview is available, this authentication method can use the
+`gemini-3.1-pro-preview-customtools` model variant. Other authentication methods
+use `gemini-3.1-pro-preview` instead.
 
 To authenticate and use Gemini CLI with a Gemini API key:
 

--- a/docs/get-started/gemini-3.md
+++ b/docs/get-started/gemini-3.md
@@ -16,6 +16,11 @@ Learn about how you can use Gemini 3 Pro and Gemini 3 Flash on Gemini CLI.
 > gemini -m gemini-3.1-pro-preview
 > ```
 >
+> When using a Gemini API key from Google AI Studio, Gemini CLI may route Gemini
+> 3.1 Pro Preview requests to the
+> `gemini-3.1-pro-preview-customtools` variant. Other authentication methods use
+> `gemini-3.1-pro-preview`.
+>
 > Learn more about [models](../cli/model.md) and
 > [model routing](../cli/model-routing.md).
 


### PR DESCRIPTION
Fixes #22062

## Summary
- documents that gemini-3.1-pro-preview-customtools is available only with Gemini API key authentication from Google AI Studio
- adds the clarification to authentication, /model, Gemini 3, and model routing docs
- notes that other authentication methods resolve to gemini-3.1-pro-preview

## Verification
- npx prettier --check docs/get-started/authentication.mdx docs/cli/model.md docs/get-started/gemini-3.md docs/cli/model-routing.md
- rg customtools/auth wording across the updated docs
- git diff --check

## Duplicate check
- No active PR was found for #22062 or the customtools auth documentation gap.