### PR TITLE
fix(core): don't flag non-auth 401 substrings as authentication errors

### DIFF
--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -103,6 +103,30 @@ describe('isAuthenticationError', () => {
     expect(isAuthenticationError(new Error('401 Unauthorized'))).toBe(true);
     expect(isAuthenticationError(new Error('HTTP 401'))).toBe(true);
     expect(isAuthenticationError(new Error('Status code: 401'))).toBe(true);
+    // the actual MCP SDK message shape the fallback exists for
+    expect(
+      isAuthenticationError(
+        new Error('Error POSTing to endpoint (HTTP 401): access denied'),
+      ),
+    ).toBe(true);
+  });
+
+  it('should not treat non-auth 401 substrings as authentication errors', () => {
+    expect(
+      isAuthenticationError(
+        new Error('Error connecting to http://localhost:4012'),
+      ),
+    ).toBe(false);
+    expect(
+      isAuthenticationError(new Error('Command failed: exit status 4010')),
+    ).toBe(false);
+    expect(isAuthenticationError(new Error('error at line 401'))).toBe(false);
+    // a context word and an unrelated 401 far apart in the same message
+    expect(
+      isAuthenticationError(
+        new Error('Process status: active. Error at line 401.'),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -296,10 +296,20 @@ export function isAuthenticationError(error: unknown): boolean {
     return true;
   }
 
-  // Fallback: Check for MCP SDK's plain Error messages with HTTP 401
-  // The SDK sometimes throws: new Error(`Error POSTing to endpoint (HTTP 401): ...`)
+  // Fallback: Check for MCP SDK's plain Error messages with HTTP 401, e.g.
+  // `Error POSTing to endpoint (HTTP 401): ...`. Match a standalone 401 token only when it
+  // sits close to an HTTP/auth keyword, so a port or line number (localhost:4012, "error at
+  // line 401") — or a stray context word far from an unrelated 401 — isn't read as an auth
+  // failure.
   const message = getErrorMessage(error);
-  if (message.includes('401')) {
+  if (
+    /\b(?:HTTP|status|unauthorized|authentication)\b.{0,15}\b401\b/i.test(
+      message,
+    ) ||
+    /\b401\b.{0,15}\b(?:HTTP|status|unauthorized|authentication)\b/i.test(
+      message,
+    )
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## What & why

`isAuthenticationError`'s last-resort fallback matched **any** message containing the substring `401`. So connection or logic errors like `http://localhost:4012`, `exit status 4010`, or `error at line 401` were classified as authentication failures, which triggers unnecessary OAuth fallback and shows a misleading `requires authentication` diagnostic instead of the real error (#28203).

## Change

Replace the `message.includes('401')` fallback with a check that requires a **standalone `401` token** (`\b401\b`) **near an HTTP/auth context word** (`HTTP`, `status`, `unauthorized`, `authentication`). This:

- keeps the existing formats matching — `401 Unauthorized`, `HTTP 401`, `Status code: 401`, and the real SDK shape `Error POSTing to endpoint (HTTP 401): ...`
- stops the false positives — `localhost:4012` / `exit status 4010` (401 is part of a larger number, so no `\b401\b`) and `error at line 401` (a standalone 401 with no auth context)

The structured checks above this (`error.code === 401`, `UnauthorizedError`) are unchanged; this only tightens the plain-message fallback.

## Trade-off

This is a heuristic. A bare `...401` message with no HTTP/auth keyword now falls through to normal error handling instead of being treated as auth. For a last-resort fallback I judged fewer false positives (which wrongly trigger OAuth) more valuable than catching every possible 401 string — happy to broaden the context words if you'd prefer.

## Testing

`packages/core/src/utils/errors.test.ts`: added a case asserting the port/exit/line-number 401s are **not** auth errors, plus the real SDK message shape **is**. Full file: 30 tests pass. eslint + prettier clean.

Fixes #28203
