### PR TITLE
feat(cli): auto-compress chat history on context window overflow

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1119,6 +1119,16 @@ const SETTINGS_SCHEMA = {
         showInDialog: true,
         unit: '%',
       },
+      autoCompressOnOverflow: {
+        type: 'boolean',
+        label: 'Auto-Compress on Context Overflow',
+        category: 'Model',
+        requiresRestart: false,
+        default: false,
+        description:
+          'When the context window is about to overflow, automatically compress the chat history and retry the prompt instead of stopping with an error.',
+        showInDialog: true,
+      },
       disableLoopDetection: {
         type: 'boolean',
         label: 'Disable Loop Detection',

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -70,6 +70,7 @@ import type {
   IndividualToolCallDisplay,
   SlashCommandProcessorResult,
   HistoryItemModel,
+  HistoryItemCompression,
 } from '../types.js';
 import {
   StreamingState,
@@ -1345,6 +1346,52 @@ export const useGeminiStream = (
       const isMoreThan25PercentUsed =
         limit > 0 && remainingTokenCount < limit * 0.75;
 
+      if (
+        isMoreThan25PercentUsed &&
+        settings.merged.model.autoCompressOnOverflow
+      ) {
+        addItem({
+          type: 'info',
+          text: `Context window limit reached (${remainingTokenCount.toLocaleString()} tokens left). Auto-compressing history — your prompt will be ready to re-send after compression completes.`,
+        });
+
+        void (async () => {
+          try {
+            const promptId = `auto-compress-overflow-${Date.now()}`;
+            const compressed = await geminiClient.tryCompressChat(
+              promptId,
+              true,
+            );
+            if (compressed) {
+              addItem({
+                type: MessageType.COMPRESSION,
+                compression: {
+                  isPending: false,
+                  originalTokenCount: compressed.originalTokenCount,
+                  newTokenCount: compressed.newTokenCount,
+                  compressionStatus: compressed.compressionStatus,
+                },
+              } as HistoryItemCompression);
+              addItem({
+                type: 'info',
+                text: 'Auto-compression complete. Please re-send your prompt.',
+              });
+            } else {
+              addItem({
+                type: 'info',
+                text: 'Auto-compression failed. Use `/compress` manually or reduce your message size.',
+              });
+            }
+          } catch {
+            addItem({
+              type: 'info',
+              text: 'Auto-compression encountered an error. Use `/compress` manually.',
+            });
+          }
+        })();
+        return;
+      }
+
       let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the context window limit (${remainingTokenCount.toLocaleString()} tokens left).`;
 
       if (isMoreThan25PercentUsed) {
@@ -1357,7 +1404,7 @@ export const useGeminiStream = (
         text,
       });
     },
-    [addItem, onCancelSubmit, config],
+    [addItem, onCancelSubmit, config, settings, geminiClient],
   );
 
   const handleChatModelEvent = useCallback(

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -721,6 +721,13 @@
           "default": 0.5,
           "type": "number"
         },
+        "autoCompressOnOverflow": {
+          "title": "Auto-Compress on Context Overflow",
+          "description": "When the context window is about to overflow, automatically compress the chat history and retry the prompt instead of stopping with an error.",
+          "markdownDescription": "When the context window is about to overflow, automatically compress the chat history and retry the prompt instead of stopping with an error.\n\n- Category: `Model`\n- Requires restart: `no`\n- Default: `false`",
+          "default": false,
+          "type": "boolean"
+        },
         "disableLoopDetection": {
           "title": "Disable Loop Detection",
           "description": "Disable automatic detection and prevention of infinite loops.",


### PR DESCRIPTION
Add a new `model.autoCompressOnOverflow` setting that automatically compresses chat history when the context window is about to overflow, instead of stopping with a warning.

- Cancel the current submit
- Show a clear info message that auto-compression is starting
- Await geminiClient.tryCompressChat() in the background
- Display the compression result when done
- Prompt the user to re-send their message