### PR TITLE
fix(docker): copy packed artifacts from the builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,12 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 USER node
 
 # install gemini-cli and clean up
-COPY --chown=node:node packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
-COPY --chown=node:node packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
+# Copy the packed artifacts from the builder stage (which runs `npm run build`
+# and `npm pack` above) rather than from the build context, so that a plain
+# `docker build .` is self-contained and does not require the .tgz files to be
+# pre-built on the host first.
+COPY --from=builder --chown=node:node /build/packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
+COPY --from=builder --chown=node:node /build/packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
 RUN npm install -g /tmp/gemini-core.tgz \
   && npm install -g /tmp/gemini-cli.tgz \
   && node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json','utf8')); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json','utf8'));" \


### PR DESCRIPTION
## Summary

The `Dockerfile` is a multi-stage build. **Stage 1 (`builder`)** runs `npm ci`, `npm run build`, and `npm pack` to produce `packages/cli/dist/google-gemini-cli-*.tgz` and `packages/core/dist/google-gemini-cli-core-*.tgz`. But **Stage 2 (runtime)** copied those `.tgz` files from the **build context** instead of from the builder stage:

```dockerfile
COPY --chown=node:node packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
COPY --chown=node:node packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
```

As a result the builder stage's output was never used, and a plain `docker build .` fails at this `COPY` unless the `.tgz` files were already packed onto the host first (which `scripts/build_sandbox.js` does via host-side `npm run build` + `npm pack`). That host pre-pack requirement is what made `docker build .` fail on its own — issue #21308.

## Fix

Copy the artifacts from the builder stage with `--from=builder` so the multi-stage build is self-contained:

```dockerfile
COPY --from=builder --chown=node:node /build/packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
COPY --from=builder --chown=node:node /build/packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
```

The builder stage's `WORKDIR` is `/build` and it packs into `packages/{cli,core}/dist/`, so these paths resolve to the freshly-built tarballs.

## Verification

Built the image locally **with all host `packages/**/*.tgz` removed first**, so the only possible source of the tarballs is the builder stage:

- `docker build .` (no host pre-pack) **succeeds**; the `COPY --from=builder` steps resolve the tarballs, `npm install -g` installs both packages, and the in-Dockerfile `gemini --version` smoke test passes.
- `docker run --rm --entrypoint gemini <image> --version` prints the expected version.

With the previous context-based `COPY`, the same clean build would fail because no `.tgz` exists in the context.

Fixes #21308