### PR TITLE
fix(core-tools): show ellipsis on multi-line edit snippets

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -1436,4 +1436,112 @@ function doIt() {
       fs.rmSync(plansDir, { recursive: true, force: true });
     });
   });
+
+  describe('getDescription', () => {
+    const testFile = 'describe_me.txt';
+    let filePath: string;
+
+    beforeEach(() => {
+      filePath = path.join(rootDir, testFile);
+    });
+
+    it("returns 'Create <path>' when old_string is empty", () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Create file',
+        old_string: '',
+        new_string: 'hello',
+      };
+      expect(tool.build(params).getDescription()).toBe(`Create ${testFile}`);
+    });
+
+    it('returns no-change message when old_string equals new_string', () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'No-op',
+        old_string: 'same',
+        new_string: 'same',
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `No file changes to ${testFile}`,
+      );
+    });
+
+    it('does not append ellipsis to single-line strings within the snippet limit', () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Short replace',
+        old_string: 'short old',
+        new_string: 'short new',
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: short old => short new`,
+      );
+    });
+
+    it('does not append ellipsis when the first line is exactly the snippet limit', () => {
+      const exact = 'a'.repeat(30);
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Boundary replace',
+        old_string: exact,
+        new_string: exact + 'b',
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: ${exact} => ${exact}...`,
+      );
+    });
+
+    it('appends ellipsis when a single-line string exceeds the snippet limit', () => {
+      const longOld = 'a'.repeat(35);
+      const longNew = 'b'.repeat(40);
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Long replace',
+        old_string: longOld,
+        new_string: longNew,
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: ${'a'.repeat(30)}... => ${'b'.repeat(30)}...`,
+      );
+    });
+
+    // Regression for #28110 and #28109: when an edit spans multiple lines but the
+    // first line is short, the snippet should still signal hidden content with `...`.
+    it('appends ellipsis to multi-line edits whose first line is short', () => {
+      const oldStr = 'function foo() {\n  return 1;\n}';
+      const newStr = 'function foo() {\n  return 2;\n}';
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Multi-line replace with short first line',
+        old_string: oldStr,
+        new_string: newStr,
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: function foo() {... => function foo() {...`,
+      );
+    });
+
+    it('appends ellipsis to multi-line edits with very short first lines', () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Tiny multi-line',
+        old_string: 'a\nb\nc',
+        new_string: 'x\ny\nz',
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: a... => x...`,
+      );
+    });
+
+    it('emits an empty snippet without ellipsis when deleting to empty', () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Delete content',
+        old_string: 'a\nb\nc',
+        new_string: '',
+      };
+      expect(tool.build(params).getDescription()).toBe(`${testFile}: a... => `);
+    });
+  });
 });

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -1534,6 +1534,32 @@ function doIt() {
       );
     });
 
+    it('strips carriage returns before appending ellipsis for CRLF edits', () => {
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'CRLF multi-line',
+        old_string: 'foo\r\nbar',
+        new_string: 'baz\r\nqux',
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: foo... => baz...`,
+      );
+    });
+
+    it('does not split emoji when truncating long snippets', () => {
+      const oldStr = `${'a'.repeat(29)}😀b`;
+      const newStr = `${'c'.repeat(29)}😀d`;
+      const params: EditToolParams = {
+        file_path: filePath,
+        instruction: 'Unicode truncate',
+        old_string: oldStr,
+        new_string: newStr,
+      };
+      expect(tool.build(params).getDescription()).toBe(
+        `${testFile}: ${'a'.repeat(29)}😀... => ${'c'.repeat(29)}😀...`,
+      );
+    });
+
     it('emits an empty snippet without ellipsis when deleting to empty', () => {
       const params: EditToolParams = {
         file_path: filePath,

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -863,12 +863,15 @@ class EditToolInvocation
       return `Create ${shortenPath(relativePath)}`;
     }
 
-    const oldStringSnippet =
-      this.params.old_string.split('\n')[0].substring(0, 30) +
-      (this.params.old_string.length > 30 ? '...' : '');
-    const newStringSnippet =
-      this.params.new_string.split('\n')[0].substring(0, 30) +
-      (this.params.new_string.length > 30 ? '...' : '');
+    // Append `...` when the snippet hides content from the user: the first
+    // line was truncated, or there are additional lines below it.
+    const snippet = (s: string) => {
+      const firstLine = s.split('\n')[0];
+      const hasHiddenContent = firstLine.length > 30 || s.includes('\n');
+      return firstLine.substring(0, 30) + (hasHiddenContent ? '...' : '');
+    };
+    const oldStringSnippet = snippet(this.params.old_string);
+    const newStringSnippet = snippet(this.params.new_string);
 
     if (this.params.old_string === this.params.new_string) {
       return `No file changes to ${shortenPath(relativePath)}`;

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -866,9 +866,11 @@ class EditToolInvocation
     // Append `...` when the snippet hides content from the user: the first
     // line was truncated, or there are additional lines below it.
     const snippet = (s: string) => {
-      const firstLine = s.split('\n')[0];
-      const hasHiddenContent = firstLine.length > 30 || s.includes('\n');
-      return firstLine.substring(0, 30) + (hasHiddenContent ? '...' : '');
+      const lineBreakIndex = s.search(/\r\n|\r|\n/);
+      const firstLine = lineBreakIndex === -1 ? s : s.slice(0, lineBreakIndex);
+      const chars = Array.from(firstLine);
+      const hasHiddenContent = chars.length > 30 || lineBreakIndex !== -1;
+      return chars.slice(0, 30).join('') + (hasHiddenContent ? '...' : '');
     };
     const oldStringSnippet = snippet(this.params.old_string);
     const newStringSnippet = snippet(this.params.new_string);


### PR DESCRIPTION
## Summary

`EditToolInvocation.getDescription()` now appends `...` when the displayed
snippet hides content from the user: either the first line exceeds 30 characters,
or the edit spans multiple lines. This keeps multi-line edits with a short first
line from looking like a single-line change in the confirmation UI.

The snippet helper also treats `\r\n`, `\r`, and `\n` as line breaks before
rendering, so CRLF input does not leave a carriage return in terminal output. It
truncates with `Array.from()` to avoid splitting simple multi-byte characters
such as emoji.

## Details

The old logic displayed only the first `\n`-delimited line, but decided whether
to append `...` from the full string length. That missed cases where additional
lines were hidden behind a short first line. After review, the helper now also
avoids the CRLF case where `split('\n')` could leave `\r` in the rendered
snippet.

## Related Issues

Fixes #28110
Fixes #28109

## How to Validate

```bash
npx vitest run packages/core/src/tools/edit.test.ts -t getDescription
# 10 passed

npx vitest run packages/core/src/tools/edit.test.ts
# 74 passed

npx eslint packages/core/src/tools/edit.ts packages/core/src/tools/edit.test.ts --max-warnings 0
# passed

git diff --check upstream/main...HEAD
# passed
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [ ] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
