### PR TITLE
fix(core): drop the leading space from PascalCase markdown table headers

### DIFF
--- a/packages/core/src/utils/markdownUtils.test.ts
+++ b/packages/core/src/utils/markdownUtils.test.ts
@@ -64,6 +64,12 @@ describe('markdownUtils', () => {
       );
     });
 
+    it('does not prefix table headers with a stray space for PascalCase keys', () => {
+      const data = [{ UserId: 1, Name: 'Alice' }];
+      const result = jsonToMarkdown(data);
+      expect(result).toBe('| User Id | Name |\n| --- | --- |\n| 1 | Alice |');
+    });
+
     it('should handle pipe characters, backslashes, and newlines in table data', () => {
       const data = [
         { colInfo: 'val|ue', otherInfo: 'line\nbreak', pathInfo: 'C:\\test' },

--- a/packages/core/src/utils/markdownUtils.ts
+++ b/packages/core/src/utils/markdownUtils.ts
@@ -9,8 +9,8 @@
  * e.g., "camelCaseString" -> "Camel Case String"
  */
 function camelToSpace(text: string): string {
-  const result = text.replace(/([A-Z])/g, ' $1');
-  return result.charAt(0).toUpperCase() + result.slice(1).trim();
+  const result = text.replace(/([A-Z])/g, ' $1').trim();
+  return result.charAt(0).toUpperCase() + result.slice(1);
 }
 
 /**


### PR DESCRIPTION
## What

`camelToSpace` (used for `jsonToMarkdown` object keys and table headers) leaves a stray leading space when the key starts with an uppercase letter:

```ts
const result = text.replace(/([A-Z])/g, ' $1'); // "UserId" -> " User Id"
return result.charAt(0).toUpperCase() + result.slice(1).trim();
// charAt(0) is the leading space, so it survives -> " User Id"
```

`"userId"` → `"User Id"` (fine), but `"UserId"` → `" User Id"`, `"Name"` → `" Name"`, `"ID"` → `" I D"`. JSON whose keys are PascalCase or acronyms (common for .NET/Pascal-style APIs and keys like `ID`/`URL`) then renders table headers as `|  User Id |` (double space) instead of `| User Id |`.

## Fix

Trim before capitalizing, so the first real character is the one that gets upper-cased:

```ts
const result = text.replace(/([A-Z])/g, ' $1').trim();
return result.charAt(0).toUpperCase() + result.slice(1);
```

`"userId"` still maps to `"User Id"`; `"UserId"` now also maps to `"User Id"`.

## Test

Added a case to `markdownUtils.test.ts` asserting that a PascalCase-keyed table renders `| User Id | Name |` (no leading space). It fails on `main` (`'|  User Id |  Name |...'`) and passes with this change. `vitest run` on the file is green (14 tests); prettier and eslint are clean.
