### PR TITLE
fix(mcp): use longest-prefix matching in parseMcpToolName for server names with underscores

### DIFF
--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -225,7 +225,17 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           return;
         }
 
-        const parsed = parseMcpToolName(toolName);
+        const knownServerNames = Array.from(
+          new Set(
+            parentToolRegistry
+              .getAllTools()
+              .filter(
+                (t): t is DiscoveredMCPTool => t instanceof DiscoveredMCPTool,
+              )
+              .map((t) => t.serverName),
+          ),
+        );
+        const parsed = parseMcpToolName(toolName, knownServerNames);
         if (parsed.serverName && parsed.toolName === '*') {
           for (const tool of parentToolRegistry.getToolsByServer(
             parsed.serverName,

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -19,6 +19,7 @@ import {
   DiscoveredMCPTool,
   generateValidName,
   formatMcpToolName,
+  parseMcpToolName,
 } from './mcp-tool.js'; // Added getStringifiedResultForDisplay
 import { ToolConfirmationOutcome, type ToolResult } from './tools.js';
 import type { CallableTool, Part } from '@google/genai';
@@ -109,6 +110,67 @@ describe('formatMcpToolName', () => {
 
   it('should format explicitly global wildcard with specific tool', () => {
     expect(formatMcpToolName('*', 'list_repos')).toBe('mcp_*_list_repos');
+  });
+});
+
+describe('parseMcpToolName', () => {
+  it('returns empty object for non-MCP tool names', () => {
+    expect(parseMcpToolName('glob')).toEqual({});
+    expect(parseMcpToolName('read_file')).toEqual({});
+    expect(parseMcpToolName('')).toEqual({});
+  });
+
+  it('parses simple server and tool names without underscores', () => {
+    expect(parseMcpToolName('mcp_github_list_repos')).toEqual({
+      serverName: 'github',
+      toolName: 'list_repos',
+    });
+  });
+
+  it('falls back to first-underscore split when no server names provided', () => {
+    // Without knownServerNames the regex splits at the first '_' after the prefix,
+    // so a server name of 'my_server' is incorrectly identified as 'my'.
+    expect(parseMcpToolName('mcp_my_server_my_tool')).toEqual({
+      serverName: 'my',
+      toolName: 'server_my_tool',
+    });
+  });
+
+  it('correctly resolves server names with underscores using knownServerNames', () => {
+    const known = ['my_server'];
+    expect(parseMcpToolName('mcp_my_server_my_tool', known)).toEqual({
+      serverName: 'my_server',
+      toolName: 'my_tool',
+    });
+  });
+
+  it('handles wildcard tool names when server contains underscores', () => {
+    const known = ['my_server'];
+    expect(parseMcpToolName('mcp_my_server_*', known)).toEqual({
+      serverName: 'my_server',
+      toolName: '*',
+    });
+  });
+
+  it('picks the longest matching server prefix when names share a common prefix', () => {
+    const known = ['my', 'my_server'];
+    // 'my_server' (longer) must win over 'my'
+    expect(parseMcpToolName('mcp_my_server_my_tool', known)).toEqual({
+      serverName: 'my_server',
+      toolName: 'my_tool',
+    });
+  });
+
+  it('falls back to first-underscore split when no registered server matches', () => {
+    const known = ['other_server'];
+    expect(parseMcpToolName('mcp_github_list_repos', known)).toEqual({
+      serverName: 'github',
+      toolName: 'list_repos',
+    });
+  });
+
+  it('returns empty object when name has no tool component', () => {
+    expect(parseMcpToolName('mcp_onlyserver')).toEqual({});
   });
 });
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -47,21 +47,47 @@ export function isMcpToolName(name: string): boolean {
 /**
  * Extracts the server name and tool name from a fully qualified MCP tool name.
  * Expected format: `mcp_{server_name}_{tool_name}`
+ *
+ * When `knownServerNames` is supplied the function uses longest-prefix matching
+ * so that server names containing underscores (e.g. `my_server`) are resolved
+ * correctly.  Without a list it falls back to splitting at the first underscore,
+ * which is correct for servers whose names do not contain underscores.
+ *
  * @param name The fully qualified tool name.
+ * @param knownServerNames Optional list of registered server names used for
+ *   unambiguous longest-prefix matching.
  * @returns An object containing the extracted `serverName` and `toolName`, or
  *          `undefined` properties if the name doesn't match the expected format.
  */
-export function parseMcpToolName(name: string): {
+export function parseMcpToolName(
+  name: string,
+  knownServerNames?: string[],
+): {
   serverName?: string;
   toolName?: string;
 } {
   if (!isMcpToolName(name)) {
     return {};
   }
-  // Remove the prefix
   const withoutPrefix = name.slice(MCP_TOOL_PREFIX.length);
-  // The first segment is the server name, the rest is the tool name
-  // Must be strictly `server_tool` where neither are empty
+
+  // When the caller provides a registry of server names, use longest-prefix
+  // matching so that underscores inside server names are handled correctly.
+  if (knownServerNames && knownServerNames.length > 0) {
+    const sorted = [...knownServerNames].sort((a, b) => b.length - a.length);
+    for (const server of sorted) {
+      const prefix = `${server}_`;
+      if (withoutPrefix.startsWith(prefix)) {
+        const toolName = withoutPrefix.slice(prefix.length);
+        if (toolName) {
+          return { serverName: server, toolName };
+        }
+      }
+    }
+  }
+
+  // Fallback: split at the first underscore (original behaviour, correct for
+  // server names that do not contain underscores).
   const match = withoutPrefix.match(/^([^_]+)_(.+)$/);
   if (match) {
     return {


### PR DESCRIPTION
## What

Adds an optional `knownServerNames` parameter to `parseMcpToolName` that enables longest-prefix matching, fixing incorrect tool routing when MCP server names contain underscores.

## Why

Fixes #27981.

The current regex `withoutPrefix.match(/^([^_]+)_(.+)$/)` stops at the first underscore, so a server named `my_server` is misidentified as `my`. For example:

- Qualified name: `mcp_my_server_my_tool`
- Before (broken): `{ serverName: 'my', toolName: 'server_my_tool' }`
- After (fixed): `{ serverName: 'my_server', toolName: 'my_tool' }`

Underscores are common in server names (`github_copilot`, `google_workspace`, `my_custom_server`), making this a broad correctness issue affecting wildcard routing and policy matching.

## How

`parseMcpToolName` now accepts an optional `knownServerNames?: string[]` second argument. When provided, the function sorts the known names longest-first and uses prefix matching to unambiguously identify the server component. The original first-underscore regex is used as a fallback so all existing call sites without a registry remain backward compatible.

`local-executor.ts` — the call site that routes `mcp_<server>_*` wildcards — now extracts the registered server names from `parentToolRegistry` and passes them to `parseMcpToolName`, fixing the wildcard case for underscore servers.

## Testing

```
bun run test -- --run src/tools/mcp-tool.test.ts
```

8 new tests added to `mcp-tool.test.ts`:
- Returns empty for non-MCP names
- Parses simple (no-underscore) server names correctly
- Documents the first-underscore fallback behaviour when no server list is provided
- Correctly resolves underscore server names with `knownServerNames`
- Handles `mcp_my_server_*` wildcards when server name has underscores
- Picks the longest prefix when two server names share a common prefix (`my` vs `my_server`)
- Falls back to first-underscore split when no registered server matches
- Returns empty when the name has no tool component

All 70 tests in `mcp-tool.test.ts` pass.