### PR TITLE
fix(a2a-server): deep-merge user and workspace settings

### DIFF
--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { loadSettings, USER_SETTINGS_PATH } from './settings.js';
+import {
+  deepMergeSettings,
+  loadSettings,
+  USER_SETTINGS_PATH,
+} from './settings.js';
 import { debugLogger, checkPathTrust } from '@google/gemini-cli-core';
 
 const mocks = vi.hoisted(() => {
@@ -215,6 +219,35 @@ describe('loadSettings', () => {
     expect(result.showMemoryUsage).toBe(true);
   });
 
+  it('does not crash when the user settings file contains null', () => {
+    // JSON.parse("null") returns null, which would otherwise crash downstream
+    // property access and the deep merge.
+    fs.writeFileSync(USER_SETTINGS_PATH, 'null');
+
+    expect(() => loadSettings(mockWorkspaceDir)).not.toThrow();
+    const result = loadSettings(mockWorkspaceDir);
+    expect(result).toEqual({
+      policyPaths: undefined,
+      adminPolicyPaths: undefined,
+    });
+  });
+
+  it('does not crash when the workspace settings file contains null', () => {
+    fs.writeFileSync(
+      USER_SETTINGS_PATH,
+      JSON.stringify({ showMemoryUsage: true }),
+    );
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, 'null');
+
+    expect(() => loadSettings(mockWorkspaceDir, true)).not.toThrow();
+    const result = loadSettings(mockWorkspaceDir, true);
+    expect(result.showMemoryUsage).toBe(true);
+  });
+
   describe('security', () => {
     it('should NOT load workspace settings if workspace is NOT trusted', () => {
       const userSettings = { showMemoryUsage: false };
@@ -287,5 +320,44 @@ describe('loadSettings', () => {
       expect(result.adminPolicyPaths).toEqual(['/trusted/admin']);
       expect(result.policyPaths).toEqual(['/trusted/user']);
     });
+  });
+});
+
+describe('deepMergeSettings', () => {
+  it('does not throw when either side is null', () => {
+    const nullValue = null as unknown as Record<string, unknown>;
+    expect(() => deepMergeSettings(nullValue, { a: 1 })).not.toThrow();
+    expect(() => deepMergeSettings({ a: 1 }, nullValue)).not.toThrow();
+    expect(() => deepMergeSettings(nullValue, nullValue)).not.toThrow();
+
+    expect(deepMergeSettings(nullValue, { a: 1 })).toEqual({ a: 1 });
+    expect(deepMergeSettings({ a: 1 }, nullValue)).toEqual({ a: 1 });
+    expect(deepMergeSettings(nullValue, nullValue)).toEqual({});
+  });
+
+  it('deep-clones nested source objects so the result does not share references', () => {
+    // `target` has no `nested` key, so `source.nested` would previously be
+    // assigned by reference, letting later mutations of the result leak back
+    // into the source object.
+    const source = { nested: { keep: true } };
+    const result = deepMergeSettings<Record<string, unknown>>({}, source);
+
+    expect(result['nested']).toEqual({ keep: true });
+    expect(result['nested']).not.toBe(source.nested);
+
+    // Mutating the merged result must not affect the original source object.
+    (result['nested'] as Record<string, unknown>)['keep'] = false;
+    expect(source.nested.keep).toBe(true);
+  });
+
+  it('deep-clones nested objects even when the target value is a primitive', () => {
+    const source = { section: { value: 1 } };
+    const result = deepMergeSettings<Record<string, unknown>>(
+      { section: 'not-an-object' },
+      source,
+    );
+
+    expect(result['section']).toEqual({ value: 1 });
+    expect(result['section']).not.toBe(source.section);
   });
 });

--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -360,4 +360,23 @@ describe('deepMergeSettings', () => {
     expect(result['section']).toEqual({ value: 1 });
     expect(result['section']).not.toBe(source.section);
   });
+
+  it('clones arrays so the result does not share references with the source', () => {
+    // Arrays replace the target value wholesale, but the merged result must not
+    // share the array reference with the original source object.
+    const source = { customIgnoreFilePaths: ['a', 'b'] };
+    const result = deepMergeSettings<Record<string, unknown>>(
+      { customIgnoreFilePaths: ['old'] },
+      source,
+    );
+
+    expect(result['customIgnoreFilePaths']).toEqual(['a', 'b']);
+    expect(result['customIgnoreFilePaths']).not.toBe(
+      source.customIgnoreFilePaths,
+    );
+
+    // Mutating the merged array must not affect the original source array.
+    (result['customIgnoreFilePaths'] as string[]).push('c');
+    expect(source.customIgnoreFilePaths).toEqual(['a', 'b']);
+  });
 });

--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -128,7 +128,7 @@ describe('loadSettings', () => {
     expect(result.experimental?.enableAgents).toBe(true);
   });
 
