### PR TITLE
fix(core): strip login/interactive shell wrappers in stripShellWrapper

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -398,6 +398,34 @@ describe('stripShellWrapper', () => {
     const expected = 'hg commit -m "title\n\nbody"';
     expect(stripShellWrapper(multiLine)).toEqual(expected);
   });
+
+  it('should strip bash -lc (login shell) with quotes', () => {
+    expect(stripShellWrapper('bash -lc "rm -rf ~"')).toEqual('rm -rf ~');
+  });
+
+  it('should strip bash -ic (interactive shell) with quotes', () => {
+    expect(stripShellWrapper('bash -ic "rm -rf ~"')).toEqual('rm -rf ~');
+  });
+
+  it('should strip sh -lc without quotes', () => {
+    expect(stripShellWrapper('sh -lc rm -rf ~')).toEqual('rm -rf ~');
+  });
+
+  it('should strip separated login and command flags (bash -l -c)', () => {
+    expect(stripShellWrapper('bash -l -c "rm -rf ~"')).toEqual('rm -rf ~');
+  });
+
+  it('should strip long-form login flag with -c (bash --login -c)', () => {
+    expect(stripShellWrapper('bash --login -c "rm -rf ~"')).toEqual('rm -rf ~');
+  });
+
+  it('should strip an absolute-path login shell (/bin/bash -lc)', () => {
+    expect(stripShellWrapper('/bin/bash -lc "rm -rf ~"')).toEqual('rm -rf ~');
+  });
+
+  it('should not strip an interactive shell that has no -c flag', () => {
+    expect(stripShellWrapper('bash -i')).toEqual('bash -i');
+  });
 });
 
 describe('escapeShellArg', () => {

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -426,6 +426,24 @@ describe('stripShellWrapper', () => {
   it('should not strip an interactive shell that has no -c flag', () => {
     expect(stripShellWrapper('bash -i')).toEqual('bash -i');
   });
+
+  it('should not strip non-canonical option groups where -c is not last', () => {
+    // POSIX Utility Syntax Guideline 5: the argument-taking option (-c) should
+    // be last. For -ci/-cl the command source is shell-dependent, so we leave
+    // the wrapper intact and let the shell-level policy check gate it.
+    expect(stripShellWrapper('bash -ci "rm -rf ~"')).toEqual(
+      'bash -ci "rm -rf ~"',
+    );
+    expect(stripShellWrapper('bash -cl "rm -rf ~"')).toEqual(
+      'bash -cl "rm -rf ~"',
+    );
+  });
+
+  it('should strip an absolute Windows-path login shell (backslash separator)', () => {
+    expect(stripShellWrapper('C:\\tools\\bash -lc "rm -rf ~"')).toEqual(
+      'rm -rf ~',
+    );
+  });
 });
 
 describe('escapeShellArg', () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -840,8 +840,14 @@ export function getCommandRoots(command: string): string[] {
 }
 
 export function stripShellWrapper(command: string): string {
+  // POSIX shells run the wrapped command string whenever the command-string
+  // flag (-c) is present, including when it is combined with login/interactive
+  // flags: `bash -lc "..."`, `bash -ic "..."`, `bash -l -c "..."`,
+  // `bash --login -c "..."`. These forms must be stripped (and re-checked by the
+  // policy engine) exactly like a bare `-c`; matching only `-c` here let the
+  // login/interactive variants slip past the wrapper re-check.
   const pattern =
-    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))\s+-c|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
+    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))\s+(?:(?:-[il]+|--login|--interactive)\s+)*-[il]*c[il]*|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
   const match = command.match(pattern);
   if (match) {
     let newCommand = command.substring(match[0].length).trim();
@@ -850,7 +856,12 @@ export function stripShellWrapper(command: string): string {
       ((newCommand.startsWith('"') && newCommand.endsWith('"')) ||
         (newCommand.startsWith("'") && newCommand.endsWith("'")))
     ) {
-      const isPosixShell = match[0].trim().endsWith('-c');
+      // Detect a POSIX shell wrapper by its shell name rather than a literal
+      // `-c` suffix, so login/interactive forms (`-lc`, `--login -c`, …) take
+      // the same shell-word parsing path as a bare `-c`.
+      const isPosixShell = /(?:^|\/)(?:sh|bash|zsh)\b/i.test(
+        match[0].trimStart(),
+      );
       if (isPosixShell && newCommand.startsWith('"')) {
         try {
           const parsed = parse(newCommand, (key) => '$' + key);

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -846,8 +846,14 @@ export function stripShellWrapper(command: string): string {
   // `bash --login -c "..."`. These forms must be stripped (and re-checked by the
   // policy engine) exactly like a bare `-c`; matching only `-c` here let the
   // login/interactive variants slip past the wrapper re-check.
+  // `-c` must be the LAST character in an option group (`-[il]*c`, e.g. `-lc`):
+  // POSIX Utility Syntax Guideline 5 requires the argument-taking option last,
+  // and for non-canonical groups like `-ci`/`-cl` the command source is
+  // shell-dependent, so we do not fine-grain re-check them here — they fall
+  // through to the shell-level policy check instead. The executable prefix
+  // accepts `/` or `\` so absolute-path invocations are matched on Windows too.
   const pattern =
-    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))\s+(?:(?:-[il]+|--login|--interactive)\s+)*-[il]*c[il]*|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
+    /^\s*(?:(?:(?:\S+[/\\])?(?:sh|bash|zsh))\s+(?:(?:-[il]+|--login|--interactive)\s+)*-[il]*c|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
   const match = command.match(pattern);
   if (match) {
     let newCommand = command.substring(match[0].length).trim();
@@ -858,8 +864,9 @@ export function stripShellWrapper(command: string): string {
     ) {
       // Detect a POSIX shell wrapper by its shell name rather than a literal
       // `-c` suffix, so login/interactive forms (`-lc`, `--login -c`, …) take
-      // the same shell-word parsing path as a bare `-c`.
-      const isPosixShell = /(?:^|\/)(?:sh|bash|zsh)\b/i.test(
+      // the same shell-word parsing path as a bare `-c`. Accept `/` or `\` as
+      // the path separator so an absolute-path shell is still recognised.
+      const isPosixShell = /(?:^|[/\\])(?:sh|bash|zsh)\b/i.test(
         match[0].trimStart(),
       );
       if (isPosixShell && newCommand.startsWith('"')) {


### PR DESCRIPTION
`stripShellWrapper` only recognised a bare `-c` after `sh`/`bash`/`zsh`, so login/interactive command wrappers — `bash -lc "..."`, `bash -ic "..."`, `bash -l -c "..."`, `bash --login -c "..."` — were returned unchanged.

The policy engine only re-checks a wrapped payload when the wrapper is stripped (`stripped !== subCmd` in `policy/policy-engine.ts`). For the login/interactive forms the wrapper wasn't stripped, so the inner command was never re-evaluated against the command allowlist: with `bash` on the allowlist, `bash -lc "rm -rf ~"` ran without confirmation while `bash -c "rm -rf ~"` correctly re-prompted. `isDangerousCommand` doesn't catch it either (no `bash`/`sh` case, no recursion into the quoted arg).

This widens the wrapper regex to accept `-c` combined with login/interactive flags (clustered or separated), and detects the POSIX shell by name so the existing shell-word unquoting path is used for the new forms. Added unit coverage for the login/interactive variants.

Same shape as the previously-fixed "allowlist doesn't apply to chained commands" gap — the wrapper parser was missing another invocation form.