### PR TITLE
fix(policy): restrict tools.core wildcard DENY to built-in tools only (#28361)

### DIFF
--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -554,6 +554,7 @@ export async function createPolicyEngineConfig(
     // at a slightly lower priority than the explicit allows.
     rules.push({
       toolName: '*',
+      excludeMcp: true,
       decision: PolicyDecision.DENY,
       priority: CORE_TOOLS_FLAG_PRIORITY - 0.01,
       source: 'Settings (Core Tools Allowlist Enforcement)',

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -3800,6 +3800,37 @@ describe('PolicyEngine', () => {
         ).decision,
       ).toBe(PolicyDecision.ALLOW);
     });
+
+    it('should respect excludeMcp and not match MCP tools on wildcard rule', async () => {
+      const engine = new PolicyEngine({
+        rules: [
+          {
+            toolName: '*',
+            excludeMcp: true,
+            decision: PolicyDecision.DENY,
+          },
+        ],
+        defaultDecision: PolicyDecision.ALLOW,
+      });
+
+      const builtInResult = await engine.check(
+        { name: 'read_file', args: {} },
+        undefined,
+      );
+      expect(builtInResult.decision).toBe(PolicyDecision.DENY);
+
+      const mcpServerResult = await engine.check(
+        { name: 'mcp_my-server_my-tool', args: {} },
+        'my-server',
+      );
+      expect(mcpServerResult.decision).toBe(PolicyDecision.ALLOW);
+
+      const mcpPrefixResult = await engine.check(
+        { name: 'mcp_my-server_my-tool', args: {} },
+        undefined,
+      );
+      expect(mcpPrefixResult.decision).toBe(PolicyDecision.ALLOW);
+    });
   });
 
   describe('additional_permissions', () => {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -121,7 +121,14 @@ function ruleMatches(
   if (rule.toolName !== undefined) {
     // Support wildcard patterns: "mcp_serverName_*" matches "mcp_serverName_anyTool"
     if (rule.toolName === '*') {
-      // Match all tools
+      if (
+        'excludeMcp' in rule &&
+        rule.excludeMcp &&
+        (serverName !== undefined ||
+          (toolCall.name && isMcpToolName(toolCall.name)))
+      ) {
+        return false;
+      }
     } else if (isWildcardPattern(rule.toolName)) {
       if (
         !toolCall.name ||

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -137,6 +137,11 @@ export interface PolicyRule {
   mcpName?: string;
 
   /**
+   * If true, this rule will not match any MCP tools.
+   */
+  excludeMcp?: boolean;
+
+  /**
    * Pattern to match against tool arguments.
    * Can be used for more fine-grained control.
    */


### PR DESCRIPTION
Fixes tools.core wildcard DENY silently excluding all MCP tools by introducing excludeMcp property on wildcard rules, scoping it to core tools only.

Closes #28361