### PR TITLE
docs(get-started): add Windows PowerShell troubleshooting for gemini command

### DIFF
--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -82,6 +82,10 @@ gemini
 For a list of options and additional commands, see the
 [CLI cheatsheet](../cli/cli-reference.md).
 
+> **Windows (PowerShell):** If `gemini` fails to run after installation (for
+> example, `running scripts is disabled on this system`), see the
+> [Troubleshooting guide](../resources/troubleshooting.md).
+
 You can also run Gemini CLI using one of the following advanced methods:
 
 <Tabs>

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -84,7 +84,7 @@ For a list of options and additional commands, see the
 
 > **Windows (PowerShell):** If `gemini` fails to run after installation (for
 > example, `running scripts is disabled on this system`), see the
-> [Troubleshooting guide](../resources/troubleshooting.md).
+> [Troubleshooting guide](../resources/troubleshooting.md). 
 
 You can also run Gemini CLI using one of the following advanced methods:
 

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -85,10 +85,28 @@ topics on:
     - If you installed `gemini` globally, check that your `npm` global binary
       directory is in your `PATH`. You can update Gemini CLI using the command
       `npm install -g @google/gemini-cli@latest`.
+    - On Windows, restart your terminal after installing so that `PATH` changes
+      take effect, and confirm that your npm global directory (typically
+      `%AppData%\npm`) is on your `PATH`. You can find the directory by running
+      `npm config get prefix`.
     - If you are running `gemini` from source, ensure you are using the correct
       command to invoke it (for example, `node packages/cli/dist/index.js ...`).
       To update Gemini CLI, pull the latest changes from the repository, and
       then rebuild using the command `npm run build`.
+
+- **Error:
+  `gemini.ps1 cannot be loaded because running scripts is disabled on this system`
+  (Windows PowerShell).**
+
+  - **Cause:** PowerShell's default `Restricted` execution policy prevents the
+    `gemini.ps1` shim that npm creates from running.
+  - **Solution:** Allow locally created scripts to run for your user account:
+    ```powershell
+    Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+    ```
+    Then restart PowerShell and run `gemini` again. Alternatively, run Gemini
+    CLI with `npx @google/gemini-cli`, which does not depend on the PowerShell
+    shim.
 
 - **Error: `MODULE_NOT_FOUND` or import errors.**
 


### PR DESCRIPTION
## Summary

Users installing Gemini CLI on Windows report that the `gemini` command fails to
run in PowerShell after a global npm install. The installation docs list
PowerShell as a supported shell but give no Windows-specific guidance, and the
troubleshooting guide did not cover the PowerShell execution-policy error. This
PR documents the fix so affected users are unblocked.

## Details

This is an environment/documentation gap, not a packaging bug: the published
`bundle/gemini.js` retains a valid `#!/usr/bin/env node` shebang and the package
is `"type": "module"`, so npm's Windows shims are generated correctly.

The detailed fix lives once in the troubleshooting guide (the canonical location)
to avoid duplication; the installation page carries a short pointer to it so the
user who lands there finds it. Two failure modes are covered: the npm global bin
directory not being on `PATH`, and PowerShell's default `Restricted` execution
policy blocking the `gemini.ps1` shim.

## Related Issues

Fixes #28314

## How to Validate

- Preview `docs/get-started/installation.mdx` and confirm the PowerShell note
  renders under "Run Gemini CLI" and links to the troubleshooting guide.
- Preview `docs/resources/troubleshooting.md` and confirm the new
  `gemini.ps1 ... running scripts is disabled` entry and the Windows `PATH` note.
- Formatting: `npm run format` (or `prettier --check`) — `.md` is Prettier-clean;
  `.mdx` is excluded per `.prettierignore`.
- All internal links resolve.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) — N/A, documentation-only
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods — N/A, documentation-only; no
      build artifacts or runtime behavior changed
