### PR TITLE
fix(core): make direct GCP telemetry exporters optional

### DIFF
--- a/docs/cli/telemetry.md
+++ b/docs/cli/telemetry.md
@@ -156,6 +156,20 @@ You must complete several setup steps before enabling Google Cloud telemetry.
 We recommend using direct export to send telemetry directly to Google Cloud
 services.
 
+If you embed `@google/gemini-cli-core` as a library and enable direct Google
+Cloud export, install the optional Google Cloud exporter peer dependencies in
+your application:
+
+```bash
+npm install @google-cloud/logging \
+  @google-cloud/opentelemetry-cloud-monitoring-exporter \
+  @google-cloud/opentelemetry-cloud-trace-exporter
+```
+
+The bundled Gemini CLI includes the direct exporters. Core library consumers who
+do not install these optional packages can still export through an OTLP
+collector by setting `telemetry.useCollector` to `true`.
+
 1.  Enable telemetry in `.gemini/settings.json`:
     ```json
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.52.0-nightly.20260707.g27a3da3e8",
+  "version": "0.51.0-nightly.20260625.g3fbf93e26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "workspaces": [
         "packages/*"
       ],
@@ -23,9 +23,7 @@
       },
       "devDependencies": {
         "@agentclientprotocol/sdk": "0.16.1",
-        "@modelcontextprotocol/sdk": "1.23.0",
         "@octokit/rest": "22.0.0",
-        "@types/express": "5.0.3",
         "@types/marked": "5.0.2",
         "@types/mime-types": "3.0.1",
         "@types/minimatch": "5.1.2",
@@ -50,7 +48,6 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",
-        "express": "5.1.0",
         "glob": "12.0.0",
         "globals": "16.0.0",
         "google-artifactregistry-auth": "3.4.0",
@@ -1172,6 +1169,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
       "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
@@ -1192,6 +1190,7 @@
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.1.tgz",
       "integrity": "sha512-2h9HBJG3OAsvzXmb81qXmaTPfXYU7KJTQUxunoOKFGnY293YQ/eCkW1Y5mHLocwpEqeqQYT/Qvl6Tk+Q7PfStw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/common": "^5.0.0",
@@ -1219,6 +1218,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -1234,6 +1234,7 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.21.0.tgz",
       "integrity": "sha512-+lAew44pWt6rA4l8dQ1gGhH7Uo95wZKfq/GBf9aEyuNDDLQ2XppGEEReu6ujesSqTtZ8ueQFt73+7SReSHbwqg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
@@ -1255,6 +1256,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-exporter/-/opentelemetry-cloud-trace-exporter-3.0.0.tgz",
       "integrity": "sha512-mUfLJBFo+ESbO0dAGboErx2VyZ7rbrHcQvTP99yH/J72dGaPbH2IzS+04TFbTbEd1VW5R9uK3xq2CqawQaG+1Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^3.0.0",
@@ -1276,6 +1278,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -1294,6 +1297,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-resource-util/-/opentelemetry-resource-util-3.0.0.tgz",
       "integrity": "sha512-CGR/lNzIfTKlZoZFfS6CkVzx+nsC9gzy6S8VcyaLegfEJbiPjxbMLP7csyhJTvZe/iRRcQJxSk0q8gfrGqD3/Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -1324,6 +1328,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
       "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
@@ -1549,6 +1554,7 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -2054,64 +2060,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
-      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.39.5",
@@ -3977,6 +3925,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/marked": {
@@ -8264,6 +8213,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
       "integrity": "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^8.0.0"
@@ -8276,6 +8226,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -8372,18 +8323,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -8411,21 +8363,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -9392,6 +9329,7 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
       "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
@@ -9424,6 +9362,7 @@
       "version": "137.1.0",
       "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
       "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0",
@@ -9437,6 +9376,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
       "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -10423,6 +10363,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12432,6 +12373,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -13285,6 +13227,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
       "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "protobufjs": "^7.2.5"
@@ -13391,6 +13334,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
       "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "duplexify": "^4.1.1",
@@ -16480,6 +16424,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
       "license": "BSD"
     },
     "node_modules/util-deprecate": {
@@ -17782,7 +17727,7 @@
     },
     "packages/a2a-server": {
       "name": "@google/gemini-cli-a2a-server",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "dependencies": {
         "@a2a-js/sdk": "0.3.11",
         "@google-cloud/storage": "7.19.0",
@@ -17977,6 +17922,48 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "packages/a2a-server/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/a2a-server/node_modules/fdir": {
@@ -18242,7 +18229,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.16.1",
@@ -18307,6 +18294,51 @@
         "node": ">=20"
       }
     },
+    "packages/cli/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
+      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "packages/cli/node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/cli/node_modules/@types/node": {
       "version": "20.11.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
@@ -18335,6 +18367,22 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
+      }
+    },
+    "packages/cli/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "packages/cli/node_modules/ansi-escapes": {
@@ -18371,6 +18419,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/cli/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "packages/cli/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/cli/node_modules/string-width": {
       "version": "8.1.0",
@@ -18458,14 +18527,11 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "0.3.11",
         "@bufbuild/protobuf": "2.11.0",
-        "@google-cloud/logging": "11.2.1",
-        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "0.21.0",
-        "@google-cloud/opentelemetry-cloud-trace-exporter": "3.0.0",
         "@google/genai": "1.30.0",
         "@grpc/grpc-js": "1.14.3",
         "@iarna/toml": "2.2.5",
@@ -18502,7 +18568,7 @@
         "fdir": "6.4.6",
         "fzf": "0.5.2",
         "glob": "12.0.0",
-        "google-auth-library": "10.9.0",
+        "google-auth-library": "9.11.0",
         "html-to-text": "9.0.5",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -18532,6 +18598,9 @@
         "zod-to-json-schema": "3.25.1"
       },
       "devDependencies": {
+        "@google-cloud/logging": "11.2.1",
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "0.21.0",
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "3.0.0",
         "@google/gemini-cli-test-utils": "file:../test-utils",
         "@types/fast-levenshtein": "0.0.4",
         "@types/js-yaml": "4.0.9",
@@ -18554,6 +18623,22 @@
         "@lydell/node-pty-win32-arm64": "1.1.0",
         "@lydell/node-pty-win32-x64": "1.1.0",
         "node-pty": "1.0.0"
+      },
+      "peerDependencies": {
+        "@google-cloud/logging": "^11.2.1",
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+        "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@google-cloud/logging": {
+          "optional": true
+        },
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+          "optional": true
+        },
+        "@google-cloud/opentelemetry-cloud-trace-exporter": {
+          "optional": true
+        }
       }
     },
     "packages/core/node_modules/@a2a-js/sdk": {
@@ -18682,6 +18767,42 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/core/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
+      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "packages/core/node_modules/@mswjs/interceptors": {
@@ -18834,6 +18955,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "packages/core/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "packages/core/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -18848,56 +18984,19 @@
         }
       }
     },
-    "packages/core/node_modules/gaxios": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
-      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/core/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/core/node_modules/google-auth-library": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
-      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/core/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -18984,24 +19083,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "packages/core/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "packages/core/node_modules/path-to-regexp": {
@@ -19131,7 +19212,7 @@
     },
     "packages/devtools": {
       "name": "@google/gemini-cli-devtools",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "8.16.0"
@@ -19167,7 +19248,7 @@
     },
     "packages/sdk": {
       "name": "@google/gemini-cli-sdk",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "Apache-2.0",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
@@ -19506,7 +19587,7 @@
     },
     "packages/test-utils": {
       "name": "@google/gemini-cli-test-utils",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "Apache-2.0",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
@@ -19524,7 +19605,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",
-      "version": "0.52.0-nightly.20260707.g27a3da3e8",
+      "version": "0.51.0-nightly.20260625.g3fbf93e26",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.23.0",
@@ -19998,6 +20079,58 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "packages/vscode-ide-companion/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
+      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "packages/vscode-ide-companion/node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/vscode-ide-companion/node_modules/@types/vscode": {
       "version": "1.99.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.99.0.tgz",
@@ -20341,6 +20474,63 @@
         "node": "*"
       }
     },
+    "packages/vscode-ide-companion/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "packages/vscode-ide-companion/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "packages/vscode-ide-companion/node_modules/isexe": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
@@ -20350,6 +20540,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "packages/vscode-ide-companion/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/vscode-ide-companion/node_modules/minimatch": {
       "version": "9.0.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,9 +25,6 @@
   "dependencies": {
     "@a2a-js/sdk": "0.3.11",
     "@bufbuild/protobuf": "2.11.0",
-    "@google-cloud/logging": "11.2.1",
-    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "0.21.0",
-    "@google-cloud/opentelemetry-cloud-trace-exporter": "3.0.0",
     "@google/genai": "1.30.0",
     "@grpc/grpc-js": "1.14.3",
     "@iarna/toml": "2.2.5",
@@ -93,6 +90,22 @@
     "zod": "3.25.76",
     "zod-to-json-schema": "3.25.1"
   },
+  "peerDependencies": {
+    "@google-cloud/logging": "^11.2.1",
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.21.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@google-cloud/logging": {
+      "optional": true
+    },
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+      "optional": true
+    },
+    "@google-cloud/opentelemetry-cloud-trace-exporter": {
+      "optional": true
+    }
+  },
   "optionalDependencies": {
     "@github/keytar": "7.10.6",
     "@lydell/node-pty": "1.1.0",
@@ -105,6 +118,9 @@
   },
   "devDependencies": {
     "@google/gemini-cli-test-utils": "file:../test-utils",
+    "@google-cloud/logging": "11.2.1",
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "0.21.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "3.0.0",
     "@types/fast-levenshtein": "0.0.4",
     "@types/js-yaml": "4.0.9",
     "@types/json-stable-stringify": "1.1.0",

--- a/packages/core/src/telemetry/gcp-exporters.test.ts
+++ b/packages/core/src/telemetry/gcp-exporters.test.ts
@@ -82,6 +82,22 @@ describe('GCP Exporters', () => {
     describe('constructor', () => {
       it('should create a log exporter with project ID', () => {
         expect(exporter).toBeDefined();
+      });
+
+      it('should lazily create the Cloud Logging client on first export', async () => {
+        const mockLogRecords: ReadableLogRecord[] = [
+          {
+            hrTime: [1234567890, 123456789],
+            hrTimeObserved: [1234567890, 123456789],
+            body: 'Test log message',
+          } as unknown as ReadableLogRecord,
+        ];
+
+        const callback = vi.fn();
+
+        exporter.export(mockLogRecords, callback);
+        await exporter.forceFlush();
+
         expect(mockLogging.log).toHaveBeenCalledWith('gemini_cli');
       });
 
@@ -236,7 +252,7 @@ describe('GCP Exporters', () => {
         });
       });
 
-      it('should handle synchronous errors', () => {
+      it('should handle synchronous errors', async () => {
         const mockLogRecords: ReadableLogRecord[] = [
           {
             hrTime: [1234567890, 123456789],
@@ -252,6 +268,7 @@ describe('GCP Exporters', () => {
         const callback = vi.fn();
 
         exporter.export(mockLogRecords, callback);
+        await exporter.forceFlush();
 
         expect(callback).toHaveBeenCalledWith({
           code: ExportResultCode.FAILED,
@@ -261,7 +278,7 @@ describe('GCP Exporters', () => {
     });
 
     describe('severity mapping', () => {
-      it('should map OpenTelemetry severity numbers to Cloud Logging levels', () => {
+      it('should map OpenTelemetry severity numbers to Cloud Logging levels', async () => {
         const testCases = [
           { severityNumber: undefined, expected: 'DEFAULT' },
           { severityNumber: 1, expected: 'DEFAULT' },
@@ -273,7 +290,7 @@ describe('GCP Exporters', () => {
           { severityNumber: 25, expected: 'CRITICAL' },
         ];
 
-        testCases.forEach(({ severityNumber, expected }) => {
+        for (const { severityNumber, expected } of testCases) {
           const mockLogRecords: ReadableLogRecord[] = [
             {
               hrTime: [1234567890, 123456789],
@@ -285,6 +302,7 @@ describe('GCP Exporters', () => {
 
           const callback = vi.fn();
           exporter.export(mockLogRecords, callback);
+          await exporter.forceFlush();
 
           expect(mockLog.entry).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -294,7 +312,7 @@ describe('GCP Exporters', () => {
           );
 
           mockLog.entry.mockClear();
-        });
+        }
       });
     });
 

--- a/packages/core/src/telemetry/gcp-exporters.ts
+++ b/packages/core/src/telemetry/gcp-exporters.ts
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type JWTInput } from 'google-auth-library';
-import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
-import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
-import { Logging, type Log } from '@google-cloud/logging';
+import type { JWTInput } from 'google-auth-library';
+import type { TraceExporter as CloudTraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
+import type { MetricExporter as CloudMetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
+import type {
+  Logging as CloudLogging,
+  Log as CloudLog,
+} from '@google-cloud/logging';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import type {
+  PushMetricExporter,
+  ResourceMetrics,
+} from '@opentelemetry/sdk-metrics';
 import {
   hrTimeToMilliseconds,
   ExportResultCode,
@@ -17,58 +25,178 @@ import type {
   ReadableLogRecord,
   LogRecordExporter,
 } from '@opentelemetry/sdk-logs';
-import type { ResourceMetrics } from '@opentelemetry/sdk-metrics';
+
+const DIRECT_GCP_TELEMETRY_INSTALL_HINT =
+  'Direct GCP telemetry export requires optional peer dependencies. ' +
+  'Install @google-cloud/opentelemetry-cloud-trace-exporter, ' +
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter, and ' +
+  '@google-cloud/logging, or configure telemetry to use an OTLP collector.';
+
+let traceExporterClassPromise: Promise<typeof CloudTraceExporter> | undefined;
+let metricExporterClassPromise: Promise<typeof CloudMetricExporter> | undefined;
+let loggingClassPromise: Promise<typeof CloudLogging> | undefined;
+
+function createOptionalDependencyError(error: unknown): Error {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return new Error(`${DIRECT_GCP_TELEMETRY_INSTALL_HINT} ${errorMessage}`);
+}
+
+async function loadTraceExporterClass(): Promise<typeof CloudTraceExporter> {
+  traceExporterClassPromise ??= import(
+    '@google-cloud/opentelemetry-cloud-trace-exporter'
+  )
+    .then((module) => module.TraceExporter)
+    .catch((error: unknown) => {
+      traceExporterClassPromise = undefined;
+      throw createOptionalDependencyError(error);
+    });
+  return traceExporterClassPromise;
+}
+
+async function loadMetricExporterClass(): Promise<typeof CloudMetricExporter> {
+  metricExporterClassPromise ??= import(
+    '@google-cloud/opentelemetry-cloud-monitoring-exporter'
+  )
+    .then((module) => module.MetricExporter)
+    .catch((error: unknown) => {
+      metricExporterClassPromise = undefined;
+      throw createOptionalDependencyError(error);
+    });
+  return metricExporterClassPromise;
+}
+
+async function loadLoggingClass(): Promise<typeof CloudLogging> {
+  loggingClassPromise ??= import('@google-cloud/logging')
+    .then((module) => module.Logging)
+    .catch((error: unknown) => {
+      loggingClassPromise = undefined;
+      throw createOptionalDependencyError(error);
+    });
+  return loggingClassPromise;
+}
+
+export async function ensureGcpExporterDependenciesAvailable(): Promise<void> {
+  await Promise.all([
+    loadTraceExporterClass(),
+    loadMetricExporterClass(),
+    loadLoggingClass(),
+  ]);
+}
 
 /**
- * Google Cloud Trace exporter that extends the official trace exporter
+ * Google Cloud Trace exporter that delegates to the optional Cloud Trace exporter.
  */
-export class GcpTraceExporter extends TraceExporter {
+export class GcpTraceExporter implements SpanExporter {
+  private exporterPromise: Promise<CloudTraceExporter> | undefined;
+
   constructor(projectId?: string, credentials?: JWTInput) {
-    super({
-      projectId,
-      credentials,
-      resourceFilter: /^gcp\./,
-    });
+    this.projectId = projectId;
+    this.credentials = credentials;
+  }
+
+  private readonly projectId?: string;
+  private readonly credentials?: JWTInput;
+
+  private getExporter(): Promise<CloudTraceExporter> {
+    this.exporterPromise ??= loadTraceExporterClass().then(
+      (TraceExporter) =>
+        new TraceExporter({
+          projectId: this.projectId,
+          credentials: this.credentials,
+          resourceFilter: /^gcp\./,
+        }),
+    );
+    return this.exporterPromise;
+  }
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    void this.getExporter()
+      .then((exporter) => exporter.export(spans, resultCallback))
+      .catch((error: Error) => {
+        resultCallback({ code: ExportResultCode.FAILED, error });
+      });
   }
 
   async forceFlush(): Promise<void> {
     return Promise.resolve();
   }
+
+  async shutdown(): Promise<void> {
+    await this.getExporter().then((exporter) => exporter.shutdown());
+  }
 }
 
 /**
- * Google Cloud Monitoring exporter that extends the official metrics exporter
+ * Google Cloud Monitoring exporter that delegates to the optional Monitoring exporter.
  */
-export class GcpMetricExporter extends MetricExporter {
+export class GcpMetricExporter implements PushMetricExporter {
+  private exporterPromise: Promise<CloudMetricExporter> | undefined;
+
   constructor(projectId?: string, credentials?: JWTInput) {
-    super({
-      projectId,
-      credentials,
-      prefix: 'custom.googleapis.com/gemini_cli',
-    });
+    this.projectId = projectId;
+    this.credentials = credentials;
   }
 
-  override export(
+  private readonly projectId?: string;
+  private readonly credentials?: JWTInput;
+
+  private getExporter(): Promise<CloudMetricExporter> {
+    this.exporterPromise ??= loadMetricExporterClass().then(
+      (MetricExporter) =>
+        new MetricExporter({
+          projectId: this.projectId,
+          credentials: this.credentials,
+          prefix: 'custom.googleapis.com/gemini_cli',
+        }),
+    );
+    return this.exporterPromise;
+  }
+
+  private handleExportResult(
+    result: ExportResult,
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    if (result.code === ExportResultCode.FAILED && result.error) {
+      // Suppress errors related to writing too frequently, as they are
+      // expected when the CLI shuts down quickly after a periodic export.
+      const errorMessage = result.error.message || String(result.error);
+      if (
+        process.env['GEMINI_STRICT_TELEMETRY_LIMITS'] === 'true' &&
+        errorMessage.includes(
+          'written more frequently than the maximum sampling period',
+        )
+      ) {
+        resultCallback({ code: ExportResultCode.SUCCESS });
+        return;
+      }
+    }
+    resultCallback(result);
+  }
+
+  export(
     metrics: ResourceMetrics,
     resultCallback: (result: ExportResult) => void,
   ): void {
-    super.export(metrics, (result: ExportResult) => {
-      if (result.code === ExportResultCode.FAILED && result.error) {
-        // Suppress errors related to writing too frequently, as they are
-        // expected when the CLI shuts down quickly after a periodic export.
-        const errorMessage = result.error.message || String(result.error);
-        if (
-          process.env['GEMINI_STRICT_TELEMETRY_LIMITS'] === 'true' &&
-          errorMessage.includes(
-            'written more frequently than the maximum sampling period',
-          )
-        ) {
-          resultCallback({ code: ExportResultCode.SUCCESS });
-          return;
-        }
-      }
-      resultCallback(result);
-    });
+    void this.getExporter()
+      .then((exporter) => {
+        exporter.export(metrics, (result: ExportResult) => {
+          this.handleExportResult(result, resultCallback);
+        });
+      })
+      .catch((error: Error) => {
+        resultCallback({ code: ExportResultCode.FAILED, error });
+      });
+  }
+
+  async forceFlush(): Promise<void> {
+    await this.getExporter().then((exporter) => exporter.forceFlush());
+  }
+
+  async shutdown(): Promise<void> {
+    await this.getExporter().then((exporter) => exporter.shutdown());
   }
 }
 
@@ -96,16 +224,31 @@ function truncateLogPayload(payload: unknown, limit = 200000): unknown {
 }
 
 /**
- * Google Cloud Logging exporter that uses the Cloud Logging client
+ * Google Cloud Logging exporter that delegates to the optional Cloud Logging client.
  */
 export class GcpLogExporter implements LogRecordExporter {
-  private logging: Logging;
-  private log: Log;
+  private loggingPromise:
+    | Promise<{ logging: CloudLogging; log: CloudLog }>
+    | undefined;
   private pendingWrites: Array<Promise<void>> = [];
 
   constructor(projectId?: string, credentials?: JWTInput) {
-    this.logging = new Logging({ projectId, credentials });
-    this.log = this.logging.log('gemini_cli');
+    this.projectId = projectId;
+    this.credentials = credentials;
+  }
+
+  private readonly projectId?: string;
+  private readonly credentials?: JWTInput;
+
+  private getLogging(): Promise<{ logging: CloudLogging; log: CloudLog }> {
+    this.loggingPromise ??= loadLoggingClass().then((Logging) => {
+      const logging = new Logging({
+        projectId: this.projectId,
+        credentials: this.credentials,
+      });
+      return { logging, log: logging.log('gemini_cli') };
+    });
+    return this.loggingPromise;
   }
 
   export(
@@ -113,65 +256,87 @@ export class GcpLogExporter implements LogRecordExporter {
     resultCallback: (result: ExportResult) => void,
   ): void {
     try {
-      const entries = logs.map((log) => {
-        const rawPayload = {
-          ...log.attributes,
-          ...log.resource?.attributes,
-          message: log.body,
-        };
+      const writePromise = this.getLogging()
+        .then(({ logging, log }) => {
+          try {
+            const entries = logs.map((logRecord) => {
+              const rawPayload = {
+                ...logRecord.attributes,
+                ...logRecord.resource?.attributes,
+                message: logRecord.body,
+              };
 
-        const isStrictTelemetry =
-          process.env['GEMINI_STRICT_TELEMETRY_LIMITS'] === 'true';
+              const isStrictTelemetry =
+                process.env['GEMINI_STRICT_TELEMETRY_LIMITS'] === 'true';
 
-        let finalPayload: unknown = rawPayload;
+              let finalPayload: unknown = rawPayload;
 
-        if (isStrictTelemetry) {
-          // Enforce a strict cap on the entire payload to avoid 256KB limit crashes in CI.
-          let safePayload = truncateLogPayload(rawPayload, 10000);
-          let payloadString = JSON.stringify(safePayload);
+              if (isStrictTelemetry) {
+                // Enforce a strict cap on the entire payload to avoid 256KB limit crashes in CI.
+                let safePayload = truncateLogPayload(rawPayload, 10000);
+                let payloadString = JSON.stringify(safePayload);
 
-          if (payloadString && payloadString.length > 100000) {
-            // If still too large, apply a stricter limit
-            safePayload = truncateLogPayload(rawPayload, 2000);
-            payloadString = JSON.stringify(safePayload);
+                if (payloadString && payloadString.length > 100000) {
+                  // If still too large, apply a stricter limit
+                  safePayload = truncateLogPayload(rawPayload, 2000);
+                  payloadString = JSON.stringify(safePayload);
 
-            if (payloadString && payloadString.length > 100000) {
-              safePayload = truncateLogPayload(rawPayload, 5000);
-              payloadString = JSON.stringify(safePayload);
+                  if (payloadString && payloadString.length > 100000) {
+                    safePayload = truncateLogPayload(rawPayload, 5000);
+                    payloadString = JSON.stringify(safePayload);
 
-              if (payloadString && payloadString.length > 100000) {
-                // Fallback: strip structure and send a truncated raw string
-                safePayload = {
-                  _warning: 'Payload heavily truncated due to strict limits',
-                  data: payloadString.substring(0, 50000) + '... (truncated)',
-                };
+                    if (payloadString && payloadString.length > 100000) {
+                      // Fallback: strip structure and send a truncated raw string
+                      safePayload = {
+                        _warning:
+                          'Payload heavily truncated due to strict limits',
+                        data:
+                          payloadString.substring(0, 50000) + '... (truncated)',
+                      };
+                    }
+                  }
+                }
+                finalPayload = safePayload;
               }
-            }
+
+              const entry = log.entry(
+                {
+                  severity: this.mapSeverityToCloudLogging(
+                    logRecord.severityNumber,
+                  ),
+                  timestamp: new Date(hrTimeToMilliseconds(logRecord.hrTime)),
+                  resource: {
+                    type: 'global',
+                    labels: {
+                      project_id: logging.projectId,
+                    },
+                  },
+                },
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+                finalPayload as Record<string, unknown>,
+              );
+              return entry;
+            });
+
+            return log
+              .write(entries)
+              .then(() => {
+                resultCallback({ code: ExportResultCode.SUCCESS });
+              })
+              .catch((error: Error) => {
+                resultCallback({
+                  code: ExportResultCode.FAILED,
+                  error,
+                });
+              });
+          } catch (error) {
+            resultCallback({
+              code: ExportResultCode.FAILED,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              error: error as Error,
+            });
+            return undefined;
           }
-          finalPayload = safePayload;
-        }
-
-        const entry = this.log.entry(
-          {
-            severity: this.mapSeverityToCloudLogging(log.severityNumber),
-            timestamp: new Date(hrTimeToMilliseconds(log.hrTime)),
-            resource: {
-              type: 'global',
-              labels: {
-                project_id: this.logging.projectId,
-              },
-            },
-          },
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          finalPayload as Record<string, unknown>,
-        );
-        return entry;
-      });
-
-      const writePromise = this.log
-        .write(entries)
-        .then(() => {
-          resultCallback({ code: ExportResultCode.SUCCESS });
         })
         .catch((error: Error) => {
           resultCallback({

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -24,6 +24,7 @@ import {
   GcpTraceExporter,
   GcpLogExporter,
   GcpMetricExporter,
+  ensureGcpExporterDependenciesAvailable,
 } from './gcp-exporters.js';
 import { TelemetryTarget } from './index.js';
 
@@ -63,6 +64,9 @@ describe('Telemetry SDK', () => {
         ({
           getApplicationDefault: mockGetApplicationDefault,
         }) as unknown as GoogleAuth,
+    );
+    vi.mocked(ensureGcpExporterDependenciesAvailable).mockResolvedValue(
+      undefined,
     );
     mockConfig = {
       getTelemetryEnabled: () => true,
@@ -170,6 +174,29 @@ describe('Telemetry SDK', () => {
         delete process.env['OTLP_GOOGLE_CLOUD_PROJECT'];
       }
     }
+  });
+
+  it('should disable direct GCP telemetry when optional exporter dependencies are missing', async () => {
+    const error = new Error('Cannot find package @google-cloud/logging');
+    vi.mocked(ensureGcpExporterDependenciesAvailable).mockRejectedValueOnce(
+      error,
+    );
+    vi.spyOn(mockConfig, 'getTelemetryTarget').mockReturnValue(
+      TelemetryTarget.GCP,
+    );
+    vi.spyOn(mockConfig, 'getTelemetryUseCollector').mockReturnValue(false);
+    vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
+
+    await initializeTelemetry(mockConfig);
+
+    expect(debugLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Direct GCP telemetry exporters are unavailable'),
+      error,
+    );
+    expect(GcpTraceExporter).not.toHaveBeenCalled();
+    expect(GcpLogExporter).not.toHaveBeenCalled();
+    expect(GcpMetricExporter).not.toHaveBeenCalled();
+    expect(NodeSDK.prototype.start).not.toHaveBeenCalled();
   });
 
   it('should use OTLP exporters when target is gcp but useCollector is true', async () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -49,6 +49,7 @@ import {
   GcpTraceExporter,
   GcpMetricExporter,
   GcpLogExporter,
+  ensureGcpExporterDependenciesAvailable,
 } from './gcp-exporters.js';
 import { TelemetryTarget } from './index.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -121,6 +122,28 @@ export function bufferTelemetryEvent(fn: () => void | Promise<void>): void {
   } else {
     telemetryBuffer.push(fn);
   }
+}
+
+function unregisterTelemetryEventListeners(): void {
+  if (authListener) {
+    authEvents.off('post_auth', authListener);
+    authListener = undefined;
+  }
+  if (keychainAvailabilityListener) {
+    coreEvents.off(
+      CoreEvent.TelemetryKeychainAvailability,
+      keychainAvailabilityListener,
+    );
+    keychainAvailabilityListener = undefined;
+  }
+  if (tokenStorageTypeListener) {
+    coreEvents.off(
+      CoreEvent.TelemetryTokenStorageType,
+      tokenStorageTypeListener,
+    );
+    tokenStorageTypeListener = undefined;
+  }
+  callbackRegistered = false;
 }
 
 async function flushTelemetryBuffer(): Promise<void> {
@@ -272,6 +295,19 @@ export async function initializeTelemetry(
       'using',
       credentials ? 'provided credentials' : 'ADC',
     );
+    try {
+      await ensureGcpExporterDependenciesAvailable();
+    } catch (error) {
+      debugLogger.error(
+        'Direct GCP telemetry exporters are unavailable. ' +
+          'Install the optional Google Cloud exporter peer dependencies ' +
+          'or enable telemetry.useCollector to export through an OTLP collector.',
+        error,
+      );
+      unregisterTelemetryEventListeners();
+      return;
+    }
+
     spanExporter = new GcpTraceExporter(gcpProjectId, credentials);
     logExporter = new GcpLogExporter(gcpProjectId, credentials);
     metricReader = new PeriodicExportingMetricReader({
@@ -439,25 +475,7 @@ export async function shutdownTelemetry(
     metrics.disable();
     propagation.disable();
     diag.disable();
-    if (authListener) {
-      authEvents.off('post_auth', authListener);
-      authListener = undefined;
-    }
-    if (keychainAvailabilityListener) {
-      coreEvents.off(
-        CoreEvent.TelemetryKeychainAvailability,
-        keychainAvailabilityListener,
-      );
-      keychainAvailabilityListener = undefined;
-    }
-    if (tokenStorageTypeListener) {
-      coreEvents.off(
-        CoreEvent.TelemetryTokenStorageType,
-        tokenStorageTypeListener,
-      );
-      tokenStorageTypeListener = undefined;
-    }
-    callbackRegistered = false;
+    unregisterTelemetryEventListeners();
     activeTelemetryEmail = undefined;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #27100.

This makes the direct Google Cloud telemetry exporters optional for `@google/gemini-cli-core` consumers:

- moves `@google-cloud/logging`, `@google-cloud/opentelemetry-cloud-monitoring-exporter`, and `@google-cloud/opentelemetry-cloud-trace-exporter` out of core runtime dependencies
- declares those packages as optional peer dependencies and keeps them as dev dependencies for local build/test
- lazy-loads the direct GCP exporters only when `telemetry.target === "gcp"` and collector mode is disabled
- reports a clear configuration error if direct GCP export is requested without the optional exporter packages installed
- documents the optional peer dependency requirement for `@google/gemini-cli-core` embedders

This is intended as a focused proposal for the dependency-warning issue. If maintainers prefer to keep direct GCP exporters bundled by default for core consumers, I can adjust the direction.

## Validation

- `npm ci --ignore-scripts`
- `npm run generate`
- `npm run typecheck -w @google/gemini-cli-core`
- `npx vitest run src/telemetry/gcp-exporters.test.ts src/telemetry/sdk.test.ts --coverage.enabled=false`
- `npx eslint packages/core/src/telemetry/gcp-exporters.ts packages/core/src/telemetry/gcp-exporters.test.ts packages/core/src/telemetry/sdk.ts packages/core/src/telemetry/sdk.test.ts --max-warnings 0`
- `npm run build -w @google/gemini-cli-core`
- `git diff --check`

I also packed the local `@google/gemini-cli-core` package and installed it into a fresh temp project. The install no longer pulled in the three direct GCP exporter packages. The remaining install warnings were from unrelated dependencies (`node-domexception@1.0.0`, `uuid@9.0.1`).
