### PR TITLE
Improve 'Install source not found' error in gemini-cli

### DIFF
--- a/packages/cli/src/commands/extensions/install.test.ts
+++ b/packages/cli/src/commands/extensions/install.test.ts
@@ -227,14 +227,16 @@ describe('handleInstall', () => {
   });
 
   it('throws an error from an unknown source', async () => {
-    mockInferInstallMetadata.mockRejectedValue(
-      new Error('Install source not found.'),
-    );
+    const errorMessage =
+      'Install source not found: "test://google.com". If you are installing ' +
+      'from GitHub, provide the full repository URL ' +
+      '(e.g. "https://github.com/owner/repo").';
+    mockInferInstallMetadata.mockRejectedValue(new Error(errorMessage));
     await handleInstall({
       source: 'test://google.com',
     });
 
-    expect(debugErrorSpy).toHaveBeenCalledWith('Install source not found.');
+    expect(debugErrorSpy).toHaveBeenCalledWith(errorMessage);
     expect(processSpy).toHaveBeenCalledWith(1);
   });
 

--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { ExtensionManager } from './extension-manager.js';
+import { ExtensionManager, inferInstallMetadata } from './extension-manager.js';
 import { createTestMergedSettings, type MergedSettings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
 import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
@@ -635,6 +635,33 @@ describe('ExtensionManager', () => {
       expect(themeManager.getCustomThemeNames()).not.toContain(
         'MyTheme (disabled-ext)',
       );
+    });
+  });
+
+  describe('inferInstallMetadata', () => {
+    it('throws a helpful error when a local install source is not found', async () => {
+      const missingSource = path.join(tempHomeDir, 'does-not-exist');
+
+      await expect(inferInstallMetadata(missingSource)).rejects.toThrow(
+        /Install source not found/,
+      );
+    });
+
+    it('suggests the GitHub URL form and an auth hint in the error', async () => {
+      const missingSource = path.join(tempHomeDir, 'does-not-exist');
+
+      let thrown: Error | undefined;
+      try {
+        await inferInstallMetadata(missingSource);
+      } catch (e) {
+        thrown = e as Error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown!.message).toContain(missingSource);
+      expect(thrown!.message).toContain('https://github.com/owner/repo');
+      expect(thrown!.message.toLowerCase()).toContain('authenticated');
+      expect(thrown!.message).toContain('sso://');
     });
   });
 });

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -1325,7 +1325,14 @@ export async function inferInstallMetadata(
         type: 'local',
       };
     } catch {
-      throw new Error('Install source not found.');
+      throw new Error(
+        `Install source not found: "${source}". ` +
+          `If you are installing from GitHub, provide the full repository URL ` +
+          `(e.g. "https://github.com/owner/repo"). ` +
+          `For private or SSO-protected repositories, make sure you are ` +
+          `authenticated (e.g. via an SSH key with the appropriate SSO ` +
+          `authorization, or by using an "sso://" URL).`,
+      );
     }
   }
 }


### PR DESCRIPTION
### Why
Better error messaging cuts user confusion when an install source is missing by pointing to the right GitHub URL and an auth fix.

### What
Improved the 'Install source not found' error thrown by inferInstallMetadata in packages/cli/src/config/extension-manager.ts. The previous message was a bare 'Install source not found.' with no guidance; the new message echoes the offending source, points the user to the full 'https://github.com/owner/repo' URL form, and adds an authentication hint for private/SSO-protected repos (use an SSH key with SSO authorization or an 'sso://' URL). Updated the existing handler test in install.test.ts to assert against the new message and added a direct unit test in extension-manager.test.ts that exercises the real inferInstallMetadata function and verifies the GitHub URL suggestion, the auth hint, and the sso:// mention. Ran the cli package tests for both files plus typecheck and lint.

### Changes
```
.../cli/src/commands/extensions/install.test.ts    | 10 +++++---
 packages/cli/src/config/extension-manager.test.ts  | 29 +++++++++++++++++++++-
 packages/cli/src/config/extension-manager.ts       | 13 +++++++---
 3 files changed, 44 insertions(+), 8 deletions(-)
```

### Automated review — approve-with-nits
The change replaces the terse 'Install source not found.' error in inferInstallMetadata with a more actionable message that echoes the offending source and suggests the full GitHub URL form and SSO/auth remedies. It is low-risk, the new branch is purely a string change in an existing catch path, and it is covered by two new unit tests plus an updated install handler test; all targeted tests pass. A few minor inconsistencies and UX wording concerns are worth noting but none are blocking.

**Risks:** The new error text only fires in the non-git, local-path branch, so a simple mistyped local path now also surfaces GitHub/SSO guidance, which can be slightly confusing for genuinely local installs.; The catch block still labels every stat() failure (including permission or I/O errors, not just ENOENT) as 'Install source not found', so the more confident, detailed wording could now misdescribe non-existence vs. access errors. This is pre-existing behavior but the richer message makes the mismatch more noticeable.

**Test gaps:** install.test.ts hardcodes a shortened, hand-edited copy of the real error message in its mock (omitting the SSO/auth sentence); because inferInstallMetadata is fully mocked there, this passes but the duplicated string can silently drift from the real message over time.; No positive test asserting inferInstallMetadata still returns local metadata for an existing path alongside the new failure tests (pre-existing gap, not introduced by this change).

_Generated by the Standup Orchestrator (task `improve-install-source-error`). Draft until reviewed in Obsidian._