### PR TITLE
docs(policy-engine): use a safe test command instead of rm -rf /

### DIFF
--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -33,8 +33,10 @@ To create your first policy:
     decision = "deny"
     priority = 100
     ```
-3.  **Run a command** that triggers the policy (for example, ask Gemini CLI to
-    `rm -rf /`). The tool will now be blocked automatically.
+3.  **Test the policy.** Ask Gemini CLI to run a command that matches the rule,
+    such as `rm -rf ./policy-test`. The tool is now blocked automatically. Use a
+    harmless throwaway path like this rather than a destructive target such as
+    `rm -rf /`, so the test stays safe even if the rule fails to load.
 
 ## Core concepts
 


### PR DESCRIPTION
Fixes #28231

## What

The policy engine quick-start (`docs/reference/policy-engine.md`) told readers to test a `deny` rule by asking Gemini CLI to run `rm -rf /`:

> 3. **Run a command** that triggers the policy (for example, ask Gemini CLI to `rm -rf /`). The tool will now be blocked automatically.

## Why

The step is meant to demonstrate that the rule blocks the command — but if the rule fails to load or is misconfigured, a reader who follows the instruction verbatim executes `rm -rf /` with no policy stopping it, potentially destroying their data. A getting-started example should be safe even when the thing it is demonstrating does not work.

## Change

Keep the realistic "block dangerous `rm -rf`" example, but make the **test** command safe by construction:

- Use a harmless throwaway path (`rm -rf ./policy-test`) that still matches the example rule's `commandPrefix = "rm -rf"`, so it demonstrates the block.
- Explicitly warn against destructive targets such as `rm -rf /`, so the test stays safe even if the policy does not block it.

Documentation-only change; no code or behavior is affected.

## Testing

- `npx prettier --check docs/reference/policy-engine.md` passes.
- The pre-commit hook (prettier over `*.{json,md}`) ran clean on commit.
