### PR TITLE
Harden file-write scope: stop sandbox/auto-accept writes to .gemini and .gitconfig

### DIFF
--- a/packages/cli/src/utils/sandbox-macos-permissive-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-open.sb
@@ -9,10 +9,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (subpath (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-proxied.sb
@@ -9,10 +9,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (subpath (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-open.sb
@@ -67,10 +67,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (subpath (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-restrictive-proxied.sb
@@ -67,10 +67,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (subpath (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/cli/src/utils/sandbox-macos-strict-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-strict-open.sb
@@ -102,10 +102,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (literal (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/cli/src/utils/sandbox-macos-strict-proxied.sb
+++ b/packages/cli/src/utils/sandbox-macos-strict-proxied.sb
@@ -102,10 +102,10 @@
     (subpath (param "TARGET_DIR"))
     (subpath (param "TMP_DIR"))
     (subpath (param "CACHE_DIR"))
-    (subpath (string-append (param "HOME_DIR") "/.gemini"))
     (subpath (string-append (param "HOME_DIR") "/.npm"))
     (subpath (string-append (param "HOME_DIR") "/.cache"))
-    (literal (string-append (param "HOME_DIR") "/.gitconfig"))
+    ;; SECURITY: ~/.gemini and ~/.gitconfig are intentionally NOT writable to
+    ;; prevent prompt-injected sandbox escape via self-config/git changes.
     ;; Allow writes to included directories from --include-directories
     (subpath (param "INCLUDE_DIR_0"))
     (subpath (param "INCLUDE_DIR_1"))

--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -308,4 +308,70 @@ describe('AllowedPathChecker', () => {
       }
     });
   });
+
+  describe('Security Regression: Gemini/git config HITL', () => {
+    it('should require ASK_USER for .gemini config writes inside the workspace, including case-insensitive and Windows trailing/ADS bypasses', async () => {
+      const geminiPaths = [
+        path.join(mockCwd, '.gemini', 'settings.json'),
+        path.join(mockCwd, '.gemini', 'config.yaml'),
+        path.join(mockCwd, '.GEMINI', 'settings.json'),
+        path.join(mockCwd, '.Gemini', 'settings.json'),
+        // Nested workspace root
+        path.join(mockWorkspaces[1], '.gemini', 'settings.json'),
+        // Windows trailing character bypasses
+        path.join(mockCwd, '.gemini ', 'settings.json'),
+        path.join(mockCwd, '.gemini.', 'settings.json'),
+        // NTFS Alternate Data Stream bypasses
+        path.join(mockCwd, '.gemini::$DATA', 'settings.json'),
+      ];
+
+      for (const p of geminiPaths) {
+        const input = createInput({ path: p });
+        const result = await checker.check(input);
+        expect(result.decision).toBe(SafetyCheckDecision.ASK_USER);
+        expect(result.reason).toContain('requires explicit user confirmation');
+      }
+    });
+
+    it('should require ASK_USER for .gitconfig writes inside the workspace, including case-insensitive and Windows trailing/ADS bypasses', async () => {
+      const gitconfigPaths = [
+        path.join(mockCwd, '.gitconfig'),
+        path.join(mockCwd, '.GITCONFIG'),
+        path.join(mockCwd, 'nested', '.gitconfig'),
+        // Windows trailing character bypasses
+        path.join(mockCwd, '.gitconfig '),
+        path.join(mockCwd, '.gitconfig.'),
+        // NTFS Alternate Data Stream bypasses
+        path.join(mockCwd, '.gitconfig::$DATA'),
+      ];
+
+      for (const p of gitconfigPaths) {
+        const input = createInput({ path: p });
+        const result = await checker.check(input);
+        expect(result.decision).toBe(SafetyCheckDecision.ASK_USER);
+        expect(result.reason).toContain('requires explicit user confirmation');
+      }
+    });
+
+    it('should still DENY .git directory writes (not confused with .gitconfig)', async () => {
+      const input = createInput({ path: path.join(mockCwd, '.git', 'config') });
+      const result = await checker.check(input);
+      expect(result.decision).toBe(SafetyCheckDecision.DENY);
+      expect(result.reason).toContain('Access to sensitive path');
+    });
+
+    it('should DENY .gemini/.gitconfig paths outside the workspace rather than asking', async () => {
+      const outsidePaths = [
+        path.join(testRootDir, 'outside', '.gemini', 'settings.json'),
+        path.join(testRootDir, 'outside', '.gitconfig'),
+      ];
+
+      for (const p of outsidePaths) {
+        const input = createInput({ path: p });
+        const result = await checker.check(input);
+        expect(result.decision).toBe(SafetyCheckDecision.DENY);
+        expect(result.reason).toContain('outside of the allowed workspace');
+      }
+    });
+  });
 });

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -11,7 +11,13 @@ import {
   type SafetyCheckResult,
 } from './protocol.js';
 import type { AllowedPathConfig } from '../policy/types.js';
-import { resolveToRealPath } from '../utils/paths.js';
+import { GEMINI_DIR, resolveToRealPath } from '../utils/paths.js';
+
+/**
+ * The git config filename. Writing it can repoint git's editor/pager at an
+ * arbitrary command, so edits must be confirmed even under auto-accept.
+ */
+const GITCONFIG_FILENAME = '.gitconfig';
 
 /**
  * Interface for all in-process safety checkers.
@@ -65,6 +71,7 @@ export class AllowedPathChecker implements InProcessChecker {
       // Check for blocked segments case-insensitively
       let hasBlockedSegment = false;
       let isVscodePath = false;
+      let isProtectedConfigPath = false;
 
       for (const resolvedDir of resolvedAllowedDirs) {
         if (!this.isPathAllowed(resolvedPath, resolvedDir)) continue;
@@ -84,6 +91,14 @@ export class AllowedPathChecker implements InProcessChecker {
           if (clean === '.vscode') {
             isVscodePath = true;
           }
+          // The Gemini config directory (.gemini) and the git config file
+          // (.gitconfig) control the agent's own permissions and git's
+          // behavior. Writing them silently under auto-accept would let a
+          // prompt-injected edit escalate its privileges, so always require
+          // explicit user confirmation.
+          if (clean === GEMINI_DIR || clean === GITCONFIG_FILENAME) {
+            isProtectedConfigPath = true;
+          }
         }
       }
 
@@ -98,6 +113,13 @@ export class AllowedPathChecker implements InProcessChecker {
         return {
           decision: SafetyCheckDecision.ASK_USER,
           reason: `Modifying .vscode configuration files requires explicit user confirmation.`,
+        };
+      }
+
+      if (isProtectedConfigPath) {
+        return {
+          decision: SafetyCheckDecision.ASK_USER,
+          reason: `Modifying Gemini CLI configuration (${GEMINI_DIR}) or git configuration (${GITCONFIG_FILENAME}) requires explicit user confirmation.`,
         };
       }
 


### PR DESCRIPTION
### Why
Gemini CLI's file-write permissions are too broad and enable a sandbox escape under prompt injection: (1) With auto-accept on, the agent can write into the workspace `.gemini/` folder and thus modify its own configuration, making the next launch significantly more permissive (up to unrestricted command execution). (2) The macOS Seatbelt profiles explicitly allow writes to `~/.gemini` and `~/.gitconfig`, letting an attacker change global settings or git behavior (e.g. point git's editor at an arbitrary command) and execute code outside the sandbox. An attacker who can inject prompts could bypass both the ./.gemini/settings.json restrictions and the Seatbelt sandbox to gain arbitrary unsandboxed execution on the victim's machine.

### What
Hardened Gemini CLI's file-write scope to close a prompt-injection sandbox-escape path. (1) Sandbox: removed the `~/.gemini` and `~/.gitconfig` entries from the `(allow file-write* …)` block in all six macOS Seatbelt profiles (packages/cli/src/utils/sandbox-macos-*.sb), so the sandbox no longer permits writing the user's global Gemini/git config; read access is preserved (the strict profiles keep both in their file-read* block) and a short SECURITY comment documents the intent. (2) Write tools: extended the AllowedPathChecker safety checker (which gates write_file/replace in auto-accept/AUTO_EDIT mode) to return ASK_USER for any path inside a `.gemini` directory or named `.gitconfig`, mirroring the existing `.vscode` HITL handling, so an injected prompt cannot silently rewrite the agent's own config to escalate its permissions. Added Vitest cases covering case-insensitive, Windows trailing-char and NTFS ADS bypasses, and that `.git` is still DENY while out-of-workspace configs remain DENY. Verified all six .sb profiles still compile and that writes to .gemini/.gitconfig are denied while reads succeed via sandbox-exec.

### Changes
```
.../cli/src/utils/sandbox-macos-permissive-open.sb |  4 +-
 .../src/utils/sandbox-macos-permissive-proxied.sb  |  4 +-
 .../src/utils/sandbox-macos-restrictive-open.sb    |  4 +-
 .../src/utils/sandbox-macos-restrictive-proxied.sb |  4 +-
 .../cli/src/utils/sandbox-macos-strict-open.sb     |  4 +-
 .../cli/src/utils/sandbox-macos-strict-proxied.sb  |  4 +-
 packages/core/src/safety/built-in.test.ts          | 66 ++++++++++++++++++++++
 packages/core/src/safety/built-in.ts               | 24 +++++++-
 8 files changed, 101 insertions(+), 13 deletions(-)
```

### Tests — pass
Ran the Vitest suite covering the changed AllowedPathChecker (packages/core/src/safety/built-in.test.ts): all 20 tests passed, including the 4 new security-regression cases for .gemini/.gitconfig ASK_USER behavior, .git DENY, and out-of-workspace DENY. A core typecheck (tsc --noEmit) also passed.

### Review panel — request-changes
- **cloudcode:claude-opus-4-8@default: request-changes** — The AllowedPathChecker change (packages/core/src/safety/built-in.ts) that gates in-workspace .gemini/.gitconfig writes behind ASK_USER is correct, well-placed (before the final allow check), and thoroughly tested (case-insensitive, trailing dot/space, NTFS ADS, outside-workspace DENY, and .git-vs-.gitconfig disambiguation). However, the seatbelt change is over-broad: removing ~/.gemini from the macOS sandbox writable list breaks the CLI's own legitimate runtime writes. The seatbelt profile wraps the entire CLI process (sandbox.ts: `sandbox-exec -f profile sh -c '... gemini ...'`), and the CLI must write under ~/.gemini at runtime (installation_id, the project temp dir for logs/checkpoints/history/plans/tracker/chats, trustedFolders.json, settings persistence, and the file-keychain fallback). This will cause EPERM failures/regressions for macOS seatbelt users (default profile permissive-open) and diverges from the Docker backend, which still mounts ~/.gemini read-write.
  - risks: REGRESSION (blocking): Removing `(subpath HOME_DIR/.gemini)` from all six macOS seatbelt profiles denies the CLI's own writes under sandbox. After `(deny file-write*)`, ~/.gemini is no longer in the allow list, so runtime writes fail: Storage.ensureProjectTempDirExists() does an UNGUARDED fs.mkdirSync(~/.gemini/tmp/<hash>) at packages/core/src/config/storage.ts:203 (used for logs/checkpoints/history/plans/tracker/chats), plus installation_id, google_accounts.json, trustedFolders.json, settings.json, and the file-keychain fallback all live under ~/.gemini. Expect EPERM crashes or broken logging/checkpointing/folder-trust under macOS seatbelt.; Backend inconsistency: the Docker sandbox still bind-mounts ~/.gemini READ-WRITE (packages/cli/src/utils/sandbox.ts:360-363, no :ro), so this macOS-only seatbelt removal makes the two sandbox backends behave differently and contradicts the original intent (the line was deliberately added in 2025-05 because the CLI needs to write there).; Recommended fix: narrow rather than blanket-remove. Keep runtime-required subpaths writable (at minimum `(subpath HOME_DIR/.gemini/tmp)`, and the history dir) while denying the sensitive config; or invert order — keep `(subpath HOME_DIR/.gemini)` allowed and add trailing `(deny file-write* (literal HOME_DIR/.gemini/settings.json) ...)` rules (seatbelt is last-match-wins). The ~/.gitconfig removal is comparatively safe and aligned with the goal.
  - test gaps: No test or smoke check verifies the CLI's own ~/.gemini writes (e.g. ensureProjectTempDirExists / installation_id / trustedFolders.json) still succeed under the seatbelt profile; an integration check would have caught the regression. The six .sb edits ship with zero coverage.; built-in.ts tests cover the deny/ask paths well but do not assert ALLOW for a benign in-workspace sibling whose name merely starts with '.gemini'/'.gitconfig' (e.g. '.geminirc', '.gitconfignore') to lock in that the segment-equality match does not over-block. Current logic is correct via exact `clean === GEMINI_DIR`, so this is a guard-rail, not a defect.
- **gemini:default: approve** — This change successfully hardens the file-write scope for Gemini CLI by blocking direct sandbox writes and requiring explicit user confirmation under auto-accept for .gemini and .gitconfig. The implementation of case-insensitive checks, Windows trailing character handling, and NTFS Alternate Data Streams parsing is robust, secure, and has 100% test coverage.
- **jetski:default: —** — no structured verdict produced

_Generated by the Standup Orchestrator (task `harden-gemini-gitconfig-write-scope`). Draft until reviewed in Obsidian._