-  it('should overwrite top-level settings from workspace (shallow merge)', () => {
+  it('should deep-merge nested settings from workspace', () => {
     const userSettings = {
       showMemoryUsage: false,
       fileFiltering: {
@@ -154,9 +154,65 @@ describe('loadSettings', () => {
     // Primitive value overwritten
     expect(result.showMemoryUsage).toBe(true);
 
-    // Object value completely replaced (shallow merge behavior)
+    // Nested object is deep-merged: the workspace overrides only the key it
+    // defines, and the user's unrelated nested key is preserved.
     expect(result.fileFiltering?.respectGitIgnore).toBe(false);
-    expect(result.fileFiltering?.enableRecursiveFileSearch).toBeUndefined();
+    expect(result.fileFiltering?.enableRecursiveFileSearch).toBe(true);
+  });
+
+  it('deep-merges multiple nested sections independently', () => {
+    const userSettings = {
+      tools: { core: ['core-tool'], allowed: ['user-tool'] },
+      fileFiltering: {
+        respectGitIgnore: true,
+        enableRecursiveFileSearch: true,
+      },
+    };
+    fs.writeFileSync(USER_SETTINGS_PATH, JSON.stringify(userSettings));
+
+    const workspaceSettings = {
+      tools: { allowed: ['workspace-tool'] },
+      fileFiltering: { respectGitIgnore: false },
+    };
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    fs.writeFileSync(workspaceSettingsPath, JSON.stringify(workspaceSettings));
+
+    const result = loadSettings(mockWorkspaceDir, true);
+
+    // User-only nested keys are preserved across both sections.
+    expect(result.tools?.core).toEqual(['core-tool']);
+    expect(result.fileFiltering?.enableRecursiveFileSearch).toBe(true);
+    // Workspace overrides only the specific key it defines.
+    expect(result.fileFiltering?.respectGitIgnore).toBe(false);
+    // Arrays are replaced wholesale, not concatenated.
+    expect(result.tools?.allowed).toEqual(['workspace-tool']);
+  });
+
+  it('does not allow prototype pollution through merged settings', () => {
+    fs.writeFileSync(
+      USER_SETTINGS_PATH,
+      JSON.stringify({ showMemoryUsage: true }),
+    );
+    const workspaceSettingsPath = path.join(
+      mockGeminiWorkspaceDir,
+      'settings.json',
+    );
+    // Raw JSON: JSON.parse turns __proto__ into an own property.
+    fs.writeFileSync(
+      workspaceSettingsPath,
+      '{ "__proto__": { "polluted": true } }',
+    );
+
+    const result = loadSettings(mockWorkspaceDir, true);
+
+    expect(
+      (Object.prototype as Record<string, unknown>)['polluted'],
+    ).toBeUndefined();
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(result.showMemoryUsage).toBe(true);
   });
 
   describe('security', () => {

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -257,6 +257,11 @@ export function deepMergeSettings<T extends object>(target: T, source: T): T {
       // merged result share references with the original `source` object,
       // allowing later mutations to leak back into it.
       output[key] = deepMergeSettings({}, sourceValue);
+    } else if (Array.isArray(sourceValue)) {
+      // Arrays replace the target value wholesale, but clone them so the merged
+      // result does not share references with the original `source` object
+      // (same reasoning as nested objects above).
+      output[key] = structuredClone(sourceValue);
     } else {
       output[key] = sourceValue;
     }

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -87,7 +87,9 @@ export function loadSettings(
       const parsedUserSettings = JSON.parse(
         stripJsonComments(userContent),
       ) as Settings;
-      userSettings = resolveEnvVarsInObject(parsedUserSettings);
+      userSettings = normalizeSettings(
+        resolveEnvVarsInObject(parsedUserSettings),
+      );
     }
   } catch (error: unknown) {
     settingsErrors.push({
@@ -121,7 +123,9 @@ export function loadSettings(
         const parsedWorkspaceSettings = JSON.parse(
           stripJsonComments(projectContent),
         ) as Settings;
-        workspaceSettings = resolveEnvVarsInObject(parsedWorkspaceSettings);
+        workspaceSettings = normalizeSettings(
+          resolveEnvVarsInObject(parsedWorkspaceSettings),
+        );
       }
     } catch (error: unknown) {
       settingsErrors.push({
@@ -208,17 +212,34 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Normalizes a parsed settings value into a plain `Settings` object. An empty
+ * settings file or one containing `null` or a primitive parses to a non-object
+ * (e.g. `JSON.parse("null")` returns `null`); returning `{}` in those cases
+ * keeps downstream property access and merging safe instead of crashing.
+ */
+function normalizeSettings(value: unknown): Settings {
+  return isPlainObject(value) ? (value as Settings) : {};
+}
+
+/**
  * Deeply merges two settings objects. Nested plain objects are merged
  * recursively so that the `source` settings override only the specific keys
  * they define, instead of replacing an entire nested section. Arrays and
  * primitive values in `source` replace those in `target`, and `undefined`
  * values in `source` are ignored so they never clobber an existing value.
+ *
+ * Exported for testing.
  */
-function deepMergeSettings<T extends object>(target: T, source: T): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-  const output = { ...target } as Record<string, unknown>;
+export function deepMergeSettings<T extends object>(target: T, source: T): T {
+  // Defensively default to empty objects when either side is not a plain
+  // object. An empty or `null` settings file parses to `null`
+  // (`JSON.parse("null")`), and calling `Object.entries(null)` would throw and
+  // crash the server.
+  const t = isPlainObject(target) ? target : {};
+  const s = isPlainObject(source) ? source : {};
+  const output: Record<string, unknown> = { ...t };
 
-  for (const [key, sourceValue] of Object.entries(source)) {
+  for (const [key, sourceValue] of Object.entries(s)) {
     // Skip dangerous keys that JSON.parse can create as own properties, to
     // prevent prototype pollution.
     if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
@@ -230,6 +251,12 @@ function deepMergeSettings<T extends object>(target: T, source: T): T {
     const targetValue = output[key];
     if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
       output[key] = deepMergeSettings(targetValue, sourceValue);
+    } else if (isPlainObject(sourceValue)) {
+      // The source value is a nested object but the target value is not, so
+      // recursively clone it. Assigning `sourceValue` directly would make the
+      // merged result share references with the original `source` object,
+      // allowing later mutations to leak back into it.
+      output[key] = deepMergeSettings({}, sourceValue);
     } else {
       output[key] = sourceValue;
     }

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -140,11 +140,11 @@ export function loadSettings(
   }
 
   // If there are overlapping keys, the values of workspaceSettings will
-  // override values from userSettings
-  const mergedSettings = {
-    ...userSettings,
-    ...workspaceSettings,
-  };
+  // override values from userSettings. Nested objects are merged recursively
+  // so workspace settings override only the specific keys they define, instead
+  // of replacing an entire nested section and silently dropping unrelated
+  // user-level configuration.
+  const mergedSettings = deepMergeSettings(userSettings, workspaceSettings);
 
   // Security: ensure policyPaths and adminPolicyPaths are only loaded from trusted, user-level
   // configuration and cannot be overridden by workspace-level settings, even if the
@@ -201,4 +201,40 @@ function resolveEnvVarsInObject<T>(obj: T): T {
   }
 
   return obj;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Deeply merges two settings objects. Nested plain objects are merged
+ * recursively so that the `source` settings override only the specific keys
+ * they define, instead of replacing an entire nested section. Arrays and
+ * primitive values in `source` replace those in `target`, and `undefined`
+ * values in `source` are ignored so they never clobber an existing value.
+ */
+function deepMergeSettings<T extends object>(target: T, source: T): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const output = { ...target } as Record<string, unknown>;
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    // Skip dangerous keys that JSON.parse can create as own properties, to
+    // prevent prototype pollution.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+    if (sourceValue === undefined) {
+      continue;
+    }
+    const targetValue = output[key];
+    if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+      output[key] = deepMergeSettings(targetValue, sourceValue);
+    } else {
+      output[key] = sourceValue;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return output as T;
 }


### PR DESCRIPTION
## Summary

`loadSettings()` in `packages/a2a-server/src/config/settings.ts` combined user and workspace settings with a **shallow** object spread (`{ ...userSettings, ...workspaceSettings }`).

Any nested section (`tools`, `telemetry`, `fileFiltering`, `experimental`, ...) defined in workspace settings replaced the **entire** corresponding section from user settings, silently dropping unrelated user-level configuration.

### Example

User settings: `{ "fileFiltering": { "respectGitIgnore": true, "enableRecursiveFileSearch": true } }`
Workspace settings: `{ "fileFiltering": { "respectGitIgnore": false } }`

- **Before:** `enableRecursiveFileSearch` is silently lost.
- **After:** it is preserved; only `respectGitIgnore` is overridden.

## Fix

Replace the shallow spread with a self-contained recursive deep merge:
- nested plain objects are merged key-by-key;
- arrays and primitive values from workspace settings still override the user values;
- `__proto__` / `constructor` / `prototype` keys are skipped to prevent prototype pollution;
- `undefined` source values are ignored.

The a2a-server only depends on `core`, so this intentionally avoids the cli-only `customDeepMerge` (which is coupled to cli's `MergeStrategy`/`settingsSchema`). The `policyPaths`/`adminPolicyPaths` security override is unchanged.

## Tests

- Updated the existing test that encoded the shallow-merge bug (it previously asserted a nested key becomes `undefined`).
- Added: multi-section deep merge with array replacement, and prototype-pollution safety.

Verified locally (Node 20):
- The updated/added merge tests **fail without the fix** and pass with it (red/green).
- `a2a-server` suite — all 140 tests pass.
- `prettier --check`, `eslint --max-warnings 0`, `tsc --noEmit` — all clean.

Fixes #25747
