### PR TITLE
fix(vscode-ide-companion): stop leaking gemini.diff.accept and onDidChangeWorkspaceFolders disposables

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -131,6 +131,37 @@ describe('activate', () => {
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
   });
 
+  it('registers every created Disposable into context.subscriptions (no leaked commands/listeners)', async () => {
+    // Tag each created Disposable so we can verify it actually landed in
+    // context.subscriptions. The bug (#27790) wrapped two registrations in a
+    // stray parenthesis pair, turning them into a comma expression whose value
+    // was only the last operand — so the `gemini.diff.accept` command and the
+    // `onDidChangeWorkspaceFolders` listener were created but never tracked
+    // for disposal.
+    vi.mocked(vscode.commands.registerCommand).mockImplementation(
+      (id: string) =>
+        ({ command: id, dispose: vi.fn() }) as unknown as vscode.Disposable,
+    );
+    vi.mocked(vscode.workspace.onDidChangeWorkspaceFolders).mockImplementation(
+      () =>
+        ({
+          kind: 'onDidChangeWorkspaceFolders',
+          dispose: vi.fn(),
+        }) as unknown as vscode.Disposable,
+    );
+
+    await activate(context);
+
+    const pushed = context.subscriptions as Array<{
+      command?: string;
+      kind?: string;
+    }>;
+    expect(pushed.some((d) => d.command === 'gemini.diff.accept')).toBe(true);
+    expect(
+      pushed.some((d) => d.kind === 'onDidChangeWorkspaceFolders'),
+    ).toBe(true);
+  });
+
   it('should launch the Gemini CLI when the user clicks the button', async () => {
     const showInformationMessageMock = vi
       .mocked(vscode.window.showInformationMessage)

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -152,14 +152,16 @@ describe('activate', () => {
 
     await activate(context);
 
-    const pushed = context.subscriptions as Array<{
-      command?: string;
-      kind?: string;
-    }>;
-    expect(pushed.some((d) => d.command === 'gemini.diff.accept')).toBe(true);
-    expect(
-      pushed.some((d) => d.kind === 'onDidChangeWorkspaceFolders'),
-    ).toBe(true);
+    // Some mocked VS Code APIs return `undefined` by default in the test
+    // environment, so `context.subscriptions` can contain `undefined` entries.
+    // Guard property access with optional chaining to avoid a TypeError.
+    const pushed = context.subscriptions as Array<
+      { command?: string; kind?: string } | undefined
+    >;
+    expect(pushed.some((d) => d?.command === 'gemini.diff.accept')).toBe(true);
+    expect(pushed.some((d) => d?.kind === 'onDidChangeWorkspaceFolders')).toBe(
+      true,
+    );
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary
Fixes #27790.

The two `context.subscriptions.push(...)` calls in `activate()` wrapped a pair of registrations in a stray parenthesis pair, collapsing them into a comma expression whose value was only the last operand. As a result the `gemini.diff.accept` command Disposable and the `onDidChangeWorkspaceFolders` listener Disposable were created but never added to `context.subscriptions`, so they were never disposed on deactivation. On re-activation within the same extension host this threw `command 'gemini.diff.accept' already exists`, and the stale `onDidChangeWorkspaceFolders` listener kept firing `ideServer.syncEnvVars()` against a stopped `IDEServer`.

- Removed the extra parentheses so each registration is its own argument to `push()`.
- Added a regression test in `extension.test.ts` that tags the created Disposables and asserts both `gemini.diff.accept` and `onDidChangeWorkspaceFolders` land in `context.subscriptions`.

## Test plan
- `cd packages/vscode-ide-companion && npm test` (vitest): new test in `extension.test.ts` passes; existing tests unaffected.