### PR TITLE
Eval inventory json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "schema:settings": "tsx ./scripts/generate-settings-schema.ts",
     "docs:settings": "tsx ./scripts/generate-settings-doc.ts",
     "docs:keybindings": "tsx ./scripts/generate-keybindings-doc.ts",
+    "eval:inventory": "tsx ./scripts/eval-inventory-cli.ts",
     "build": "node scripts/build.js",
     "build-and-start": "npm run build && npm run start --",
     "build:vscode": "node scripts/build_vscode_companion.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "docs:settings": "tsx ./scripts/generate-settings-doc.ts",
     "docs:keybindings": "tsx ./scripts/generate-keybindings-doc.ts",
     "eval:inventory": "tsx ./scripts/eval-inventory-cli.ts",
+    "eval:inventory:json": "tsx ./scripts/eval-inventory-cli.ts --json",
     "build": "node scripts/build.js",
     "build-and-start": "npm run build && npm run start --",
     "build:vscode": "node scripts/build_vscode_companion.js",

--- a/scripts/eval-inventory-cli.ts
+++ b/scripts/eval-inventory-cli.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env tsx
+
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview CLI entry point for the eval inventory command.
+ *
+ * Scans all eval source files, runs the static analyzer on each,
+ * and prints a human-readable inventory report grouped by policy,
+ * file, and suite.
+ *
+ * Usage:
+ *   npm run eval:inventory
+ *   npm run eval:inventory -- --root /path/to/repo
+ */
+
+import {
+  collectInventory,
+  formatInventoryReport,
+} from './utils/eval-inventory.js';
+
+async function main() {
+  const rootFlagIndex = process.argv.indexOf('--root');
+  const repoRoot =
+    rootFlagIndex !== -1 && process.argv[rootFlagIndex + 1]
+      ? process.argv[rootFlagIndex + 1]
+      : process.cwd();
+
+  const result = await collectInventory(repoRoot);
+
+  if (result.totalFiles === 0) {
+    console.error('No eval files found under evals/.');
+    process.exit(1);
+  }
+
+  console.log(formatInventoryReport(result));
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/eval-inventory-cli.ts
+++ b/scripts/eval-inventory-cli.ts
@@ -10,16 +10,18 @@
  * @fileoverview CLI entry point for the eval inventory command.
  *
  * Scans all eval source files, runs the static analyzer on each,
- * and prints a human-readable inventory report grouped by policy,
- * file, and suite.
+ * and prints an inventory report grouped by policy, file, and suite.
  *
  * Usage:
  *   npm run eval:inventory
+ *   npm run eval:inventory -- --json
  *   npm run eval:inventory -- --root /path/to/repo
+ *   npm run eval:inventory -- --root /path/to/repo --json
  */
 
 import {
   collectInventory,
+  formatInventoryJson,
   formatInventoryReport,
 } from './utils/eval-inventory.js';
 
@@ -30,6 +32,8 @@ async function main() {
       ? process.argv[rootFlagIndex + 1]
       : process.cwd();
 
+  const jsonMode = process.argv.includes('--json');
+
   const result = await collectInventory(repoRoot);
 
   if (result.totalFiles === 0) {
@@ -37,7 +41,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(formatInventoryReport(result));
+  console.log(
+    jsonMode ? formatInventoryJson(result) : formatInventoryReport(result),
+  );
 }
 
 main().catch((error) => {

--- a/scripts/tests/eval-inventory.test.ts
+++ b/scripts/tests/eval-inventory.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  collectInventory,
+  formatInventoryReport,
+  type InventoryResult,
+} from '../utils/eval-inventory.js';
+import type { EvalCaseRecord } from '../utils/eval-analysis.js';
+
+function makeCaseRecord(
+  overrides: Partial<EvalCaseRecord> = {},
+): EvalCaseRecord {
+  return {
+    filePath: '/repo/evals/test.eval.ts',
+    relativePath: 'evals/test.eval.ts',
+    helperName: 'evalTest',
+    baseHelperName: 'evalTest',
+    policy: 'USUALLY_PASSES',
+    name: 'test case',
+    hasFiles: false,
+    hasPrompt: true,
+    location: { line: 1, column: 1 },
+    ...overrides,
+  };
+}
+
+describe('eval-inventory', () => {
+  describe('collectInventory', () => {
+    it('discovers eval files from the real evals directory', async () => {
+      const repoRoot = path.resolve(import.meta.dirname, '../../');
+      const result = await collectInventory(repoRoot);
+
+      expect(result.totalFiles).toBeGreaterThanOrEqual(36);
+      expect(result.totalCases).toBeGreaterThanOrEqual(90);
+      expect(result.files.length).toBe(result.totalFiles);
+      expect(result.cases.length).toBe(result.totalCases);
+
+      for (const evalCase of result.cases) {
+        expect(evalCase.name).toBeTruthy();
+        expect(evalCase.relativePath).toBeTruthy();
+        expect(evalCase.relativePath).toMatch(/^evals\//);
+      }
+    });
+
+    it('returns zero counts for a directory with no eval files', async () => {
+      const result = await collectInventory(import.meta.dirname);
+
+      expect(result.totalFiles).toBe(0);
+      expect(result.totalCases).toBe(0);
+      expect(result.files).toEqual([]);
+      expect(result.cases).toEqual([]);
+    });
+  });
+
+  describe('formatInventoryReport', () => {
+    it('includes summary line with correct counts', () => {
+      const result: InventoryResult = {
+        totalFiles: 2,
+        totalCases: 3,
+        files: [],
+        cases: [
+          makeCaseRecord({ policy: 'ALWAYS_PASSES', name: 'case-1' }),
+          makeCaseRecord({ policy: 'USUALLY_PASSES', name: 'case-2' }),
+          makeCaseRecord({ policy: 'USUALLY_PASSES', name: 'case-3' }),
+        ],
+        diagnostics: [],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).toContain('2 files · 3 cases · 0 diagnostics');
+    });
+
+    it('groups cases by policy', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 2,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            policy: 'ALWAYS_PASSES',
+            name: 'stable test',
+          }),
+          makeCaseRecord({
+            policy: 'USUALLY_PASSES',
+            name: 'flaky test',
+          }),
+        ],
+        diagnostics: [],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).toContain('By Policy');
+      expect(report).toContain('ALWAYS_PASSES (1 cases)');
+      expect(report).toContain('USUALLY_PASSES (1 cases)');
+      expect(report).toContain('• stable test');
+      expect(report).toContain('• flaky test');
+    });
+
+    it('groups cases by suite name', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 2,
+        files: [],
+        cases: [
+          makeCaseRecord({ suiteName: 'default', name: 'suite-test' }),
+          makeCaseRecord({ name: 'no-suite-test' }),
+        ],
+        diagnostics: [],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).toContain('By Suite');
+      expect(report).toContain('default (1 cases)');
+      expect(report).toContain('(no suite) (1 cases)');
+    });
+
+    it('shows diagnostics section when diagnostics exist', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 0,
+        files: [],
+        cases: [],
+        diagnostics: [
+          {
+            severity: 'warning',
+            message: 'Could not resolve policy',
+            filePath: '/repo/evals/bad.eval.ts',
+            location: { line: 5, column: 3 },
+          },
+        ],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).toContain('Diagnostics');
+      expect(report).toContain('1 diagnostics');
+      expect(report).toContain(
+        '⚠ /repo/evals/bad.eval.ts:5:3 — Could not resolve policy',
+      );
+    });
+
+    it('omits diagnostics section when there are none', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [makeCaseRecord()],
+        diagnostics: [],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).not.toContain('Diagnostics');
+      expect(report).not.toContain('⚠');
+    });
+
+    it('includes helper name in case listing', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            helperName: 'customHelper',
+            name: 'custom test',
+          }),
+        ],
+        diagnostics: [],
+      };
+
+      const report = formatInventoryReport(result);
+
+      expect(report).toContain('• custom test [customHelper]');
+    });
+  });
+});

