### PR TITLE
fix: forward SIGINT/SIGTERM/SIGQUIT to child process during relaunch

### DIFF
--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -71,9 +71,20 @@ export async function relaunchAppInChildProcess(
       }
     });
 
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      child.kill(signal);
+    };
+
+    process.on('SIGINT', forwardSignal);
+    process.on('SIGTERM', forwardSignal);
+    process.on('SIGQUIT', forwardSignal);
+
     return new Promise<number>((resolve, reject) => {
       child.on('error', reject);
       child.on('close', (code) => {
+        process.off('SIGINT', forwardSignal);
+        process.off('SIGTERM', forwardSignal);
+        process.off('SIGQUIT', forwardSignal);
         // Resume stdin before the parent process exits.
         process.stdin.resume();
         resolve(code ?? 1);


### PR DESCRIPTION
## Summary
Fixes #25590

When Gemini CLI relaunches itself via `relaunchAppInChildProcess`, signals like SIGINT and SIGTERM were not forwarded to the child process. This meant that pressing Ctrl+C during an update/relaunch would kill the parent but leave the child orphaned.

## Changes
- `packages/cli/src/utils/relaunch.ts`: Added signal forwarding (SIGINT, SIGTERM, SIGQUIT) from the parent process to the spawned child process. Listeners are cleaned up when the child process closes.

## Testing
- Existing relaunch tests continue to pass.