### PR TITLE
fix(security): remove ISSUE_BODY and ISSUE_TITLE from ALWAYS_ALLOWED environment variables

### DIFF
--- a/packages/core/src/services/environmentSanitization.ts
+++ b/packages/core/src/services/environmentSanitization.ts
@@ -82,9 +82,9 @@ export const ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES: ReadonlySet<string> =
     'GITHUB_ENV',
     'IS_PULL_REQUEST',
     'ISSUES_TO_TRIAGE',
-    'ISSUE_BODY',
+    // 'ISSUE_BODY' removed: attacker-controlled GitHub event data; must not bypass sanitization
     'ISSUE_NUMBER',
-    'ISSUE_TITLE',
+    // 'ISSUE_TITLE' removed: attacker-controlled GitHub event data; must not bypass sanitization
     'PULL_REQUEST_NUMBER',
     'REPOSITORY',
     'TITLE',


### PR DESCRIPTION
## Summary

`ISSUE_BODY` and `ISSUE_TITLE` are currently listed in `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES` in `environmentSanitization.ts`. This means they bypass all sanitization — including the strict CI mode triggered by `GITHUB_SHA` — and are always passed through to AI agent prompts unredacted.

## Vulnerability Details

These variables are populated from `github.event.issue.title` and `github.event.issue.body` in GitHub Actions workflows (e.g. `gemini-automated-issue-triage.yml`). They are **attacker-controlled**: any public GitHub user can set them by opening an issue.

Whitelisting them unconditionally means:
- Even with `enableEnvironmentVariableRedaction: true`, this content is never filtered
- Even in strict CI sanitization mode (`isStrictSanitization=true`), this content passes through
- Content flows into Gemini CLI prompts with `run_shell_command` tool available

## Fix

Removed `ISSUE_BODY` and `ISSUE_TITLE` from `ALWAYS_ALLOWED_ENVIRONMENT_VARIABLES`. Workflows that need to pass this data to agents should do so explicitly after sanitization, not via a blanket allowlist bypass.

## Testing

Existing sanitization tests cover the general allowlist behavior. No new test surface needed — this is a removal from a constant.