### PR TITLE
docs: add missing .md extensions to six cross-reference links

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -82,7 +82,7 @@ For `BeforeTool` and `AfterTool` events, the `matcher` field in your settings is
 compared against the name of the tool being executed.
 
 - **Built-in Tools**: You can match any built-in tool (for example, `read_file`,
-  `run_shell_command`). See the [Tools Reference](../reference/tools) for a full
+  `run_shell_command`). See the [Tools Reference](../reference/tools.md) for a full
   list of available tool names.
 - **MCP Tools**: Tools from MCP servers follow the naming pattern
   `mcp_<server_name>_<tool_name>`.

--- a/docs/reference/policy-engine.md
+++ b/docs/reference/policy-engine.md
@@ -73,7 +73,7 @@ primary conditions are the tool's name and its arguments.
 
 The `toolName` in the rule must match the name of the tool being called. For a
 complete list of built-in tool names, see the
-[Tools reference](/docs/reference/tools#available-tools).
+[Tools reference](../reference/tools.md#available-tools).
 
 - **Wildcards**: You can use wildcards to match multiple tools.
   - `*`: Matches **any tool** (built-in or MCP).
@@ -91,7 +91,7 @@ If `argsPattern` is specified, the tool's arguments are converted to a stable
 JSON string, which is then tested against the provided regular expression. If
 the arguments don't match the pattern, the rule does not apply. For a list of
 argument keys available for each tool, see the **Parameters** in the
-[Tools reference](/docs/reference/tools#available-tools).
+[Tools reference](../reference/tools.md#available-tools).
 
 #### Execution environment
 
@@ -287,7 +287,7 @@ This section describes the fields available in a TOML policy rule.
 
 For valid built-in `toolName` values and their argument structures (used by
 `argsPattern`), see the
-[Tools reference](/docs/reference/tools#available-tools).
+[Tools reference](../reference/tools.md#available-tools).
 
 ```toml
 [[rule]]
@@ -374,8 +374,8 @@ priority = 10
 To simplify writing policies for `run_shell_command`, you can use
 `commandPrefix` or `commandRegex` instead of the more complex `argsPattern`.
 These are policy-rule shorthands, not arguments of the `run_shell_command` tool
-itself. For the tool's invocation arguments, see [Shell tool](/docs/tools/shell)
-and [Tools reference](/docs/reference/tools#available-tools).
+itself. For the tool's invocation arguments, see [Shell tool](../tools/shell.md)
+and [Tools reference](../reference/tools.md#available-tools).
 
 - `commandPrefix`: Matches if the `command` argument starts with the given
   string.


### PR DESCRIPTION
Six cross-references in `docs/reference/policy-engine.md` (5) and `docs/hooks/reference.md` (1) link other doc pages extensionless — four also with site-absolute `/docs/...` paths — e.g. `](/docs/reference/tools#available-tools)` and `](../reference/tools)`. On GitHub's rendered view these 404 (`docs/reference/tools` has no extensionless file). The other 57 cross-references in the same directories consistently use relative `.md` links, and both targets (`docs/reference/tools.md`, `docs/tools/shell.md`) exist — so this normalizes the stragglers to the dominant convention. Anchors preserved.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)