### PR TITLE
fix(core): buffer chat compression telemetry until SDK is initialized

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -199,6 +199,26 @@ describe('loggers', () => {
         { tokens_before: 9001, tokens_after: 9000 },
       );
     });
+
+    it('defers the OTEL emit and metrics through bufferTelemetryEvent', () => {
+      const mockConfig = makeFakeConfig();
+      // Simulate the SDK not yet being initialized: the buffered callback is
+      // held rather than executed. The OTEL emit and metrics must not run
+      // directly, otherwise the event is dropped against a no-op provider.
+      vi.spyOn(sdk, 'bufferTelemetryEvent').mockImplementation(() => {});
+
+      logChatCompression(
+        mockConfig,
+        makeChatCompressionEvent({
+          tokens_before: 9001,
+          tokens_after: 9000,
+        }),
+      );
+
+      expect(sdk.bufferTelemetryEvent).toHaveBeenCalledOnce();
+      expect(mockLogger.emit).not.toHaveBeenCalled();
+      expect(metrics.recordChatCompressionMetrics).not.toHaveBeenCalled();
+    });
   });
 
   describe('logCliConfiguration', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -461,16 +461,18 @@ export function logChatCompression(
 ): void {
   ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  recordChatCompressionMetrics(config, {
-    tokens_before: event.tokens_before,
-    tokens_after: event.tokens_after,
+    recordChatCompressionMetrics(config, {
+      tokens_before: event.tokens_before,
+      tokens_after: event.tokens_after,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

`logChatCompression()` in `packages/core/src/telemetry/loggers.ts` emitted its OpenTelemetry log record and recorded its metrics **directly**, bypassing the `bufferTelemetryEvent()` wrapper that every other logging function in the file uses.

`bufferTelemetryEvent()` defers telemetry emission until the OTel SDK has finished initializing. Without it, if chat compression fires before initialization completes — which is likely, since compression happens during early, history-heavy sessions — the log event and the `recordChatCompressionMetrics()` data point are emitted against a no-op provider and **silently dropped**.

## Fix

Wrap the OTel emit and metrics call in `bufferTelemetryEvent()`, matching the established pattern (e.g. `logApiResponse`, `logMalformedJsonResponse`). The `ClearcutLogger` call stays outside the wrapper, unchanged — consistent with the rest of the file.

```ts
ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
bufferTelemetryEvent(() => {
  const logger = logs.getLogger(SERVICE_NAME);
  logger.emit(logRecord);
  recordChatCompressionMetrics(config, { ... });
});
```

## Tests

Added a regression test to the existing `logChatCompression` block: when the buffered callback is held back (simulating the SDK not yet initialized), the OTel `emit` and `recordChatCompressionMetrics` must **not** be called directly.

Verified locally (Node 20):
- The new test **fails without the fix** and passes with it (red/green)
- `loggers.test.ts` — all 53 tests pass
- `prettier --check`, `eslint --max-warnings 0`, `tsc --noEmit` — all clean

Fixes #23445
