### PR TITLE
fix(ide-companion): set token file mode atomically to close TOCTOU window

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -28,6 +28,7 @@ vi.mock('node:fs/promises', () => ({
   unlink: vi.fn(() => Promise.resolve(undefined)),
   chmod: vi.fn(() => Promise.resolve(undefined)),
   mkdir: vi.fn(() => Promise.resolve(undefined)),
+  rename: vi.fn(() => Promise.resolve(undefined)),
 }));
 
 vi.mock('node:os', async (importOriginal) => {
@@ -158,13 +159,18 @@ describe('IDEServer', () => {
     expect(fs.mkdir).toHaveBeenCalledWith(path.join('/tmp', 'gemini', 'ide'), {
       recursive: true,
     });
-    // The stale/pre-created file is removed before the exclusive write so the
-    // 0o600 mode always applies to a fresh file (see #28278).
-    expect(fs.unlink).toHaveBeenCalledWith(expectedPortFile);
+    // The temp file is removed before the exclusive write so the 0o600 mode
+    // always applies to a fresh file, then renamed into place atomically
+    // (see #28278).
+    expect(fs.unlink).toHaveBeenCalledWith(expectedPortFile + '.tmp');
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expectedPortFile,
+      expectedPortFile + '.tmp',
       expectedContent,
       { mode: 0o600, flag: 'wx' },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(
+      expectedPortFile + '.tmp',
+      expectedPortFile,
     );
   });
 
@@ -192,9 +198,13 @@ describe('IDEServer', () => {
       authToken: 'test-auth-token',
     });
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expectedPortFile,
+      expectedPortFile + '.tmp',
       expectedContent,
       { mode: 0o600, flag: 'wx' },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(
+      expectedPortFile + '.tmp',
+      expectedPortFile,
     );
   });
 
@@ -222,9 +232,13 @@ describe('IDEServer', () => {
       authToken: 'test-auth-token',
     });
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expectedPortFile,
+      expectedPortFile + '.tmp',
       expectedContent,
       { mode: 0o600, flag: 'wx' },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(
+      expectedPortFile + '.tmp',
+      expectedPortFile,
     );
   });
 
@@ -270,9 +284,13 @@ describe('IDEServer', () => {
       authToken: 'test-auth-token',
     });
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expectedPortFile,
+      expectedPortFile + '.tmp',
       expectedContent,
       { mode: 0o600, flag: 'wx' },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(
+      expectedPortFile + '.tmp',
+      expectedPortFile,
     );
 
     // Simulate removing a folder
@@ -289,9 +307,13 @@ describe('IDEServer', () => {
       authToken: 'test-auth-token',
     });
     expect(fs.writeFile).toHaveBeenCalledWith(
-      expectedPortFile,
+      expectedPortFile + '.tmp',
       expectedContent2,
       { mode: 0o600, flag: 'wx' },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(
+      expectedPortFile + '.tmp',
+      expectedPortFile,
     );
   });
 
@@ -305,10 +327,15 @@ describe('IDEServer', () => {
       'ide',
       `gemini-ide-server-${process.ppid}-${port}.json`,
     );
-    expect(fs.writeFile).toHaveBeenCalledWith(portFile, expect.any(String), {
-      mode: 0o600,
-      flag: 'wx',
-    });
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      portFile + '.tmp',
+      expect.any(String),
+      {
+        mode: 0o600,
+        flag: 'wx',
+      },
+    );
+    expect(fs.rename).toHaveBeenCalledWith(portFile + '.tmp', portFile);
 
     await ideServer.stop();
 
@@ -346,9 +373,13 @@ describe('IDEServer', () => {
         authToken: 'test-auth-token',
       });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        expectedPortFile,
+        expectedPortFile + '.tmp',
         expectedContent,
         { mode: 0o600, flag: 'wx' },
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expectedPortFile + '.tmp',
+        expectedPortFile,
       );
     },
   );

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -161,8 +161,8 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
+      { mode: 0o600 },
     );
-    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
   });
 
   it('should set a single folder path', async () => {
@@ -191,8 +191,8 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
+      { mode: 0o600 },
     );
-    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
   });
 
   it('should set an empty string if no folders are open', async () => {
@@ -221,8 +221,8 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
+      { mode: 0o600 },
     );
-    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
   });
 
   it('should update the path when workspace folders change', async () => {
@@ -269,8 +269,8 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
+      { mode: 0o600 },
     );
-    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
 
     // Simulate removing a folder
     vscodeMock.workspace.workspaceFolders = [{ uri: { fsPath: '/baz/qux' } }];
@@ -288,8 +288,8 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent2,
+      { mode: 0o600 },
     );
