### PR TITLE
fix(auth): use native fetch for OAuth token exchange to avoid "Premature close"

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -9,6 +9,7 @@ import {
   Compute,
   GoogleAuth,
   type Credentials,
+  type OAuth2ClientOptions,
 } from 'google-auth-library';
 import {
   describe,
@@ -1604,6 +1605,84 @@ describe('oauth2', () => {
         // Third call, after clearing cache, should create a new client
         await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
         expect(OAuth2Client).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('transporter fetch implementation', () => {
+      const primeCachedClient = async () => {
+        const mockOAuth2Client = {
+          setCredentials: vi.fn(),
+          getAccessToken: vi.fn().mockResolvedValue({ token: 'test-token' }),
+          getTokenInfo: vi.fn().mockResolvedValue({}),
+          on: vi.fn(),
+        } as unknown as OAuth2Client;
+        vi.mocked(OAuth2Client).mockImplementation(() => mockOAuth2Client);
+
+        // Seed a cached token so getOauthClient takes the fast path. It still
+        // builds the OAuth2Client first, which is the part we want to inspect.
+        const credsPath = path.join(
+          tempHomeDir,
+          GEMINI_DIR,
+          'oauth_creds.json',
+        );
+        await fs.promises.mkdir(path.dirname(credsPath), { recursive: true });
+        await fs.promises.writeFile(
+          credsPath,
+          JSON.stringify({ refresh_token: 'token' }),
+        );
+      };
+
+      const getTransporterOptions = () => {
+        const options = vi.mocked(OAuth2Client).mock
+          .calls[0][0] as OAuth2ClientOptions;
+        return options.transporterOptions as
+          | { proxy?: string; fetchImplementation?: unknown }
+          | undefined;
+      };
+
+      it('uses the native fetch implementation when no proxy is configured', async () => {
+        const mockConfigNoProxy = {
+          getNoBrowser: () => false,
+          getProxy: () => undefined,
+          isBrowserLaunchSuppressed: () => false,
+          getAcpMode: () => false,
+          isInteractive: () => true,
+        } as unknown as Config;
+        await primeCachedClient();
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfigNoProxy);
+
+        const transporterOptions = getTransporterOptions();
+        expect(transporterOptions?.proxy).toBeUndefined();
+        expect(typeof transporterOptions?.fetchImplementation).toBe('function');
+      });
+
+      it('keeps the default (node-fetch) implementation when a proxy is configured', async () => {
+        await primeCachedClient();
+
+        // mockConfig already points at a proxy.
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+        const transporterOptions = getTransporterOptions();
+        expect(transporterOptions?.proxy).toBe('http://test.proxy.com:8080');
+        expect(transporterOptions?.fetchImplementation).toBeUndefined();
+      });
+
+      it('respects the GEMINI_OAUTH_USE_NODE_FETCH escape hatch', async () => {
+        vi.stubEnv('GEMINI_OAUTH_USE_NODE_FETCH', '1');
+        const mockConfigNoProxy = {
+          getNoBrowser: () => false,
+          getProxy: () => undefined,
+          isBrowserLaunchSuppressed: () => false,
+          getAcpMode: () => false,
+          isInteractive: () => true,
+        } as unknown as Config;
+        await primeCachedClient();
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfigNoProxy);
+
+        const transporterOptions = getTransporterOptions();
+        expect(transporterOptions?.fetchImplementation).toBeUndefined();
       });
     });
   });

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -12,6 +12,7 @@ import {
   type Credentials,
   type AuthClient,
   type JWTInput,
+  type OAuth2ClientOptions,
 } from 'google-auth-library';
 import * as http from 'node:http';
 import url from 'node:url';
@@ -113,6 +114,43 @@ function getUseEncryptedStorageFlag() {
   return process.env[FORCE_ENCRYPTED_FILE_ENV_VAR] === 'true';
 }
 
+type TransporterOptions = OAuth2ClientOptions['transporterOptions'];
+
+// gaxios (pulled in through google-auth-library) picks its fetch by looking for
+// a browser `window.fetch`. That check never passes in Node, so it always falls
+// back to node-fetch@2, even on Node versions that already have a global fetch.
+//
+// On some headless VPSes node-fetch chokes on the token-exchange response and
+// throws "Invalid response body while trying to fetch
+// https://oauth2.googleapis.com/token: Premature close", which makes login
+// impossible. The exact same request succeeds via curl and Node's built-in
+// fetch, so we just point gaxios at the native fetch instead.
+//
+// We only do this when there's no proxy. gaxios routes proxies through a Node
+// http(s) agent that native fetch doesn't understand, so proxied setups keep
+// using node-fetch. GEMINI_OAUTH_USE_NODE_FETCH=1 forces the old behaviour if
+// the native path ever misbehaves somewhere.
+function getOauthTransporterOptions(
+  proxy: string | undefined,
+): TransporterOptions {
+  const options = { proxy } as NonNullable<TransporterOptions>;
+
+  const nativeFetch = globalThis.fetch;
+  if (
+    !proxy &&
+    typeof nativeFetch === 'function' &&
+    process.env['GEMINI_OAUTH_USE_NODE_FETCH'] !== '1'
+  ) {
+    // Bind it so undici's fetch keeps its own `this`, then cast to the type
+    // gaxios expects.
+    options.fetchImplementation = nativeFetch.bind(
+      globalThis,
+    ) as NonNullable<TransporterOptions>['fetchImplementation'];
+  }
+
+  return options;
+}
+
 async function initOauthClient(
   authType: AuthType,
   config: Config,
@@ -143,9 +181,7 @@ async function initOauthClient(
   const client = new OAuth2Client({
     clientId: OAUTH_CLIENT_ID,
     clientSecret: OAUTH_CLIENT_SECRET,
-    transporterOptions: {
-      proxy: config.getProxy(),
-    },
+    transporterOptions: getOauthTransporterOptions(config.getProxy()),
   });
   const useEncryptedStorage = getUseEncryptedStorageFlag();
 


### PR DESCRIPTION
Fixes #28440

## What's happening

On some headless VPSes, `gemini` login always dies at the token exchange with:

    Invalid response body while trying to fetch
    https://oauth2.googleapis.com/token: Premature close

The reporter showed the endpoint works fine on the same box via curl, Python
urllib, and raw Node `fetch` — only the CLI's bundled HTTP stack fails.

## Why

The token exchange goes through `OAuth2Client` → gaxios (bundled via
google-auth-library). gaxios@6 chooses its fetch implementation by checking for
a browser `window.fetch`. That check can never pass under Node, so it always
falls back to `node-fetch@2`, even on Node versions that ship a native `fetch`.
On these hosts node-fetch mishandles the response body and throws "Premature
close", which is why the native fetch and curl succeed but the CLI doesn't.

## The fix

Pass Node's native `fetch` to gaxios via `transporterOptions.fetchImplementation`
when no proxy is configured. Proxied setups are left on node-fetch because gaxios
drives proxies through a Node http(s) agent that native fetch doesn't honor.
`GEMINI_OAUTH_USE_NODE_FETCH=1` restores the old behaviour as an escape hatch.

## Testing

- Added unit tests covering the no-proxy (native fetch), proxy (node-fetch), and
  env-var opt-out paths.
- `npm run lint`, `typecheck`, and the full `@google/gemini-cli-core` suite pass.