### PR TITLE
Trim tool names before registry lookup

### DIFF
--- a/scripts/tests/tool-registry.test.ts
+++ b/scripts/tests/tool-registry.test.ts
@@ -73,6 +73,10 @@ describe('tool-registry', () => {
       );
     });
 
+    it('trims whitespace around tool names', () => {
+      expect(resolveToolName(registry, ' grep_search ')).toBe('grep_search');
+    });
+
     it('returns undefined for unknown tool names', () => {
       expect(resolveToolName(registry, 'nonexistent_tool')).toBeUndefined();
     });

--- a/scripts/utils/tool-registry.ts
+++ b/scripts/utils/tool-registry.ts
@@ -129,10 +129,11 @@ export function resolveToolName(
   registry: ToolRegistry,
   name: string,
 ): string | undefined {
-  if (!name) {
+  const normalizedName = name.trim();
+  if (!normalizedName) {
     return undefined;
   }
-  return registry.aliasLookup.get(name);
+  return registry.aliasLookup.get(normalizedName);
 }
 
 export function getToolsByCategory(


### PR DESCRIPTION
## Summary
- trim outer whitespace before resolving tool names through the script tool registry
- add a focused regression test for whitespace-padded tool names

## Validation
- npm ci --ignore-scripts
- npm run generate
- npm run build --workspace @google/gemini-cli-core
- npm run test:scripts -- scripts/tests/tool-registry.test.ts