### PR TITLE
fix(core): shorten MCP tools/list discovery timeout so it fails fast

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -190,7 +190,129 @@ describe('mcp-client', () => {
       });
       expect(mockedClient.listTools).toHaveBeenCalledWith(
         {},
-        expect.objectContaining({ timeout: 600000, progressReporter: client }),
+        expect.objectContaining({ timeout: 10000, progressReporter: client }),
+      );
+    });
+
+    it('should use a short discovery timeout for tools/list when no per-server timeout is configured', async () => {
+      const mockedClient = {
+        connect: vi.fn(),
+        getStatus: vi.fn(),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        setNotificationHandler: vi.fn(),
+        getServerCapabilities: vi.fn().mockReturnValue({ tools: {} }),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            {
+              name: 'testFunction',
+              inputSchema: { type: 'object', properties: {} },
+            },
+          ],
+        }),
+        listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+        request: vi.fn().mockResolvedValue({}),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+        {} as SdkClientStdioLib.StdioClientTransport,
+      );
+      const mockedToolRegistry = {
+        registerTool: vi.fn(),
+        sortTools: vi.fn(),
+        getToolsByServer: vi.fn().mockReturnValue([]),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
+      } as unknown as ToolRegistry;
+      const promptRegistry = {
+        registerPrompt: vi.fn(),
+        getPromptsByServer: vi.fn().mockReturnValue([]),
+        removePromptsByServer: vi.fn(),
+      } as unknown as PromptRegistry;
+      const resourceRegistry = {
+        getResourcesByServer: vi.fn().mockReturnValue([]),
+        setResourcesForServer: vi.fn(),
+        removeResourcesByServer: vi.fn(),
+      } as unknown as ResourceRegistry;
+      const client = new McpClient(
+        'test-server',
+        { command: 'test-command' },
+        workspaceContext,
+        MOCK_CONTEXT,
+        false,
+        '0.0.1',
+      );
+      await client.connect();
+      await client.discoverInto(MOCK_CONTEXT, {
+        toolRegistry: mockedToolRegistry,
+        promptRegistry,
+        resourceRegistry,
+      });
+      expect(mockedClient.listTools).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ timeout: 10000 }),
+      );
+    });
+
+    it('should honor an explicit per-server timeout for tools/list discovery', async () => {
+      const mockedClient = {
+        connect: vi.fn(),
+        getStatus: vi.fn(),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        setNotificationHandler: vi.fn(),
+        getServerCapabilities: vi.fn().mockReturnValue({ tools: {} }),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            {
+              name: 'testFunction',
+              inputSchema: { type: 'object', properties: {} },
+            },
+          ],
+        }),
+        listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+        request: vi.fn().mockResolvedValue({}),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+        {} as SdkClientStdioLib.StdioClientTransport,
+      );
+      const mockedToolRegistry = {
+        registerTool: vi.fn(),
+        sortTools: vi.fn(),
+        getToolsByServer: vi.fn().mockReturnValue([]),
+        getMessageBus: vi.fn().mockReturnValue(undefined),
+      } as unknown as ToolRegistry;
+      const promptRegistry = {
+        registerPrompt: vi.fn(),
+        getPromptsByServer: vi.fn().mockReturnValue([]),
+        removePromptsByServer: vi.fn(),
+      } as unknown as PromptRegistry;
+      const resourceRegistry = {
+        getResourcesByServer: vi.fn().mockReturnValue([]),
+        setResourcesForServer: vi.fn(),
+        removeResourcesByServer: vi.fn(),
+      } as unknown as ResourceRegistry;
+      const client = new McpClient(
+        'test-server',
+        { command: 'test-command', timeout: 45000 },
+        workspaceContext,
+        MOCK_CONTEXT,
+        false,
+        '0.0.1',
+      );
+      await client.connect();
+      await client.discoverInto(MOCK_CONTEXT, {
+        toolRegistry: mockedToolRegistry,
+        promptRegistry,
+        resourceRegistry,
+      });
+      expect(mockedClient.listTools).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ timeout: 45000 }),
       );
     });
 