-    expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
   });
 
   it('should clear env vars and delete port file on stop', async () => {
@@ -302,7 +302,9 @@ describe('IDEServer', () => {
       'ide',
       `gemini-ide-server-${process.ppid}-${port}.json`,
     );
-    expect(fs.writeFile).toHaveBeenCalledWith(portFile, expect.any(String));
+    expect(fs.writeFile).toHaveBeenCalledWith(portFile, expect.any(String), {
+      mode: 0o600,
+    });
 
     await ideServer.stop();
 
@@ -342,8 +344,8 @@ describe('IDEServer', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expectedPortFile,
         expectedContent,
+        { mode: 0o600 },
       );
-      expect(fs.chmod).toHaveBeenCalledWith(expectedPortFile, 0o600);
     },
   );
 

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -158,10 +158,13 @@ describe('IDEServer', () => {
     expect(fs.mkdir).toHaveBeenCalledWith(path.join('/tmp', 'gemini', 'ide'), {
       recursive: true,
     });
+    // The stale/pre-created file is removed before the exclusive write so the
+    // 0o600 mode always applies to a fresh file (see #28278).
+    expect(fs.unlink).toHaveBeenCalledWith(expectedPortFile);
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
-      { mode: 0o600 },
+      { mode: 0o600, flag: 'wx' },
     );
   });
 
@@ -191,7 +194,7 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
-      { mode: 0o600 },
+      { mode: 0o600, flag: 'wx' },
     );
   });
 
@@ -221,7 +224,7 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
-      { mode: 0o600 },
+      { mode: 0o600, flag: 'wx' },
     );
   });
 
@@ -269,7 +272,7 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent,
-      { mode: 0o600 },
+      { mode: 0o600, flag: 'wx' },
     );
 
     // Simulate removing a folder
@@ -288,7 +291,7 @@ describe('IDEServer', () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       expectedPortFile,
       expectedContent2,
-      { mode: 0o600 },
+      { mode: 0o600, flag: 'wx' },
     );
   });
 
@@ -304,6 +307,7 @@ describe('IDEServer', () => {
     );
     expect(fs.writeFile).toHaveBeenCalledWith(portFile, expect.any(String), {
       mode: 0o600,
+      flag: 'wx',
     });
 
     await ideServer.stop();
@@ -344,7 +348,7 @@ describe('IDEServer', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expectedPortFile,
         expectedContent,
-        { mode: 0o600 },
+        { mode: 0o600, flag: 'wx' },
       );
     },
   );

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -88,7 +88,13 @@ async function writePortAndWorkspace({
   log(`Writing port file to: ${portFile}`);
 
   try {
-    await fs.writeFile(portFile, content).then(() => fs.chmod(portFile, 0o600));
+    // Set the file mode atomically at creation time (0o600) instead of
+    // writeFile + chmod. The two-step approach opened a TOCTOU window where
+    // the token file was briefly world-readable (default umask) before chmod
+    // locked it down, letting local attackers read the IDE companion auth
+    // token on multi-user systems. `mode` is honored on POSIX; on Windows it
+    // is ignored (the original chmod was also a no-op there). See #28278.
+    await fs.writeFile(portFile, content, { mode: 0o600 });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log(`Failed to write port to file: ${message}`);

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -93,8 +93,18 @@ async function writePortAndWorkspace({
     // the token file was briefly world-readable (default umask) before chmod
     // locked it down, letting local attackers read the IDE companion auth
     // token on multi-user systems. `mode` is honored on POSIX; on Windows it
-    // is ignored (the original chmod was also a no-op there). See #28278.
-    await fs.writeFile(portFile, content, { mode: 0o600 });
+    // is ignored (the original chmod was also a no-op there).
+    //
+    // `mode` only applies to newly created files - if the file already exists
+    // (e.g. an attacker pre-created it with loose permissions in the shared
+    // /tmp dir, or a stale file from a prior run), writeFile would overwrite
+    // the contents but preserve the insecure mode. Unlink first, then use the
+    // exclusive `wx` flag so creation fails (rather than silently overwriting)
+    // if the file reappears between the unlink and the write. See #28278.
+    await fs.unlink(portFile).catch(() => {
+      // File didn't exist (the common case) - expected, ignore.
+    });
+    await fs.writeFile(portFile, content, { mode: 0o600, flag: 'wx' });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log(`Failed to write port to file: ${message}`);

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -87,25 +87,34 @@ async function writePortAndWorkspace({
 
   log(`Writing port file to: ${portFile}`);
 
+  // Write the port file securely and atomically.
+  //
+  // The original `writeFile + chmod` opened a TOCTOU window where the token
+  // file was briefly world-readable (default umask) before chmod locked it
+  // down, letting local attackers read the IDE companion auth token on
+  // multi-user systems (#28278). `mode` only applies to newly created files,
+  // so we also unlink-then-write with the exclusive `wx` flag to guarantee
+  // 0o600 lands on a fresh file (prevents pre-creation/stale-file attacks
+  // where an attacker pre-creates the file with loose permissions).
+  //
+  // To avoid a window where the port file is missing (unlink + write is not
+  // atomic - a client read in between fails, and a failed write leaves no
+  // file at all), write to a temp file then `rename` it into place. rename is
+  // atomic on POSIX, so clients always see either the old or the new file,
+  // and a failed write leaves the previous port file intact. `mode` is
+  // honored on POSIX; on Windows it is ignored (the prior chmod was already
+  // a no-op there).
+  const tempPortFile = portFile + '.tmp';
   try {
-    // Set the file mode atomically at creation time (0o600) instead of
-    // writeFile + chmod. The two-step approach opened a TOCTOU window where
-    // the token file was briefly world-readable (default umask) before chmod
-    // locked it down, letting local attackers read the IDE companion auth
-    // token on multi-user systems. `mode` is honored on POSIX; on Windows it
-    // is ignored (the original chmod was also a no-op there).
-    //
-    // `mode` only applies to newly created files - if the file already exists
-    // (e.g. an attacker pre-created it with loose permissions in the shared
-    // /tmp dir, or a stale file from a prior run), writeFile would overwrite
-    // the contents but preserve the insecure mode. Unlink first, then use the
-    // exclusive `wx` flag so creation fails (rather than silently overwriting)
-    // if the file reappears between the unlink and the write. See #28278.
-    await fs.unlink(portFile).catch(() => {
-      // File didn't exist (the common case) - expected, ignore.
+    await fs.unlink(tempPortFile).catch(() => {
+      // Temp file didn't exist (the common case) - expected, ignore.
     });
-    await fs.writeFile(portFile, content, { mode: 0o600, flag: 'wx' });
+    await fs.writeFile(tempPortFile, content, { mode: 0o600, flag: 'wx' });
+    await fs.rename(tempPortFile, portFile);
   } catch (err) {
+    await fs.unlink(tempPortFile).catch(() => {
+      // Best-effort cleanup of the temp file on failure.
+    });
     const message = err instanceof Error ? err.message : String(err);
     log(`Failed to write port to file: ${message}`);
   }


### PR DESCRIPTION
Fixes #28278

## Summary

The IDE server wrote the auth-token port file with `fs.writeFile(...).then(() => fs.chmod(portFile, 0o600))`. Between `writeFile` (which creates the file with the default umask, typically `0o666`/`0o644`) and the asynchronous `chmod`, the file was briefly world-readable. On multi-user systems a local attacker could read the IDE companion auth token during that window (TOCTOU).

## Change

Pass `{ mode: 0o600 }` directly to `fs.writeFile` so the file is created with restrictive permissions atomically - no `chmod` step, no window. `mode` is honored on POSIX; on Windows it is ignored (the prior `chmod` was already a no-op there).

```diff
- await fs.writeFile(portFile, content).then(() => fs.chmod(portFile, 0o600));
+ await fs.writeFile(portFile, content, { mode: 0o600 });
```

## Test plan

Updated the existing `ide-server.test.ts` assertions:
- All `expect(fs.writeFile)` calls now assert the third `{ mode: 0o600 }` argument.
- Removed the now-obsolete `expect(fs.chmod).toHaveBeenCalledWith(...)` assertions (chmod is no longer called).

`npx vitest run packages/vscode-ide-companion/src/ide-server.test.ts` -> 13 passed. `tsc -p packages/vscode-ide-companion/tsconfig.json --noEmit` -> no errors.

## Risk & scope

- One production line changed (writeFile + chmod -> writeFile with mode). Same permissions end state (0o600) on POSIX, no behavior change on Windows.
- Only the IDE companion port-file write path is affected; no other call sites.
