### PR TITLE
fix(skills): respect .gitignore/.geminiignore in skill resource listing

### DIFF
--- a/packages/core/src/tools/activate-skill.test.ts
+++ b/packages/core/src/tools/activate-skill.test.ts
@@ -9,6 +9,8 @@ import { ActivateSkillTool } from './activate-skill.js';
 import type { Config } from '../config/config.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
+import { getFolderStructure } from '../utils/getFolderStructure.js';
+import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 
 vi.mock('../utils/getFolderStructure.js', () => ({
   getFolderStructure: vi.fn().mockResolvedValue('Mock folder structure'),
@@ -18,9 +20,14 @@ describe('ActivateSkillTool', () => {
   let mockConfig: Config;
   let tool: ActivateSkillTool;
   let mockMessageBus: MessageBus;
+  let mockFileService: FileDiscoveryService;
 
   beforeEach(() => {
     mockMessageBus = createMockMessageBus();
+    mockFileService = {
+      shouldIgnoreFile: vi.fn(),
+      shouldIgnoreDirectory: vi.fn(),
+    } as unknown as FileDiscoveryService;
     const skills = [
       {
         name: 'test-skill',
@@ -48,8 +55,10 @@ describe('ActivateSkillTool', () => {
         }),
         activateSkill: vi.fn(),
       }),
+      getFileService: vi.fn().mockReturnValue(mockFileService),
     } as unknown as Config;
     tool = new ActivateSkillTool(mockConfig, mockMessageBus);
+    vi.mocked(getFolderStructure).mockClear();
   });
 
   it('should return enhanced description', () => {
@@ -74,6 +83,24 @@ describe('ActivateSkillTool', () => {
     expect(details.prompt).toContain('enable the specialized agent skill');
     expect(details.prompt).toContain('A test skill');
     expect(details.prompt).toContain('Mock folder structure');
+  });
+
+  it('builds the resource list with the file service so ignored paths (e.g. .venv) are honored', async () => {
+    const params = { name: 'test-skill' };
+    const invocation = tool.build(params);
+    await (
+      invocation as unknown as {
+        getConfirmationDetails: (signal: AbortSignal) => Promise<unknown>;
+      }
+    ).getConfirmationDetails(new AbortController().signal);
+
+    // The skill's folder structure must be built with the file service, so
+    // that .gitignore/.geminiignore are respected (issue #27205). Without it,
+    // ignored directories are shared with the model.
+    expect(getFolderStructure).toHaveBeenCalledWith(
+      '/path/to/test-skill',
+      expect.objectContaining({ fileService: mockFileService }),
+    );
   });
 
   it('should skip confirmation for built-in skills', async () => {

--- a/packages/core/src/tools/activate-skill.ts
+++ b/packages/core/src/tools/activate-skill.ts
@@ -64,6 +64,11 @@ class ActivateSkillToolInvocation extends BaseToolInvocation<
     if (this.cachedFolderStructure === undefined) {
       this.cachedFolderStructure = await getFolderStructure(
         path.dirname(skillLocation),
+        // Pass the file service so the skill's folder structure honors
+        // .gitignore/.geminiignore (matching how the workspace structure is
+        // built). Without it, ignored directories such as a Python `.venv`
+        // are shared with the model, wasting context. See issue #27205.
+        { fileService: this.config.getFileService() },
       );
     }
     return this.cachedFolderStructure;


### PR DESCRIPTION
## Summary

When a skill is activated, its folder structure is shared with the model as the skill's "available resources". That listing is built by `getFolderStructure()` in `activate-skill.ts`, but it was called **without a file service**:

```ts
this.cachedFolderStructure = await getFolderStructure(path.dirname(skillLocation));
```

Without a `fileService`, `getFolderStructure()` only skips a small hardcoded set of folders (`node_modules`, `.git`, `dist`, `__pycache__`) and does **not** apply `.gitignore`/`.geminiignore`. So an ignored directory inside a skill — most commonly a Python `.venv` created by tools like `uv` — gets fully enumerated and sent to the model. This wastes context (thousands of irrelevant library files) and instantly hits the 200-item display limit, hiding the real source files (issue #27205).

The workspace directory structure already does this correctly in `environmentContext.ts`:

```ts
getFolderStructure(dir, { fileService: config.getFileService() })
```

## Fix

Pass the file service when building the skill's folder structure, so it honors the same `.gitignore`/`.geminiignore` rules as the rest of the CLI:

```ts
this.cachedFolderStructure = await getFolderStructure(
  path.dirname(skillLocation),
  { fileService: this.config.getFileService() },
);
```

`getFolderStructure` defaults `fileFilteringOptions` to `DEFAULT_FILE_FILTERING_OPTIONS` (`respectGitIgnore: true`, `respectGeminiIgnore: true`), so passing the file service alone is sufficient.

## Testing

- Added a unit test asserting `activate-skill` calls `getFolderStructure` with the `fileService` (the wiring that was missing). Combined with the existing `getFolderStructure` gitignore/geminiignore tests (which prove `{ fileService }` causes ignored paths to be excluded), this verifies the full chain.
- Verified at runtime against the exact reported scenario: a skill containing `scripts/.venv/...` with `.venv/` in `.geminiignore`.
  - **Before:** `.venv` is expanded, leaking `pyvenv.cfg` and `lib/big.py`.
  - **After:** `.venv\...` is collapsed and its contents are excluded.

`eslint` and `tsc --noEmit` are clean for the package.

Fixes #27205