### PR TITLE
fix(core): enforce HTTPS for GoogleCredentialsAuthProvider to prevent cleartext leakage

### DIFF
--- a/packages/core/src/agents/auth-provider/credential-leak-prevention.test.ts
+++ b/packages/core/src/agents/auth-provider/credential-leak-prevention.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { GoogleCredentialsAuthProvider } from './google-credentials-provider.js';
+import type { GoogleCredentialsAuthConfig } from './types.js';
+import { GoogleAuth } from 'google-auth-library';
+
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: vi.fn(),
+}));
+
+describe('Credential Leak Prevention (RCA / PoC Verification)', () => {
+  const mockConfig: GoogleCredentialsAuthConfig = {
+    type: 'google-credentials',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (GoogleAuth as unknown as Mock).mockImplementation(() => ({
+      getClient: vi.fn().mockResolvedValue({
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'leaked-token' }),
+        credentials: { expiry_date: Date.now() + 3600 * 1000 },
+      }),
+      getIdTokenClient: vi.fn().mockResolvedValue({
+        idTokenProvider: {
+          fetchIdToken: vi.fn().mockResolvedValue('leaked-id-token'),
+        },
+      }),
+    }));
+  });
+
+  it('should FAIL (throw error) when trying to initialize with an untrusted arbitrary remote agent URL (reproducing vulnerability prevention)', () => {
+    // This test simulates the reproduction scenario: registering a remote agent with an arbitrary external URL
+    // e.g., http://127.0.0.1:1337 or https://malicious-agent.evil.com
+    const untrustedUrls = [
+      {
+        url: 'http://127.0.0.1:1337/.well-known/agent.json',
+        error: /requires HTTPS/,
+      },
+      {
+        url: 'https://malicious-agent.evil.com/card',
+        error: /is not an allowed host/,
+      },
+      {
+        url: 'https://untrusted-third-party.com/agent',
+        error: /is not an allowed host/,
+      },
+    ];
+
+    for (const item of untrustedUrls) {
+      expect(() => {
+        new GoogleCredentialsAuthProvider(mockConfig, item.url);
+      }).toThrow(item.error);
+    }
+  });
+
+  it('should SUCCEED only for allowed Google Services (proving the allowlist constraint)', () => {
+    const trustedUrls = [
+      'https://language.googleapis.com/v1/models',
+      'https://vertex-ai-agent.googleapis.com/agent',
+      'https://my-secure-service-abc.run.app/card',
+    ];
+
+    for (const url of trustedUrls) {
+      expect(() => {
+        new GoogleCredentialsAuthProvider(mockConfig, url);
+      }).not.toThrow();
+    }
+  });
+});

--- a/packages/core/src/agents/auth-provider/google-credentials-provider.test.ts
+++ b/packages/core/src/agents/auth-provider/google-credentials-provider.test.ts
@@ -82,6 +82,24 @@ describe('GoogleCredentialsAuthProvider', () => {
           ),
       ).not.toThrow();
     });
+
+    it('throws if the protocol is not HTTPS', () => {
+      expect(
+        () =>
+          new GoogleCredentialsAuthProvider(
+            mockConfig,
+            'http://language.googleapis.com/v1/models',
+          ),
+      ).toThrow(/requires HTTPS/);
+
+      expect(
+        () =>
+          new GoogleCredentialsAuthProvider(
+            mockConfig,
+            'http://my-cloud-run-service.run.app',
+          ),
+      ).toThrow(/requires HTTPS/);
+    });
   });
 
   describe('Token Fetching', () => {

--- a/packages/core/src/agents/auth-provider/google-credentials-provider.ts
+++ b/packages/core/src/agents/auth-provider/google-credentials-provider.ts
@@ -40,7 +40,14 @@ export class GoogleCredentialsAuthProvider extends BaseA2AAuthProvider {
       );
     }
 
-    const hostname = new URL(targetUrl).hostname;
+    const urlObj = new URL(targetUrl);
+    if (urlObj.protocol !== 'https:') {
+      throw new Error(
+        `Protocol "${urlObj.protocol}" is not secure. Google Credential provider requires HTTPS.`,
+      );
+    }
+
+    const hostname = urlObj.hostname;
     const isRunAppHost = CLOUD_RUN_HOST_REGEX.test(hostname);
 
     if (isRunAppHost) {


### PR DESCRIPTION
## Summary

Enforces secure HTTPS protocol for `GoogleCredentialsAuthProvider` to prevent transmission of sensitive Application Default Credentials (ADC) access and identity tokens over cleartext HTTP connections.

## Details

- **Protocol Security:** Adds a protocol verification check during `GoogleCredentialsAuthProvider` initialization to ensure `targetUrl` uses `https:`.
- **Preemptive Interception:** Prevents high-privilege credentials (such as broad-scope `cloud-platform` tokens) from being sent over plain HTTP connections, mitigating MITM/interception.
- **Unit Testing:** Adds comprehensive unit tests in `google-credentials-provider.test.ts` and `credential-leak-prevention.test.ts` to assert that unsecure HTTP connections are correctly intercepted and throw security exceptions.

## Related Issues

Fixes the vulnerability outlined in `issue.md`.

## How to Validate

Run the targeted unit tests for `GoogleCredentialsAuthProvider` and the new leak prevention test:
```bash
npm test -w @google/gemini-cli-core -- src/agents/auth-provider/google-credentials-provider.test.ts --run
npm test -w @google/gemini-cli-core -- src/agents/auth-provider/credential-leak-prevention.test.ts --run
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
