### PR TITLE
fix(core): prevent AbortSignal listener leak in ShellExecutionService

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1303,18 +1303,23 @@ export class ShellExecutionService {
           }
 
           const processingComplete = processingChain.then(() => 'processed');
+          let onAbort: (() => void) | undefined;
           const abortFired = new Promise<'aborted'>((res) => {
             if (abortSignal.aborted) {
               res('aborted');
               return;
             }
-            abortSignal.addEventListener('abort', () => res('aborted'), {
+            onAbort = () => res('aborted');
+            abortSignal.addEventListener('abort', onAbort, {
               once: true,
             });
           });
 
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           Promise.race([processingComplete, abortFired]).then(() => {
+            if (onAbort) {
+              abortSignal.removeEventListener('abort', onAbort);
+            }
             finalize();
           });
         },


### PR DESCRIPTION
## Summary
- fix(core): prevent AbortSignal listener leak in ShellExecutionService

## Details
Ensured the `AbortSignal` event listener is explicitly removed when a process finishes naturally, preventing potential memory leaks during long-lived CLI sessions.

## Related Issues
Fixes #28280

## Validate
Run `npm test -w @google/gemini-cli-core -- src/service/shellExecutionService.test.ts`
Should pass all 66 tests