### PR TITLE
fix(cli): sync footer branch name on filesystems without fs.watch events

### DIFF
--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -255,6 +255,67 @@ describe('useGitBranchName', () => {
     expect(result.current).toBe('feature-x');
   });
 
+  it('should update branch name via HEAD polling when fs.watch delivers no events', async () => {
+    vi.spyOn(fsPromises, 'access').mockResolvedValue(undefined);
+    // Simulate a filesystem where fs.watch never delivers events
+    // (e.g. a WSL mount of a Windows drive, or a network share).
+    const watchSpy = vi.spyOn(fs, 'watch').mockImplementation((() => ({
+      close: vi.fn(),
+    })) as unknown as typeof fs.watch);
+
+    let watchFileCallback:
+      | ((curr: { mtimeMs: number }, prev: { mtimeMs: number }) => void)
+      | undefined;
+    const watchFileSpy = vi.spyOn(fs, 'watchFile').mockImplementation(((
+      _path: string,
+      _options: unknown,
+      callback: (curr: { mtimeMs: number }, prev: { mtimeMs: number }) => void,
+    ) => {
+      watchFileCallback = callback;
+      return undefined as unknown as ReturnType<typeof fs.watchFile>;
+    }) as unknown as typeof fs.watchFile);
+
+    const { result } = await renderGitBranchNameHook(CWD);
+
+    await resolveInitialSpawns('main');
+    expect(result.current).toBe('main');
+
+    // The polling fallback should be registered on the HEAD file.
+    await waitFor(() => {
+      expect(watchFileSpy).toHaveBeenCalledWith(
+        GIT_HEAD_PATH,
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+    // The directory watcher is registered too, but we never fire it here.
+    expect(watchSpy).toHaveBeenCalled();
+
+    // Simulate HEAD changing on disk: the poll observes a new mtime.
+    await act(async () => {
+      watchFileCallback?.({ mtimeMs: 2 }, { mtimeMs: 1 });
+      await vi.advanceTimersByTimeAsync(150); // triggers debounce
+    });
+
+    await act(async () => {
+      const spawn = deferredSpawn.find((s) => s.args.includes('--abbrev-ref'))!;
+      deferredSpawn.splice(deferredSpawn.indexOf(spawn), 1);
+      spawn.resolve({ stdout: 'develop\n', stderr: '', code: 0 });
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(result.current).toBe('develop');
+
+    // An unchanged mtime (spurious poll) should not trigger a refetch.
+    await act(async () => {
+      watchFileCallback?.({ mtimeMs: 2 }, { mtimeMs: 2 });
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(
+      deferredSpawn.filter((s) => s.args.includes('--abbrev-ref')).length,
+    ).toBe(0);
+  });
+
   it('should handle watcher setup error silently', async () => {
     // Cause an error in absolute git dir setup
     vi.mocked(mockGetAbsoluteGitDir).mockRejectedValueOnce(
@@ -291,6 +352,14 @@ describe('useGitBranchName', () => {
     const watchMock = vi.spyOn(fs, 'watch').mockReturnValue({
       close: closeMock,
     } as unknown as ReturnType<typeof fs.watch>);
+    vi.spyOn(fs, 'watchFile').mockReturnValue(
+      undefined as unknown as ReturnType<typeof fs.watchFile>,
+    );
+    const unwatchMock = vi
+      .spyOn(fs, 'unwatchFile')
+      .mockImplementation(
+        (() => undefined) as unknown as typeof fs.unwatchFile,
+      );
 
     const { unmount } = await renderGitBranchNameHook(CWD);
 
@@ -303,5 +372,7 @@ describe('useGitBranchName', () => {
 
     unmount();
     expect(closeMock).toHaveBeenCalled();
+    // The HEAD poll fallback must also be torn down on unmount.
+    expect(unwatchMock).toHaveBeenCalledWith(GIT_HEAD_PATH);
   });
 });

--- a/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
+++ b/packages/cli/src/ui/hooks/useGitBranchName.test.tsx
@@ -373,6 +373,6 @@ describe('useGitBranchName', () => {
     unmount();
     expect(closeMock).toHaveBeenCalled();
     // The HEAD poll fallback must also be torn down on unmount.
-    expect(unwatchMock).toHaveBeenCalledWith(GIT_HEAD_PATH);
+    expect(unwatchMock).toHaveBeenCalledWith(GIT_HEAD_PATH, expect.any(Function));
   });
 });

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -8,6 +8,10 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { spawnAsync, getAbsoluteGitDir } from '@google/gemini-cli-core';
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+
+// How often to poll HEAD as a fallback when fs.watch delivers no events.
+const HEAD_POLL_INTERVAL_MS = 2000;
 
 export function useGitBranchName(cwd: string): string | undefined {
   const [branchName, setBranchName] = useState<string | undefined>(undefined);
@@ -40,7 +44,17 @@ export function useGitBranchName(cwd: string): string | undefined {
     void fetchBranchName(); // Initial fetch
 
     let watcher: fs.FSWatcher | undefined;
+    let watchedHeadPath: string | undefined;
     let cancelled = false;
+
+    const scheduleRefresh = () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        void fetchBranchName();
+      }, 100);
+    };
 
     const setupWatcher = async () => {
       try {
@@ -53,24 +67,36 @@ export function useGitBranchName(cwd: string): string | undefined {
 
         const w = fs.watch(
           gitDir,
-          (eventType: string, filename: string | null) => {
+          (_eventType: string, filename: string | null) => {
             // Changes to HEAD indicate branch checkout or detached commit.
             // On some platforms filename may be null, so we refresh in that case too.
             if (!filename || filename === 'HEAD') {
-              if (timeoutRef.current) {
-                clearTimeout(timeoutRef.current);
-              }
-              timeoutRef.current = setTimeout(() => {
-                void fetchBranchName();
-              }, 100);
+              scheduleRefresh();
+            }
+          },
+        );
+
+        // fs.watch relies on the OS notification layer (inotify/FSEvents),
+        // which delivers no events on some filesystems — most notably WSL
+        // mounts of Windows drives and network shares. Poll HEAD with stat as
+        // a reliable fallback so the branch still updates in those setups.
+        const headPath = path.join(gitDir, 'HEAD');
+        fs.watchFile(
+          headPath,
+          { interval: HEAD_POLL_INTERVAL_MS },
+          (curr, prev) => {
+            if (curr.mtimeMs !== prev.mtimeMs) {
+              scheduleRefresh();
             }
           },
         );
 
         if (cancelled) {
           w.close();
+          fs.unwatchFile(headPath);
         } else {
           watcher = w;
+          watchedHeadPath = headPath;
         }
       } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),
@@ -87,6 +113,9 @@ export function useGitBranchName(cwd: string): string | undefined {
         clearTimeout(timeoutRef.current);
       }
       watcher?.close();
+      if (watchedHeadPath) {
+        fs.unwatchFile(watchedHeadPath);
+      }
     };
   }, [cwd, fetchBranchName]);
 

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -114,8 +114,8 @@ export function useGitBranchName(cwd: string): string | undefined {
         clearTimeout(timeoutRef.current);
       }
       watcher?.close();
-      if (watchedHeadPath) {
-        fs.unwatchFile(watchedHeadPath);
+      if (watchedHeadPath && watchedHeadListener) {
+        fs.unwatchFile(watchedHeadPath, watchedHeadListener);
       }
     };
   }, [cwd, fetchBranchName]);

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -45,7 +45,9 @@ export function useGitBranchName(cwd: string): string | undefined {
 
     let watcher: fs.FSWatcher | undefined;
     let watchedHeadPath: string | undefined;
-    let watchedHeadListener: ((curr: fs.Stats, prev: fs.Stats) => void) | undefined;
+    let watchedHeadListener:
+      | ((curr: fs.Stats, prev: fs.Stats) => void)
+      | undefined;
     let cancelled = false;
 
     const scheduleRefresh = () => {
@@ -82,22 +84,24 @@ export function useGitBranchName(cwd: string): string | undefined {
         // mounts of Windows drives and network shares. Poll HEAD with stat as
         // a reliable fallback so the branch still updates in those setups.
         const headPath = path.join(gitDir, 'HEAD');
+        const headListener = (curr: fs.Stats, prev: fs.Stats) => {
+          if (curr.mtimeMs !== prev.mtimeMs) {
+            scheduleRefresh();
+          }
+        };
         fs.watchFile(
           headPath,
           { interval: HEAD_POLL_INTERVAL_MS },
-          (curr, prev) => {
-            if (curr.mtimeMs !== prev.mtimeMs) {
-              scheduleRefresh();
-            }
-          },
+          headListener,
         );
 
         if (cancelled) {
           w.close();
-          fs.unwatchFile(headPath);
+          fs.unwatchFile(headPath, headListener);
         } else {
           watcher = w;
           watchedHeadPath = headPath;
+          watchedHeadListener = headListener;
         }
       } catch {
         // Silently ignore watcher errors (e.g. permissions or file not existing),

--- a/packages/cli/src/ui/hooks/useGitBranchName.ts
+++ b/packages/cli/src/ui/hooks/useGitBranchName.ts
@@ -45,6 +45,7 @@ export function useGitBranchName(cwd: string): string | undefined {
 
     let watcher: fs.FSWatcher | undefined;
     let watchedHeadPath: string | undefined;
+    let watchedHeadListener: ((curr: fs.Stats, prev: fs.Stats) => void) | undefined;
     let cancelled = false;
 
     const scheduleRefresh = () => {


### PR DESCRIPTION
## Summary

The footer **Branch** indicator does not update after a `git checkout` on filesystems where `fs.watch` delivers no change events — most notably WSL mounts of Windows drives (`/mnt/c/...`) and network shares. The displayed branch stays stuck on whatever was checked out when the CLI started.

Fixes #27957

> This supersedes #28012, which was auto-closed by the stale bot after 14 days without a `help wanted` label on the linked issue (GitHub would not let me reopen it). The branch has been rebased onto the latest `main`; the diff is unchanged (+112/-7, 2 files). The `fs.unwatchFile` cleanup point raised by `gemini-code-assist` on #28012 is already addressed here (the poll listener is stored and passed explicitly to `fs.unwatchFile`).

## Details

`useGitBranchName` already watches the git directory with `fs.watch` and re-fetches the branch when `HEAD` changes. But `fs.watch` relies on the OS notification layer (inotify on Linux, FSEvents on macOS), and on WSL mounts of Windows drives and on many network filesystems that layer delivers **no events at all** — so the watcher silently never fires and the branch is never refreshed (the environment in #27957 is WSL).

This adds a stat-based `fs.watchFile` poll on `HEAD` as a reliable fallback that works regardless of the underlying filesystem, running **alongside** the existing `fs.watch` (which remains the fast, event-driven path where it works):

- Both paths funnel into a single debounced `scheduleRefresh()` helper (no behavior change to the existing fast path).
- The poll only refreshes when `HEAD`'s `mtime` actually changes, so steady state does no work.
- Poll interval is 2s (a single `stat` of a tiny file; negligible cost).
- The poll is torn down on unmount via `fs.unwatchFile`, passing the exact listener so only this hook instance's watcher is removed.

No changes are needed in the footer component or UI state — they already react to whatever the hook returns.

## How to Validate

Manual (on WSL with the repo under `/mnt/<drive>`, on a network share, or any affected FS):

1. Start `gemini` in a git repo and note the branch shown in the footer.
2. Switch branches, e.g. `! git checkout -b some-branch` (or in another shell).
3. **Expected:** within ~2s the footer reflects the new branch. Before this change it stayed on the old branch on affected filesystems.

Automated:

```bash
npm run --workspace packages/cli test -- src/ui/hooks/useGitBranchName.test.tsx
```

A new test covers the polling fallback (when `fs.watch` never fires), and the cleanup test is extended to assert the poll is removed on unmount.

## Pre-Merge Checklist

- [x] Prettier, ESLint (`--max-warnings 0`) and TypeScript typecheck pass for the changed files.
- [x] Unit tests added and passing (`useGitBranchName.test.tsx`, plus `Footer.test.tsx` consumers).
- [x] Change is scoped to a single hook; no public API changes.
- [x] Linked issue: #27957
