### PR TITLE
fix(prompts): use function replacer in applySubstitutions to prevent $-pattern corruption

### DIFF
--- a/packages/core/src/prompts/utils.test.ts
+++ b/packages/core/src/prompts/utils.test.ts
@@ -312,4 +312,36 @@ describe('applySubstitutions', () => {
     );
     expect(result).toBe('A plain prompt with no variables.');
   });
+
+  it("should insert skills content containing $' (dollar-quote) literally", () => {
+    const skillsWithDollarQuote = "Run: echo $'a\\nb' to print two lines";
+    const result = applySubstitutions(
+      'Header.\n${AgentSkills}\nTAIL: follow policy.',
+      mockConfig,
+      skillsWithDollarQuote,
+    );
+    expect(result).toBe(
+      `Header.\n${skillsWithDollarQuote}\nTAIL: follow policy.`,
+    );
+  });
+
+  it('should insert skills content containing $$ literally without collapsing', () => {
+    const skillsWithDoubleDollar = 'Cost is $$5 for the $$VAR variable';
+    const result = applySubstitutions(
+      'Header.\n${AgentSkills}\nTAIL.',
+      mockConfig,
+      skillsWithDoubleDollar,
+    );
+    expect(result).toBe(`Header.\n${skillsWithDoubleDollar}\nTAIL.`);
+  });
+
+  it('should insert skills content containing $& literally without re-inserting the match', () => {
+    const skillsWithDollarAmp = 'Use $& carefully';
+    const result = applySubstitutions(
+      'Header.\n${AgentSkills}\nTAIL.',
+      mockConfig,
+      skillsWithDollarAmp,
+    );
+    expect(result).toBe(`Header.\n${skillsWithDollarAmp}\nTAIL.`);
+  });
 });

--- a/packages/core/src/prompts/utils.ts
+++ b/packages/core/src/prompts/utils.ts
@@ -69,7 +69,7 @@ export function applySubstitutions(
 ): string {
   let result = prompt;
 
-  result = result.replace(/\${AgentSkills}/g, skillsPrompt);
+  result = result.replace(/\${AgentSkills}/g, () => skillsPrompt);
 
   const activeSnippets = isGemini3 ? snippets : legacySnippets;
   const subAgentsContent = activeSnippets.renderSubAgents(
@@ -82,7 +82,7 @@ export function applySubstitutions(
       })),
   );
 
-  result = result.replace(/\${SubAgents}/g, subAgentsContent);
+  result = result.replace(/\${SubAgents}/g, () => subAgentsContent);
 
   const toolRegistry = context.toolRegistry;
   const allToolNames = toolRegistry.getAllToolNames();
@@ -90,13 +90,13 @@ export function applySubstitutions(
     allToolNames.length > 0
       ? allToolNames.map((name) => `- ${name}`).join('\n')
       : 'No tools are currently available.';
-  result = result.replace(/\${AvailableTools}/g, availableToolsList);
+  result = result.replace(/\${AvailableTools}/g, () => availableToolsList);
 
   for (const toolName of allToolNames) {
     const varName = `${toolName}_ToolName`;
     result = result.replace(
       new RegExp(`\\\${\\b${varName}\\b}`, 'g'),
-      toolName,
+      () => toolName,
     );
   }
 


### PR DESCRIPTION
## Summary

`applySubstitutions` in `packages/core/src/prompts/utils.ts` passes a plain string as the second argument to `String.prototype.replace`. JavaScript interprets `$`-prefixed patterns in string replacements (`$$`, `$&`, `` $` ``, `$'`, `$n`), so any skill, sub-agent, or tool description that legitimately contains shell notation like `$'…'`, `$$`, or `$VAR` silently corrupts the assembled system prompt — duplicating content, collapsing `$$` to `$`, or re-inserting the placeholder text.

## Details

The fix replaces all four string-form replacements with arrow-function replacers, which bypass `$`-pattern substitution entirely. This is the same pattern already used in `HookRunner.expandCommand` (`packages/core/src/hooks/hookRunner.ts`):

```ts
// before
result = result.replace(/\${AgentSkills}/g, skillsPrompt);
// after
result = result.replace(/\${AgentSkills}/g, () => skillsPrompt);
```

The same change is applied to the `${SubAgents}`, `${AvailableTools}`, and per-tool `${toolName_ToolName}` replacements.

## Related Issues

Fixes #27993

## How to Validate

Run the targeted test file:

```
cd packages/core && npx vitest run src/prompts/utils.test.ts
```

The three new tests (`$'`, `$$`, `$&` cases) would have failed before this change. All 33 tests pass after it.

Reproduce the original corruption manually (Node ≥18):

```js
const prompt = "Header.\n${AgentSkills}\nTAIL: behave safely.";
const skills = "Run: echo $'a\\nb' to print two lines";
console.log(prompt.replace(/\${AgentSkills}/g, skills));        // BUGGY — duplicates TAIL
console.log(prompt.replace(/\${AgentSkills}/g, () => skills));  // FIXED — literal insert
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — no docs change required
- [x] Added/updated tests (if needed) — three regression tests added in `utils.test.ts`
- [x] Noted breaking changes (if any) — none; pure correctness fix
- [x] Validated on required platforms/methods:
  - [x] MacOS — npm run / unit tests pass locally