### PR TITLE
fix(core,cli): sanitize URLs in error messages

### DIFF
--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -14,7 +14,10 @@ import {
   isAccountSuspendedError,
   ProjectIdRequiredError,
 } from '@google/gemini-cli-core';
-import { getErrorMessage } from '@google/gemini-cli-core';
+import {
+  getErrorMessage,
+  sanitizeUrlsInMessage,
+} from '@google/gemini-cli-core';
 import { AuthState } from '../types.js';
 import { validateAuthMethod } from '../../config/auth.js';
 
@@ -153,7 +156,9 @@ export const useAuthCommand = (
           // Show the error message directly without "Failed to login" prefix
           onAuthError(getErrorMessage(e));
         } else {
-          onAuthError(`Failed to sign in. Message: ${getErrorMessage(e)}`);
+          onAuthError(
+            `Failed to sign in. Message: ${sanitizeUrlsInMessage(getErrorMessage(e))}`,
+          );
         }
       }
     })();

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -15,6 +15,7 @@ import {
   AccountSuspendedError,
   getErrorMessage,
   getErrorType,
+  sanitizeUrlsInMessage,
   FatalAuthenticationError,
   FatalCancellationError,
   FatalInputError,
@@ -379,5 +380,42 @@ describe('getErrorType', () => {
       }
     }
     expect(getErrorType(new _AbortError2('test'))).toBe('AbortError');
+  });
+});
+
+describe('sanitizeUrlsInMessage', () => {
+  it('strips trailing period from URL at end of message (issue #28052)', () => {
+    expect(
+      sanitizeUrlsInMessage(
+        'Please migrate to the Antigravity suite of products: https://antigravity.google.',
+      ),
+    ).toBe(
+      'Please migrate to the Antigravity suite of products: https://antigravity.google',
+    );
+  });
+
+  it('strips trailing period from URL followed by whitespace', () => {
+    expect(
+      sanitizeUrlsInMessage('Visit https://example.com. Then do something.'),
+    ).toBe('Visit https://example.com Then do something.');
+  });
+
+  it('does not strip non-trailing punctuation within URL path', () => {
+    expect(
+      sanitizeUrlsInMessage(
+        'See https://example.com/path/to/page for details.',
+      ),
+    ).toBe('See https://example.com/path/to/page for details.');
+  });
+
+  it('strips trailing exclamation mark from URL', () => {
+    expect(sanitizeUrlsInMessage('Go to https://example.com!')).toBe(
+      'Go to https://example.com',
+    );
+  });
+
+  it('leaves messages without URLs unchanged', () => {
+    const msg = 'No URLs here. Just plain text.';
+    expect(sanitizeUrlsInMessage(msg)).toBe(msg);
   });
 });

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -33,6 +33,14 @@ export function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
 
+/**
+ * Strips trailing sentence punctuation (`.`, `!`, `?`) from URLs in a message
+ * so that links copied from error text remain valid.
+ */
+export function sanitizeUrlsInMessage(message: string): string {
+  return message.replace(/(https?:\/\/\S+?)([.!?]+)(\s|$)/g, '$1$3');
+}
+
 export function getErrorMessage(error: unknown): string {
   const friendlyError = toFriendlyError(error);
   if (friendlyError instanceof Error) {


### PR DESCRIPTION
- Add sanitizeUrlsInMessage utility to strip trailing sentence punctuation from URLs in error messages (closes #28052)
- Apply it to CLI auth error messages
- Add core unit tests for sanitizeUrlsInMessage