### PR TITLE
docs: explain MCP env expansion

### DIFF
--- a/docs/cli/tutorials/mcp-setup.md
+++ b/docs/cli/tutorials/mcp-setup.md
@@ -68,6 +68,11 @@ You tell Gemini about new servers by editing your `settings.json`.
 > map the local environment variable into the container so your secret isn't
 > hardcoded in the config file.
 
+`mcpServers` string values support environment-variable expansion. Use `$VAR` or
+`${VAR}` on all platforms, `${VAR:-fallback}` for defaults, and `%VAR%` on
+Windows. Mustache-style `{{VAR}}`, `${env:VAR}`, and `~` are not expanded; use
+`${HOME}` or `%USERPROFILE%` in paths instead.
+
 ## How to verify the connection
 
 Restart Gemini CLI. It will automatically try to start the defined servers.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2473,6 +2473,36 @@ must be provided. If multiple are specified, the order of precedence is
     precedence over `includeTools` - if a tool is in both lists, it will be
     excluded.
 
+##### Path and environment variable expansion
+
+String values in `mcpServers` entries are expanded when settings load. Use
+standard environment-variable syntax:
+
+- `$VAR` or `${VAR}` on all platforms.
+- `${VAR:-fallback}` to provide a fallback value.
+- `%VAR%` on Windows.
+
+`{{VAR}}` template syntax and `${env:VAR}` are not supported. `~` is not
+expanded automatically, so use `$HOME` or `${HOME}` instead. Missing variables
+expand to an empty string, which can turn a mistyped command or path into an
+invalid value.
+
+Examples:
+
+```json
+{
+  "mcpServers": {
+    "node-server": {
+      "command": "$HOME/bin/my-mcp-server",
+      "args": ["--cache", "${XDG_CACHE_HOME:-$HOME/.cache}/my-server"]
+    },
+    "windows-server": {
+      "command": "%USERPROFILE%\\bin\\my-mcp-server.exe"
+    }
+  }
+}
+```
+
 #### `telemetry`
 
 Configures logging and metrics collection for Gemini CLI. For more information,


### PR DESCRIPTION
## Summary
- add a dedicated mcpServers path/environment expansion subsection
- document supported `$VAR`, `${VAR}`, `${VAR:-fallback}`, and Windows `%VAR%` syntax
- call out unsupported `{{VAR}}`, `${env:VAR}`, and `~`, plus missing variables expanding to an empty string
- mirror the warning in the MCP setup tutorial

Fixes #28228.

## Verification
- `npx prettier --check docs/reference/configuration.md docs/cli/tutorials/mcp-setup.md`