### PR TITLE
fix(core): preserve dollar sequences in prompt template substitutions

### DIFF
--- a/packages/core/src/prompts/utils.test.ts
+++ b/packages/core/src/prompts/utils.test.ts
@@ -349,4 +349,18 @@ describe('applySubstitutions', () => {
     );
     expect(result).toContain("- echo $'a\\nb'\n- $$\n- $& | Tail");
   });
+
+  it('should replace tool-specific ${toolName_ToolName} variables containing special characters', () => {
+    (mockConfig as unknown as { toolRegistry: ToolRegistry }).toolRegistry = {
+      getAllToolNames: vi.fn().mockReturnValue(["echo $'a\\nb'"]),
+      getAllTools: vi.fn().mockReturnValue([]),
+    } as unknown as ToolRegistry;
+
+    const result = applySubstitutions(
+      "Use ${echo $'a\\nb'_ToolName} to run",
+      mockConfig,
+      '',
+    );
+    expect(result).toBe("Use echo $'a\\nb' to run");
+  });
 });

--- a/packages/core/src/prompts/utils.test.ts
+++ b/packages/core/src/prompts/utils.test.ts
@@ -13,6 +13,7 @@ import {
 } from './utils.js';
 import type { Config } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
+import * as snippets from './snippets.js';
 
 vi.mock('../utils/paths.js', () => ({
   homedir: vi.fn().mockReturnValue('/mock/home'),
@@ -311,5 +312,41 @@ describe('applySubstitutions', () => {
       '',
     );
     expect(result).toBe('A plain prompt with no variables.');
+  });
+
+  it('should preserve dollar sequences in ${AgentSkills} verbatim', () => {
+    const result = applySubstitutions(
+      'Skills: ${AgentSkills} | Tail',
+      mockConfig,
+      "echo $'a\\nb' and $$ and $& and $VAR",
+    );
+    expect(result).toBe("Skills: echo $'a\\nb' and $$ and $& and $VAR | Tail");
+  });
+
+  it('should preserve dollar sequences in ${SubAgents} verbatim', () => {
+    vi.mocked(snippets.renderSubAgents).mockReturnValueOnce(
+      "echo $'a\\nb' and $$ and $&",
+    );
+    const result = applySubstitutions(
+      'Agents: ${SubAgents} | Tail',
+      mockConfig,
+      '',
+      true,
+    );
+    expect(result).toBe("Agents: echo $'a\\nb' and $$ and $& | Tail");
+  });
+
+  it('should preserve dollar sequences in ${AvailableTools} verbatim', () => {
+    (mockConfig as unknown as { toolRegistry: ToolRegistry }).toolRegistry = {
+      getAllToolNames: vi.fn().mockReturnValue(["echo $'a\\nb'", '$$', '$&']),
+      getAllTools: vi.fn().mockReturnValue([]),
+    } as unknown as ToolRegistry;
+
+    const result = applySubstitutions(
+      'Tools: ${AvailableTools} | Tail',
+      mockConfig,
+      '',
+    );
+    expect(result).toContain("- echo $'a\\nb'\n- $$\n- $& | Tail");
   });
 });

--- a/packages/core/src/prompts/utils.ts
+++ b/packages/core/src/prompts/utils.ts
@@ -94,8 +94,9 @@ export function applySubstitutions(
 
   for (const toolName of allToolNames) {
     const varName = `${toolName}_ToolName`;
+    const escapedVarName = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     result = result.replace(
-      new RegExp(`\\\${\\b${varName}\\b}`, 'g'),
+      new RegExp(`\\$\\{${escapedVarName}\\}`, 'g'),
       () => toolName,
     );
   }

--- a/packages/core/src/prompts/utils.ts
+++ b/packages/core/src/prompts/utils.ts
@@ -69,7 +69,7 @@ export function applySubstitutions(
 ): string {
   let result = prompt;
 
-  result = result.replace(/\${AgentSkills}/g, skillsPrompt);
+  result = result.replace(/\${AgentSkills}/g, () => skillsPrompt);
 
   const activeSnippets = isGemini3 ? snippets : legacySnippets;
   const subAgentsContent = activeSnippets.renderSubAgents(
@@ -82,7 +82,7 @@ export function applySubstitutions(
       })),
   );
 
-  result = result.replace(/\${SubAgents}/g, subAgentsContent);
+  result = result.replace(/\${SubAgents}/g, () => subAgentsContent);
 
   const toolRegistry = context.toolRegistry;
   const allToolNames = toolRegistry.getAllToolNames();
@@ -90,13 +90,13 @@ export function applySubstitutions(
     allToolNames.length > 0
       ? allToolNames.map((name) => `- ${name}`).join('\n')
       : 'No tools are currently available.';
-  result = result.replace(/\${AvailableTools}/g, availableToolsList);
+  result = result.replace(/\${AvailableTools}/g, () => availableToolsList);
 
   for (const toolName of allToolNames) {
     const varName = `${toolName}_ToolName`;
     result = result.replace(
       new RegExp(`\\\${\\b${varName}\\b}`, 'g'),
-      toolName,
+      () => toolName,
     );
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in system prompt template substitutions that corrupts content containing `$` sequences (e.g. `$$`, `$'`, `$&`) inside skill, sub-agent, or tool descriptions.

## Details

`applySubstitutions()` in `packages/core/src/prompts/utils.ts` was performing template substitutions using the string form of `String.prototype.replace()` (e.g. `result.replace(/\${AgentSkills}/g, skillsPrompt)`). Because the replacement values are strings, JavaScript parses special sequences like `$'` (duplicates the tail of the prompt), `$$` (collapses to `$`), and `$&` (inserts the match itself) inside the descriptions.

We fixed this by passing callback functions instead (e.g. `() => skillsPrompt`), which forces JavaScript to treat the replacement strings literally.

We also added regression unit tests in `packages/core/src/prompts/utils.test.ts` to ensure this behavior remains robust in the future.

## Related Issues

Fixes #27993

## How to Validate

1. Run the prompt utility unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/prompts/utils.test.ts
   ```

2. Run the workspace-wide validation checks:
   ```bash
   npm run build && npm run lint
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
