### PR TITLE
feat(core): add skill name dimension to tool call telemetry (#18189)

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -52,6 +52,7 @@ import {
   logOnboardingSuccess,
 } from './loggers.js';
 import { ToolCallDecision } from './tool-call-decision.js';
+import { ACTIVATE_SKILL_TOOL_NAME } from '../tools/tool-names.js';
 import {
   EVENT_API_ERROR,
   EVENT_API_REQUEST,
@@ -1473,6 +1474,65 @@ describe('loggers', () => {
         2,
         'removed',
         { function_name: 'test-function' },
+      );
+    });
+
+    it('should log a tool call with skill_name for activate_skill', () => {
+      const tool = new EditTool(mockConfig, createMockMessageBus());
+      const call: CompletedToolCall = {
+        status: CoreToolCallStatus.Success,
+        request: {
+          name: ACTIVATE_SKILL_TOOL_NAME,
+          args: {
+            name: 'test-skill',
+          },
+          callId: 'test-call-id',
+          isClientInitiated: true,
+          prompt_id: 'prompt-id-1',
+        },
+        response: {
+          callId: 'test-call-id',
+          responseParts: [{ text: 'test-response' }],
+          resultDisplay: {
+            fileDiff: 'diff',
+            fileName: 'file.txt',
+            filePath: 'file.txt',
+            originalContent: 'old content',
+            newContent: 'new content',
+            diffStat: {
+              model_added_lines: 0,
+              model_removed_lines: 0,
+              model_added_chars: 0,
+              model_removed_chars: 0,
+              user_added_lines: 0,
+              user_removed_lines: 0,
+              user_added_chars: 0,
+              user_removed_chars: 0,
+            },
+          },
+          error: undefined,
+          errorType: undefined,
+          contentLength: 13,
+        },
+        tool,
+        invocation: {} as AnyToolInvocation,
+        durationMs: 100,
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+      };
+      const event = new ToolCallEvent(call);
+
+      logToolCall(mockConfig, event);
+
+      expect(mockMetrics.recordToolCallMetrics).toHaveBeenCalledWith(
+        mockConfig,
+        100,
+        {
+          function_name: ACTIVATE_SKILL_TOOL_NAME,
+          success: true,
+          decision: ToolCallDecision.ACCEPT,
+          tool_type: 'native',
+          skill_name: 'test-skill',
+        },
       );
     });
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -1484,7 +1484,7 @@ describe('loggers', () => {
         request: {
           name: ACTIVATE_SKILL_TOOL_NAME,
           args: {
-            name: 'test-skill',
+            name: '  test-skill  ',
           },
           callId: 'test-call-id',
           isClientInitiated: true,
@@ -1532,6 +1532,65 @@ describe('loggers', () => {
           decision: ToolCallDecision.ACCEPT,
           tool_type: 'native',
           skill_name: 'test-skill',
+        },
+      );
+    });
+
+    it('should not log skill_name if name argument is whitespace-only for activate_skill', () => {
+      const tool = new EditTool(mockConfig, createMockMessageBus());
+      const call: CompletedToolCall = {
+        status: CoreToolCallStatus.Success,
+        request: {
+          name: ACTIVATE_SKILL_TOOL_NAME,
+          args: {
+            name: '   ',
+          },
+          callId: 'test-call-id',
+          isClientInitiated: true,
+          prompt_id: 'prompt-id-1',
+        },
+        response: {
+          callId: 'test-call-id',
+          responseParts: [{ text: 'test-response' }],
+          resultDisplay: {
+            fileDiff: 'diff',
+            fileName: 'file.txt',
+            filePath: 'file.txt',
+            originalContent: 'old content',
+            newContent: 'new content',
+            diffStat: {
+              model_added_lines: 0,
+              model_removed_lines: 0,
+              model_added_chars: 0,
+              model_removed_chars: 0,
+              user_added_lines: 0,
+              user_removed_lines: 0,
+              user_added_chars: 0,
+              user_removed_chars: 0,
+            },
+          },
+          error: undefined,
+          errorType: undefined,
+          contentLength: 13,
+        },
+        tool,
+        invocation: {} as AnyToolInvocation,
+        durationMs: 100,
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+      };
+      const event = new ToolCallEvent(call);
+
+      logToolCall(mockConfig, event);
+
+      expect(mockMetrics.recordToolCallMetrics).toHaveBeenCalledWith(
+        mockConfig,
+        100,
+        {
+          function_name: ACTIVATE_SKILL_TOOL_NAME,
+          success: true,
+          decision: ToolCallDecision.ACCEPT,
+          tool_type: 'native',
+          skill_name: undefined,
         },
       );
     });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -161,7 +161,10 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
     ) {
       const nameVal = event.function_args['name'];
       if (typeof nameVal === 'string') {
-        skill_name = nameVal;
+        const trimmed = nameVal.trim();
+        if (trimmed !== '') {
+          skill_name = trimmed;
+        }
       }
     }
 

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -99,6 +99,7 @@ import {
   EmptyWalletMenuShownEvent,
   CreditPurchaseClickEvent,
 } from './billingEvents.js';
+import { ACTIVATE_SKILL_TOOL_NAME } from '../tools/tool-names.js';
 
 export function logCliConfiguration(
   config: Config,
@@ -153,11 +154,23 @@ export function logToolCall(config: Config, event: ToolCallEvent): void {
       attributes: event.toOpenTelemetryAttributes(config),
     };
     logger.emit(logRecord);
+    let skill_name: string | undefined;
+    if (
+      event.function_name === ACTIVATE_SKILL_TOOL_NAME &&
+      event.function_args
+    ) {
+      const nameVal = event.function_args['name'];
+      if (typeof nameVal === 'string') {
+        skill_name = nameVal;
+      }
+    }
+
     recordToolCallMetrics(config, event.duration_ms, {
       function_name: event.function_name,
       success: event.success,
       decision: event.decision,
       tool_type: event.tool_type,
+      skill_name,
     });
 
     if (event.metadata) {

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -118,6 +118,7 @@ const COUNTER_DEFINITIONS = {
       success: boolean;
       decision?: 'accept' | 'reject' | 'modify' | 'auto_accept';
       tool_type?: 'native' | 'mcp';
+      skill_name?: string;
     },
   },
   [API_REQUEST_COUNT]: {
@@ -401,6 +402,7 @@ const HISTOGRAM_DEFINITIONS = {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     attributes: {} as {
       function_name: string;
+      skill_name?: string;
     },
   },
   [API_REQUEST_LATENCY]: {
@@ -889,10 +891,15 @@ export function recordToolCallMetrics(
     ...attributes,
   };
   toolCallCounter.add(1, metricAttributes);
-  toolCallLatencyHistogram.record(durationMs, {
+
+  const histogramAttributes: Attributes = {
     ...baseMetricDefinition.getCommonAttributes(config),
     function_name: attributes.function_name,
-  });
+  };
+  if (attributes.skill_name !== undefined) {
+    histogramAttributes['skill_name'] = attributes.skill_name;
+  }
+  toolCallLatencyHistogram.record(durationMs, histogramAttributes);
 }
 
 export function recordCustomTokenUsageMetrics(


### PR DESCRIPTION
## Summary

Add a `skill_name` dimension to tool call telemetry.

## Details


Disclaimer: I am not familiar with the code base and this was entirely vibe coded.


Extract the skill name from `activate_skill` tool call arguments and include it as an optional `skill_name` dimension/label in `gemini_cli.tool.call.count` and `gemini_cli.tool.call.latency` metrics.

- Update `TOOL_CALL_COUNT` and `TOOL_CALL_LATENCY` attribute schemas in `metrics.ts`
- Modify `recordToolCallMetrics` to pass `skill_name` attribute to `toolCallLatencyHistogram`
- Update `logToolCall` in `loggers.ts` to extract and supply the `skill_name` dimension
- Add unit tests in `loggers.test.ts` to verify correct behavior


## Related Issues

Fixes #18189


## How to Validate

- unit tests

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run

