### PR TITLE
Fix trust dialog disclosure for runnable hooks

### DIFF
--- a/packages/core/src/services/FolderTrustDiscoveryService.test.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.test.ts
@@ -53,7 +53,11 @@ describe('FolderTrustDiscoveryService', () => {
         'test-mcp': { command: 'node', args: ['test.js'] },
       },
       hooks: {
-        BeforeTool: [{ command: 'test-hook' }],
+        BeforeTool: [
+          {
+            hooks: [{ type: 'command', command: 'test-hook' }],
+          },
+        ],
       },
       general: { vimMode: true },
       ui: { theme: 'Dark' },
@@ -70,10 +74,72 @@ describe('FolderTrustDiscoveryService', () => {
     expect(results.agents).toContain('test-agent');
     expect(results.mcps).toContain('test-mcp');
     expect(results.hooks).toContain('test-hook');
+    expect(results.securityWarnings).toContain(
+      'This project contains hooks that can execute commands.',
+    );
     expect(results.settings).toContain('general');
     expect(results.settings).toContain('ui');
     expect(results.settings).not.toContain('mcpServers');
     expect(results.settings).not.toContain('hooks');
+  });
+
+  it('should discover commands from nested hook definitions that execute', async () => {
+    const geminiDir = path.join(tempDir, GEMINI_DIR);
+    await fs.mkdir(geminiDir, { recursive: true });
+
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: 'echo NESTED_RAN',
+              },
+            ],
+          },
+        ],
+      },
+      ui: { hideBanner: true },
+    };
+    await fs.writeFile(
+      path.join(geminiDir, 'settings.json'),
+      JSON.stringify(settings),
+    );
+
+    const results = await FolderTrustDiscoveryService.discover(tempDir);
+
+    expect(results.hooks).toEqual(['echo NESTED_RAN']);
+    expect(results.securityWarnings).toContain(
+      'This project contains hooks that can execute commands.',
+    );
+  });
+
+  it('should not disclose flat hooks as runnable commands', async () => {
+    const geminiDir = path.join(tempDir, GEMINI_DIR);
+    await fs.mkdir(geminiDir, { recursive: true });
+
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            type: 'command',
+            command: 'echo FLAT_DOES_NOT_RUN',
+          },
+        ],
+      },
+    };
+    await fs.writeFile(
+      path.join(geminiDir, 'settings.json'),
+      JSON.stringify(settings),
+    );
+
+    const results = await FolderTrustDiscoveryService.discover(tempDir);
+
+    expect(results.hooks).toHaveLength(0);
+    expect(results.securityWarnings).not.toContain(
+      'This project contains hooks that can execute commands.',
+    );
   });
 
   it('should flag security warnings for sensitive settings', async () => {

--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -159,17 +159,12 @@ export class FolderTrustDiscoveryService {
 
       const hooksConfig = settings['hooks'];
       if (this.isRecord(hooksConfig)) {
-        const hooks = new Set<string>();
-        for (const event of Object.values(hooksConfig)) {
-          if (!Array.isArray(event)) continue;
-          for (const hook of event) {
-            // eslint-disable-next-line no-restricted-syntax
-            if (this.isRecord(hook) && typeof hook['command'] === 'string') {
-              hooks.add(hook['command']);
-            }
-          }
+        results.hooks = this.extractCommandHooks(hooksConfig);
+        if (results.hooks.length > 0) {
+          results.securityWarnings.push(
+            'This project contains hooks that can execute commands.',
+          );
         }
-        results.hooks = Array.from(hooks);
       }
     } catch (e) {
       results.discoveryErrors.push(
@@ -219,6 +214,35 @@ export class FolderTrustDiscoveryService {
     }
 
     return warnings;
+  }
+
+  private static extractCommandHooks(
+    hooksConfig: Record<string, unknown>,
+  ): string[] {
+    const hooks = new Set<string>();
+
+    for (const definitions of Object.values(hooksConfig)) {
+      if (!Array.isArray(definitions)) continue;
+
+      for (const definition of definitions) {
+        if (!this.isRecord(definition) || !Array.isArray(definition['hooks'])) {
+          continue;
+        }
+
+        for (const hookConfig of definition['hooks']) {
+          if (!this.isRecord(hookConfig) || hookConfig['type'] !== 'command') {
+            continue;
+          }
+
+          const command = hookConfig['command'];
+          if (typeof command === 'string') {
+            hooks.add(command);
+          }
+        }
+      }
+    }
+
+    return Array.from(hooks);
   }
 
   private static isRecord(val: unknown): val is Record<string, unknown> {


### PR DESCRIPTION
Fixes #27901.

## Summary
- Make folder-trust discovery inspect the canonical nested hook definition shape that the hook executor actually runs.
- Stop reporting flat, invalid hook entries as runnable commands.
- Add a warning when project settings contain command hooks that can execute.
- Add regression coverage for nested runnable hooks and flat non-runnable hooks.

## Testing
- npm test --workspace @google/gemini-cli-core -- src/services/FolderTrustDiscoveryService.test.ts
- npm run typecheck --workspace @google/gemini-cli-core
- npm run lint --workspace @google/gemini-cli-core -- --max-warnings 0 src/services/FolderTrustDiscoveryService.ts src/services/FolderTrustDiscoveryService.test.ts
- git diff --check