--- a/scripts/tests/eval-inventory.test.ts
+++ b/scripts/tests/eval-inventory.test.ts
@@ -8,7 +8,9 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   collectInventory,
+  formatInventoryJson,
   formatInventoryReport,
+  type InventoryJsonOutput,
   type InventoryResult,
 } from '../utils/eval-inventory.js';
 import type { EvalCaseRecord } from '../utils/eval-analysis.js';
@@ -29,6 +31,9 @@ function makeCaseRecord(
     ...overrides,
   };
 }
+
+/** Fixed timestamp for deterministic snapshot tests. */
+const FIXED_NOW = new Date('2026-06-03T12:00:00.000Z');
 
 describe('eval-inventory', () => {
   describe('collectInventory', () => {
@@ -180,6 +185,355 @@ describe('eval-inventory', () => {
       const report = formatInventoryReport(result);
 
       expect(report).toContain('• custom test [customHelper]');
+    });
+  });
+
+  describe('formatInventoryJson', () => {
+    it('snapshot: minimal inventory', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            name: 'basic eval',
+            policy: 'ALWAYS_PASSES',
+            suiteName: 'core',
+          }),
+        ],
+        diagnostics: [],
+      };
+
+      const json = formatInventoryJson(result, FIXED_NOW);
+
+      expect(json).toMatchInlineSnapshot(`
+        "{
+          "version": 1,
+          "generated": "2026-06-03T12:00:00.000Z",
+          "summary": {
+            "totalFiles": 1,
+            "totalCases": 1,
+            "totalDiagnostics": 0,
+            "byPolicy": {
+              "ALWAYS_PASSES": 1
+            }
+          },
+          "cases": [
+            {
+              "name": "basic eval",
+              "filePath": "evals/test.eval.ts",
+              "helperName": "evalTest",
+              "baseHelperName": "evalTest",
+              "policy": "ALWAYS_PASSES",
+              "suiteName": "core",
+              "suiteType": null,
+              "timeout": null,
+              "hasFiles": false,
+              "hasPrompt": true,
+              "location": {
+                "line": 1,
+                "column": 1
+              }
+            }
+          ],
+          "diagnostics": []
+        }"
+      `);
+    });
+
+    it('snapshot: mixed policies with diagnostics', () => {
+      const result: InventoryResult = {
+        totalFiles: 2,
+        totalCases: 3,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            name: 'stable test',
+            policy: 'ALWAYS_PASSES',
+            relativePath: 'evals/a.eval.ts',
+          }),
+          makeCaseRecord({
+            name: 'flaky test',
+            policy: 'USUALLY_PASSES',
+            suiteName: 'tools',
+            suiteType: 'behavioral',
+            relativePath: 'evals/b.eval.ts',
+          }),
+          makeCaseRecord({
+            name: 'failing test',
+            policy: 'USUALLY_FAILS',
+            timeout: 30000,
+            hasFiles: true,
+            relativePath: 'evals/b.eval.ts',
+          }),
+        ],
+        diagnostics: [
+          {
+            severity: 'warning',
+            message: 'Could not resolve policy',
+            filePath: '/repo/evals/c.eval.ts',
+            location: { line: 10, column: 5 },
+          },
+        ],
+      };
+
+      const json = formatInventoryJson(result, FIXED_NOW);
+
+      expect(json).toMatchInlineSnapshot(`
+        "{
+          "version": 1,
+          "generated": "2026-06-03T12:00:00.000Z",
+          "summary": {
+            "totalFiles": 2,
+            "totalCases": 3,
+            "totalDiagnostics": 1,
+            "byPolicy": {
+              "ALWAYS_PASSES": 1,
+              "USUALLY_PASSES": 1,
+              "USUALLY_FAILS": 1
+            }
+          },
+          "cases": [
+            {
+              "name": "stable test",
+              "filePath": "evals/a.eval.ts",
+              "helperName": "evalTest",
+              "baseHelperName": "evalTest",
+              "policy": "ALWAYS_PASSES",
+              "suiteName": null,
+              "suiteType": null,
+              "timeout": null,
+              "hasFiles": false,
+              "hasPrompt": true,
+              "location": {
+                "line": 1,
+                "column": 1
+              }
+            },
+            {
+              "name": "flaky test",
+              "filePath": "evals/b.eval.ts",
+              "helperName": "evalTest",
+              "baseHelperName": "evalTest",
+              "policy": "USUALLY_PASSES",
+              "suiteName": "tools",
+              "suiteType": "behavioral",
+              "timeout": null,
+              "hasFiles": false,
+              "hasPrompt": true,
+              "location": {
+                "line": 1,
+                "column": 1
+              }
+            },
+            {
+              "name": "failing test",
+              "filePath": "evals/b.eval.ts",
+              "helperName": "evalTest",
+              "baseHelperName": "evalTest",
+              "policy": "USUALLY_FAILS",
+              "suiteName": null,
+              "suiteType": null,
+              "timeout": 30000,
+              "hasFiles": true,
+              "hasPrompt": true,
+              "location": {
+                "line": 1,
+                "column": 1
+              }
+            }
+          ],
+          "diagnostics": [
+            {
+              "severity": "warning",
+              "message": "Could not resolve policy",
+              "filePath": "/repo/evals/c.eval.ts",
+              "location": {
+                "line": 10,
+                "column": 5
+              }
+            }
+          ]
+        }"
+      `);
+    });
+
+    it('snapshot: empty inventory', () => {
+      const result: InventoryResult = {
+        totalFiles: 0,
+        totalCases: 0,
+        files: [],
+        cases: [],
+        diagnostics: [],
+      };
+
+      const json = formatInventoryJson(result, FIXED_NOW);
+
+      expect(json).toMatchInlineSnapshot(`
+        "{
+          "version": 1,
+          "generated": "2026-06-03T12:00:00.000Z",
+          "summary": {
+            "totalFiles": 0,
+            "totalCases": 0,
+            "totalDiagnostics": 0,
+            "byPolicy": {}
+          },
+          "cases": [],
+          "diagnostics": []
+        }"
+      `);
+    });
+
+    it('produces valid JSON with version field', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [makeCaseRecord()],
+        diagnostics: [],
+      };
+
+      const json = formatInventoryJson(result, FIXED_NOW);
+      const parsed: InventoryJsonOutput = JSON.parse(json);
+
+      expect(parsed.version).toBe(1);
+    });
+
+    it('includes correct summary counts', () => {
+      const result: InventoryResult = {
+        totalFiles: 3,
+        totalCases: 4,
+        files: [],
+        cases: [
+          makeCaseRecord({ policy: 'ALWAYS_PASSES' }),
+          makeCaseRecord({ policy: 'ALWAYS_PASSES' }),
+          makeCaseRecord({ policy: 'USUALLY_PASSES' }),
+          makeCaseRecord({ policy: 'USUALLY_FAILS' }),
+        ],
+        diagnostics: [
+          {
+            severity: 'warning',
+            message: 'test',
+            filePath: 'test.ts',
+            location: { line: 1, column: 1 },
+          },
+        ],
+      };
+
+      const parsed: InventoryJsonOutput = JSON.parse(
+        formatInventoryJson(result, FIXED_NOW),
+      );
+
+      expect(parsed.summary).toEqual({
+        totalFiles: 3,
+        totalCases: 4,
+        totalDiagnostics: 1,
+        byPolicy: {
+          ALWAYS_PASSES: 2,
+          USUALLY_PASSES: 1,
+          USUALLY_FAILS: 1,
+        },
+      });
+    });
+
+    it('maps case fields correctly with nulls for missing optionals', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            name: 'detailed case',
+            relativePath: 'evals/detail.eval.ts',
+            helperName: 'appEvalTest',
+            baseHelperName: 'appEvalTest',
+            policy: 'USUALLY_PASSES',
+            hasFiles: true,
+            hasPrompt: true,
+            location: { line: 42, column: 3 },
+            // suiteName, suiteType, timeout intentionally omitted
+          }),
+        ],
+        diagnostics: [],
+      };
+
+      const parsed: InventoryJsonOutput = JSON.parse(
+        formatInventoryJson(result, FIXED_NOW),
+      );
+      const firstCase = parsed.cases[0];
+
+      expect(firstCase).toEqual({
+        name: 'detailed case',
+        filePath: 'evals/detail.eval.ts',
+        helperName: 'appEvalTest',
+        baseHelperName: 'appEvalTest',
+        policy: 'USUALLY_PASSES',
+        suiteName: null,
+        suiteType: null,
+        timeout: null,
+        hasFiles: true,
+        hasPrompt: true,
+        location: { line: 42, column: 3 },
+      });
+    });
+
+    it('uses relative paths not absolute paths', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        files: [],
+        cases: [
+          makeCaseRecord({
+            filePath: '/absolute/repo/evals/test.eval.ts',
+            relativePath: 'evals/test.eval.ts',
+          }),
+        ],
+        diagnostics: [],
+      };
+
+      const json = formatInventoryJson(result, FIXED_NOW);
+
+      expect(json).not.toContain('/absolute/repo');
+      expect(json).toContain('evals/test.eval.ts');
+    });
+
+    it('emits deterministic output', () => {
+      const result: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 2,
+        files: [],
+        cases: [
+          makeCaseRecord({ name: 'a', policy: 'ALWAYS_PASSES' }),
+          makeCaseRecord({ name: 'b', policy: 'USUALLY_PASSES' }),
+        ],
+        diagnostics: [],
+      };
+
+      const first = formatInventoryJson(result, FIXED_NOW);
+      const second = formatInventoryJson(result, FIXED_NOW);
+
+      expect(first).toBe(second);
+    });
+
+    it('generated field is valid ISO-8601', () => {
+      const result: InventoryResult = {
+        totalFiles: 0,
+        totalCases: 0,
+        files: [],
+        cases: [],
+        diagnostics: [],
+      };
+
+      const parsed: InventoryJsonOutput = JSON.parse(
+        formatInventoryJson(result),
+      );
+
+      const date = new Date(parsed.generated);
+      expect(date.getTime()).not.toBeNaN();
+      expect(parsed.generated).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/,
+      );
     });
   });
 });

