### PR TITLE
fix(cli): avoid splitting emoji when truncating display strings

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -33,6 +33,15 @@ describe('textUtils', () => {
       expect(sanitizeForDisplay(longInput, 20)).toBe('a'.repeat(17) + '...');
     });
 
+    it('should not split a surrogate pair when truncating', () => {
+      // Each 🎉 is a single code point stored as two UTF-16 code units.
+      const input = '🎉'.repeat(10);
+      const result = sanitizeForDisplay(input, 8);
+      expect(result).toBe('🎉'.repeat(5) + '...');
+      // No lone surrogate should remain.
+      expect(/[\uD800-\uDFFF]/u.test(result)).toBe(false);
+    });
+
     it('should handle empty or null input', () => {
       expect(sanitizeForDisplay('')).toBe('');
       expect(sanitizeForDisplay(null as unknown as string)).toBe('');

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -155,8 +155,11 @@ export function sanitizeForDisplay(str: string, maxLength?: number): string {
 
   let sanitized = stripUnsafeCharacters(str).replace(/\s+/g, ' ');
 
-  if (maxLength && sanitized.length > maxLength) {
-    sanitized = sanitized.substring(0, maxLength - 3) + '...';
+  // Count and slice by code points so an astral character (e.g. an emoji,
+  // stored as a surrogate pair) isn't split in half, which would leave a lone
+  // surrogate and render as a replacement character.
+  if (maxLength && cpLen(sanitized) > maxLength) {
+    sanitized = cpSlice(sanitized, 0, maxLength - 3) + '...';
   }
 
   return sanitized;


### PR DESCRIPTION
## Summary

`sanitizeForDisplay` truncates with `str.length` and `str.substring`, which count UTF-16 code units. When `maxLength` falls inside a surrogate pair (an emoji or other astral character), the pair is split and the leftover lone surrogate renders as a replacement character. This affects terminal notification titles/bodies and slash-command descriptions, which can contain emoji.

## Details

The same file already exports `cpLen` and `cpSlice`, which operate on code points. `sanitizeForDisplay` now uses them, so length checks and truncation happen on code-point boundaries and a trailing emoji is either kept whole or dropped, never cut in half.

For a purely ASCII string the behavior is unchanged (`cpLen`/`cpSlice` short-circuit on the ASCII fast path).

## How to Validate

```
sanitizeForDisplay('🎉'.repeat(10), 8)
// before: "🎉🎉\uD83C..."  (lone surrogate -> renders as )
// after:  "🎉🎉🎉🎉🎉..."
```

Added a unit test in `textUtils.test.ts` covering this case (asserts the result contains no lone surrogate) alongside the existing ASCII truncation test.