@@ -1785,6 +1907,9 @@ describe('mcp-client', () => {
         expect.anything(),
         expect.objectContaining({
           signal: expect.any(AbortSignal),
+          // The configured per-server timeout must still be forwarded on the
+          // refresh path, not discarded when a signal is also passed.
+          timeout: 50,
         }),
       );
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -94,6 +94,12 @@ import {
 
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
+// Default timeout for the MCP tools/list discovery request. Discovery runs at
+// startup and should fail fast so a slow or misbehaving server does not silently
+// freeze the CLI for the full invocation timeout. This is only a default: an
+// explicit per-server `timeout` still takes precedence.
+export const MCP_DISCOVERY_TIMEOUT_MSEC = 10 * 1000; // default to 10 seconds
+
 export type DiscoveredMCPPrompt = Prompt & {
   serverName: string;
   invoke: (params: Record<string, unknown>) => Promise<GetPromptResult>;
@@ -338,9 +344,11 @@ export class McpClient implements McpProgressReporter {
       cliConfig,
       messageBus,
       {
-        ...(options ?? {
-          timeout: this.serverConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
-        }),
+        // Apply the discovery default first so it is used even when a caller
+        // (e.g. the refresh path) passes other options such as an abort signal.
+        // An explicit `timeout` in `options` still takes precedence.
+        timeout: this.serverConfig.timeout ?? MCP_DISCOVERY_TIMEOUT_MSEC,
+        ...options,
         progressReporter: this,
       },
     );
@@ -1238,7 +1246,7 @@ export async function connectAndDiscover(
       mcpClient,
       cliConfig,
       toolRegistry.messageBus,
-      { timeout: mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC },
+      { timeout: mcpServerConfig.timeout ?? MCP_DISCOVERY_TIMEOUT_MSEC },
     );
 
     // If we have neither prompts nor tools, it's a failed discovery


### PR DESCRIPTION
## Summary

The MCP `tools/list` discovery request could silently freeze the CLI for 10
minutes at startup when a server did not answer it (for example, replying with a
mismatched JSON-RPC id). This gives `tools/list` discovery a short default
timeout so it fails fast.

## Details

`tools/list` discovery reused `MCP_DEFAULT_TIMEOUT_MSEC` (10 minutes), the
default meant for long-running tool invocations. It was the only discovery call
that passed that 10-minute value. When a server's response is ignored per
JSON-RPC (mismatched id), the request stays pending for the full timeout with no
spinner or warning, then disconnects.

This adds `MCP_DISCOVERY_TIMEOUT_MSEC` (10s) and uses it as the default for the
`tools/list` discovery calls (both the live `discoverInto` path and the
standalone `connectAndDiscover` path). It is only a default: an explicit
per-server `timeout` still wins, so a deliberately slow server keeps its
configured value. The failure is reported through the existing MCP diagnostic
channel, which now fires within 10s instead of 10 minutes.

### Scope and trade-offs

This is deliberately limited to the `tools/list` discovery request, which is the
one call that used the 10-minute default:

- `prompts/list` and `resources/list` do not pass this default; they already use
  the MCP SDK default (60s), so they were never part of the 10-minute freeze.
- The connection handshake (`connect` / `initialize`) and the tool-invocation
  timeout are intentionally unchanged. The handshake is a separate failure mode
  and touches the OAuth/SSE paths, so it is out of scope for this fix.
- A server whose `tools/list` legitimately takes longer than the default and has
  no explicit `timeout` set will be skipped for that session. The escape hatch
  is the existing per-server `timeout` setting, which still takes precedence.

## Related Issues

Fixes #28355

## How to Validate

1. Configure an MCP server that never answers `tools/list`, or answers with a
   mismatched JSON-RPC id.
2. Start the CLI.
   - Before: discovery hangs about 10 minutes with no feedback.
   - After: discovery gives up in about 10 seconds and the MCP diagnostic
     surfaces the failure.
3. Set an explicit `timeout` for that server and confirm discovery honors it.

Unit tests:

```
npm test -w @google/gemini-cli-core -- src/tools/mcp-client.test.ts
```

- `tools/list` discovery uses the 10s default when no per-server timeout is set
- `tools/list` discovery honors an explicit per-server timeout

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed). Not needed, there
      is no user-facing setting or docs change.
- [x] Added/updated tests
- [ ] Noted breaking changes (none)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Validated on macOS via the core unit test suite (the change is
platform-independent timeout logic). Not manually exercised on Windows, Linux,
or the container and sandbox launchers.
