### PR TITLE
fix(core): sequentially verify cached credentials and restore GOOGLE_APPLICATION_CREDENTIALS fallback

### DIFF
--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -680,6 +680,64 @@ describe('oauth2', () => {
         expect(mockFromJSON).toHaveBeenCalledWith(byoidCredentials);
         expect(client).toBe(mockExternalAccountClient);
       });
+
+      it('should fall back to GOOGLE_APPLICATION_CREDENTIALS if default cached credentials are invalid or expired', async () => {
+        // Setup default cached credentials that are expired/invalid
+        const defaultCreds = { refresh_token: 'expired-token' };
+        const defaultCredsPath = path.join(
+          tempHomeDir,
+          GEMINI_DIR,
+          'oauth_creds.json',
+        );
+        await fs.promises.mkdir(path.dirname(defaultCredsPath), {
+          recursive: true,
+        });
+        await fs.promises.writeFile(
+          defaultCredsPath,
+          JSON.stringify(defaultCreds),
+        );
+
+        // Setup valid fallback credentials via environment variable
+        const envCreds = { refresh_token: 'valid-env-token' };
+        const envCredsPath = path.join(tempHomeDir, 'env_creds.json');
+        await fs.promises.writeFile(envCredsPath, JSON.stringify(envCreds));
+        vi.stubEnv('GOOGLE_APPLICATION_CREDENTIALS', envCredsPath);
+
+        let currentCredentials: Credentials | null = null;
+        const mockClient = {
+          setCredentials: vi.fn((creds) => {
+            currentCredentials = creds as Credentials;
+          }),
+          getAccessToken: vi.fn(async () => {
+            if (
+              currentCredentials &&
+              currentCredentials.refresh_token === 'expired-token'
+            ) {
+              throw new Error('Token is expired or revoked');
+            }
+            return { token: 'valid-token' };
+          }),
+          getTokenInfo: vi.fn(async (_token) => {
+            if (
+              currentCredentials &&
+              currentCredentials.refresh_token === 'expired-token'
+            ) {
+              throw new Error('Token is expired or revoked');
+            }
+            return {};
+          }),
+          on: vi.fn(),
+        };
+
+        vi.mocked(OAuth2Client).mockImplementation(
+          () => mockClient as unknown as OAuth2Client,
+        );
+
+        await getOauthClient(AuthType.LOGIN_WITH_GOOGLE, mockConfig);
+
+        // Assert that fallback envCreds were eventually loaded and used
+        expect(mockClient.setCredentials).toHaveBeenCalledWith(envCreds);
+      });
     });
 
     describe('with GCP environment variables', () => {

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -117,42 +117,68 @@ async function initOauthClient(
   authType: AuthType,
   config: Config,
 ): Promise<AuthClient> {
-  const credentials = await fetchCachedCredentials();
+  function createBaseOAuth2Client(): OAuth2Client {
+    const client = new OAuth2Client({
+      clientId: OAUTH_CLIENT_ID,
+      clientSecret: OAUTH_CLIENT_SECRET,
+      transporterOptions: {
+        proxy: config.getProxy(),
+      },
+    });
+    const useEncryptedStorage = getUseEncryptedStorageFlag();
 
-  if (
-    credentials &&
-    typeof credentials === 'object' &&
-    'type' in credentials &&
-    (credentials.type === 'external_account_authorized_user' ||
-      credentials.type === 'service_account')
-  ) {
-    const auth = new GoogleAuth({
-      scopes: OAUTH_SCOPE,
+    client.on('tokens', async (tokens: Credentials) => {
+      if (useEncryptedStorage) {
+        await OAuthCredentialStorage.saveCredentials(tokens);
+      } else {
+        await cacheCredentials(tokens);
+      }
+
+      await triggerPostAuthCallbacks(tokens);
     });
-    const byoidClient = auth.fromJSON({
-      ...credentials,
-      refresh_token: credentials.refresh_token ?? undefined,
-    });
-    const token = await byoidClient.getAccessToken();
-    if (token) {
-      debugLogger.debug(`Created ${credentials.type} auth client.`);
-      return byoidClient;
+
+    return client;
+  }
+
+  const credentialsList = await fetchCachedCredentialsList();
+
+  // 1. Try BYOID credentials first
+  for (const credentials of credentialsList) {
+    if (
+      credentials &&
+      typeof credentials === 'object' &&
+      'type' in credentials &&
+      (credentials.type === 'external_account_authorized_user' ||
+        credentials.type === 'service_account')
+    ) {
+      try {
+        const auth = new GoogleAuth({
+          scopes: OAUTH_SCOPE,
+        });
+        const byoidClient = auth.fromJSON({
+          ...credentials,
+          refresh_token: credentials.refresh_token ?? undefined,
+        });
+        const token = await byoidClient.getAccessToken();
+        if (token) {
+          debugLogger.debug(`Created ${credentials.type} auth client.`);
+          return byoidClient;
+        }
+      } catch (error) {
+        debugLogger.debug(
+          `BYOID credentials verification failed:`,
+          getErrorMessage(error),
+        );
+      }
     }
   }
 
-  const client = new OAuth2Client({
-    clientId: OAUTH_CLIENT_ID,
-    clientSecret: OAUTH_CLIENT_SECRET,
-    transporterOptions: {
-      proxy: config.getProxy(),
-    },
-  });
-  const useEncryptedStorage = getUseEncryptedStorageFlag();
-
+  // 2. Try GOOGLE_CLOUD_ACCESS_TOKEN override
   if (
     process.env['GOOGLE_GENAI_USE_GCA'] &&
     process.env['GOOGLE_CLOUD_ACCESS_TOKEN']
   ) {
+    const client = createBaseOAuth2Client();
     client.setCredentials({
       access_token: process.env['GOOGLE_CLOUD_ACCESS_TOKEN'],
     });
@@ -160,48 +186,51 @@ async function initOauthClient(
     return client;
   }
 
-  client.on('tokens', async (tokens: Credentials) => {
-    if (useEncryptedStorage) {
-      await OAuthCredentialStorage.saveCredentials(tokens);
-    } else {
-      await cacheCredentials(tokens);
-    }
+  // 3. Try standard cached credentials
+  for (const credentials of credentialsList) {
+    const isByoid =
+      credentials &&
+      typeof credentials === 'object' &&
+      'type' in credentials &&
+      (credentials.type === 'external_account_authorized_user' ||
+        credentials.type === 'service_account');
 
-    await triggerPostAuthCallbacks(tokens);
-  });
+    if (!isByoid && credentials) {
+      const client = createBaseOAuth2Client();
+      client.setCredentials(credentials as Credentials);
+      try {
+        // This will verify locally that the credentials look good.
+        const { token } = await client.getAccessToken();
+        if (token) {
+          // This will check with the server to see if it hasn't been revoked.
+          await client.getTokenInfo(token);
 
-  if (credentials) {
-    client.setCredentials(credentials as Credentials);
-    try {
-      // This will verify locally that the credentials look good.
-      const { token } = await client.getAccessToken();
-      if (token) {
-        // This will check with the server to see if it hasn't been revoked.
-        await client.getTokenInfo(token);
-
-        if (!userAccountManager.getCachedGoogleAccount()) {
-          try {
-            await fetchAndCacheUserInfo(client);
-          } catch (error) {
-            // Non-fatal, continue with existing auth.
-            debugLogger.warn(
-              'Failed to fetch user info:',
-              getErrorMessage(error),
-            );
+          if (!userAccountManager.getCachedGoogleAccount()) {
+            try {
+              await fetchAndCacheUserInfo(client);
+            } catch (error) {
+              // Non-fatal, continue with existing auth.
+              debugLogger.warn(
+                'Failed to fetch user info:',
+                getErrorMessage(error),
+              );
+            }
           }
-        }
-        debugLogger.log('Loaded cached credentials.');
-        await triggerPostAuthCallbacks(credentials as Credentials);
+          debugLogger.log('Loaded cached credentials.');
+          await triggerPostAuthCallbacks(credentials as Credentials);
 
-        return client;
+          return client;
+        }
+      } catch (error) {
+        debugLogger.debug(
+          `Cached credentials are not valid:`,
+          getErrorMessage(error),
+        );
       }
-    } catch (error) {
-      debugLogger.debug(
-        `Cached credentials are not valid:`,
-        getErrorMessage(error),
-      );
     }
   }
+
+  const client = createBaseOAuth2Client();
 
   // In Google Compute Engine based environments (including Cloud Shell), we can
   // use Application Default Credentials (ADC) provided via its metadata server
@@ -663,12 +692,13 @@ export function getAvailablePort(): Promise<number> {
   });
 }
 
-async function fetchCachedCredentials(): Promise<
-  Credentials | JWTInput | null
+async function fetchCachedCredentialsList(): Promise<
+  Array<Credentials | JWTInput>
 > {
   const useEncryptedStorage = getUseEncryptedStorageFlag();
   if (useEncryptedStorage) {
-    return OAuthCredentialStorage.loadCredentials();
+    const creds = await OAuthCredentialStorage.loadCredentials();
+    return creds ? [creds] : [];
   }
 
   const pathsToTry = [
@@ -676,6 +706,7 @@ async function fetchCachedCredentials(): Promise<
     process.env['GOOGLE_APPLICATION_CREDENTIALS'],
   ].filter((p): p is string => !!p);
 
+  const credentialsList: Array<Credentials | JWTInput> = [];
   for (const keyFile of pathsToTry) {
     try {
       const keyFileString = await fs.readFile(keyFile, 'utf-8');
@@ -683,9 +714,10 @@ async function fetchCachedCredentials(): Promise<
       const isOAuthCreds = (val: unknown): val is Credentials | JWTInput =>
         typeof val === 'object' && val !== null;
       if (isOAuthCreds(parsed)) {
-        return parsed;
+        credentialsList.push(parsed);
+      } else {
+        throw new Error('Invalid credentials format');
       }
-      throw new Error('Invalid credentials format');
     } catch (error) {
       // Log specific error for debugging, but continue trying other paths
       debugLogger.debug(
@@ -695,7 +727,7 @@ async function fetchCachedCredentials(): Promise<
     }
   }
 
-  return null;
+  return credentialsList;
 }
 
 export function clearOauthClientCache() {


### PR DESCRIPTION
## Summary

This PR surgically resolves a critical authentication fallback regression in Gemini Code Assist (GCA) Agent Mode (exiting with code `41` / `FatalAuthenticationError` and triggering *"Agent process exited unexpectedly with code 1 and signal null"* in VS Code). 

The issue was caused by an early-exit bug in `fetchCachedCredentials()` (introduced in October 2025 and typed in May 2026), which returned `.gemini/oauth_creds.json` immediately if it existed and was valid JSON, completely skipping the evaluation of `GOOGLE_APPLICATION_CREDENTIALS`. When the cached OAuth tokens expired or failed to refresh (e.g., due to corporate VPN drops), the system fell back to GCE Metadata Server (`COMPUTE_ADC`) on local developer machines, resulting in a network timeout at `169.254.169.254` and crashing the agent.

This fix restores the robust, cascading fallback contract by sequentially loading and verifying each credential path.

---

## Details

*   **Refactored `fetchCachedCredentials()` to `fetchCachedCredentialsList()`**: Instead of returning the first parsed JSON object immediately, it now reads and parses all available credential paths in `pathsToTry` and returns them as an array of credentials.
*   **Refactored `initOauthClient()`**: Iterates sequentially over the returned credentials list. For each credential, it performs the appropriate active verification (`GoogleAuth` for BYOID/Service Accounts, `OAuth2Client` for standard OAuth). If verification succeeds, it returns the authenticated client immediately. If it fails, it catches the error and continues to the next credential in the list.
*   **Added Regression Test**: Integrated a high-fidelity regression test case directly into `packages/core/src/code_assist/oauth2.test.ts` to verify that the system successfully falls back to `GOOGLE_APPLICATION_CREDENTIALS` when default cached credentials are present but invalid or expired.

---

## Related Issues


---

## How to Validate

### 1. Run the Regression Test Suite
Execute the Vitest test suite for the core package to verify the new regression test case and all existing authentication tests:
```bash
npx vitest run packages/core/src/code_assist/oauth2.test.ts
```
*Expected Result:* All 36 tests pass successfully, including the new fallback regression test.

### 2. Run Linter and Typechecker
Ensure the codebase remains 100% clean and compliant with style guidelines:
```bash
npm run lint
npm run typecheck
```
*Expected Result:* Zero linting or compilation errors.

---

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker