### PR TITLE
fix(ci): append trailing slash to registry url in npmrc

### DIFF
--- a/.github/actions/setup-npmrc/action.yml
+++ b/.github/actions/setup-npmrc/action.yml
@@ -19,6 +19,6 @@ runs:
       run: |-
         echo ""@google-gemini:registry=https://npm.pkg.github.com"" > ~/.npmrc
         echo ""//npm.pkg.github.com/:_authToken=${INPUTS_GITHUB_TOKEN}"" >> ~/.npmrc
-        echo ""@google:registry=https://wombat-dressing-room.appspot.com"" >> ~/.npmrc
+        echo ""@google:registry=https://wombat-dressing-room.appspot.com/"" >> ~/.npmrc
       env:
         INPUTS_GITHUB_TOKEN: '${{ inputs.github-token }}'

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@google:registry=https://wombat-dressing-room.appspot.com
+@google:registry=https://wombat-dressing-room.appspot.com/


### PR DESCRIPTION
## Summary

This PR appends a trailing slash to the `@google` registry URL in both the root `.npmrc` and `.github/actions/setup-npmrc/action.yml`. This fixes the nightly release credential mapping issue where npm was unable to match credentials with the registry.

## Details

Without the trailing slash (`/`), `npm publish` fails with `ENEEDAUTH` because the registry endpoint `https://wombat-dressing-room.appspot.com/` (which npm resolves with a trailing slash) does not match the exact key `//wombat-dressing-room.appspot.com:_authToken` or similar credential mapping without the slash. Aligning both files to include the trailing slash resolves this authentication mismatch.

## Related Issues

Fixes #28029 Fixes #28028 Fixes #28026 Fixes #27991 Fixes #27955

## How to Validate

Validate that the setup is syntactically correct and aligns with standard npm scoped registry configurations:

1. Ensure `.npmrc` matches the setup-npmrc action configuration.
1. The nightly release workflow will utilize the setup-npmrc action, where `@google:registry=https://wombat-dressing-room.appspot.com/` is properly written.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
