### PR TITLE
fix(auth): strip URL punctuation in sign-in errors

### DIFF
--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -315,6 +315,23 @@ describe('useAuth', () => {
       expect(result.current.authState).toBe(AuthState.Updating);
     });
 
+    it('should remove a trailing period from URLs in sign-in errors', async () => {
+      const { result } = await renderHook(() =>
+        useAuthCommand(createSettings(AuthType.LOGIN_WITH_GOOGLE), mockConfig),
+      );
+
+      await act(async () => {
+        deferredRefreshAuth.reject(
+          new Error('Migrate to https://antigravity.google.'),
+        );
+      });
+
+      expect(result.current.authError).toBe(
+        'Failed to sign in. Message: Migrate to https://antigravity.google',
+      );
+      expect(result.current.authState).toBe(AuthState.Updating);
+    });
+
     it('should handle ProjectIdRequiredError without "Failed to login" prefix', async () => {
       const projectIdError = new ProjectIdRequiredError();
       const { result } = await renderHook(() =>

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -18,6 +18,10 @@ import { getErrorMessage } from '@google/gemini-cli-core';
 import { AuthState } from '../types.js';
 import { validateAuthMethod } from '../../config/auth.js';
 
+function stripTrailingPeriodsFromUrls(message: string): string {
+  return message.replace(/(https?:\/\/\S+)\.(?=\s|$)/g, '$1');
+}
+
 export async function validateAuthMethodWithSettings(
   authType: AuthType,
   settings: LoadedSettings,
@@ -153,7 +157,8 @@ export const useAuthCommand = (
           // Show the error message directly without "Failed to login" prefix
           onAuthError(getErrorMessage(e));
         } else {
-          onAuthError(`Failed to sign in. Message: ${getErrorMessage(e)}`);
+          const message = stripTrailingPeriodsFromUrls(getErrorMessage(e));
+          onAuthError(`Failed to sign in. Message: ${message}`);
         }
       }
     })();


### PR DESCRIPTION
Fixes #28052 by removing sentence-ending periods from HTTP(S) URLs only when the interactive sign-in error is rendered.

This keeps `getErrorMessage` unchanged for logging, telemetry, tool output, and control-flow consumers while preserving clickable URLs in the `Failed to sign in` message.

Validation:

- `npm test -w @google/gemini-cli -- src/ui/auth/useAuth.test.tsx`
- `npm run typecheck -w @google/gemini-cli`
- ESLint and Prettier checks for the changed files
