### PR TITLE
fix(core): preserve escape sequences in string literals for modern models

### DIFF
--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -85,7 +85,7 @@ const mockConfigInternal = {
   getIdeMode: vi.fn(() => false),
   getWorkspaceContext: () => new WorkspaceContext(rootDir, [plansDir]),
   getApiKey: () => 'test-key',
-  getModel: () => 'test-model',
+  getModel: () => 'gemini-1.5-flash',
   getSandbox: () => false,
   getDebugMode: () => false,
   getQuestion: () => undefined,
@@ -107,7 +107,7 @@ const mockConfigInternal = {
   isInteractive: () => false,
   getDisableLLMCorrection: vi.fn(() => true),
   isPlanMode: vi.fn(() => false),
-  getActiveModel: () => 'test-model',
+  getActiveModel: () => 'gemini-1.5-flash',
   storage: {
     getProjectTempDir: vi.fn().mockReturnValue('/tmp/project'),
   },

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -55,7 +55,12 @@ import { WRITE_FILE_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
 import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 import { resolveAndValidatePlanPath } from '../utils/planUtils.js';
-import { isGemini3Model } from '../config/models.js';
+import {
+  isGemini3Model,
+  isGemini2Model,
+  isCustomModel,
+  resolveModel,
+} from '../config/models.js';
 import { discoverJitContext, appendJitContext } from './jit-context.js';
 
 /**
@@ -193,7 +198,13 @@ export async function getCorrectedFileContent(
     }
   }
 
-  const aggressiveUnescape = !isGemini3Model(config.getActiveModel());
+  const activeModel = config.getActiveModel();
+  const resolvedModel = resolveModel(activeModel, false, false, true, config);
+
+  const aggressiveUnescape =
+    !isGemini3Model(resolvedModel, config) &&
+    !isGemini2Model(resolvedModel) &&
+    !isCustomModel(resolvedModel, config);
 
   correctedContent = await ensureCorrectFileContent(
     proposedContent,

--- a/packages/core/src/utils/editCorrector.test.ts
+++ b/packages/core/src/utils/editCorrector.test.ts
@@ -245,5 +245,20 @@ describe('editCorrector', () => {
       expect(result).toBe(content);
       expect(mockGenerateJson).not.toHaveBeenCalled();
     });
+
+    it('should preserve \\n inside string literals even when aggressiveUnescape is false (b-496211054)', async () => {
+      const content =
+        'fmt.Printf("OpenFile with FailIfExists failed: %v\\n", err)';
+
+      const result = await ensureCorrectFileContent(
+        content,
+        mockBaseLlmClientInstance,
+        abortSignal,
+        true, // disableLLMCorrection
+        false, // aggressiveUnescape (now false for Gemini 2.5/3.x/Custom)
+      );
+
+      expect(result).toBe(content);
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the newline-in-string bug (b-496211054) where valid escape sequences (like `\n` or `\t`) inside string literals were being converted to literal newlines when writing files.

## Details

The fix disables aggressive unescaping for all modern models (Gemini 2.x, Gemini 3.x, and Custom models) by resolving the model first and checking their families in `packages/core/src/tools/write-file.ts`.

To support dynamic model configurations (e.g., via `getExperimentalDynamicModelConfiguration`), the config context is passed to `resolveModel`, `isGemini3Model`, and `isCustomModel`.

Comprehensive unit tests have been added/updated:
- `packages/core/src/utils/editCorrector.test.ts`: Verifies that escape sequences are preserved when `aggressiveUnescape` is `false`.
- `packages/core/src/tools/write-file.test.ts`: Updated mock model to `gemini-1.5-flash` to ensure correct test coverage and alignment with the new unescaping logic.

## Related Issues


## How to Validate

1. **Run unit tests:**
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/editCorrector.test.ts src/tools/write-file.test.ts
   ```
   Expected output: All tests pass successfully.

2. **Run linter:**
   ```bash
   npm run lint
   ```
   Expected output: 0 warnings and 0 errors.

3. **Run typecheck:**
   ```bash
   npm run typecheck
   ```
   Expected output: Successful compilation with no TypeScript errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker