### PR TITLE
fix(ci): provide fallbacks for package variables in nightly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -145,12 +145,12 @@ jobs:
           skip-branch-cleanup: true
           force-skip-tests: "${{ github.event_name != 'schedule' && github.event.inputs.force_skip_tests == 'true' }}"
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
-          npm-registry-publish-url: '${{ vars.NPM_REGISTRY_PUBLISH_URL }}'
-          npm-registry-url: '${{ vars.NPM_REGISTRY_URL }}'
-          npm-registry-scope: '${{ vars.NPM_REGISTRY_SCOPE }}'
-          cli-package-name: '${{ vars.CLI_PACKAGE_NAME }}'
-          core-package-name: '${{ vars.CORE_PACKAGE_NAME }}'
-          a2a-package-name: '${{ vars.A2A_PACKAGE_NAME }}'
+          npm-registry-publish-url: "${{ vars.NPM_REGISTRY_PUBLISH_URL || 'https://registry.npmjs.org/' }}"
+          npm-registry-url: "${{ vars.NPM_REGISTRY_URL || 'https://registry.npmjs.org/' }}"
+          npm-registry-scope: "${{ vars.NPM_REGISTRY_SCOPE || '@google' }}"
+          cli-package-name: "${{ vars.CLI_PACKAGE_NAME || '@google/gemini-cli' }}"
+          core-package-name: "${{ vars.CORE_PACKAGE_NAME || '@google/gemini-cli-core' }}"
+          a2a-package-name: "${{ vars.A2A_PACKAGE_NAME || '@google/gemini-cli-a2a-server' }}"
 
       - name: 'Create and Merge Pull Request'
         if: "github.event.inputs.environment != 'dev'"


### PR DESCRIPTION
## Summary

Fixes the nightly release workflow failing during the publish step for scheduled runs. Scheduled runs use the `internal` environment which does not define the package name variables, resulting in `npm publish` receiving empty workspace names and failing. This adds default fallbacks for these variables.

## Details

The scheduled `release-nightly.yml` workflow was changed recently to use the `internal` environment instead of `prod`. The `internal` environment doesn't have the `vars.CLI_PACKAGE_NAME`, `vars.CORE_PACKAGE_NAME`, and `vars.A2A_PACKAGE_NAME` repository variables configured. Consequently, they evaluate to empty strings, causing the `npm publish --workspace=""` command to fail with an error `npm error No workspaces found`. 

This PR adds default values to the variables directly in the workflow file. 

## Related Issues

Fixes #28001 (Scheduled release failure)

## How to Validate

1. Trigger the `Release: Nightly` workflow via workflow_dispatch with the `internal` environment (if possible) or review the generated variables.
2. Ensure that the package names correctly fall back to `@google/gemini-cli`, `@google/gemini-cli-core`, and `@google/gemini-cli-a2a-server`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker