### PR TITLE
fix(cli): propagate AbortSignal in /compress command

### DIFF
--- a/packages/cli/src/ui/commands/compressCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressCommand.test.ts
@@ -10,7 +10,7 @@ import {
   type GeminiClient,
 } from '@google/gemini-cli-core';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { compressCommand } from './compressCommand.js';
+import { compressCommand, abortActiveCompression } from './compressCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
 
@@ -29,6 +29,8 @@ describe('compressCommand', () => {
         },
       },
     });
+    // Reset any leftover abort controller from a previous test.
+    abortActiveCompression();
   });
 
   it('should do nothing if a compression is already pending', async () => {
@@ -54,7 +56,7 @@ describe('compressCommand', () => {
     expect(mockTryCompressChat).not.toHaveBeenCalled();
   });
 
-  it('should set pending item, call tryCompressChat, and add result on success', async () => {
+  it('should set pending item, call tryCompressChat with AbortSignal, and add result on success', async () => {
     const compressedResult: ChatCompressionInfo = {
       originalTokenCount: 200,
       compressionStatus: CompressionStatus.COMPRESSED,
@@ -78,6 +80,7 @@ describe('compressCommand', () => {
     expect(mockTryCompressChat).toHaveBeenCalledWith(
       expect.stringMatching(/^compress-\d+$/),
       true,
+      expect.any(AbortSignal),
     );
 
     expect(context.ui.addItem).toHaveBeenCalledWith(
@@ -134,6 +137,63 @@ describe('compressCommand', () => {
     await compressCommand.action!(context, '');
     await new Promise((r) => setTimeout(r, 0));
     expect(context.ui.setPendingItem).toHaveBeenCalledWith(null);
+  });
+
+  it('should silently bail out if aborted during compression', async () => {
+    // Make tryCompressChat hang until we manually abort.
+    let resolveCompress: (value: ChatCompressionInfo | null) => void;
+    mockTryCompressChat.mockReturnValue(
+      new Promise<ChatCompressionInfo | null>((resolve) => {
+        resolveCompress = resolve;
+      }),
+    );
+
+    await compressCommand.action!(context, '');
+
+    // Abort while the compression is still in flight.
+    abortActiveCompression();
+
+    // Now let the promise resolve — the UI should NOT be updated with the result.
+    resolveCompress!({
+      originalTokenCount: 200,
+      compressionStatus: CompressionStatus.COMPRESSED,
+      newTokenCount: 100,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // addItem should NOT have been called with a COMPRESSION result
+    // (only setPendingItem(null) in the finally block).
+    const addItemCalls = (context.ui.addItem as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const compressionResults = addItemCalls.filter(
+      ([item]: [{ type: string }]) => item.type === MessageType.COMPRESSION,
+    );
+    expect(compressionResults).toHaveLength(0);
+  });
+
+  it('should swallow errors when aborted', async () => {
+    // Make tryCompressChat reject after abort.
+    mockTryCompressChat.mockImplementation(
+      (_id: string, _force: boolean, signal: AbortSignal) => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(
+              new DOMException('The operation was aborted.', 'AbortError'),
+            );
+          });
+        }),
+    );
+
+    await compressCommand.action!(context, '');
+    abortActiveCompression();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No error item should be added.
+    const addItemCalls = (context.ui.addItem as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const errorItems = addItemCalls.filter(
+      ([item]: [{ type: string }]) => item.type === MessageType.ERROR,
+    );
+    expect(errorItems).toHaveLength(0);
   });
 
   describe('metadata', () => {

--- a/packages/cli/src/ui/commands/compressCommand.ts
+++ b/packages/cli/src/ui/commands/compressCommand.ts
@@ -7,6 +7,8 @@
 import { MessageType, type HistoryItemCompression } from '../types.js';
 import { CommandKind, type SlashCommand } from './types.js';
 
+let activeAbortController: AbortController | null = null;
+
 export const compressCommand: SlashCommand = {
   name: 'compress',
   altNames: ['summarize', 'compact'],
@@ -38,6 +40,12 @@ export const compressCommand: SlashCommand = {
 
     ui.setPendingItem(pendingMessage);
 
+    // Create an AbortController so the compression can be cancelled
+    // (e.g. when the user starts a new prompt or presses Escape).
+    const abortController = new AbortController();
+    activeAbortController = abortController;
+    const signal = abortController.signal;
+
     void (async () => {
       try {
         const promptId = `compress-${Date.now()}`;
@@ -45,7 +53,15 @@ export const compressCommand: SlashCommand = {
           await context.services.agentContext?.geminiClient?.tryCompressChat(
             promptId,
             true,
+            signal,
           );
+
+        // If cancelled while the network request was in flight, bail out
+        // silently — the UI is no longer waiting for this result.
+        if (signal.aborted) {
+          return;
+        }
+
         if (compressed) {
           ui.addItem(
             {
@@ -69,6 +85,10 @@ export const compressCommand: SlashCommand = {
           );
         }
       } catch (e) {
+        // Swallow abort errors — they are expected when the user cancels.
+        if (signal.aborted) {
+          return;
+        }
         ui.addItem(
           {
             type: MessageType.ERROR,
@@ -79,8 +99,22 @@ export const compressCommand: SlashCommand = {
           Date.now(),
         );
       } finally {
+        if (activeAbortController === abortController) {
+          activeAbortController = null;
+        }
         ui.setPendingItem(null);
       }
     })();
   },
 };
+
+/**
+ * Aborts any in-flight compression started by the `/compress` command.
+ * Call this when the user cancels a turn or starts a new prompt.
+ */
+export function abortActiveCompression(): void {
+  if (activeAbortController) {
+    activeAbortController.abort();
+    activeAbortController = null;
+  }
+}


### PR DESCRIPTION
## Summary

The `/compress` command fired `tryCompressChat` without an `AbortSignal`, making the background compression impossible to cancel. This could leave dangling network requests when the user starts a new prompt or presses Escape.

## Changes

- Create an `AbortController` and pass its `signal` to `tryCompressChat`
- Check `signal.aborted` after `await` to discard stale results
- Swallow `AbortError` in `catch` when signal is aborted
- Export `abortActiveCompression()` for external cancellation

## Context

Addresses review feedback raised in https://github.com/google-gemini/gemini-cli/issues/28483#issuecomment-5048966186

> The asynchronous auto-compression task runs in the background without proper cancellation handling. Asynchronous operations that can be cancelled by the user should accept and propagate an AbortSignal to ensure cancellability and prevent dangling processes or network requests, rather than relying on checking a ref like turnCancelledRef.current after the operation has already run.

## Testing

All 8 tests pass (6 existing updated + 2 new):
- Verifies `AbortSignal` is passed to `tryCompressChat`
- Silently bails out if aborted during compression
- Swallows errors when aborted
