### PR TITLE
fix(core): buffer chat compression telemetry

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -183,16 +183,29 @@ describe('loggers', () => {
       ).toHaveBeenCalledWith(event);
     });
 
-    it('records the chat compression event to OTEL', () => {
+    it('buffers the chat compression OTEL event and metrics', () => {
+      const bufferTelemetryEvent = vi
+        .spyOn(sdk, 'bufferTelemetryEvent')
+        .mockImplementation(() => {});
       const mockConfig = makeFakeConfig();
+      const event = makeChatCompressionEvent({
+        tokens_before: 9001,
+        tokens_after: 9000,
+      });
 
-      logChatCompression(
-        mockConfig,
-        makeChatCompressionEvent({
-          tokens_before: 9001,
-          tokens_after: 9000,
-        }),
-      );
+      logChatCompression(mockConfig, event);
+
+      expect(bufferTelemetryEvent).toHaveBeenCalledTimes(1);
+      expect(mockLogger.emit).not.toHaveBeenCalled();
+      expect(metrics.recordChatCompressionMetrics).not.toHaveBeenCalled();
+
+      const bufferedCallback = bufferTelemetryEvent.mock.calls[0]![0];
+      bufferedCallback();
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: event.toLogBody(),
+        attributes: event.toOpenTelemetryAttributes(mockConfig),
+      });
 
       expect(metrics.recordChatCompressionMetrics).toHaveBeenCalledWith(
         mockConfig,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -460,17 +460,18 @@ export function logChatCompression(
   event: ChatCompressionEvent,
 ): void {
   ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
-
-  recordChatCompressionMetrics(config, {
-    tokens_before: event.tokens_before,
-    tokens_after: event.tokens_after,
+    recordChatCompressionMetrics(config, {
+      tokens_before: event.tokens_before,
+      tokens_after: event.tokens_after,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- wrap chat compression OTEL log emission and metrics in the telemetry buffer
- update the logChatCompression regression test to prove the buffered callback owns both operations

Fixes #23445

## Validation
- npm run test --workspace @google/gemini-cli-core -- src/telemetry/loggers.test.ts -t logChatCompression
- npm run typecheck --workspace @google/gemini-cli-core