### PR TITLE
fix(availability): apply modelIdResolutions to tool sub-agent model configs

### DIFF
--- a/packages/core/src/availability/fallbackIntegration.test.ts
+++ b/packages/core/src/availability/fallbackIntegration.test.ts
@@ -29,6 +29,8 @@ describe('Fallback Integration', () => {
       setActiveModel: vi.fn(),
       getUserTier: () => undefined,
       getHasAccessToPreviewModel: () => true,
+      getGemini31LaunchedSync: () => false,
+      hasGemini35FlashGAAccess: () => false,
       getModelAvailabilityService: () => availabilityService,
       modelConfigService: undefined as unknown as ModelConfigService,
     } as unknown as Config;

--- a/packages/core/src/availability/policyHelpers.test.ts
+++ b/packages/core/src/availability/policyHelpers.test.ts
@@ -37,6 +37,7 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config => {
     },
     getContentGeneratorConfig: () => ({ authType: undefined }),
     getHasAccessToPreviewModel: () => true,
+    hasGemini35FlashGAAccess: () => false,
     getMaxAttemptsPerTurn: () => 3,
     getExperimentalDynamicModelConfiguration: () => false,
     getReleaseChannel: () => 'preview',
@@ -283,6 +284,9 @@ describe('policyHelpers', () => {
   describe('applyModelSelection', () => {
     const mockModelConfigService = {
       getResolvedConfig: vi.fn(),
+      // resolveModelId is called for non-chat-model calls to apply modelIdResolutions
+      // (preview-gated model fallback for API-key users).
+      resolveModelId: vi.fn((model: string) => model),
     };
 
     const mockAvailabilityService = {
@@ -445,6 +449,72 @@ describe('policyHelpers', () => {
       ).not.toHaveBeenCalled();
       expect(config.setActiveModel).toHaveBeenCalledWith('gemini-pro');
       expect(result.maxAttempts).toBe(1);
+    });
+
+    it('applies modelIdResolutions for non-chat tool configs (web-search/web-fetch preview fallback)', () => {
+      // Reproduces the INVALID_MODEL bug: API-key users have hasAccessToPreview=false,
+      // but web-search/web-fetch alias chains resolve to gemini-3-flash-preview which
+      // requires preview access. resolveModelId must map it to gemini-2.5-flash.
+      const config = createExtendedMockConfig({
+        getHasAccessToPreviewModel: () => false,
+        getGemini31LaunchedSync: () => false,
+        hasGemini35FlashGAAccess: () => false,
+      });
+
+      // Alias chain resolves web-search → gemini-3-flash-base → gemini-3-flash-preview
+      mockModelConfigService.getResolvedConfig
+        .mockReturnValueOnce({
+          model: 'gemini-3-flash-preview',
+          generateContentConfig: { tools: [{ googleSearch: {} }] },
+        })
+        // Second call after resolveModelId returns the fallback model config
+        .mockReturnValueOnce({
+          model: 'gemini-2.5-flash',
+          generateContentConfig: { tools: [{ googleSearch: {} }] },
+        });
+
+      // resolveModelId maps gemini-3-flash-preview → gemini-2.5-flash for non-preview users
+      mockModelConfigService.resolveModelId.mockImplementation(
+        (model: string) =>
+          model === 'gemini-3-flash-preview' ? 'gemini-2.5-flash' : model,
+      );
+
+      mockAvailabilityService.selectFirstAvailable.mockReturnValue({
+        selectedModel: 'gemini-2.5-flash',
+      });
+
+      const result = applyModelSelection(config, {
+        model: 'web-search',
+        isChatModel: false,
+      });
+
+      expect(result.model).toBe('gemini-2.5-flash');
+      expect(mockModelConfigService.resolveModelId).toHaveBeenCalledWith(
+        'gemini-3-flash-preview',
+        expect.objectContaining({ hasAccessToPreview: false }),
+      );
+      expect(config.setActiveModel).not.toHaveBeenCalled();
+    });
+
+    it('does not apply modelIdResolutions for chat model calls (already routed)', () => {
+      const config = createExtendedMockConfig({
+        getHasAccessToPreviewModel: () => false,
+      });
+      mockModelConfigService.getResolvedConfig.mockReturnValue({
+        model: 'gemini-2.5-pro',
+        generateContentConfig: {},
+      });
+      mockAvailabilityService.selectFirstAvailable.mockReturnValue({
+        selectedModel: 'gemini-2.5-pro',
+      });
+
+      applyModelSelection(config, {
+        model: 'gemini-2.5-pro',
+        isChatModel: true,
+      });
+
+      // resolveModelId must NOT be called for chat model — router already handled it
+      expect(mockModelConfigService.resolveModelId).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/availability/policyHelpers.ts
+++ b/packages/core/src/availability/policyHelpers.ts
@@ -286,15 +286,39 @@ export function applyModelSelection(
   options: { consumeAttempt?: boolean } = {},
 ): { model: string; config: GenerateContentConfig; maxAttempts?: number } {
   const resolved = config.modelConfigService.getResolvedConfig(modelConfigKey);
-  const model = resolved.model;
+
+  // Tool sub-agent configs (web-search, web-fetch, loop-detection, etc.) resolve
+  // their alias chain to a concrete model ID (e.g. gemini-3-flash-preview via
+  // gemini-3-flash-base) but never go through modelIdResolutions. This means
+  // API-key users without preview access hit INVALID_MODEL. For non-chat-model
+  // calls, apply modelIdResolutions now so preview-gated sub-agent models fall
+  // back to the appropriate GA model (e.g. gemini-2.5-flash).
+  let model = resolved.model;
+  let resolvedGenerateContentConfig = resolved.generateContentConfig;
+  if (!modelConfigKey.isChatModel) {
+    const resolvedModelId = config.modelConfigService.resolveModelId(model, {
+      hasAccessToPreview: config.getHasAccessToPreviewModel?.() ?? false,
+      useGemini3_1: config.getGemini31LaunchedSync?.() ?? false,
+      useGemini3_5Flash: config.hasGemini35FlashGAAccess?.() ?? false,
+    });
+    if (resolvedModelId !== model) {
+      model = resolvedModelId;
+      const refetchedResolved = config.modelConfigService.getResolvedConfig({
+        ...modelConfigKey,
+        model,
+      });
+      resolvedGenerateContentConfig = refetchedResolved.generateContentConfig;
+    }
+  }
+
   const selection = selectModelForAvailability(config, model);
 
   if (!selection) {
-    return { model, config: resolved.generateContentConfig };
+    return { model, config: resolvedGenerateContentConfig };
   }
 
   const finalModel = selection.selectedModel ?? model;
-  let generateContentConfig = resolved.generateContentConfig;
+  let generateContentConfig = resolvedGenerateContentConfig;
 
   if (finalModel !== model) {
     const fallbackResolved = config.modelConfigService.getResolvedConfig({

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -118,6 +118,7 @@ describe('BaseLlmClient', () => {
         getResolvedConfig: vi
           .fn()
           .mockImplementation(({ model }) => makeResolvedModelConfig(model)),
+        resolveModelId: vi.fn((model: string) => model),
       } as unknown as ModelConfigService,
       getModelAvailabilityService: vi
         .fn()
@@ -128,6 +129,9 @@ describe('BaseLlmClient', () => {
       getMaxAttempts: vi.fn().mockReturnValue(3),
       getModel: vi.fn().mockReturnValue('test-model'),
       getActiveModel: vi.fn().mockReturnValue('test-model'),
+      getHasAccessToPreviewModel: vi.fn().mockReturnValue(true),
+      getGemini31LaunchedSync: vi.fn().mockReturnValue(false),
+      hasGemini35FlashGAAccess: vi.fn().mockReturnValue(false),
     } as unknown as Mocked<Config>;
 
     client = new BaseLlmClient(mockContentGenerator, mockConfig);


### PR DESCRIPTION
## Problem

Fixes #28390

`web-search`, `web-fetch`, and other utility tool configs extend `gemini-3-flash-base` which hardcodes `gemini-3-flash-preview`. This model ID was never run through `modelIdResolutions`, so API-key users without preview access (`hasAccessToPreview: false`) hit `INVALID_MODEL` on every web tool call — completely breaking web search and URL fetching for these users.

**Affected aliases** (all inherit from `gemini-3-flash-base`):
- `web-search`
- `web-fetch`
- `web-fetch-fallback`
- `loop-detection`
- `llm-edit-fixer`
- `next-speaker-checker`
- `context-snapshotter`

## Root Cause

`applyModelSelection` calls `getResolvedConfig` to walk the alias chain:

```
web-search → gemini-3-flash-base → (base) → model: gemini-3-flash-preview
```

The resolved model string (`gemini-3-flash-preview`) is returned directly and used as-is. It is never passed through `resolveModelId`, which already has the correct fallback contexts defined in `defaultModelConfigs.ts`:

```typescript
'gemini-3-flash-preview': {
  default: 'gemini-3-flash-preview',
  contexts: [
    { condition: { hasAccessToPreview: false, useGemini3_5Flash: true }, target: 'gemini-3.5-flash' },
    { condition: { hasAccessToPreview: false, useGemini3_5Flash: false }, target: 'gemini-2.5-flash' },
  ],
},
```

The fix logic exists — it just was not applied to non-chat-model calls.

For comparison, the main chat model goes through `ModelRouterService` which does call `resolveModelId`. Tool/utility model calls go directly through `applyModelSelection` and skip that step entirely.

## Fix

In `applyModelSelection` (`packages/core/src/availability/policyHelpers.ts`), for non-chat-model requests, run the alias-resolved model through `resolveModelId` with the current session context before proceeding with availability selection:

```typescript
if (!modelConfigKey.isChatModel) {
  const resolvedModelId = config.modelConfigService.resolveModelId(model, {
    hasAccessToPreview: config.getHasAccessToPreviewModel(),
    useGemini3_1: config.getGemini31LaunchedSync(),
    useGemini3_5Flash: config.hasGemini35FlashGAAccess(),
  });
  if (resolvedModelId !== model) {
    model = resolvedModelId;
    // Re-fetch generateContentConfig for the resolved model
    const refetchedResolved = config.modelConfigService.getResolvedConfig({
      ...modelConfigKey,
      model,
    });
    resolvedGenerateContentConfig = refetchedResolved.generateContentConfig;
  }
}
```

Chat model calls are explicitly excluded — the router already handles resolution for those.

## Result

| User type | Before | After |
|---|---|---|
| OAuth / preview access | `gemini-3-flash-preview` ✓ | `gemini-3-flash-preview` ✓ (unchanged) |
| API key, no preview, no Gemini 3.5 GA | `INVALID_MODEL` ✗ | `gemini-2.5-flash` ✓ |
| API key, no preview, Gemini 3.5 GA | `INVALID_MODEL` ✗ | `gemini-3.5-flash` ✓ |

## Testing

- Added `applies modelIdResolutions for non-chat tool configs (web-search/web-fetch preview fallback)` — asserts `gemini-3-flash-preview` → `gemini-2.5-flash` when `hasAccessToPreview: false`
- Added `does not apply modelIdResolutions for chat model calls (already routed)` — asserts `resolveModelId` is NOT called for chat model path
- Updated 3 partial mock configs in `policyHelpers.test.ts`, `fallbackIntegration.test.ts`, and `baseLlmClient.test.ts` that were missing the new config methods
- 208 tests pass across all affected packages

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] Tests pass locally (`npx vitest run packages/core/src/availability/ packages/core/src/core/baseLlmClient.test.ts packages/core/src/tools/web-search.test.ts packages/core/src/tools/web-fetch.test.ts`)
- [x] Linting passes (pre-commit hook: prettier + eslint)
- [x] My commits are signed off