### PR TITLE
fix(core): ignore stale update_topic calls after a session reset

### DIFF
--- a/packages/core/src/tools/topicTool.test.ts
+++ b/packages/core/src/tools/topicTool.test.ts
@@ -61,12 +61,15 @@ describe('UpdateTopicTool', () => {
   let tool: UpdateTopicTool;
   let mockMessageBus: MessageBus;
   let mockConfig: Config;
+  let currentSessionId: string;
 
   beforeEach(() => {
     mockMessageBus = new MessageBus(vi.mocked({} as PolicyEngine));
+    currentSessionId = 'session-a';
     // Mock enough of Config to satisfy the tool
     mockConfig = {
       topicState: new TopicState(),
+      getSessionId: vi.fn(() => currentSessionId),
     } as unknown as Config;
     tool = new UpdateTopicTool(mockConfig, mockMessageBus);
   });
@@ -116,6 +119,41 @@ describe('UpdateTopicTool', () => {
       '> [!STRATEGY]\n> **Intent:** Subsequent Move',
     );
     expect(result.llmContent).toBe('Strategic Intent: Subsequent Move');
+  });
+
+  it('does not write topic state when the session was reset after scheduling (e.g. /clear)', async () => {
+    // Tool call is scheduled in session-a.
+    const invocation = tool.build({
+      [TOPIC_PARAM_TITLE]: 'Stale Topic',
+      [TOPIC_PARAM_STRATEGIC_INTENT]: 'Stale Intent',
+    });
+
+    // Session is reset (new id) before the orphaned call executes.
+    currentSessionId = 'session-b';
+
+    const result = await invocation.execute({
+      abortSignal: new AbortController().signal,
+    });
+
+    // The shared topic state must not be poisoned with the previous session's
+    // topic (issue #26402).
+    expect(mockConfig.topicState.getTopic()).toBeUndefined();
+    expect(mockConfig.topicState.getIntent()).toBeUndefined();
+    expect(result.llmContent).toContain('Topic update skipped');
+  });
+
+  it('does not write topic state when the call was aborted', async () => {
+    const invocation = tool.build({
+      [TOPIC_PARAM_TITLE]: 'Aborted Topic',
+      [TOPIC_PARAM_STRATEGIC_INTENT]: 'Aborted Intent',
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const result = await invocation.execute({ abortSignal: controller.signal });
+
+    expect(mockConfig.topicState.getTopic()).toBeUndefined();
+    expect(result.llmContent).toContain('Topic update skipped');
   });
 
   it('should return error if strategic_intent is missing', async () => {

--- a/packages/core/src/tools/topicTool.ts
+++ b/packages/core/src/tools/topicTool.ts
@@ -33,6 +33,13 @@ class UpdateTopicInvocation extends BaseToolInvocation<
   UpdateTopicParams,
   ToolResult
 > {
+  /**
+   * The session id this tool call was scheduled in. If the session is reset
+   * (e.g. via /clear) before this call executes, applying the update would
+   * write the previous session's topic into the fresh one. See issue #26402.
+   */
+  private readonly scheduledSessionId: string;
+
   constructor(
     params: UpdateTopicParams,
     messageBus: MessageBus,
@@ -40,6 +47,7 @@ class UpdateTopicInvocation extends BaseToolInvocation<
     private readonly config: Config,
   ) {
     super(params, messageBus, toolName);
+    this.scheduledSessionId = config.getSessionId();
   }
 
   getDescription(): string {
@@ -51,7 +59,20 @@ class UpdateTopicInvocation extends BaseToolInvocation<
     return `Update tactical intent: "${intent || '...'}"`;
   }
 
-  async execute(_options: ExecuteOptions): Promise<ToolResult> {
+  async execute(options: ExecuteOptions): Promise<ToolResult> {
+    // Guard against orphaned/stale calls. If this call was cancelled, or the
+    // session was reset (e.g. via /clear) after it was scheduled, do not touch
+    // the shared topicState — otherwise the previous session's topic would be
+    // re-injected into the new session's system prompt. See issue #26402.
+    if (
+      options.abortSignal?.aborted ||
+      this.config.getSessionId() !== this.scheduledSessionId
+    ) {
+      const message =
+        'Topic update skipped: the session was reset before it could be applied.';
+      return { llmContent: message, returnDisplay: '' };
+    }
+
     const title = this.params[TOPIC_PARAM_TITLE];
     const summary = this.params[TOPIC_PARAM_SUMMARY];
     const strategicIntent = this.params[TOPIC_PARAM_STRATEGIC_INTENT];


### PR DESCRIPTION
## Summary

`update_topic` writes to the shared `topicState` singleton on `Config` **unconditionally** (`topicTool.ts`):

```ts
this.config.topicState.setTopic(title, strategicIntent);
```

If the model emits a final `update_topic` tool call around the moment the user runs `/clear`, that orphaned call can execute **after** the session has been reset (`/clear` → `resetNewSessionState(newId)` resets `topicState` and assigns a new session id). The late write re-populates `topicState`, so every subsequent prompt re-injects the previous session's `[Active Topic: …]` into the system prompt and the model pivots back to the cleared session's goal. (This is distinct from #26237/#26238, which only changed the marker formatting — the stale state still gets injected.)

The tool had **no check** that the call was still valid: no abort check, and no check that the current session id still matches the session the call was scheduled in.

## Fix

Capture the session id the call was scheduled in (at invocation construction) and skip the write at execute time when:
- the call's `abortSignal` is aborted, or
- the current session id no longer matches (the session was reset, e.g. via `/clear`).

```ts
this.scheduledSessionId = config.getSessionId();
// ...
if (options.abortSignal?.aborted ||
    this.config.getSessionId() !== this.scheduledSessionId) {
  return { llmContent: 'Topic update skipped: the session was reset before it could be applied.', returnDisplay: '' };
}
```

This is exactly the abort/session guard the issue identifies as missing, and it leaves normal same-session behavior untouched.

## Testing

Added unit tests in `topicTool.test.ts`:
- a call scheduled in one session that executes after the session id changes does **not** write to `topicState` (the re-poisoning scenario);
- an aborted call does **not** write to `topicState`;
- existing same-session behavior is unchanged (topic/intent still applied).

All 11 tests pass; `eslint` and `tsc --noEmit` are clean for the package.

### Note on scope

This addresses root cause #1 from the issue (the unguarded write) directly and verifiably. It does not change `/clear` to proactively abort the in-flight stream (a separate, cross-cutting concern); the guard makes the orphaned write a no-op regardless, which is what prevents the cross-session topic leak.

Fixes #26402