### PR TITLE
fix(core,a2a): group cancelled tool responses and coalesce consecutive roles to prevent 400 Bad Request

### DIFF
--- a/packages/a2a-server/src/agent/task.ts
+++ b/packages/a2a-server/src/agent/task.ts
@@ -1092,19 +1092,21 @@ export class Task {
     logger.info(
       `[Task] Adding ${completedTools.length} tool responses to history without generating a new response.`,
     );
-    const responsesToAdd = completedTools.flatMap(
-      (toolCall) => toolCall.response.responseParts,
-    );
-
-    for (const response of responsesToAdd) {
-      let parts: genAiPart[];
-      if (Array.isArray(response)) {
-        parts = response;
-      } else if (typeof response === 'string') {
-        parts = [{ text: response }];
-      } else {
-        parts = [response];
+    const parts: genAiPart[] = [];
+    for (const toolCall of completedTools) {
+      const response = toolCall.response?.responseParts;
+      if (!response) {
+        continue;
       }
+      if (Array.isArray(response)) {
+        parts.push(...response);
+      } else if (typeof response === 'string') {
+        parts.push({ text: response });
+      } else {
+        parts.push(response);
+      }
+    }
+    if (parts.length > 0) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.geminiClient.addHistory({
         role: 'user',

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -21,6 +21,7 @@ import {
   type StreamEvent,
   stripToolCallIdPrefixes,
   type HistoryTurn,
+  coalesceConsecutiveRoles,
 } from './geminiChat.js';
 import {
   type CompletedToolCall,
@@ -3135,6 +3136,64 @@ describe('GeminiChat', () => {
       const stripped = stripToolCallIdPrefixes(contents);
       expect(stripped[0].parts![0].functionCall!.id).toBe('call_123');
       expect(stripped[1].parts![0].functionResponse!.id).toBe('call_123');
+    });
+  });
+
+  describe('coalesceConsecutiveRoles', () => {
+    it('should return empty history if empty array is passed', () => {
+      expect(coalesceConsecutiveRoles([])).toEqual([]);
+    });
+
+    it('should not modify history when roles alternate correctly', () => {
+      const history: HistoryTurn[] = [
+        { id: '1', content: { role: 'user', parts: [{ text: 'hello' }] } },
+        { id: '2', content: { role: 'model', parts: [{ text: 'hi' }] } },
+        {
+          id: '3',
+          content: { role: 'user', parts: [{ text: 'how are you?' }] },
+        },
+      ];
+      expect(coalesceConsecutiveRoles(history)).toEqual(history);
+    });
+
+    it('should coalesce consecutive user turns', () => {
+      const history: HistoryTurn[] = [
+        { id: '1', content: { role: 'user', parts: [{ text: 'hello' }] } },
+        { id: '2', content: { role: 'user', parts: [{ text: 'world' }] } },
+      ];
+      expect(coalesceConsecutiveRoles(history)).toEqual([
+        {
+          id: '1',
+          content: {
+            role: 'user',
+            parts: [{ text: 'hello' }, { text: 'world' }],
+          },
+        },
+      ]);
+    });
+
+    it('should handle undefined or missing parts gracefully', () => {
+      const history: HistoryTurn[] = [
+        { id: '1', content: { role: 'user' } },
+        { id: '2', content: { role: 'user', parts: [{ text: 'world' }] } },
+      ];
+      expect(coalesceConsecutiveRoles(history)).toEqual([
+        {
+          id: '1',
+          content: {
+            role: 'user',
+            parts: [{ text: 'world' }],
+          },
+        },
+      ]);
+    });
+
+    it('should not coalesce turns if roles are undefined', () => {
+      const history: HistoryTurn[] = [
+        { id: '1', content: { parts: [{ text: 'hello' }] } },
+        { id: '2', content: { parts: [{ text: 'world' }] } },
+      ];
+      expect(coalesceConsecutiveRoles(history)).toEqual(history);
     });
   });
 });

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -683,9 +683,12 @@ export class GeminiChat {
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     // Last mile scrubbing to remove internal tracking properties (e.g. callIndex)
     // before sending to the Gemini API. This whitelists only standard Gemini fields.
-    const scrubbedHistory = this.context.config.isContextManagementEnabled()
+    let scrubbedHistory = this.context.config.isContextManagementEnabled()
       ? scrubHistory([...requestHistory])
       : [...requestHistory];
+
+    // Always coalesce consecutive roles to prevent 400 Bad Request errors
+    scrubbedHistory = coalesceConsecutiveRoles(scrubbedHistory);
 
     const scrubbedContents = scrubbedHistory.map((h) => h.content);
 
@@ -1471,4 +1474,32 @@ export function stripToolCallIdPrefixes(contents: Content[]): Content[] {
       return newPart;
     }),
   }));
+}
+
+export function coalesceConsecutiveRoles(
+  history: HistoryTurn[],
+): HistoryTurn[] {
+  const result: HistoryTurn[] = [];
+  for (const turn of history) {
+    const lastIdx = result.length - 1;
+    const last = result[lastIdx];
+    if (last && last.content.role && last.content.role === turn.content.role) {
+      const hasParts = last.content.parts || turn.content.parts;
+      result[lastIdx] = {
+        id: last.id,
+        content: {
+          ...last.content,
+          parts: hasParts
+            ? [...(last.content.parts || []), ...(turn.content.parts || [])]
+            : undefined,
+        },
+      };
+    } else {
+      result.push({
+        id: turn.id,
+        content: { ...turn.content },
+      });
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

This PR fixes the severe `400 Bad Request` error that occurs when a user sends a subsequent prompt after rejecting/cancelling tool calls in a chat session. This issue was highly disruptive as it completely broke chat continuity, forcing users to start a new chat session and lose all context.

## Details

The `400 Bad Request` error was caused by two distinct history corruption bugs that violated the Gemini API's strict conversation history schema:

1. **Issue A (Parallel Tool Rejections):** In `packages/a2a-server/src/agent/task.ts`, the `addToolResponsesToHistory` method looped over completed (cancelled) tools and added each one as a **separate** user turn. This violated the Gemini API requirement that all parallel tool responses must be grouped within a **single** user turn.
   * *Fix:* Refactored `addToolResponsesToHistory` to group all cancelled tool responses into a single user turn with multiple `functionResponse` parts.

2. **Issue B (Consecutive User Turns):** Even for a single tool rejection, a user turn is added for the rejection, and the next prompt adds another consecutive user turn. Because `contextManagement` is disabled by default, these consecutive user turns were sent directly to the Gemini API, violating its strict role-alternation protocol.
   * *Fix:* Added a lightweight `coalesceConsecutiveRoles` helper function and integrated it into `makeApiCallAndProcessStream` in `packages/core/src/core/geminiChat.ts` to always merge consecutive turns of the same role before sending history to the Gemini API. This ensures consecutive user turns are always coalesced, while perfectly preserving thoughts and binary injections when context management is disabled.

## Related Issues


## How to Validate

1. **Install Dependencies & Build:**
   ```bash
   npm install && npm run build
   ```

2. **Run A2A Server Tests:**
   ```bash
   npx vitest run packages/a2a-server
   ```
   Verify that all 140 tests pass successfully.

3. **Run Core Chat Tests:**
   ```bash
   npx vitest run packages/core/src/core/geminiChat.test.ts --test-timeout=15000
   ```
   Verify that all 60 tests pass successfully (including the complex binary injection tests).

4. **Run Linter:**
   ```bash
   npm run lint
   ```
   Verify that the linter passes with 0 warnings and 0 errors.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker