### PR TITLE
docs(hooks): document all usageMetadata token fields in LLMResponse reference

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -325,6 +325,10 @@ Gemini CLI uses these structures to ensure hooks don't break across SDK updates.
     "content": { "role": "model", "parts": string[] },
     "finishReason": string
   }>,
-  "usageMetadata": { "totalTokenCount": number }
+  "usageMetadata": {
+    "promptTokenCount": number,
+    "candidatesTokenCount": number,
+    "totalTokenCount": number
+  }
 }
 ```


### PR DESCRIPTION
## Summary

The hooks reference (`docs/hooks/reference.md`) documented `LLMResponse.usageMetadata` as containing a single field:

```typescript
"usageMetadata": { "totalTokenCount": number }
```

However, the hook actually receives **all three** token fields. Both the `LLMResponse` interface and `toHookLLMResponse()` in `packages/core/src/hooks/hookTranslator.ts` populate `promptTokenCount`, `candidatesTokenCount`, and `totalTokenCount`.

This PR updates the reference so the documented shape matches what hooks really receive.

## Change

```diff
-  "usageMetadata": { "totalTokenCount": number }
+  "usageMetadata": {
+    "promptTokenCount": number,
+    "candidatesTokenCount": number,
+    "totalTokenCount": number
+  }
```

Docs-only change; no code behavior is affected.

Fixes #28048