### PR TITLE
fix(core): rotate session ID on model fallback to prevent stateful API errors

### DIFF
--- a/packages/core/src/availability/autoRoutingFallback.integration.test.ts
+++ b/packages/core/src/availability/autoRoutingFallback.integration.test.ts
@@ -414,4 +414,86 @@ describe('Auto Routing Fallback Integration', () => {
       'Pro success',
     );
   });
+
+  it('should rotate session ID on fallback and retry successfully with the Flash model', async () => {
+    const originalSessionId = 'test-session-rotate-id';
+    config = new Config({
+      sessionId: originalSessionId,
+      targetDir: '/test',
+      debugMode: false,
+      cwd: '/test',
+      model: PREVIEW_GEMINI_MODEL_AUTO,
+    });
+
+    vi.spyOn(config, 'isInteractive').mockReturnValue(true);
+
+    client = new BaseLlmClient(
+      fakeGenerator,
+      config,
+      AuthType.LOGIN_WITH_GOOGLE,
+    );
+
+    let attemptsPro = 0;
+    let attemptsFlash = 0;
+
+    const mockGoogleApiError = {
+      code: 429,
+      message:
+        'Automatically switching from gemini-2.5-pro to gemini-2.5-flash for faster responses for the remainder of this session. Possible reasons for this are...',
+      details: [],
+    };
+
+    vi.spyOn(fakeGenerator, 'generateContent').mockImplementation(
+      async (params) => {
+        if (params.model === PREVIEW_GEMINI_MODEL) {
+          attemptsPro++;
+          throw new RetryableQuotaError(
+            'Quota exceeded for Pro',
+            mockGoogleApiError,
+            0,
+          );
+        } else if (params.model === PREVIEW_GEMINI_FLASH_MODEL) {
+          attemptsFlash++;
+          return {
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [{ text: 'Flash success after rotation' }],
+                },
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        }
+        throw new Error(`Unexpected model: ${params.model}`);
+      },
+    );
+
+    config.setFallbackModelHandler(
+      async (_failed, _fallback, _error): Promise<FallbackIntent | null> =>
+        'retry_always', // Approve switch to Flash
+    );
+
+    const promise = client.generateContent({
+      modelConfigKey: { model: PREVIEW_GEMINI_MODEL, isChatModel: true },
+      contents: [{ role: 'user', parts: [{ text: 'test query' }] }],
+      abortSignal: new AbortController().signal,
+      promptId: 'test-prompt',
+      role: LlmRole.UTILITY_TOOL,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    // Verify it resolved to Flash success instead of failing with Please submit a new query
+    expect(result.candidates?.[0]?.content?.parts?.[0]?.text).toBe(
+      'Flash success after rotation',
+    );
+    expect(attemptsPro).toBe(3);
+    expect(attemptsFlash).toBe(1);
+
+    // Verify session ID has been rotated
+    expect(config.getSessionId()).not.toBe(originalSessionId);
+    expect(config.getSessionId()).toBeDefined();
+  });
 });

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -157,7 +157,7 @@ export class CodeAssistServer implements ContentGenerator {
           translatedResponse,
           streamingLatency,
           req.config?.abortSignal,
-          server.sessionId, // Use sessionId as trajectoryId
+          server.getEffectiveSessionId(), // Use sessionId as trajectoryId
         );
 
         if (response.consumedCredits) {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -86,6 +86,10 @@ export class CodeAssistServer implements ContentGenerator {
     readonly config?: Config,
   ) {}
 
+  getEffectiveSessionId(): string | undefined {
+    return this.config?.getSessionId() ?? this.sessionId;
+  }
+
   async generateContentStream(
     req: GenerateContentParameters,
     userPromptId: string,
@@ -117,7 +121,7 @@ export class CodeAssistServer implements ContentGenerator {
           req,
           userPromptId,
           this.projectId,
-          this.sessionId,
+          this.getEffectiveSessionId(),
           enabledCreditTypes,
         ),
         req.config?.abortSignal,
@@ -204,7 +208,7 @@ export class CodeAssistServer implements ContentGenerator {
         req,
         userPromptId,
         this.projectId,
-        this.sessionId,
+        this.getEffectiveSessionId(),
         undefined,
       ),
       req.config?.abortSignal,
@@ -224,7 +228,7 @@ export class CodeAssistServer implements ContentGenerator {
       translatedResponse,
       streamingLatency,
       req.config?.abortSignal,
-      this.sessionId, // Use sessionId as trajectoryId
+      this.getEffectiveSessionId(), // Use sessionId as trajectoryId
     );
 
     if (response.remainingCredits) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1859,16 +1859,7 @@ export class Config implements McpContext, AgentLoopContext {
   }
 
   rotateSessionId(sessionId: string): void {
-    const previousPlansDir = this.storage.isInitialized()
-      ? this.storage.getPlansDir()
-      : undefined;
-
     this._sessionId = sessionId;
-    this.storage.setSessionId(sessionId);
-
-    if (previousPlansDir) {
-      this.refreshSessionScopedPlansDirectory(previousPlansDir);
-    }
   }
 
   resetNewSessionState(sessionId: string): void {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1858,6 +1858,19 @@ export class Config implements McpContext, AgentLoopContext {
     }
   }
 
+  rotateSessionId(sessionId: string): void {
+    const previousPlansDir = this.storage.isInitialized()
+      ? this.storage.getPlansDir()
+      : undefined;
+
+    this._sessionId = sessionId;
+    this.storage.setSessionId(sessionId);
+
+    if (previousPlansDir) {
+      this.refreshSessionScopedPlansDirectory(previousPlansDir);
+    }
+  }
+
   resetNewSessionState(sessionId: string): void {
     this.setSessionId(sessionId);
   }

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -67,6 +67,7 @@ const createMockConfig = (overrides: Partial<Config> = {}): Config =>
     setActiveModel: vi.fn(),
     setModel: vi.fn(),
     activateFallbackMode: vi.fn(),
+    rotateSessionId: vi.fn(),
     getModelAvailabilityService: vi.fn(() =>
       createAvailabilityServiceMock({
         selectedModel: FALLBACK_MODEL,

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Config } from '../config/config.js';
+import { createSessionId } from '../utils/session.js';
 import {
   openBrowserSecurely,
   shouldLaunchBrowser,
@@ -161,8 +162,9 @@ async function processIntent(
 ): Promise<boolean> {
   switch (intent) {
     case 'retry_always':
-      // TODO(telemetry): Implement generic fallback event logging. Existing
-      // logFlashFallback is specific to a single Model.
+      // Rotate the session ID to ensure the backend treats the retried request
+      // as a brand-new session, preventing stateful model-switching errors.
+      config.setSessionId(createSessionId());
       config.activateFallbackMode(fallbackModel, failedModel);
       return true;
 

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -164,7 +164,7 @@ async function processIntent(
     case 'retry_always':
       // Rotate the session ID to ensure the backend treats the retried request
       // as a brand-new session, preventing stateful model-switching errors.
-      config.setSessionId(createSessionId());
+      config.rotateSessionId(createSessionId());
       config.activateFallbackMode(fallbackModel, failedModel);
       return true;
 


### PR DESCRIPTION
## Summary

Rotate the active session ID when a permanent model fallback to `gemini-2.5-flash` occurs. This fixes a blocking `[API Error: Please submit a new query to continue with the Flash model.]` error returned by the stateful Code Assist backend when immediate retries are sent under the same session ID.

## Details

- **In-Memory Session Rotation**: Added a dedicated, safe `rotateSessionId(sessionId: string)` method in `Config` (`packages/core/src/config/config.ts`) that only updates the in-memory `_sessionId` variable used by CodeAssistServer. It purposefully leaves `this.storage` untouched, ensuring that local directories (like plan settings, trackers, and local logs) do not change their paths mid-session.
- **Fallback Trigger**: Updated `processIntent` in `packages/core/src/fallback/handler.ts` (`case 'retry_always'`) to use `config.rotateSessionId()` before activating fallback mode, ensuring subsequent retries utilize the rotated session ID on the backend.
- **Unified Session ID in Telemetry**: Updated `CodeAssistServer` (`packages/core/src/code_assist/server.ts`) to fetch the active session ID dynamically via `this.getEffectiveSessionId()` for all request dispatches and telemetry logging (including within the `generateContentStream` async generator), resolving inconsistency in tracking logs.
- **Impact**: This forces the backend to treat the retried request (now utilizing `gemini-2.5-flash`) as a fresh, stateless request, completely bypassing the backend's session-specific model lock while fully preserving all local session and CLI states.

## Related Issues

Related to the issue reported in `issue.md`.

## How to Validate

Run the newly added integration test in `@google/gemini-cli-core` which simulates this exact scenario:
```bash
npm test -w @google/gemini-cli-core -- src/availability/autoRoutingFallback.integration.test.ts
```

Verify that all monorepo packages build successfully and lint without errors:
```bash
npm run build && npm run lint && npm run typecheck
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
