### PR TITLE
fix(cli): show descriptive sandbox label in footer instead of 'current process'

### DIFF
--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -351,7 +351,7 @@ describe('<Footer />', () => {
       unmount();
     });
 
-    it('should display "current process" for custom sandbox when SANDBOX env is set', async () => {
+    it('should display the sandbox name when a custom SANDBOX env is set', async () => {
       vi.stubEnv('SANDBOX', 'gemini-cli-test-sandbox');
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
         config: mockConfig,
@@ -361,12 +361,12 @@ describe('<Footer />', () => {
           sessionStats: mockSessionStats,
         },
       });
-      expect(lastFrame()).toContain('current process');
+      expect(lastFrame()).toContain('gemini-cli-test-sandbox');
       vi.unstubAllEnvs();
       unmount();
     });
 
-    it('should display "current process" for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
+    it('should display "sandbox-exec (<profile>)" for macOS Seatbelt when SANDBOX is sandbox-exec', async () => {
       vi.stubEnv('SANDBOX', 'sandbox-exec');
       vi.stubEnv('SEATBELT_PROFILE', 'test-profile');
       const { lastFrame, unmount } = await renderWithProviders(<Footer />, {
@@ -374,7 +374,7 @@ describe('<Footer />', () => {
         width: 120,
         uiState: { isTrustedFolder: true, sessionStats: mockSessionStats },
       });
-      expect(lastFrame()).toContain('current process');
+      expect(lastFrame()).toContain('sandbox-exec (test-profile)');
       vi.unstubAllEnvs();
       unmount();
     });

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -69,6 +69,20 @@ interface SandboxIndicatorProps {
   isTrustedFolder: boolean | undefined;
 }
 
+/**
+ * Returns a human-readable label for the active sandbox, mirroring the
+ * logic used by the `/about` command.
+ */
+function getSandboxLabel(): string | null {
+  const sandbox = process.env['SANDBOX'];
+  if (!sandbox) return null;
+  if (sandbox === 'sandbox-exec') {
+    const profile = process.env['SEATBELT_PROFILE'] || 'unknown';
+    return `sandbox-exec (${profile})`;
+  }
+  return sandbox;
+}
+
 const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
   isTrustedFolder,
 }) => {
@@ -78,9 +92,9 @@ const SandboxIndicator: React.FC<SandboxIndicatorProps> = ({
     return <Text color={theme.status.warning}>untrusted</Text>;
   }
 
-  const sandbox = process.env['SANDBOX'];
-  if (sandbox) {
-    return <Text color={theme.status.warning}>current process</Text>;
+  const sandboxLabel = getSandboxLabel();
+  if (sandboxLabel) {
+    return <Text color={theme.status.warning}>{sandboxLabel}</Text>;
   }
 
   if (sandboxEnabled) {
@@ -309,10 +323,12 @@ export const Footer: React.FC = () => {
       }
       case 'sandbox': {
         let str = 'no sandbox';
-        const sandbox = process.env['SANDBOX'];
         if (isTrustedFolder === false) str = 'untrusted';
-        else if (sandbox) str = 'current process';
-        else if (config.getSandboxEnabled()) str = 'all tools';
+        else {
+          const sandboxLabel = getSandboxLabel();
+          if (sandboxLabel) str = sandboxLabel;
+          else if (config.getSandboxEnabled()) str = 'all tools';
+        }
 
         addCol(
           id,


### PR DESCRIPTION
## Summary

Fixes #26697

When the CLI is launched with  on macOS and the seatbelt profile is applied, the child process has `SANDBOX=sandbox-exec` and `SEATBELT_PROFILE=<name>` set in its environment. The footer's `SandboxIndicator` component was unconditionally rendering the hardcoded string **"current process"** whenever `SANDBOX` was set — giving users no indication of which sandbox type or profile was active.

### Root cause

In `Footer.tsx`, the component checked only whether `process.env['SANDBOX']` was truthy, and always returned the literal text `"current process"`.

### Fix

Introduced a `getSandboxLabel()` helper that mirrors the logic already used by the `/about` command (`aboutCommand.ts`):

| Env state | Before | After |
|---|---|---|
| `SANDBOX=sandbox-exec`, `SEATBELT_PROFILE=strict-open` | `current process` | `sandbox-exec (strict-open)` |
| `SANDBOX=docker` | `current process` | `docker` |
| `SANDBOX` unset, sandbox enabled | `all tools` | `all tools` (unchanged) |
| No sandbox | `no sandbox` | `no sandbox` (unchanged) |
| Untrusted folder | `untrusted` | `untrusted` (unchanged) |

The same helper is used in both the `SandboxIndicator` component and the column-width budget calculation in the `'sandbox'` footer item case, so the column width now accurately reflects the displayed text length.

## Testing

- Updated two existing tests that previously asserted the now-incorrect `"current process"` string.
- All 39 existing `Footer` tests pass.
- Pre-commit hooks (Prettier + ESLint) passed cleanly.