### PR TITLE
fix(cli): parse commented settings.json in memory bootstrap

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -57,7 +57,12 @@ async function getMemoryNodeArgs(): Promise<string[]> {
       process.env['GEMINI_CLI_HOME'] || join(os.homedir(), '.gemini');
     const settingsPath = join(baseDir, 'settings.json');
     const rawSettings = readFileSync(settingsPath, 'utf8');
-    const settings = JSON.parse(rawSettings);
+    const { parseJsonWithComments } = await import(
+      './src/utils/parseJsonWithComments.js'
+    );
+    const settings = parseJsonWithComments(rawSettings) as {
+      advanced?: { autoConfigureMemory?: boolean };
+    };
     if (settings?.advanced?.autoConfigureMemory === false) {
       autoConfigureMemory = false;
     }

--- a/packages/cli/src/utils/parseJsonWithComments.test.ts
+++ b/packages/cli/src/utils/parseJsonWithComments.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseJsonWithComments } from './parseJsonWithComments.js';
+
+describe('parseJsonWithComments', () => {
+  it('parses JSON with line and block comments', () => {
+    const raw = `{
+      // disable auto memory tuning
+      "advanced": {
+        /* user preference */
+        "autoConfigureMemory": false
+      }
+    }`;
+
+    expect(parseJsonWithComments(raw)).toEqual({
+      advanced: {
+        autoConfigureMemory: false,
+      },
+    });
+  });
+});

--- a/packages/cli/src/utils/parseJsonWithComments.ts
+++ b/packages/cli/src/utils/parseJsonWithComments.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import stripJsonComments from 'strip-json-comments';
+
+export function parseJsonWithComments(raw: string): unknown {
+  return JSON.parse(stripJsonComments(raw));
+}


### PR DESCRIPTION
## Summary

Fix `getMemoryNodeArgs()` so the lightweight CLI parent process can read comment-bearing `settings.json` files without silently falling back to default memory auto-configuration.

## Motivation

The parent process reads `~/.gemini/settings.json` before relaunching the full CLI. It used raw `JSON.parse`, which throws on JSON comments. The empty `catch` block left `autoConfigureMemory` at its default `true`, so users who set `advanced.autoConfigureMemory: false` in a commented config were ignored.

The rest of the CLI already accepts commented JSON via `strip-json-comments` (e.g. `settings.ts`).

Fixes #28206

## Changes

| File | Change |
|------|--------|
| `packages/cli/index.ts` | Dynamically import and use `parseJsonWithComments` in `getMemoryNodeArgs()` |
| `packages/cli/src/utils/parseJsonWithComments.ts` | Shared helper: `JSON.parse(stripJsonComments(raw))` |
| `packages/cli/src/utils/parseJsonWithComments.test.ts` | Regression test for commented JSON with `autoConfigureMemory: false` |

## Tests

- `npm run build --workspace @google/gemini-cli-core`
- `npm run test -- src/utils/parseJsonWithComments.test.ts` — **1 passed**
- `npx eslint index.ts src/utils/parseJsonWithComments.ts src/utils/parseJsonWithComments.test.ts` — **passed**

## Notes

- Dynamic import preserves the lightweight parent-process startup path (avoids eagerly loading deps unless settings are read).
- Full `npm run preflight` was not run locally due to monorepo build time; targeted tests and lint were run on changed files.
- Composer-2.5 review: **APPROVE**