### PR TITLE
fix(core): avoid keep-alive socket reuse during OAuth token exchange

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -30,6 +30,7 @@ import { UserAccountManager } from '../utils/userAccountManager.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import http from 'node:http';
+import * as https from 'node:https';
 import open from 'open';
 import crypto from 'node:crypto';
 import * as os from 'node:os';
@@ -408,6 +409,78 @@ describe('oauth2', () => {
         redirect_uri: 'https://codeassist.google.com/authcode',
       });
       expect(mockOAuth2Client.setCredentials).toHaveBeenCalledWith(mockTokens);
+    });
+
+    describe('transporter keep-alive (nodejs/node#63989 workaround)', () => {
+      const setupUserCodeClient = () => {
+        const mockOAuth2Client = {
+          generateAuthUrl: vi.fn().mockReturnValue('https://example.com/auth'),
+          getToken: vi.fn().mockResolvedValue({
+            tokens: {
+              access_token: 'test-access-token',
+              refresh_token: 'test-refresh-token',
+            },
+          }),
+          generateCodeVerifierAsync: vi.fn().mockResolvedValue({
+            codeChallenge: 'test-challenge',
+            codeVerifier: 'test-verifier',
+          }),
+          getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+          setCredentials: vi.fn(),
+          on: vi.fn(),
+          credentials: {},
+        } as unknown as OAuth2Client;
+        vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
+        (readline.createInterface as Mock).mockReturnValue({
+          question: vi.fn((_query, callback) => callback('test-user-code')),
+          close: vi.fn(),
+          on: vi.fn(),
+        });
+      };
+
+      it('disables HTTP keep-alive when no proxy is configured', async () => {
+        setupUserCodeClient();
+        const config = {
+          getNoBrowser: () => true,
+          getProxy: () => undefined,
+          isBrowserLaunchSuppressed: () => true,
+          isInteractive: () => true,
+        } as unknown as Config;
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, config);
+
+        const transporterOptions = (
+          vi.mocked(OAuth2Client).mock.calls[0]?.[0] as unknown as {
+            transporterOptions?: {
+              agent?: { keepAlive?: boolean };
+              proxy?: string;
+            };
+          }
+        )?.transporterOptions;
+        expect(transporterOptions?.agent).toBeInstanceOf(https.Agent);
+        expect(transporterOptions?.agent?.keepAlive).toBe(false);
+        expect(transporterOptions?.proxy).toBeUndefined();
+      });
+
+      it('keeps the proxy and no custom agent when a proxy is configured', async () => {
+        setupUserCodeClient();
+        const config = {
+          getNoBrowser: () => true,
+          getProxy: () => 'http://test.proxy.com:8080',
+          isBrowserLaunchSuppressed: () => true,
+          isInteractive: () => true,
+        } as unknown as Config;
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, config);
+
+        const transporterOptions = (
+          vi.mocked(OAuth2Client).mock.calls[0]?.[0] as unknown as {
+            transporterOptions?: { agent?: unknown; proxy?: string };
+          }
+        )?.transporterOptions;
+        expect(transporterOptions?.proxy).toBe('http://test.proxy.com:8080');
+        expect(transporterOptions?.agent).toBeUndefined();
+      });
     });
 
     it('should cache Google Account when logging in with user code', async () => {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -14,6 +14,7 @@ import {
   type JWTInput,
 } from 'google-auth-library';
 import * as http from 'node:http';
+import * as https from 'node:https';
 import url from 'node:url';
 import crypto from 'node:crypto';
 import * as net from 'node:net';
@@ -140,12 +141,19 @@ async function initOauthClient(
     }
   }
 
+  // The CVE-2026-48931 fix regressed http.Agent keep-alive socket reuse in
+  // Node 24.17.0 / 22.23.0 / 26.3.1 (fixed in 24.18.0 / 22.23.1 / 26.x),
+  // making node-fetch (via gaxios) throw a spurious ERR_STREAM_PREMATURE_CLOSE
+  // during the OAuth token exchange. Disable keep-alive to avoid it; with a
+  // proxy we keep `proxy` instead, since our own agent would make gaxios
+  // ignore it. See https://github.com/nodejs/node/issues/63989
+  const proxy = config.getProxy();
   const client = new OAuth2Client({
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,
-    transporterOptions: {
-      proxy: config.getProxy(),
-    },
+    transporterOptions: proxy
+      ? { proxy }
+      : { agent: new https.Agent({ keepAlive: false }) },
   });
   const useEncryptedStorage = getUseEncryptedStorageFlag();
 


### PR DESCRIPTION
## Summary

OAuth "Sign in with Google" fails with
`Failed to exchange authorization code for tokens: ... Premature close` on the
three Node.js releases that shipped the June 2026 security fix for
**CVE-2026-48931** ("fix response queue poisoning in `http.Agent`"):
**24.17.0, 22.23.0, and 26.3.1**. That fix regressed keep-alive socket reuse,
making `node-fetch` throw a spurious `ERR_STREAM_PREMATURE_CLOSE` when a pooled
socket is reused, breaking login. Each release is fixed in its next version
(24.18.0 / 22.23.1 / 26.x), but users pinned to an affected release (e.g. a
`node:24.17.0` base image) still hit it. This change makes the OAuth token
exchange use a fresh (non-keep-alive) connection so sign-in works regardless of
the running Node version.

## Details

The token exchange runs through `google-auth-library` → `gaxios` → `node-fetch`,
which uses Node's global keep-alive agent. The CVE-2026-48931 fix attaches a
guard listener to idle pooled sockets; on reuse, `node-fetch@2` misreads this as
a premature close and throws `ERR_STREAM_PREMATURE_CLOSE` (see nodejs/node#63989).
The Node-side regression is fixed by nodejs/node#64004, shipped in
24.18.0 / 22.23.1 / 26.x.

Affected vs. unaffected (verified empirically with `mise`, `node-fetch@2` over a
keep-alive agent reusing a single socket):

| Node | Result |
|---|---|
| `24.17.0`, `22.23.0` | ❌ `ERR_STREAM_PREMATURE_CLOSE` on first reuse |
| `24.18.0`, `22.23.1` | ✅ |
| `24.13.0`, `20.17.0` (pre-fix / never patched) | ✅ |

Fix: in `initOauthClient` (`packages/core/src/code_assist/oauth2.ts`), pass
`new https.Agent({ keepAlive: false })` to the `OAuth2Client` transporter when no
proxy is configured, forcing a fresh connection per request and sidestepping the
regression on any Node version. It is harmless on fixed/unaffected versions
because the OAuth token exchange is a one-shot request that gains nothing from
keep-alive. The proxy path is left unchanged, since supplying our own agent would
make gaxios ignore the configured proxy. Because the same client also backs the
Code Assist API calls, the whole code-assist flow benefits.

## Related Issues

- #28072
- #28066
- #28088
- #26411
- nodejs/node#63989, nodejs/node#64004

## How to Validate

1. Use an affected release: Node.js **24.17.0**, **22.23.0**, or **26.3.1**
   (`node -v`). On 24.18.0 / 22.23.1 / 26.x the bug no longer reproduces without
   this change.
2. Build core: `npm run generate && npm run build --workspace=@google/gemini-cli-core`.
3. Run the unit tests: `npx vitest run packages/core/src/code_assist/oauth2.test.ts`
   - New cases assert the OAuth transporter uses a `keepAlive: false` agent when
     no proxy is set, and keeps `proxy` (no custom agent) when a proxy is set.
4. End-to-end: launch the CLI and choose "Login with Google"; the
   authorization-code → token exchange completes instead of failing with
   "Premature close".
5. Edge case (proxy): with `HTTPS_PROXY` set / `--proxy` configured, login still
   routes through the proxy as before.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

