### PR TITLE
refactor(cli): centralize dense payload detection in tool mapping

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -33,7 +33,6 @@ import {
   WEB_FETCH_DISPLAY_NAME,
   WRITE_FILE_DISPLAY_NAME,
   READ_MANY_FILES_DISPLAY_NAME,
-  isFileDiff,
 } from '@google/gemini-cli-core';
 import { buildToolVisibilityContextFromDisplay } from '../../utils/historyUtils.js';
 import { useUIState } from '../../contexts/UIStateContext.js';
@@ -68,29 +67,6 @@ export const isCompactTool = (
     hasCompactOutputSupport &&
     displayStatus !== ToolCallStatus.Confirming
   );
-};
-
-// Helper to identify if a compact tool has a payload (diff, list, etc.)
-export const hasDensePayload = (tool: IndividualToolCallDisplay): boolean => {
-  if (tool.outputFile) return true;
-  const res = tool.resultDisplay;
-  if (!res) return false;
-
-  // TODO(24053): Usage of type guards makes this class too aware of internals
-  if (isFileDiff(res)) return true;
-  if (tool.confirmationDetails?.type === 'edit') return true;
-
-  // Generic summary/payload pattern
-  if (
-    typeof res === 'object' &&
-    res !== null &&
-    'summary' in res &&
-    'payload' in res
-  ) {
-    return true;
-  }
-
-  return false;
 };
 
 interface ToolGroupMessageProps {
@@ -279,7 +255,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   for (const tool of visibleToolCalls) {
     if (tool.kind !== Kind.Agent) {
       if (isCompactTool(tool, isCompactModeEnabled)) {
-        if (hasDensePayload(tool)) {
+        if (tool.hasDensePayload) {
           countToolCallsWithResults++;
         }
       } else if (

--- a/packages/cli/src/ui/hooks/toolMapping.ts
+++ b/packages/cli/src/ui/hooks/toolMapping.ts
@@ -11,6 +11,7 @@ import {
   debugLogger,
   CoreToolCallStatus,
   type SubagentActivityItem,
+  isFileDiff,
 } from '@google/gemini-cli-core';
 import {
   type HistoryItemToolGroup,
@@ -107,6 +108,16 @@ export function mapToDisplay(
       }
     }
 
+    const hasDensePayload = !!(
+      outputFile ||
+      (resultDisplay && isFileDiff(resultDisplay)) ||
+      confirmationDetails?.type === 'edit' ||
+      (typeof resultDisplay === 'object' &&
+        resultDisplay !== null &&
+        'summary' in resultDisplay &&
+        'payload' in resultDisplay)
+    );
+
     return {
       ...baseDisplayProperties,
       status: call.status,
@@ -125,6 +136,7 @@ export function mapToDisplay(
       subagentHistory: hasSubagentHistory(call)
         ? call.subagentHistory
         : undefined,
+      hasDensePayload,
     };
   });
 

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -139,6 +139,7 @@ export interface IndividualToolCallDisplay {
   progress?: number;
   progressTotal?: number;
   subagentHistory?: SubagentActivityItem[];
+  hasDensePayload?: boolean;
 }
 
 export interface CompressionProps {


### PR DESCRIPTION
### Title: `refactor(ui): centralize dense payload detection in tool mapping`

   ## Summary
   Refactors the UI to reduce its awareness of backend data internals. It moves the complex payload density
   detection logic from `ToolGroupMessage` into `mapToDisplay` by introducing a `hasDensePayload` boolean
   property to the `IndividualToolCallDisplay` interface.

   ## Details
   Previously, UI components (`ToolGroupMessage.tsx`) contained brittle type guards (`isFileDiff`) and object
   shape checks to determine if a tool output was "dense" (e.g., a diff or structured object). This logic is
   now centralized in `mapToDisplay`, making the UI component lighter and easier to maintain.

   ## Related Issues
   #28260

   ## How to Validate
   Run the targeted UI tests to ensure no regressions in component rendering:
   ```bash
   npm test -w @google/gemini-cli-cli -- src/ui/components/messages/ToolGroupMessage.test.tsx
   npm test -w @google/gemini-cli-cli -- src/ui/components/messages/ToolGroupMessage.compact.test.tsx
   npm test -w @google/gemini-cli-cli -- src/ui/components/messages/ToolGroupMessageRegression.test.tsx
   ```

   ## Pre-Merge Checklist
   - [ ] Updated relevant documentation and README (if needed)
   - [ ] Added/updated tests (if needed)
   - [ ] Noted breaking changes (if any)
   - [ ] Validated on required platforms/methods (Please confirm validation status)
