### PR TITLE
fix(ci): prevent workspace binary shadowing in release verification

### DIFF
--- a/.github/actions/verify-release/action.yml
+++ b/.github/actions/verify-release/action.yml
@@ -98,4 +98,6 @@ runs:
         # See https://github.com/google-gemini/gemini-cli/issues/10517
         CI: 'false'
       shell: 'bash'
-      run: 'npm run test:integration:sandbox:none'
+      run: |
+        export INTEGRATION_TEST_GEMINI_BINARY_PATH=$(which gemini)
+        npm run test:integration:sandbox:none


### PR DESCRIPTION
 The recent change to use `npm ci --ignore-scripts` during release verification inadvertently caused integration tests to run
   against the local workspace source instead of the published NPM bundle.

   Because the `packages/cli/package.json` has its dependencies stripped prior to publishing, `npm ci` creates a flawed
   workspace symlink at `node_modules/.bin/gemini` missing its required runtime modules (like `dotenv`). When `npm run
   test:integration:sandbox:none` executes, `node_modules/.bin` takes precedence in the PATH, shadowing the global `gemini`
   installation and causing tests to crash with `ERR_MODULE_NOT_FOUND`.

   This commit explicitly resolves the absolute path of the globally installed `gemini` binary using `which gemini` and exports
   it via `INTEGRATION_TEST_GEMINI_BINARY_PATH`, ensuring the test rig targets the downloaded NPM artifact.
