### PR TITLE
refactor(cli): clean up profile selector logic and remove legacy config

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2179,7 +2179,7 @@ describe('loadCliConfig context management', () => {
     vi.restoreAllMocks();
   });
 
-  it('should be false by default when generalistProfile / context management is not set in settings', async () => {
+  it('should be false by default when context management is not set in settings', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments(createTestMergedSettings());
     const settings = createTestMergedSettings();

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2191,12 +2191,12 @@ describe('loadCliConfig context management', () => {
     expect(config.isContextManagementEnabled()).toBe(false);
   });
 
-  it('should be true when generalistProfile is set to true in settings', async () => {
+  it('should be true when contextManagement is set to true in settings', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments(createTestMergedSettings());
     const settings = createTestMergedSettings({
       experimental: {
-        generalistProfile: true,
+        contextManagement: true,
       },
     });
     const config = await loadCliConfig(settings, 'test-session', argv);

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -938,21 +938,8 @@ export async function loadCliConfig(
     clientName = 'tui';
   }
 
-  // TODO(joshualitt): Clean this up alongside removal of the legacy config.
-  let profileSelector: string | undefined = undefined;
-  if (settings.experimental?.stressTestProfile) {
-    profileSelector = 'stressTestProfile';
-  } else if (settings.experimental?.powerUserProfile) {
-    profileSelector = 'powerUserProfile';
-  } else if (
-    settings.experimental?.generalistProfile ||
-    settings.experimental?.contextManagement
-  ) {
-    profileSelector = 'generalistProfile';
-  }
-
   const contextManagement = {
-    enabled: !!profileSelector,
+    enabled: !!settings.experimental?.contextManagement,
   };
 
   return new Config({
@@ -976,7 +963,6 @@ export async function loadCliConfig(
     worktreeSettings,
 
     coreTools: settings.tools?.core || undefined,
-    experimentalContextManagementConfig: profileSelector,
     allowedTools: allowedTools.length > 0 ? allowedTools : undefined,
     policyEngineConfig,
     policyUpdateConfirmationRequest,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2439,25 +2439,7 @@ const SETTINGS_SCHEMA = {
           'Automatically extract memory patches and skills from past sessions in the background. Every change is written as a unified diff `.patch` file under `<projectMemoryDir>/.inbox/<kind>/` and held for review in /memory inbox; nothing is applied until you approve it.',
         showInDialog: true,
       },
-      generalistProfile: {
-        type: 'boolean',
-        label: 'Use the generalist profile to manage agent contexts.',
-        category: 'Experimental',
-        requiresRestart: true,
-        default: false,
-        description:
-          'Suitable for general coding and software development tasks.',
-        showInDialog: true,
-      },
-      powerUserProfile: {
-        type: 'boolean',
-        label: 'Use the power user profile to manage agent contexts.',
-        category: 'Experimental',
-        requiresRestart: true,
-        default: false,
-        description: 'Less cache friendly version of the generalist profile.',
-        showInDialog: false,
-      },
+
       contextManagement: {
         type: 'boolean',
         label: 'Enable Context Management',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -716,7 +716,6 @@ export interface ConfigParameters {
   autoDistillation?: boolean;
   experimentalAutoMemory?: boolean;
   experimentalGemma?: boolean;
-  experimentalContextManagementConfig?: string;
   experimentalAgentHistoryTruncation?: boolean;
   experimentalAgentHistoryTruncationThreshold?: number;
   experimentalAgentHistoryRetainedMessages?: number;
@@ -966,7 +965,6 @@ export class Config implements McpContext, AgentLoopContext {
   private readonly adminSkillsEnabled: boolean;
   private readonly experimentalAutoMemory: boolean;
   private readonly experimentalGemma: boolean;
-  private readonly experimentalContextManagementConfig?: string;
   private readonly memoryBoundaryMarkers: readonly string[];
   private readonly topicUpdateNarration: boolean;
   private readonly disableLLMCorrection: boolean;
@@ -1187,8 +1185,6 @@ export class Config implements McpContext, AgentLoopContext {
 
     this.experimentalAutoMemory = params.experimentalAutoMemory ?? false;
     this.experimentalGemma = params.experimentalGemma ?? true;
-    this.experimentalContextManagementConfig =
-      params.experimentalContextManagementConfig;
     this.memoryBoundaryMarkers = params.memoryBoundaryMarkers ?? ['.git'];
     this.contextManagement = {
       enabled: params.contextManagement?.enabled ?? false,
@@ -2629,9 +2625,7 @@ export class Config implements McpContext, AgentLoopContext {
     return this.experimentalGemma;
   }
 
-  getExperimentalContextManagementConfig(): string | undefined {
-    return this.experimentalContextManagementConfig;
-  }
+
 
   getContextManagementConfig(): ContextManagementConfig {
     return this.contextManagement;

--- a/packages/core/src/context/initializer.ts
+++ b/packages/core/src/context/initializer.ts
@@ -72,7 +72,7 @@ export async function initializeContextManager(
   });
 
   const sidecarProfile = await loadContextManagementConfig(
-    config.getExperimentalContextManagementConfig(),
+    undefined,
     registry,
   );
 


### PR DESCRIPTION
Resolves #28259.

Removes the legacy profile selector logic from the CLI's configuration.