### PR TITLE
fix(cli): detect available editors lazily to avoid slow startup

### DIFF
--- a/packages/cli/src/ui/editors/editorSettingsManager.test.ts
+++ b/packages/cli/src/ui/editors/editorSettingsManager.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { hasValidEditorCommand, allowEditorTypeInSandbox } = vi.hoisted(() => ({
+  hasValidEditorCommand: vi.fn(),
+  allowEditorTypeInSandbox: vi.fn(),
+}));
+
+vi.mock('@google/gemini-cli-core', () => ({
+  EDITOR_DISPLAY_NAMES: { vscode: 'VS Code', vim: 'Vim' },
+  hasValidEditorCommand,
+  allowEditorTypeInSandbox,
+}));
+
+import { EditorSettingsManager } from './editorSettingsManager.js';
+
+describe('EditorSettingsManager', () => {
+  beforeEach(() => {
+    hasValidEditorCommand.mockReset().mockReturnValue(true);
+    allowEditorTypeInSandbox.mockReset().mockReturnValue(true);
+  });
+
+  it('does not probe for editors during construction', () => {
+    // Probing shells out per editor (execSync) and must not run at module load
+    // / construction time, or it blocks startup. See issue #28106.
+    new EditorSettingsManager();
+    expect(hasValidEditorCommand).not.toHaveBeenCalled();
+    expect(allowEditorTypeInSandbox).not.toHaveBeenCalled();
+  });
+
+  it('computes editors lazily on first access and caches the result', () => {
+    const manager = new EditorSettingsManager();
+
+    const first = manager.getAvailableEditorDisplays();
+    // One probe per known editor (vscode, vim).
+    expect(hasValidEditorCommand).toHaveBeenCalledTimes(2);
+
+    const second = manager.getAvailableEditorDisplays();
+    // Cached: the same array is returned and no further probing happens.
+    expect(second).toBe(first);
+    expect(hasValidEditorCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('always lists "None" first and labels uninstalled editors as disabled', () => {
+    hasValidEditorCommand.mockImplementation(
+      (type: string) => type === 'vscode',
+    );
+
+    const displays = new EditorSettingsManager().getAvailableEditorDisplays();
+
+    expect(displays[0]).toEqual({
+      name: 'None',
+      type: 'not_set',
+      disabled: false,
+    });
+
+    const vim = displays.find((d) => d.type === 'vim');
+    expect(vim?.disabled).toBe(true);
+    expect(vim?.name).toContain('(Not installed)');
+
+    const vscode = displays.find((d) => d.type === 'vscode');
+    expect(vscode?.disabled).toBe(false);
+    expect(vscode?.name).toBe('VS Code');
+  });
+
+  it('marks editors not allowed in the sandbox as disabled', () => {
+    allowEditorTypeInSandbox.mockImplementation(
+      (type: string) => type !== 'vim',
+    );
+
+    const displays = new EditorSettingsManager().getAvailableEditorDisplays();
+
+    const vim = displays.find((d) => d.type === 'vim');
+    expect(vim?.disabled).toBe(true);
+    expect(vim?.name).toContain('(Not available in sandbox)');
+  });
+});

--- a/packages/cli/src/ui/editors/editorSettingsManager.ts
+++ b/packages/cli/src/ui/editors/editorSettingsManager.ts
@@ -17,15 +17,23 @@ export interface EditorDisplay {
   disabled: boolean;
 }
 
-class EditorSettingsManager {
-  private readonly availableEditors: EditorDisplay[];
+export class EditorSettingsManager {
+  private availableEditors: EditorDisplay[] | null = null;
 
-  constructor() {
+  /**
+   * Computes the list of available editors. This shells out (synchronous
+   * `execSync`) once per known editor to probe whether its command exists.
+   * Process creation can be slow on some systems (notably Windows with
+   * endpoint security intercepting every spawn), so this work is deferred
+   * until first access rather than run during module evaluation, where it
+   * would block startup for tens of seconds. See issue #28106.
+   */
+  private computeAvailableEditors(): EditorDisplay[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const editorTypes = Object.keys(
       EDITOR_DISPLAY_NAMES,
     ).sort() as EditorType[];
-    this.availableEditors = [
+    return [
       {
         name: 'None',
         type: 'not_set',
@@ -50,6 +58,9 @@ class EditorSettingsManager {
   }
 
   getAvailableEditorDisplays(): EditorDisplay[] {
+    if (this.availableEditors === null) {
+      this.availableEditors = this.computeAvailableEditors();
+    }
     return this.availableEditors;
   }
 }


### PR DESCRIPTION
## Summary

On startup, `EditorSettingsManager` is instantiated at module scope and its constructor probes **every** known editor through `hasValidEditorCommand`, which runs a synchronous `execSync` (e.g. `where.exe <editor>`) per editor. On systems where process creation is expensive — notably Windows with enterprise endpoint/antivirus software intercepting each spawn — this blocks the interactive UI from drawing its first frame for **tens of seconds** (reporter measured 50s–90s).

The probed list is only ever consumed by the **Editor Settings dialog** (`EditorSettingsDialog.tsx`), so doing this work eagerly at import time is pure startup cost for everyone who never opens that dialog.

## Fix

Defer the probing: compute the available editors on the first call to `getAvailableEditorDisplays()` and cache the result. The constructor now does no work, so importing the module (and constructing the module-scope singleton) no longer spawns any processes. The produced list is identical to before — only the timing changes (import time → first dialog open).

```ts
private availableEditors: EditorDisplay[] | null = null;

getAvailableEditorDisplays(): EditorDisplay[] {
  if (this.availableEditors === null) {
    this.availableEditors = this.computeAvailableEditors();
  }
  return this.availableEditors;
}
```

## Testing

Added `editorSettingsManager.test.ts` (the class is now exported for testability) covering:
- construction performs **no** editor probing (the regression that caused the slow startup)
- editors are computed on first access and the result is cached (no repeat probing)
- `"None"` is always listed first; uninstalled editors are labeled `(Not installed)` and disabled
- editors disallowed in the sandbox are labeled `(Not available in sandbox)` and disabled

All editor tests pass (4 new + the existing `EditorSettingsDialog` suite); `eslint` and `tsc --noEmit` are clean for the package.

Fixes #28106