### PR TITLE
fix(cli): reset slash-command conflict dedupe after each flush

### DIFF
--- a/packages/cli/src/services/SlashCommandConflictHandler.test.ts
+++ b/packages/cli/src/services/SlashCommandConflictHandler.test.ts
@@ -153,7 +153,7 @@ describe('SlashCommandConflictHandler', () => {
     expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(2);
   });
 
-  it('should deduplicate already notified conflicts', () => {
+  it('should deduplicate conflicts within a single debounce window', () => {
     const conflict = {
       name: 'deploy',
       renamedTo: 'firebase.deploy',
@@ -162,15 +162,34 @@ describe('SlashCommandConflictHandler', () => {
       winnerKind: CommandKind.BUILT_IN,
     };
 
+    // Two rapid-fire events before the debounce fires — only one notification.
+    simulateEvent([conflict]);
+    simulateEvent([conflict]);
+    vi.advanceTimersByTime(600);
+    expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should re-notify when a previously-resolved conflict reappears (issue #24333)', () => {
+    const conflict = {
+      name: 'deploy',
+      renamedTo: 'firebase.deploy',
+      loserExtensionName: 'firebase',
+      loserKind: CommandKind.EXTENSION_FILE,
+      winnerKind: CommandKind.BUILT_IN,
+    };
+
+    // First appearance — user is notified.
     simulateEvent([conflict]);
     vi.advanceTimersByTime(600);
     expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(1);
 
     vi.mocked(coreEvents.emitFeedback).mockClear();
 
+    // Conflict disappears (no event). Then reappears in a new debounce window.
     simulateEvent([conflict]);
     vi.advanceTimersByTime(600);
-    expect(coreEvents.emitFeedback).not.toHaveBeenCalled();
+    // User should be notified again — the dedupe state was reset after the flush.
+    expect(coreEvents.emitFeedback).toHaveBeenCalledTimes(1);
   });
 
   it('should display a descriptive message for a skill conflict', () => {

--- a/packages/cli/src/services/SlashCommandConflictHandler.ts
+++ b/packages/cli/src/services/SlashCommandConflictHandler.ts
@@ -70,6 +70,9 @@ export class SlashCommandConflictHandler {
     this.flushTimeout = null;
     const conflicts = [...this.pendingConflicts];
     this.pendingConflicts = [];
+    // Reset the dedupe set after each flush so that a conflict which disappears
+    // and then reappears will trigger a fresh notification (issue #24333).
+    this.notifiedConflicts.clear();
 
     if (conflicts.length === 0) {
       return;


### PR DESCRIPTION
## Summary

- `SlashCommandConflictHandler.notifiedConflicts` was an unbounded `Set` that grew for the entire process lifetime.
- Once a conflict key was recorded, it was **never removed**, so a conflict that disappeared and later reappeared would silently be suppressed forever.
- Fix: clear `notifiedConflicts` inside `flush()` after each debounce window. Deduplication still works within a single burst of events, but the slate is wiped after flushing so reintroduced conflicts trigger fresh notifications.

## Changes

| File | What changed |
|---|---|
| `packages/cli/src/services/SlashCommandConflictHandler.ts` | `this.notifiedConflicts.clear()` added at top of `flush()` |
| `packages/cli/src/services/SlashCommandConflictHandler.test.ts` | Replaced old dedup test with two tests: one for intra-window dedup and one regression test for reintroduced conflicts |

## Test plan

- [x] `npx vitest run packages/cli/src/services/SlashCommandConflictHandler.test.ts` — all 8 tests pass
- [x] New test `should re-notify when a previously-resolved conflict reappears (issue #24333)` confirms the fix

Fixes #24333