### PR TITLE
fix(cli): improve markdown rendering for CJK text wrapping and __bold__ syntax

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -77,11 +77,45 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   let inTable = false;
   let tableRows: string[][] = [];
   let tableHeaders: string[] = [];
+  let paragraphBuffer: string[] = [];
 
   function addContentBlock(block: React.ReactNode) {
     if (block) {
       contentBlocks.push(block);
       lastLineEmpty = false;
+    }
+  }
+
+  function flushParagraph() {
+    if (paragraphBuffer.length > 0) {
+      let mergedText = '';
+      paragraphBuffer.forEach((line) => {
+        if (mergedText === '') {
+          mergedText = line;
+        } else {
+          const lastChar = mergedText.slice(-1);
+          const firstChar = line.slice(0, 1);
+          const isCJK = (char: string) =>
+            /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff00-\uffef]/.test(
+              char,
+            );
+          if (isCJK(lastChar) && isCJK(firstChar)) {
+            mergedText += line;
+          } else {
+            mergedText += ' ' + line;
+          }
+        }
+      });
+
+      const key = `paragraph-${contentBlocks.length}`;
+      addContentBlock(
+        <Box key={key}>
+          <Text wrap="wrap" color={responseColor}>
+            <RenderInline text={mergedText} defaultColor={responseColor} />
+          </Text>
+        </Box>,
+      );
+      paragraphBuffer = [];
     }
   }
 
@@ -126,6 +160,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     const tableSeparatorMatch = line.match(tableSeparatorRegex);
 
     if (codeFenceMatch) {
+      flushParagraph();
       inCodeBlock = true;
       codeBlockFence = codeFenceMatch[1];
       codeBlockLang = codeFenceMatch[2] || null;
@@ -135,18 +170,13 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         index + 1 < lines.length &&
         lines[index + 1].match(tableSeparatorRegex)
       ) {
+        flushParagraph();
         inTable = true;
         tableHeaders = tableRowMatch[1].split('|').map((cell) => cell.trim());
         tableRows = [];
       } else {
         // Not a table, treat as regular text
-        addContentBlock(
-          <Box key={key}>
-            <Text wrap="wrap" color={responseColor}>
-              <RenderInline text={line} defaultColor={responseColor} />
-            </Text>
-          </Box>,
-        );
+        paragraphBuffer.push(line);
       }
     } else if (inTable && tableSeparatorMatch) {
       // Skip separator line - already handled
@@ -179,21 +209,17 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
 
       // Process current line as normal
       if (line.trim().length > 0) {
-        addContentBlock(
-          <Box key={key}>
-            <Text wrap="wrap" color={responseColor}>
-              <RenderInline text={line} defaultColor={responseColor} />
-            </Text>
-          </Box>,
-        );
+        paragraphBuffer.push(line);
       }
     } else if (hrMatch) {
+      flushParagraph();
       addContentBlock(
         <Box key={key}>
           <Text dimColor>---</Text>
         </Box>,
       );
     } else if (headerMatch) {
+      flushParagraph();
       const level = headerMatch[1].length;
       const headerText = headerMatch[2];
       let headerNode: React.ReactNode = null;
@@ -239,6 +265,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       }
       if (headerNode) addContentBlock(<Box key={key}>{headerNode}</Box>);
     } else if (ulMatch) {
+      flushParagraph();
       const leadingWhitespace = ulMatch[1];
       const marker = ulMatch[2];
       const itemText = ulMatch[3];
@@ -252,6 +279,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         />,
       );
     } else if (olMatch) {
+      flushParagraph();
       const leadingWhitespace = olMatch[1];
       const marker = olMatch[2];
       const itemText = olMatch[3];
@@ -266,6 +294,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       );
     } else {
       if (line.trim().length === 0 && !inCodeBlock) {
+        flushParagraph();
         if (!lastLineEmpty) {
           contentBlocks.push(
             <Box key={`spacer-${index}`} height={EMPTY_LINE_HEIGHT} />,
@@ -273,16 +302,12 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
           lastLineEmpty = true;
         }
       } else {
-        addContentBlock(
-          <Box key={key}>
-            <Text wrap="wrap" color={responseColor}>
-              <RenderInline text={line} defaultColor={responseColor} />
-            </Text>
-          </Box>,
-        );
+        paragraphBuffer.push(line);
       }
     }
   });
+
+  flushParagraph();
 
   if (inCodeBlock) {
     addContentBlock(

--- a/packages/cli/src/ui/utils/markdownParsingUtils.test.ts
+++ b/packages/cli/src/ui/utils/markdownParsingUtils.test.ts
@@ -88,6 +88,14 @@ describe('parsingUtils', () => {
       );
     });
 
+    it('should handle bold text with __', () => {
+      const input = 'This is __bold__ text';
+      const output = parseMarkdownToANSI(input);
+      expect(output).toBe(
+        `${primary('This is ')}${chalk.bold(primary('bold'))}${primary(' text')}`,
+      );
+    });
+
     it('should handle italic text with *', () => {
       const input = 'This is *italic* text';
       const output = parseMarkdownToANSI(input);

--- a/packages/cli/src/ui/utils/markdownParsingUtils.ts
+++ b/packages/cli/src/ui/utils/markdownParsingUtils.ts
@@ -123,7 +123,7 @@ export const parseMarkdownToANSI = (
 
   let result = '';
   const inlineRegex =
-    /(\*\*\*.*?\*\*\*|\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|\[.*?\]\(.*?\)|`+.+?`+|<u>.*?<\/u>|https?:\/\/\S+)/g;
+    /(\*\*\*.*?\*\*\*|\*\*.*?\*\*|\*.*?\*|__.*?__|_[^_]*?_|~~.*?~~|\[.*?\]\(.*?\)|`+.+?`+|<u>.*?<\/u>|https?:\/\/\S+)/g;
   let lastIndex = 0;
   let match;
 
@@ -153,8 +153,8 @@ export const parseMarkdownToANSI = (
           ),
         );
       } else if (
-        fullMatch.endsWith('**') &&
-        fullMatch.startsWith('**') &&
+        ((fullMatch.endsWith('**') && fullMatch.startsWith('**')) ||
+          (fullMatch.endsWith('__') && fullMatch.startsWith('__'))) &&
         fullMatch.length > BOLD_MARKER_LENGTH * 2
       ) {
         styledPart = chalk.bold(

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -1,7 +1,7 @@
 This file contains third-party software notices and license terms.
 
 ============================================================
-@modelcontextprotocol/sdk@1.23.0
+@modelcontextprotocol/sdk@1.26.0
 (git+https://github.com/modelcontextprotocol/typescript-sdk.git)
 
 MIT License
@@ -26,6 +26,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+============================================================
+@hono/node-server@1.19.13
+(No repository found)
+
+License text not found.
 
 ============================================================
 ajv@6.14.0
@@ -110,7 +116,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-json-schema-traverse@1.0.0
+json-schema-traverse@0.4.1
 (git+https://github.com/epoberezkin/json-schema-traverse.git)
 
 MIT License
@@ -390,7 +396,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ============================================================
-which@5.0.0
+which@2.0.2
 (git+https://github.com/npm/node-which.git)
 
 The ISC License
@@ -411,7 +417,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ============================================================
-isexe@3.1.5
+isexe@2.0.0
 (No repository found)
 
 # Blue Oak Model License
@@ -527,7 +533,7 @@ SOFTWARE.
 
 
 ============================================================
-express@5.1.0
+express@5.2.1
 (No repository found)
 
 (The MIT License)
@@ -2251,7 +2257,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-express-rate-limit@7.5.1
+express-rate-limit@8.5.2
 (git+https://github.com/express-rate-limit/express-rate-limit.git)
 
 ﻿# MIT License
@@ -2275,6 +2281,43 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
+============================================================
+ip-address@10.2.0
+(git://github.com/beaugunderson/ip-address.git)
+
+Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+============================================================
+jose@6.1.3
+(No repository found)
+
+License text not found.
+
+============================================================
+json-schema-typed@8.0.2
+(No repository found)
+
+License text not found.
 
 ============================================================
 pkce-challenge@5.0.0


### PR DESCRIPTION
This PR improves the terminal Markdown renderer in the CLI to solve two main issues:

1. **CJK Hard Line-wrapping / Misinterpreted Lists**: Currently, the renderer splits the text by \n and processes each line in a separate <Box> component. In CJK text where spaces are not used to separate words, hard wrapping in the source text results in a highly disjointed display and sometimes causes subsequent lines starting with - or * to be misidentified as new lists. This PR introduces a paragraph buffer that merges contiguous normal text lines before rendering them. When merging, lines that end/start with a CJK character are joined without spaces, while other lines are joined with spaces.
2. **Double Underscore Bold Support**: Added parsing support for double underscores (__bold__) to align with the markdown specification and prevent double underscores from being mistakenly parsed as a mixture of italics and extra underline characters.

All pre-commit checks and lints have passed successfully.