### PR TITLE
Fix no_proxy test

### DIFF
--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -261,6 +261,7 @@ describe('fetch utils', () => {
     it('should fall back to no_proxy if NO_PROXY is not set', () => {
       const proxyUrl = 'http://proxy.example.com';
       const noProxyValue = 'localhost,127.0.0.1';
+      vi.stubEnv('NO_PROXY', undefined);
       vi.stubEnv('no_proxy', noProxyValue);
 
       setGlobalProxy(proxyUrl);


### PR DESCRIPTION
If running tests in an environment that has NO_PROXY already set, this test will fail

```
> @google/gemini-cli-core@0.49.0-nightly.20260617.g4d3dcdce1 test
> vitest run src/utils/fetch.test.ts


 RUN  v3.2.4 /Users/jerrysf/Code2/gemini-cli/packages/core
      Coverage enabled with v8

 ❯ src/utils/fetch.test.ts (21 tests | 1 failed) 62ms
   ✓ fetch utils > isAddressPrivate > should identify private IPv4 addresses 1ms
   ✓ fetch utils > isAddressPrivate > should identify non-routable and reserved IPv4 addresses (RFC 6890) 0ms
   ✓ fetch utils > isAddressPrivate > should identify private IPv6 addresses 0ms
   ✓ fetch utils > isAddressPrivate > should identify special local addresses 0ms
   ✓ fetch utils > isAddressPrivate > should identify link-local addresses 0ms
   ✓ fetch utils > isAddressPrivate > should identify IPv4-mapped IPv6 private addresses 0ms
   ✓ fetch utils > isAddressPrivate > should identify public addresses as non-private 0ms
   ✓ fetch utils > isPrivateIp > should identify private IPs in URLs 0ms
   ✓ fetch utils > isPrivateIp > should identify public IPs in URLs as non-private 0ms
   ✓ fetch utils > isPrivateIpAsync > should identify private IPs directly 0ms
   ✓ fetch utils > isPrivateIpAsync > should identify domains resolving to private IPs 0ms
   ✓ fetch utils > isPrivateIpAsync > should identify domains resolving to public IPs as non-private 0ms
   ✓ fetch utils > isPrivateIpAsync > should throw error if DNS resolution fails (fail closed) 1ms
   ✓ fetch utils > isPrivateIpAsync > should return false for invalid URLs instead of throwing verification error 0ms
   ✓ fetch utils > fetchWithTimeout > should throw FetchError with ETIMEDOUT on an internal timeout 51ms
   ✓ fetch utils > fetchWithTimeout > should throw an AbortError (not ETIMEDOUT) when the caller signal is aborted 1ms
   ✓ fetch utils > setGlobalProxy > should configure EnvHttpProxyAgent with experiment flag timeout and noProxy 1ms
   × fetch utils > setGlobalProxy > should fall back to no_proxy if NO_PROXY is not set 5ms
     → expected "spy" to be called with arguments: [ ObjectContaining{…} ]

Received: 

  1st spy call:

  [
-   ObjectContaining {
-     "noProxy": "localhost,127.0.0.1",
+   {
+     "bodyTimeout": 300000,
+     "headersTimeout": 60000,
+     "httpProxy": "http://proxy.example.com",
+     "httpsProxy": "http://proxy.example.com",
+     "noProxy": "some-value",
    },
  ]

  2nd spy call:

  [
-   ObjectContaining {
-     "noProxy": "localhost,127.0.0.1",
+   {
+     "bodyTimeout": 300000,
+     "headersTimeout": 60000,
+     "httpProxy": "http://proxy.example.com",
+     "httpsProxy": "http://proxy.example.com",
+     "noProxy": "some-value",
    },
  ]


Number of calls: 2

   ✓ fetch utils > setGlobalProxy > should handle empty NO_PROXY 0ms
   ✓ fetch utils > setGlobalProxy > should handle multi-entry NO_PROXY with trimming 0ms
   ✓ fetch utils > createSafeProxyAgent > should create an EnvHttpProxyAgent with trimmed values and default timeouts 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/fetch.test.ts > fetch utils > setGlobalProxy > should fall back to no_proxy if NO_PROXY is not set
AssertionError: expected "spy" to be called with arguments: [ ObjectContaining{…} ]

Received: 

  1st spy call:

  [
-   ObjectContaining {
-     "noProxy": "localhost,127.0.0.1",
+   {
+     "bodyTimeout": 300000,
+     "headersTimeout": 60000,
+     "httpProxy": "http://proxy.example.com",
+     "httpsProxy": "http://proxy.example.com",
+     "noProxy": "some-value",
    },
  ]

  2nd spy call:

  [
-   ObjectContaining {
-     "noProxy": "localhost,127.0.0.1",
+   {
+     "bodyTimeout": 300000,
+     "headersTimeout": 60000,
+     "httpProxy": "http://proxy.example.com",
+     "httpsProxy": "http://proxy.example.com",
+     "noProxy": "some-value",
    },
  ]


Number of calls: 2

 ❯ src/utils/fetch.test.ts:268:33
    266|       setGlobalProxy(proxyUrl);
    267| 
    268|       expect(EnvHttpProxyAgent).toHaveBeenCalledWith(
       |                                 ^
    269|         expect.objectContaining({
    270|           noProxy: noProxyValue,

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
   Start at  12:48:19
   Duration  1.36s (transform 45ms, setup 31ms, collect 28ms, tests 62ms, environment 0ms, prepare 72ms)

JUNIT report written to /Users/jerrysf/Code2/gemini-cli/packages/core/junit.xml
npm error Lifecycle script `test` failed with error:
npm error code 1
npm error path /Users/jerrysf/Code2/gemini-cli/packages/core
npm error workspace @google/gemini-cli-core@0.49.0-nightly.20260617.g4d3dcdce1
npm error location /Users/jerrysf/Code2/gemini-cli/packages/core
npm error command failed
npm error command sh -c vitest run src/utils/fetch.test.ts
```