### PR TITLE
fix(vscode): track activation disposables

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -12,6 +12,11 @@ import {
   detectIdeFromEnv,
 } from '@google/gemini-cli-core/src/ide/detect-ide.js';
 
+const createDisposable = (name: string) => ({
+  name,
+  dispose: vi.fn(),
+});
+
 vi.mock('@google/gemini-cli-core/src/ide/detect-ide.js', async () => {
   const actual = await vi.importActual(
     '@google/gemini-cli-core/src/ide/detect-ide.js',
@@ -43,16 +48,26 @@ vi.mock('vscode', () => ({
   },
   workspace: {
     workspaceFolders: [],
-    onDidCloseTextDocument: vi.fn(),
-    registerTextDocumentContentProvider: vi.fn(),
-    onDidChangeWorkspaceFolders: vi.fn(),
-    onDidGrantWorkspaceTrust: vi.fn(),
+    onDidCloseTextDocument: vi.fn(() =>
+      createDisposable('onDidCloseTextDocument'),
+    ),
+    registerTextDocumentContentProvider: vi.fn(() =>
+      createDisposable('registerTextDocumentContentProvider'),
+    ),
+    onDidChangeWorkspaceFolders: vi.fn(() =>
+      createDisposable('onDidChangeWorkspaceFolders'),
+    ),
+    onDidGrantWorkspaceTrust: vi.fn(() =>
+      createDisposable('onDidGrantWorkspaceTrust'),
+    ),
     getConfiguration: vi.fn(() => ({
       get: vi.fn(),
     })),
   },
   commands: {
-    registerCommand: vi.fn(),
+    registerCommand: vi.fn((command: string) =>
+      createDisposable(`registerCommand:${command}`),
+    ),
     executeCommand: vi.fn(),
   },
   Uri: {
@@ -129,6 +144,27 @@ describe('activate', () => {
   it('should register a handler for onDidGrantWorkspaceTrust', async () => {
     await activate(context);
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
+  });
+
+  it('tracks all activation disposables for cleanup', async () => {
+    await activate(context);
+
+    expect(context.subscriptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'registerCommand:gemini.diff.accept',
+        }),
+        expect.objectContaining({
+          name: 'registerCommand:gemini.diff.cancel',
+        }),
+        expect.objectContaining({
+          name: 'onDidChangeWorkspaceFolders',
+        }),
+        expect.objectContaining({
+          name: 'onDidGrantWorkspaceTrust',
+        }),
+      ]),
+    );
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { activate } from './extension.js';
+import { activate, deactivate } from './extension.js';
 import {
   IDE_DEFINITIONS,
   detectIdeFromEnv,
@@ -31,6 +31,7 @@ vi.mock('vscode', () => ({
   window: {
     createOutputChannel: vi.fn(() => ({
       appendLine: vi.fn(),
+      dispose: vi.fn(),
     })),
     showInformationMessage: vi.fn(),
     createTerminal: vi.fn(() => ({
@@ -114,7 +115,8 @@ describe('activate', () => {
     } as unknown as vscode.ExtensionContext;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await deactivate();
     vi.restoreAllMocks();
   });
 

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

Fixes #27790.

The VS Code companion activation path was wrapping two pairs of registration calls in parentheses inside `context.subscriptions.push(...)`. In JavaScript, those become comma expressions, so both registrations run but only the last Disposable from each pair is tracked.

This PR removes the comma expressions so these activation Disposables are all retained for cleanup:

- `gemini.diff.accept`
- `gemini.diff.cancel`
- `onDidChangeWorkspaceFolders`
- `onDidGrantWorkspaceTrust`

It also updates the extension activation test mock to return tagged Disposables and adds a regression assertion for the affected registrations.

## Validation

- `npm run build -w @google/gemini-cli-core`
- `npm test -w gemini-cli-vscode-ide-companion`
- `npm run check-types -w gemini-cli-vscode-ide-companion`
- `npm run lint -w gemini-cli-vscode-ide-companion`

Note: `npm install` completed locally with engine warnings because this machine is on Node `20.15.0`; the repo recommends Node `~20.19.0` for development.
