### PR TITLE
fix(core): resolve MCP resources by server to prevent cross-server confusion

### DIFF
--- a/packages/core/src/resources/resource-registry.test.ts
+++ b/packages/core/src/resources/resource-registry.test.ts
@@ -65,6 +65,62 @@ describe('ResourceRegistry', () => {
     expect(registry.findResourceByUri('nonexistent')).toBeUndefined();
   });
 
+  it('resolves a bare URI when exactly one server exposes it', () => {
+    registry.setResourcesForServer('a', [createResource()]);
+    registry.setResourcesForServer('b', [
+      createResource({ uri: 'file:///tmp/bar.txt' }),
+    ]);
+
+    // No server prefix, but the URI is unique across servers.
+    expect(registry.findResourceByUri('file:///tmp/bar.txt')?.serverName).toBe(
+      'b',
+    );
+    // A URI scheme is never mistaken for a server name.
+    expect(registry.findResourceByUri('file:///tmp/foo.txt')?.serverName).toBe(
+      'a',
+    );
+  });
+
+  it('does not resolve a bare URI exposed by multiple servers', () => {
+    registry.setResourcesForServer('a', [createResource()]);
+    registry.setResourcesForServer('b', [createResource()]);
+
+    // Same URI on two servers is ambiguous without a server qualifier.
+    expect(registry.findResourceByUri('file:///tmp/foo.txt')).toBeUndefined();
+
+    // ...but the server-qualified identifier still resolves deterministically.
+    expect(
+      registry.findResourceByUri('a:file:///tmp/foo.txt')?.serverName,
+    ).toBe('a');
+    expect(
+      registry.findResourceByUri('b:file:///tmp/foo.txt')?.serverName,
+    ).toBe('b');
+  });
+
+  it('reports all servers exposing a given URI', () => {
+    registry.setResourcesForServer('a', [createResource()]);
+    registry.setResourcesForServer('b', [createResource()]);
+    registry.setResourcesForServer('c', [
+      createResource({ uri: 'file:///tmp/other.txt' }),
+    ]);
+
+    const matches = registry.findResourcesByUri('file:///tmp/foo.txt');
+    expect(matches.map((m) => m.serverName).sort()).toEqual(['a', 'b']);
+    expect(registry.findResourcesByUri('file:///tmp/other.txt')).toHaveLength(
+      1,
+    );
+    expect(registry.findResourcesByUri('file:///tmp/missing.txt')).toEqual([]);
+  });
+
+  it('resolves a server-qualified identifier when the server name has underscores', () => {
+    registry.setResourcesForServer('my_server', [createResource()]);
+    registry.setResourcesForServer('other', [createResource()]);
+
+    expect(
+      registry.findResourceByUri('my_server:file:///tmp/foo.txt')?.serverName,
+    ).toBe('my_server');
+  });
+
   it('clears resources for a server', () => {
     registry.setResourcesForServer('a', [createResource()]);
     registry.removeResourcesByServer('a');

--- a/packages/core/src/resources/resource-registry.ts
+++ b/packages/core/src/resources/resource-registry.ts
@@ -46,16 +46,71 @@ export class ResourceRegistry {
 
   /**
    * Find a resource by its identifier.
-   * Format: serverName:uri (e.g., "myserver:file:///data.txt")
+   *
+   * The identifier may be either:
+   *   - a server-qualified identifier, as advertised by `list_mcp_resources`
+   *     (`serverName:uri`, e.g. `myserver:file:///data.txt`), which always
+   *     resolves to that specific server, or
+   *   - a bare resource URI (e.g. `file:///data.txt`), which only resolves
+   *     when exactly one connected server exposes it.
+   *
+   * If several servers expose the same bare URI the reference is ambiguous and
+   * `undefined` is returned, so callers can ask for a server-qualified
+   * identifier instead of silently reading from an arbitrary server. Use
+   * {@link findResourcesByUri} to detect that case.
    */
   findResourceByUri(identifier: string): MCPResource | undefined {
-    const colonIndex = identifier.indexOf(':');
-    if (colonIndex <= 0) {
-      return undefined;
+    const qualified = this.findResourceByQualifiedId(identifier);
+    if (qualified) {
+      return qualified;
     }
-    const serverName = identifier.substring(0, colonIndex);
-    const uri = identifier.substring(colonIndex + 1);
-    return this.resources.get(resourceKey(serverName, uri));
+
+    // Bare URI: only resolve when unambiguous (exactly one server exposes it).
+    const matches = this.findResourcesByUri(identifier);
+    return matches.length === 1 ? matches[0] : undefined;
+  }
+
+  /**
+   * Returns every resource whose bare URI matches, across all servers. A length
+   * greater than one means the URI is exposed by multiple servers and is
+   * therefore ambiguous on its own.
+   */
+  findResourcesByUri(uri: string): MCPResource[] {
+    const matches: MCPResource[] = [];
+    for (const resource of this.resources.values()) {
+      if (resource.uri === uri) {
+        matches.push(resource);
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * Resolves a server-qualified identifier (`serverName:uri`) to a resource.
+   *
+   * Known server names are matched explicitly as a prefix, rather than naively
+   * splitting on the first colon, so a URI scheme (for example the `file` in
+   * `file:///x`) is never mistaken for a server name and server names may
+   * themselves contain colons or underscores.
+   */
+  private findResourceByQualifiedId(
+    identifier: string,
+  ): MCPResource | undefined {
+    const serverNames = new Set<string>();
+    for (const resource of this.resources.values()) {
+      serverNames.add(resource.serverName);
+    }
+    for (const serverName of serverNames) {
+      const prefix = `${serverName}:`;
+      if (identifier.startsWith(prefix)) {
+        const uri = identifier.slice(prefix.length);
+        const hit = this.resources.get(resourceKey(serverName, uri));
+        if (hit) {
+          return hit;
+        }
+      }
+    }
+    return undefined;
   }
 
   removeResourcesByServer(serverName: string): void {

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -858,34 +858,16 @@ describe('McpClientManager', () => {
   });
 
   describe('findResourceByUri', () => {
-    it('should find resource by exact URI match', () => {
-      const mockResource = { uri: 'test://resource1', name: 'Resource 1' };
+    it('delegates resolution to the ResourceRegistry', () => {
+      const mockResource = {
+        uri: 'test://resource1',
+        serverName: 'test-server',
+        name: 'Resource 1',
+      };
       const mockResourceRegistry = {
         getAllResources: vi.fn().mockReturnValue([mockResource]),
-        findResourceByUri: vi.fn(),
-      };
-      mockConfig.getResourceRegistry.mockReturnValue(
-        mockResourceRegistry as unknown as ResourceRegistry,
-      );
-
-      const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
-
-      const result = manager.findResourceByUri('test://resource1');
-      expect(result).toBe(mockResource);
-    });
-
-    it('should try ResourceRegistry.findResourceByUri first', () => {
-      const mockResourceQualified = {
-        uri: 'test://resource1',
-        name: 'Resource 1 Qualified',
-      };
-      const mockResourceDirect = {
-        uri: 'test-server:test://resource1',
-        name: 'Resource 1 Direct',
-      };
-      const mockResourceRegistry = {
-        getAllResources: vi.fn().mockReturnValue([mockResourceDirect]),
-        findResourceByUri: vi.fn().mockReturnValue(mockResourceQualified),
+        findResourceByUri: vi.fn().mockReturnValue(mockResource),
+        findResourcesByUri: vi.fn().mockReturnValue([mockResource]),
       };
       mockConfig.getResourceRegistry.mockReturnValue(
         mockResourceRegistry as unknown as ResourceRegistry,
@@ -894,17 +876,19 @@ describe('McpClientManager', () => {
       const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
 
       const result = manager.findResourceByUri('test-server:test://resource1');
-      expect(result).toBe(mockResourceQualified);
+      expect(result).toBe(mockResource);
       expect(mockResourceRegistry.findResourceByUri).toHaveBeenCalledWith(
         'test-server:test://resource1',
       );
+      // No unscoped cross-server scan: only the registry resolver is consulted.
       expect(mockResourceRegistry.getAllResources).not.toHaveBeenCalled();
     });
 
-    it('should return undefined if both fail', () => {
+    it('returns undefined when the registry cannot resolve the identifier', () => {
       const mockResourceRegistry = {
         getAllResources: vi.fn().mockReturnValue([]),
         findResourceByUri: vi.fn().mockReturnValue(undefined),
+        findResourcesByUri: vi.fn().mockReturnValue([]),
       };
       mockConfig.getResourceRegistry.mockReturnValue(
         mockResourceRegistry as unknown as ResourceRegistry,
@@ -914,6 +898,31 @@ describe('McpClientManager', () => {
 
       const result = manager.findResourceByUri('non-existent');
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('findResourcesByUri', () => {
+    it('delegates to the ResourceRegistry to surface ambiguous URIs', () => {
+      const matches = [
+        { uri: 'shared://x', serverName: 'a', name: 'X' },
+        { uri: 'shared://x', serverName: 'b', name: 'X' },
+      ];
+      const mockResourceRegistry = {
+        getAllResources: vi.fn().mockReturnValue(matches),
+        findResourceByUri: vi.fn().mockReturnValue(undefined),
+        findResourcesByUri: vi.fn().mockReturnValue(matches),
+      };
+      mockConfig.getResourceRegistry.mockReturnValue(
+        mockResourceRegistry as unknown as ResourceRegistry,
+      );
+
+      const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+
+      const result = manager.findResourcesByUri('shared://x');
+      expect(result).toBe(matches);
+      expect(mockResourceRegistry.findResourcesByUri).toHaveBeenCalledWith(
+        'shared://x',
+      );
     });
   });
 });

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -172,19 +172,26 @@ export class McpClientManager {
     return undefined;
   }
 
+  /**
+   * Resolves a resource identifier to a single resource. The identifier may be
+   * a server-qualified `serverName:uri` (recommended for disambiguation) or a
+   * bare URI. A bare URI only resolves when exactly one server exposes it; if
+   * multiple servers expose the same URI the reference is ambiguous and
+   * `undefined` is returned rather than silently picking an arbitrary server.
+   */
   findResourceByUri(uri: string): MCPResource | undefined {
     if (!this.mainResourceRegistry) return undefined;
+    return this.mainResourceRegistry.findResourceByUri(uri);
+  }
 
-    // Try serverName:uri format first
-    const qualifiedMatch = this.mainResourceRegistry.findResourceByUri(uri);
-    if (qualifiedMatch) {
-      return qualifiedMatch;
-    }
-
-    // Try direct URI match
-    return this.mainResourceRegistry
-      .getAllResources()
-      .find((r) => r.uri === uri);
+  /**
+   * Returns every resource whose bare URI matches, across all connected
+   * servers. Used to surface ambiguous references (the same URI exposed by
+   * more than one server).
+   */
+  findResourcesByUri(uri: string): MCPResource[] {
+    if (!this.mainResourceRegistry) return [];
+    return this.mainResourceRegistry.findResourcesByUri(uri);
   }
 
   getAllResources(): MCPResource[] {

--- a/packages/core/src/tools/read-mcp-resource.test.ts
+++ b/packages/core/src/tools/read-mcp-resource.test.ts
@@ -9,6 +9,8 @@ import { ReadMcpResourceTool } from './read-mcp-resource.js';
 import { ToolErrorType } from './tool-error.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import { ToolConfirmationOutcome } from './tools.js';
+import { buildParamArgsPattern } from '../policy/utils.js';
 
 describe('ReadMcpResourceTool', () => {
   let tool: ReadMcpResourceTool;
@@ -19,6 +21,7 @@ describe('ReadMcpResourceTool', () => {
   };
   let mockMcpManager: {
     findResourceByUri: Mock;
+    findResourcesByUri: Mock;
     getClient: Mock;
   };
   const abortSignal = new AbortController().signal;
@@ -26,6 +29,7 @@ describe('ReadMcpResourceTool', () => {
   beforeEach(() => {
     mockMcpManager = {
       findResourceByUri: vi.fn(),
+      findResourcesByUri: vi.fn().mockReturnValue([]),
       getClient: vi.fn(),
     };
 
@@ -190,5 +194,56 @@ describe('ReadMcpResourceTool', () => {
 
     expect(result.error?.type).toBe(ToolErrorType.MCP_TOOL_ERROR);
     expect(result.error?.message).toContain('Failed to read resource');
+  });
+
+  it('asks for a server-qualified id when a bare URI is exposed by multiple servers', async () => {
+    const uri = 'config://settings';
+    mockMcpManager.findResourceByUri.mockReturnValue(undefined);
+    mockMcpManager.findResourcesByUri.mockReturnValue([
+      { uri, serverName: 'server-b' },
+      { uri, serverName: 'server-a' },
+    ]);
+
+    const invocation = (
+      tool as unknown as {
+        createInvocation: (params: Record<string, unknown>) => {
+          execute: (options: { abortSignal: AbortSignal }) => Promise<unknown>;
+        };
+      }
+    ).createInvocation({ uri });
+    const result = (await invocation.execute({ abortSignal })) as {
+      error: { type: string; message: string };
+    };
+
+    // The wrong-server read must not happen; the model is told to disambiguate.
+    expect(mockMcpManager.getClient).not.toHaveBeenCalled();
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.error?.message).toContain('multiple MCP servers');
+    // Server names are listed deterministically (sorted).
+    expect(result.error?.message).toContain('server-a, server-b');
+    expect(result.error?.message).toContain(`server-a:${uri}`);
+  });
+
+  it('scopes an "always allow" approval to the specific resource URI', () => {
+    const uri = 'protocol://resource';
+    const invocation = (
+      tool as unknown as {
+        createInvocation: (params: Record<string, unknown>) => {
+          getPolicyUpdateOptions: (
+            outcome: ToolConfirmationOutcome,
+          ) => { argsPattern?: string } | undefined;
+        };
+      }
+    ).createInvocation({ uri });
+
+    const options = invocation.getPolicyUpdateOptions(
+      ToolConfirmationOutcome.ProceedAlways,
+    );
+
+    // Narrowed to this exact URI, not the bare tool name (which would approve
+    // every resource on every server).
+    expect(options).toEqual({
+      argsPattern: buildParamArgsPattern('uri', uri),
+    });
   });
 });

--- a/packages/core/src/tools/read-mcp-resource.ts
+++ b/packages/core/src/tools/read-mcp-resource.ts
@@ -10,6 +10,8 @@ import {
   Kind,
   type ToolResult,
   type ExecuteOptions,
+  type PolicyUpdateOptions,
+  type ToolConfirmationOutcome,
 } from './tools.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { READ_MCP_RESOURCE_TOOL_NAME } from './tool-names.js';
@@ -17,6 +19,7 @@ import { READ_MCP_RESOURCE_DEFINITION } from './definitions/coreTools.js';
 import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { ToolErrorType } from './tool-error.js';
 import type { MCPResource } from '../resources/resource-registry.js';
+import { buildParamArgsPattern } from '../policy/utils.js';
 
 export interface ReadMcpResourceParams {
   uri: string;
@@ -78,6 +81,21 @@ class ReadMcpResourceToolInvocation extends BaseToolInvocation<
     return `Read MCP resource: ${this.params.uri}`;
   }
 
+  override getPolicyUpdateOptions(
+    _outcome: ToolConfirmationOutcome,
+  ): PolicyUpdateOptions | undefined {
+    // Scope an "always allow" approval to this exact resource URI. The MCP
+    // server identity cannot be conveyed via `mcpName` here because
+    // read_mcp_resource is a flat core tool (not an `mcp_<server>_<tool>`
+    // call), so the policy engine cannot derive a server name from it.
+    // Narrowing by the URI argument mirrors how read_file/edit scope their
+    // approvals and prevents a single approval from authorizing reads of
+    // every resource on every connected server.
+    return {
+      argsPattern: buildParamArgsPattern('uri', this.params.uri),
+    };
+  }
+
   async execute({
     abortSignal: _abortSignal,
   }: ExecuteOptions): Promise<ToolResult> {
@@ -107,13 +125,32 @@ class ReadMcpResourceToolInvocation extends BaseToolInvocation<
 
     const resource = mcpManager.findResourceByUri(uri);
     if (!resource) {
-      const errorMessage = `Resource not found for URI: ${uri}`;
+      // Distinguish "no such resource" from "this bare URI is exposed by more
+      // than one server". In the ambiguous case, instruct the model to retry
+      // with a server-qualified identifier instead of failing opaquely (and
+      // instead of silently reading from an arbitrary server).
+      const candidates = mcpManager.findResourcesByUri(uri);
+      let errorMessage: string;
+      let errorType: ToolErrorType;
+      if (candidates.length > 1) {
+        const servers = candidates
+          .map((candidate) => candidate.serverName)
+          .sort((a, b) => a.localeCompare(b));
+        errorMessage =
+          `Resource URI "${uri}" is exposed by multiple MCP servers ` +
+          `(${servers.join(', ')}). Retry with a server-qualified identifier ` +
+          `of the form "serverName:uri" (for example "${servers[0]}:${uri}").`;
+        errorType = ToolErrorType.INVALID_TOOL_PARAMS;
+      } else {
+        errorMessage = `Resource not found for URI: ${uri}`;
+        errorType = ToolErrorType.MCP_RESOURCE_NOT_FOUND;
+      }
       return {
         llmContent: `Error: ${errorMessage}`,
         returnDisplay: `Error: ${errorMessage}`,
         error: {
           message: errorMessage,
-          type: ToolErrorType.MCP_RESOURCE_NOT_FOUND,
+          type: errorType,
         },
       };
     }


### PR DESCRIPTION
## Summary

`read_mcp_resource` could return the **wrong server's content** when two MCP servers exposed a resource at the same URI, and a single "always allow" approved resource reads from *every* server. This fixes both.

### Root cause

`ResourceRegistry.findResourceByUri` split the identifier on the first colon, mistaking the URI **scheme** (`file`, `https`, `config`) for a server name, so the server-qualified lookup always missed on real URIs:

```ts
const colonIndex = identifier.indexOf(':');      // for "file:///x" -> 4
const serverName = identifier.substring(0, colonIndex); // "file"  (a scheme, not a server)
```

`McpClientManager.findResourceByUri` then fell back to an **unscoped** scan that returned whichever server registered the URI first, regardless of which server was intended:

```ts
return this.mainResourceRegistry.getAllResources().find((r) => r.uri === uri);
```

So if a second (potentially untrusted) server exposed a resource at the same URI as a trusted one, the model could silently receive the wrong server's content.

Separately, `ReadMcpResourceToolInvocation` did not override `getPolicyUpdateOptions()`, so "always allow" persisted `{ toolName: 'read_mcp_resource' }` with no scope — approving all resources on all servers forever.

## Fix

**Resolution now lives in `ResourceRegistry`** and is server-aware:

- A **server-qualified id** (`serverName:uri`, exactly as advertised by `list_mcp_resources`) is matched against known server names as a prefix. A URI scheme is never treated as a server, and server names may contain underscores or colons.
- A **bare URI** resolves only when exactly one server exposes it. When several do, the reference is ambiguous: `read_mcp_resource` returns an error asking the model to retry with a `serverName:uri` identifier, instead of silently reading from an arbitrary server. (`findResourcesByUri` exposes the multi-match case.)
- `McpClientManager.findResourceByUri` now delegates to the registry; the unscoped cross-server fallback is removed.

**Approval scoping:** `getPolicyUpdateOptions` now returns an `argsPattern` narrowed to the specific URI (mirroring `read_file`/`edit` via `buildParamArgsPattern`). `mcpName` scoping does not apply here because `read_mcp_resource` is a flat core tool, not an `mcp_<server>_<tool>` call, so the policy engine cannot derive a server name from the call — using `mcpName` would make the rule never match.

## Testing

Added/updated unit tests in `resource-registry.test.ts`, `mcp-client-manager.test.ts`, and `read-mcp-resource.test.ts` covering:
- bare URI resolves only when unique; a URI scheme is never mistaken for a server
- same URI on multiple servers → not resolved; server-qualified id still resolves deterministically
- server names containing underscores resolve correctly
- `read_mcp_resource` errors with a "use serverName:uri" hint on ambiguity and does **not** call the wrong client
- "always allow" yields a URI-scoped `argsPattern`
- manager delegates to the registry (no unscoped scan)

All affected suites pass (53 core + 67 CLI `atCommandProcessor`); `eslint` and `tsc --noEmit` are clean for the package.

Fixes #28128