### PR TITLE
fix(core): honor GOOGLE_CLOUD_LOCATION for Vertex AI with API key

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -483,6 +483,110 @@ describe('createContentGenerator', () => {
     );
   });
 
+  describe('Vertex AI regional endpoint with API key', () => {
+    const vertexConfig = {
+      apiKey: 'test-api-key',
+      vertexai: true,
+      authType: AuthType.USE_VERTEX_AI,
+    } as const;
+
+    function mockVertexGenerator(): void {
+      const mockGenerator = {
+        models: {},
+      } as unknown as GoogleGenAI;
+      vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    }
+
+    it('derives the regional endpoint from GOOGLE_CLOUD_LOCATION', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'europe-west3');
+
+      await createContentGenerator({ ...vertexConfig }, mockConfig);
+
+      const regionalUrl = 'https://europe-west3-aiplatform.googleapis.com/';
+      expect(GoogleGenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpOptions: expect.objectContaining({ baseUrl: regionalUrl }),
+          googleAuthOptions: expect.objectContaining({
+            clientOptions: expect.objectContaining({
+              apiEndpoint: regionalUrl,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('trims whitespace around the configured location', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', '  us-central1  ');
+
+      await createContentGenerator({ ...vertexConfig }, mockConfig);
+
+      expect(GoogleGenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpOptions: expect.objectContaining({
+            baseUrl: 'https://us-central1-aiplatform.googleapis.com/',
+          }),
+        }),
+      );
+    });
+
+    it('uses the global endpoint (no baseUrl) when location is "global"', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'global');
+
+      await createContentGenerator({ ...vertexConfig }, mockConfig);
+
+      const callArg = vi.mocked(GoogleGenAI).mock.calls[0][0] as {
+        httpOptions?: { baseUrl?: string };
+      };
+      expect(callArg.httpOptions).not.toHaveProperty('baseUrl');
+    });
+
+    it('does not derive a baseUrl when no location is configured', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', '');
+
+      await createContentGenerator({ ...vertexConfig }, mockConfig);
+
+      const callArg = vi.mocked(GoogleGenAI).mock.calls[0][0] as {
+        httpOptions?: { baseUrl?: string };
+      };
+      expect(callArg.httpOptions).not.toHaveProperty('baseUrl');
+    });
+
+    it('lets GOOGLE_VERTEX_BASE_URL take precedence over the derived endpoint', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'europe-west3');
+      vi.stubEnv('GOOGLE_VERTEX_BASE_URL', 'https://custom.example.com/');
+
+      await createContentGenerator({ ...vertexConfig }, mockConfig);
+
+      expect(GoogleGenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpOptions: expect.objectContaining({
+            baseUrl: 'https://custom.example.com/',
+          }),
+        }),
+      );
+    });
+
+    it('does not derive a regional endpoint when no API key is used', async () => {
+      mockVertexGenerator();
+      vi.stubEnv('GOOGLE_CLOUD_LOCATION', 'europe-west3');
+
+      await createContentGenerator(
+        { vertexai: true, authType: AuthType.USE_VERTEX_AI },
+        mockConfig,
+      );
+
+      const callArg = vi.mocked(GoogleGenAI).mock.calls[0][0] as {
+        httpOptions?: { baseUrl?: string };
+      };
+      expect(callArg.httpOptions).not.toHaveProperty('baseUrl');
+    });
+  });
+
   it('should inject HttpsProxyAgent into googleAuthOptions when proxy URL uses https://', async () => {
     const mockConfigWithProxy = {
       getModel: vi.fn().mockReturnValue('gemini-pro'),

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -346,6 +346,24 @@ export async function createContentGenerator(
         validateBaseUrl(baseUrl);
       }
 
+      // When using Vertex AI with an API key, @google/genai forces the global
+      // endpoint (`aiplatform.googleapis.com`) and silently ignores
+      // GOOGLE_CLOUD_LOCATION, because it clears project/location whenever an
+      // API key is present. Derive the regional endpoint ourselves so a
+      // configured non-global location is honored (e.g. for data residency).
+      // Explicit base URL overrides (config.baseUrl, GOOGLE_VERTEX_BASE_URL)
+      // take precedence and are left untouched.
+      if (
+        !baseUrl &&
+        config.authType === AuthType.USE_VERTEX_AI &&
+        config.apiKey
+      ) {
+        const location = process.env['GOOGLE_CLOUD_LOCATION']?.trim();
+        if (location && location !== 'global') {
+          baseUrl = `https://${location}-aiplatform.googleapis.com/`;
+        }
+      }
+
       const httpOptions: {
         baseUrl?: string;
         headers: Record<string, string>;


### PR DESCRIPTION
## Summary

When authenticating to Vertex AI with an API key (`GOOGLE_API_KEY`), the configured `GOOGLE_CLOUD_LOCATION` is silently ignored and requests are routed to the **global** endpoint (`https://aiplatform.googleapis.com/`) instead of the regional one.

The root cause is in `@google/genai`: as soon as an API key is present it clears project/location and short-circuits to the global endpoint. Meanwhile `/about` still displays the configured region and `/model` lists region-appropriate models, so the displayed configuration and the actual routing disagree with no warning. For users who pick Vertex AI specifically for data residency (e.g. GDPR), this undermines exactly the expectation that made them set a location.

## Fix

In `createContentGenerator`, when a Vertex AI **API key** is used together with a non-global `GOOGLE_CLOUD_LOCATION`, derive the regional endpoint ourselves and pass it explicitly via `httpOptions.baseUrl` (which overrides the library's global default through `patchHttpOptions`):

```
https://<location>-aiplatform.googleapis.com/
```

This matches the exact URL format the library already uses for the project/location flow.

Precedence is preserved:
- An explicit base URL (config `baseUrl`) and `GOOGLE_VERTEX_BASE_URL` still take priority and are left untouched.
- `location === 'global'` and an unset location fall back to the existing global behavior (no regression).
- The API-key-less project/location flow is unchanged (the library already honors the region there).

## Testing

Added unit tests in `contentGenerator.test.ts` covering:
- regional endpoint derived from `GOOGLE_CLOUD_LOCATION` (both `httpOptions.baseUrl` and `apiEndpoint`)
- whitespace trimming around the location value
- `global` location → global endpoint (no derived `baseUrl`)
- no location configured → no derived `baseUrl`
- `GOOGLE_VERTEX_BASE_URL` taking precedence over the derived endpoint
- no derivation when no API key is used

All 59 tests in the file pass; `eslint` and `tsc --noEmit` are clean for the affected package.

Fixes #27984