### PR TITLE
docs(hooks): document all three usageMetadata token fields for LLMResponse

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -325,6 +325,10 @@ Gemini CLI uses these structures to ensure hooks don't break across SDK updates.
     "content": { "role": "model", "parts": string[] },
     "finishReason": string
   }>,
-  "usageMetadata": { "totalTokenCount": number }
+  "usageMetadata": {
+    "promptTokenCount": number,
+    "candidatesTokenCount": number,
+    "totalTokenCount": number
+  }
 }
 ```


### PR DESCRIPTION
## Summary

The hooks reference documents the **stable** `LLMResponse.usageMetadata` schema as a single field:

```typescript
"usageMetadata": { "totalTokenCount": number }
```

But a `BeforeModel`/`AfterModel` hook actually receives **three** token fields. The hook-facing translator `toHookLLMResponse()` in `packages/core/src/hooks/hookTranslator.ts` builds:

```ts
usageMetadata: sdkResponse.usageMetadata
  ? {
      promptTokenCount: sdkResponse.usageMetadata.promptTokenCount,
      candidatesTokenCount: sdkResponse.usageMetadata.candidatesTokenCount,
      totalTokenCount: sdkResponse.usageMetadata.totalTokenCount,
    }
  : undefined,
```

and the exported `LLMResponse` interface in the same file declares all three. Since this section is explicitly presented as the stable API hooks can rely on, the reference should list every field the hook is handed — otherwise integrators assume only `totalTokenCount` is available and miss the input/output token breakdown the code already provides.

## Change

Expand the `usageMetadata` schema in `docs/hooks/reference.md` to match the interface and translator:

```typescript
"usageMetadata": {
  "promptTokenCount": number,
  "candidatesTokenCount": number,
  "totalTokenCount": number
}
```

Docs-only change; `prettier --check` passes.

Fixes #28048