--- a/scripts/tests/test-setup.ts
+++ b/scripts/tests/test-setup.ts
@@ -6,7 +6,10 @@
 
 import { vi } from 'vitest';
 
-vi.mock('fs', () => ({
-  ...vi.importActual('fs'),
-  appendFileSync: vi.fn(),
-}));
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    appendFileSync: vi.fn(),
+  };
+});

--- a/scripts/utils/eval-inventory.ts
+++ b/scripts/utils/eval-inventory.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { glob } from 'glob';
+
+import {
+  analyzeEvalSource,
+  type EvalCaseRecord,
+  type EvalFileAnalysis,
+  type EvalAnalysisDiagnostic,
+  type EvalPolicy,
+} from './eval-analysis.js';
+
+export interface InventoryResult {
+  totalFiles: number;
+  totalCases: number;
+  files: EvalFileAnalysis[];
+  cases: readonly EvalCaseRecord[];
+  diagnostics: readonly EvalAnalysisDiagnostic[];
+}
+
+/**
+ * Discovers all eval files under the given repo root and runs
+ * the static analyzer on each, returning the aggregated results.
+ */
+export async function collectInventory(
+  repoRoot: string,
+): Promise<InventoryResult> {
+  const evalsDir = path.join(repoRoot, 'evals');
+  const pattern = '**/*.eval.{ts,tsx}';
+
+  const evalFiles = await glob(pattern, {
+    cwd: evalsDir,
+    absolute: true,
+    nodir: true,
+  });
+
+  evalFiles.sort();
+
+  const files: EvalFileAnalysis[] = [];
+  const allCases: EvalCaseRecord[] = [];
+  const allDiagnostics: EvalAnalysisDiagnostic[] = [];
+
+  for (const filePath of evalFiles) {
+    const sourceText = await fs.promises.readFile(filePath, 'utf-8');
+    const analysis = analyzeEvalSource(sourceText, { filePath, repoRoot });
+    files.push(analysis);
+    allCases.push(...analysis.cases);
+    allDiagnostics.push(...analysis.diagnostics);
+  }
+
+  return {
+    totalFiles: files.length,
+    totalCases: allCases.length,
+    files,
+    cases: allCases,
+    diagnostics: allDiagnostics,
+  };
+}
+
+/**
+ * Formats an InventoryResult into a human-readable report string.
+ */
+export function formatInventoryReport(result: InventoryResult): string {
+  const lines: string[] = [];
+
+  lines.push('Eval Inventory');
+  lines.push('══════════════');
+  lines.push('');
+  lines.push(
+    `${result.totalFiles} files · ${result.totalCases} cases · ${result.diagnostics.length} diagnostics`,
+  );
+  lines.push('');
+
+  // --- By Policy ---
+  lines.push('By Policy');
+  lines.push('─────────');
+
+  const byPolicy = groupBy(result.cases, (c) => c.policy);
+  const policyOrder: EvalPolicy[] = [
+    'ALWAYS_PASSES',
+    'USUALLY_PASSES',
+    'USUALLY_FAILS',
+    'unknown',
+  ];
+
+  for (const policy of policyOrder) {
+    const cases = byPolicy.get(policy);
+    if (!cases || cases.length === 0) {
+      continue;
+    }
+
+    lines.push(`${policy} (${cases.length} cases)`);
+
+    const byFile = groupBy(cases, (c) => c.relativePath);
+    for (const [filePath, fileCases] of byFile) {
+      lines.push(`  ${filePath}`);
+      for (const evalCase of fileCases) {
+        lines.push(`    • ${evalCase.name} [${evalCase.helperName}]`);
+      }
+    }
+    lines.push('');
+  }
+
+  // --- By Suite ---
+  lines.push('By Suite');
+  lines.push('────────');
+
+  const bySuite = groupBy(result.cases, (c) => c.suiteName ?? '(no suite)');
+  const suiteNames = [...bySuite.keys()].sort((a, b) => {
+    if (a === '(no suite)') return 1;
+    if (b === '(no suite)') return -1;
+    return a.localeCompare(b, 'en');
+  });
+
+  for (const suite of suiteNames) {
+    const cases = bySuite.get(suite)!;
+    lines.push(`${suite} (${cases.length} cases)`);
+
+    for (const evalCase of cases) {
+      lines.push(
+        `  • ${evalCase.name} [${evalCase.relativePath}] (${evalCase.policy})`,
+      );
+    }
+    lines.push('');
+  }
+
+  // --- Diagnostics ---
+  if (result.diagnostics.length > 0) {
+    const filePaths = new Map<string, string>();
+    for (const f of result.files) {
+      filePaths.set(f.filePath, f.relativePath);
+    }
+
+    lines.push('Diagnostics');
+    lines.push('───────────');
+    for (const diagnostic of result.diagnostics) {
+      const displayPath =
+        diagnostic.filePath === '<inline>'
+          ? diagnostic.filePath
+          : (filePaths.get(diagnostic.filePath) ?? diagnostic.filePath);
+      lines.push(
+        `⚠ ${displayPath}:${diagnostic.location.line}:${diagnostic.location.column} — ${diagnostic.message}`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function groupBy<T>(
+  items: readonly T[],
+  keyFn: (item: T) => string,
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const group = groups.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+  return groups;
+}

--- a/scripts/utils/eval-inventory.ts
+++ b/scripts/utils/eval-inventory.ts
@@ -154,6 +154,93 @@ export function formatInventoryReport(result: InventoryResult): string {
   return lines.join('\n');
 }
 
+/**
+ * JSON output schema for machine-readable inventory data.
+ * Version field allows future schema evolution without breaking consumers.
+ */
+export interface InventoryJsonOutput {
+  version: 1;
+  generated: string;
+  summary: {
+    totalFiles: number;
+    totalCases: number;
+    totalDiagnostics: number;
+    byPolicy: Record<string, number>;
+  };
+  cases: InventoryJsonCase[];
+  diagnostics: InventoryJsonDiagnostic[];
+}
+
+interface InventoryJsonCase {
+  name: string;
+  filePath: string;
+  helperName: string;
+  baseHelperName: string;
+  policy: string;
+  suiteName: string | null;
+  suiteType: string | null;
+  timeout: number | null;
+  hasFiles: boolean;
+  hasPrompt: boolean;
+  location: { line: number; column: number };
+}
+
+interface InventoryJsonDiagnostic {
+  severity: string;
+  message: string;
+  filePath: string;
+  location: { line: number; column: number };
+}
+
+/**
+ * Formats an InventoryResult as a stable, machine-readable JSON string.
+ *
+ * @param result - The inventory result to format.
+ * @param now - Optional override for the generated timestamp (for test determinism).
+ * @returns Pretty-printed JSON string.
+ */
+export function formatInventoryJson(
+  result: InventoryResult,
+  now?: Date,
+): string {
+  const byPolicy: Record<string, number> = {};
+  for (const evalCase of result.cases) {
+    byPolicy[evalCase.policy] = (byPolicy[evalCase.policy] ?? 0) + 1;
+  }
+
+  const output: InventoryJsonOutput = {
+    version: 1,
+    generated: (now ?? new Date()).toISOString(),
+    summary: {
+      totalFiles: result.totalFiles,
+      totalCases: result.totalCases,
+      totalDiagnostics: result.diagnostics.length,
+      byPolicy,
+    },
+    cases: result.cases.map((c) => ({
+      name: c.name,
+      filePath: c.relativePath,
+      helperName: c.helperName,
+      baseHelperName: c.baseHelperName,
+      policy: c.policy,
+      suiteName: c.suiteName ?? null,
+      suiteType: c.suiteType ?? null,
+      timeout: c.timeout ?? null,
+      hasFiles: c.hasFiles,
+      hasPrompt: c.hasPrompt,
+      location: { line: c.location.line, column: c.location.column },
+    })),
+    diagnostics: result.diagnostics.map((d) => ({
+      severity: d.severity,
+      message: d.message,
+      filePath: d.filePath,
+      location: { line: d.location.line, column: d.location.column },
+    })),
+  };
+
+  return JSON.stringify(output, null, 2);
+}
+
 function groupBy<T>(
   items: readonly T[],
   keyFn: (item: T) => string,


### PR DESCRIPTION
## Summary

Adds `--json` output to `npm run eval:inventory` so the inventory data can be consumed by scripts and CI tooling.

Running `npm run eval:inventory -- --json` prints the same inventory as a stable JSON object with a version field, summary counts, and the full case/diagnostic lists.

## Details

- Updated `scripts/utils/eval-inventory.ts` with a `formatInventoryJson()` function that maps the inventory result to a versioned JSON schema (`version: 1`), pre-aggregates policy counts, and normalizes optional fields to `null`.
- Updated `scripts/eval-inventory-cli.ts` to accept `--json` and switch between text and JSON output.
- Added an `eval:inventory:json` npm script as a shorthand.
- Added snapshot-based and structural tests covering the JSON schema shape, summary counts, field mapping, determinism, path portability, and timestamp format.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

@gundermanc pls have a look
