### PR TITLE
fix: sanitize trailing periods from URLs in auth error messages

### DIFF
--- a/packages/cli/src/core/auth.ts
+++ b/packages/cli/src/core/auth.ts
@@ -63,8 +63,14 @@ export async function performInitialAuth(
         accountSuspensionInfo: null,
       };
     }
+    const rawMessage = getErrorMessage(e);
+    // Strip trailing periods from URLs to prevent broken terminal links
+    const sanitizedMessage = rawMessage.replace(
+      /(https?:\/\/[^\s]+)\.(?=\s|$)/g,
+      '$1',
+    );
     return {
-      authError: `Failed to sign in. Message: ${getErrorMessage(e)}`,
+      authError: `Failed to sign in. Message: ${sanitizedMessage}`,
       accountSuspensionInfo: null,
     };
   }

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -151,9 +151,19 @@ export const useAuthCommand = (
         } else if (e instanceof ProjectIdRequiredError) {
           // OAuth succeeded but account setup requires project ID
           // Show the error message directly without "Failed to login" prefix
-          onAuthError(getErrorMessage(e));
+          const rawMessage = getErrorMessage(e);
+          const sanitizedMessage = rawMessage.replace(
+            /(https?:\/\/[^\s]+)\.(?=\s|$)/g,
+            '$1',
+          );
+          onAuthError(sanitizedMessage);
         } else {
-          onAuthError(`Failed to sign in. Message: ${getErrorMessage(e)}`);
+          const rawMessage = getErrorMessage(e);
+          const sanitizedMessage = rawMessage.replace(
+            /(https?:\/\/[^\s]+)\.(?=\s|$)/g,
+            '$1',
+          );
+          onAuthError(`Failed to sign in. Message: ${sanitizedMessage}`);
         }
       }
     })();


### PR DESCRIPTION
## Summary
Fixes #28052

Auth error messages containing URLs like `https://goo.gle/gemini-cli-auth-docs` could have trailing sentence periods appended (e.g. `https://goo.gle/gemini-cli-auth-docs.`), breaking terminal hyperlink detection.

## Changes
- `packages/cli/src/core/auth.ts`: Strip trailing periods from URLs in `performInitialAuth` error messages using a regex that only removes periods at end-of-string or before whitespace.
- `packages/cli/src/ui/auth/useAuth.ts`: Apply the same sanitization in `useAuthCommand` for both `ProjectIdRequiredError` and general auth error paths.

## Testing
- All 22 auth tests pass (`src/core/auth.test.ts` + `src/ui/auth/useAuth.test.tsx`).