### PR TITLE
docs(install): add Windows PowerShell install tab

### DIFF
--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -37,6 +37,19 @@ installation methods. Note that Gemini CLI comes pre-installed on
   ```
 
   </TabItem>
+  <TabItem label="Windows (PowerShell)">
+
+  Install globally with npm from PowerShell:
+
+  ```powershell
+  npm install -g @google/gemini-cli
+  ```
+
+  Install [Node.js](https://nodejs.org/) first if `npm` is not already
+  available. WSL and Git Bash are optional, but they can help when you want a
+  Unix-like shell for commands that do not exist in PowerShell.
+
+  </TabItem>
   <TabItem label="Homebrew (macOS/Linux)">
 
   Install globally with Homebrew:


### PR DESCRIPTION
Fixes #27946

## Summary
- adds a Windows (PowerShell) install tab using the npm package
- points users to install Node.js first if npm is unavailable
- clarifies that WSL and Git Bash are optional for Unix-like shell compatibility

## Verification
- npx prettier --check docs/get-started/installation.mdx
- git diff --check

## Duplicate check
- No active PR was found for #27946 or a Windows-specific installation clarification.