### PR TITLE
fix(vscode-ide-companion): register Disposables leaked by comma operators

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -131,6 +131,35 @@ describe('activate', () => {
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
   });
 
+  it('should register the onDidChangeWorkspaceFolders disposable in subscriptions', async () => {
+    // Regression test for #27790: a comma operator previously wrapped the two
+    // workspace-event Disposables as `(A, B)`, evaluating to only B. That leaked
+    // the onDidChangeWorkspaceFolders Disposable (A), which was never added to
+    // context.subscriptions and so never disposed on deactivate.
+    const workspaceFoldersDisposable = { dispose: vi.fn() };
+    vi.mocked(vscode.workspace.onDidChangeWorkspaceFolders).mockReturnValue(
+      workspaceFoldersDisposable as unknown as vscode.Disposable,
+    );
+    await activate(context);
+    expect(context.subscriptions).toContain(workspaceFoldersDisposable);
+  });
+
+  it('should register the gemini.diff.accept disposable in subscriptions', async () => {
+    // Regression test for #27790: a comma operator previously wrapped the
+    // gemini.diff.accept and gemini.diff.cancel command registrations as
+    // `(A, B)`, evaluating to only B. That leaked the gemini.diff.accept
+    // Disposable (A), which was never added to context.subscriptions.
+    const acceptDisposable = { dispose: vi.fn() };
+    vi.mocked(vscode.commands.registerCommand).mockImplementation(
+      (command: string) =>
+        (command === 'gemini.diff.accept'
+          ? acceptDisposable
+          : { dispose: vi.fn() }) as unknown as vscode.Disposable,
+    );
+    await activate(context);
+    expect(context.subscriptions).toContain(acceptDisposable);
+  });
+
   it('should launch the Gemini CLI when the user clicks the button', async () => {
     const showInformationMessageMock = vi
       .mocked(vscode.window.showInformationMessage)

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

`activate()` in `extension.ts` has two `context.subscriptions.push(...)` calls where a comma operator wrapped a pair of Disposables in parentheses as `(A, B)`. A comma expression evaluates to its last operand, so each `(A, B)` collapsed to just `B`. The first Disposable of each pair was therefore never passed to `push()`, never added to `context.subscriptions`, and never disposed on `deactivate()`.

Two Disposables leaked:

- `(registerCommand('gemini.diff.accept', ...), registerCommand('gemini.diff.cancel', ...))` leaked the `gemini.diff.accept` command registration.
- `(onDidChangeWorkspaceFolders(...), onDidGrantWorkspaceTrust(...))` leaked the `onDidChangeWorkspaceFolders` handler.

The fix removes the wrapping parentheses so every Disposable is passed as a separate argument to `context.subscriptions.push()`, which is the variadic API it was always meant to use.

## Test plan

- Added two regression tests asserting that the `gemini.diff.accept` and `onDidChangeWorkspaceFolders` Disposables end up in `context.subscriptions`. Both fail against the old `(A, B)` code and pass with the fix.
- `npx vitest run src/extension.test.ts` in `packages/vscode-ide-companion`: 13/13 pass.
- `eslint` and `prettier --check` clean on both changed files.

Fixes #27790