### PR TITLE
fix(a2a-server): prevent path traversal in restore command (defense-in-depth)

### DIFF
--- a/packages/a2a-server/src/commands/restore.test.ts
+++ b/packages/a2a-server/src/commands/restore.test.ts
@@ -84,6 +84,24 @@ describe('RestoreCommand', () => {
     expect(result.data).toEqual([restoreContent]);
   });
 
+  it.each([
+    '../../../etc/passwd',
+    '../secrets',
+    '../../.gemini/settings.json',
+  ])(
+    'should reject path-traversal input escaping the checkpoint directory: %s',
+    async (traversalInput) => {
+      const command = new RestoreCommand();
+      const result = await command.execute(mockConfig, [traversalInput]);
+      expect(result.data).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: `Invalid checkpoint name: ${traversalInput}`,
+      });
+      expect(mockFs.readFile).not.toHaveBeenCalled();
+    },
+  );
+
   it('should show "file not found" error for a non-existent checkpoint', async () => {
     const command = new RestoreCommand();
     const error = new Error('File not found');

--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -52,6 +52,26 @@ export class RestoreCommand implements Command {
       const checkpointDir = config.storage.getProjectTempCheckpointsDir();
       const filePath = path.join(checkpointDir, selectedFile);
 
+      // Prevent path traversal: ensure the resolved file path stays inside
+      // the checkpoint directory. `path.join` alone does not defend against
+      // inputs like `../../etc/passwd`; a `path.resolve` + `startsWith` guard
+      // rejects any input that would escape `checkpointDir`.
+      const resolvedFilePath = path.resolve(filePath);
+      const resolvedCheckpointDir = path.resolve(checkpointDir);
+      if (
+        resolvedFilePath !== resolvedCheckpointDir &&
+        !resolvedFilePath.startsWith(resolvedCheckpointDir + path.sep)
+      ) {
+        return {
+          name: this.name,
+          data: {
+            type: 'message',
+            messageType: 'error',
+            content: `Invalid checkpoint name: ${argsStr}`,
+          },
+        };
+      }
+
       let data: string;
       try {
         data = await fs.readFile(filePath, 'utf-8');


### PR DESCRIPTION
## Problem
`packages/a2a-server/src/commands/restore.ts` passes the caller-supplied argument straight to `path.join(checkpointDir, selectedFile)` with no normalization or containment check. An input like `../../../etc/passwd` resolves outside `checkpointDir`, letting the `restore` command read (and JSON-parse) any file on the local filesystem — reachable via `POST /executeCommand` to the a2a-server.

## Fix
Add a standard `path.resolve()` + `startsWith(checkpointDir + path.sep)` containment guard before the `fs.readFile` call. Traversal inputs are rejected with an "Invalid checkpoint name" error before any filesystem access occurs.

## Tests
Three new parameterised cases in `restore.test.ts` cover POSIX traversal patterns and assert `fs.readFile` is never called for them. All existing tests still pass (9/9 in the file).

## Threat model note
The a2a-server binds to `localhost` only, so this is defense-in-depth rather than a directly network-reachable vulnerability. The fix is a small hardening of `restore` alone; the underlying auth-boundary of `/executeCommand` (which bypasses `customUserBuilder`) is out of scope for this PR.

## No behaviour change for valid inputs
Checkpoints created via the normal flow live directly inside `checkpointDir` (`getProjectTempCheckpointsDir()`), so their resolved paths satisfy the `startsWith` check and continue to load unchanged.