### PR TITLE
fix(core): strip only the trailing .json from checkpoint names

### DIFF
--- a/packages/core/src/utils/checkpointUtils.test.ts
+++ b/packages/core/src/utils/checkpointUtils.test.ts
@@ -176,6 +176,32 @@ describe('checkpoint utils', () => {
       expect(fileContent.messageId).toBe('p1');
     });
 
+    it('keeps the .json in the checkpoint name when editing a .json file', async () => {
+      const toolCalls = [
+        {
+          callId: '1',
+          name: 'replace',
+          args: { file_path: 'config.json' },
+          prompt_id: 'p1',
+          isClientInitiated: false,
+        },
+      ] as ToolCallRequestInfo[];
+
+      (mockGitService.createFileSnapshot as Mock).mockResolvedValue('hash123');
+      (mockGeminiClient.getHistory as Mock).mockReturnValue([]);
+
+      const { toolCallToCheckpointMap } = await processRestorableToolCalls(
+        toolCalls,
+        mockGitService,
+        mockGeminiClient,
+        'history-data',
+      );
+
+      expect(toolCallToCheckpointMap.get('1')).toMatch(
+        /-config\.json-replace$/,
+      );
+    });
+
     it('should handle git snapshot failure by using current commit hash', async () => {
       const toolCalls = [
         {
@@ -278,6 +304,23 @@ describe('checkpoint utils', () => {
 
       const actual = getCheckpointInfoList(checkpointFiles);
       expect(actual).toEqual(expected);
+    });
+
+    it('strips only the trailing .json when the edited file is itself .json', () => {
+      const checkpointFiles = new Map([
+        [
+          '2025-01-01T12-00-00_000Z-config.json-replace.json',
+          JSON.stringify({ messageId: 'msg1' }),
+        ],
+      ]);
+
+      const actual = getCheckpointInfoList(checkpointFiles);
+      expect(actual).toEqual([
+        {
+          messageId: 'msg1',
+          checkpoint: '2025-01-01T12-00-00_000Z-config.json-replace',
+        },
+      ]);
     });
 
     it('should ignore files with invalid JSON', () => {

--- a/packages/core/src/utils/checkpointUtils.ts
+++ b/packages/core/src/utils/checkpointUtils.ts
@@ -142,7 +142,10 @@ export async function processRestorableToolCalls<HistoryType>(
       checkpointsToWrite.set(fileName, JSON.stringify(checkpointData, null, 2));
       toolCallToCheckpointMap.set(
         toolCall.callId,
-        fileName.replace('.json', ''),
+        // Use the base name directly; fileName.replace('.json', '') would strip
+        // the first ".json" instead of the extension when the edited file is
+        // itself a .json file (e.g. "...-config.json-replace.json").
+        checkpointFileName,
       );
     } catch (error) {
       errors.push(
@@ -176,7 +179,10 @@ export function getCheckpointInfoList(
       if (result.success) {
         checkpointInfoList.push({
           messageId: result.data.messageId,
-          checkpoint: file.replace('.json', ''),
+          // basename(file, '.json') strips only the trailing extension; a
+          // plain replace('.json', '') would corrupt names from edited .json
+          // files (e.g. "...-config.json-replace.json").
+          checkpoint: path.basename(file, '.json'),
         });
       }
     } catch {


### PR DESCRIPTION
## What

`processRestorableToolCalls` and `getCheckpointInfoList` strip the `.json` suffix from checkpoint names with `name.replace('.json', '')`, which removes the **first** `.json` rather than the trailing extension.

`generateCheckpointFileName` embeds the edited file's basename: `${timestamp}-${basename}-${toolName}`. So editing a `.json` file yields a checkpoint file like `2025-...-config.json-replace.json`, and `replace('.json', '')` turns it into `2025-...-config-replace.json` — the inner `.json` is dropped and the real extension is left behind, corrupting the name used to map and restore the checkpoint.

## Fix

- In `processRestorableToolCalls`, use the in-scope `checkpointFileName` directly — it is exactly the name without the `.json` we just appended.
- In `getCheckpointInfoList`, use `path.basename(file, '.json')`, which strips only the trailing extension. This is what the neighbouring `getTruncatedCheckpointNames` already does for the same kind of name.

## Test

Added two cases to `checkpointUtils.test.ts`: a checkpoint created for an edited `config.json` keeps `config.json-replace` in its mapped name, and a `2025-...-config.json-replace.json` checkpoint file resolves to `2025-...-config.json-replace`. Both fail on `main` (the name comes back as `config-replace`) and pass with this change. `vitest run` on the file is green (17 tests); prettier and eslint are clean.
