### PR TITLE
fix(ci): retry staging-tmp dist-tag removal after npm publish

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -172,7 +172,10 @@ runs:
           --workspace="${INPUTS_CORE_PACKAGE_NAME}" \
           --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} staging-tmp
+          # Wombat may ack publish before dist-tags are queryable on large packages.
+          node "${{ github.workspace }}/scripts/remove-npm-dist-tag.js" \
+            --package="${INPUTS_CORE_PACKAGE_NAME}" \
+            --tag=staging-tmp
         fi
 
     - name: '🔗 Install latest core package'
@@ -251,7 +254,10 @@ runs:
           ${PUBLISH_TARGET} \
           --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} staging-tmp
+          # Wombat may ack publish before dist-tags are queryable on large packages.
+          node "${{ github.workspace }}/scripts/remove-npm-dist-tag.js" \
+            --package="${INPUTS_CLI_PACKAGE_NAME}" \
+            --tag=staging-tmp
         fi
 
     - name: 'Get a2a-server Token'
@@ -278,9 +284,12 @@ runs:
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
           --tag staging-tmp
-          if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-            npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} staging-tmp
-          fi
+        if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
+          # Wombat may ack publish before dist-tags are queryable on large packages.
+          node "${{ github.workspace }}/scripts/remove-npm-dist-tag.js" \
+            --package="${INPUTS_A2A_PACKAGE_NAME}" \
+            --tag=staging-tmp
+        fi
 
     - name: '🏷️ Tag release'
       uses: './.github/actions/tag-npm-release'

--- a/scripts/remove-npm-dist-tag.js
+++ b/scripts/remove-npm-dist-tag.js
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Removes an npm dist-tag with retries.
+ *
+ * Wombat/npm can acknowledge `npm publish` before dist-tags are queryable
+ * ("Your package is being processed and may take a few minutes to become
+ * available."). Immediate `npm dist-tag rm` then fails with
+ * "<tag> is not a dist-tag on <package>".
+ */
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const NOT_A_DIST_TAG_RE = /is not a dist-tag/i;
+
+function sleep(ms) {
+  // Sync sleep so this helper stays callable from CI shell steps without top-level await.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function removeDistTag(packageName, tag) {
+  execFileSync('npm', ['dist-tag', 'rm', packageName, tag], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+export function removeNpmDistTag({
+  packageName,
+  tag,
+  maxAttempts = 20,
+  retryDelayMs = 15_000,
+} = {}) {
+  if (!packageName) {
+    throw new Error('packageName is required');
+  }
+  if (!tag) {
+    throw new Error('tag is required');
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      removeDistTag(packageName, tag);
+      console.log(`Removed dist-tag "${tag}" from ${packageName}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      const output = `${error.stdout ?? ''}\n${error.stderr ?? ''}\n${error.message ?? ''}`;
+      console.error(output.trim());
+
+      if (!NOT_A_DIST_TAG_RE.test(output)) {
+        throw error;
+      }
+
+      if (attempt === maxAttempts) {
+        break;
+      }
+
+      console.error(
+        `dist-tag "${tag}" not yet available on ${packageName} ` +
+          `(attempt ${attempt}/${maxAttempts}); retrying in ${retryDelayMs / 1000}s...`,
+      );
+      sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error(
+    `Failed to remove dist-tag "${tag}" from ${packageName} after ${maxAttempts} attempts: ${lastError?.message ?? lastError}`,
+  );
+}
+
+function getArgs(argv = hideBin(process.argv)) {
+  return yargs(argv)
+    .option('package', {
+      description: 'npm package name (e.g. @google/gemini-cli-core)',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('tag', {
+      description: 'dist-tag to remove',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('max-attempts', {
+      description: 'Maximum number of removal attempts',
+      type: 'number',
+      default: 20,
+    })
+    .option('retry-delay-ms', {
+      description: 'Delay between retries in milliseconds',
+      type: 'number',
+      default: 15_000,
+    })
+    .help(false)
+    .version(false)
+    .parse();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = getArgs();
+  removeNpmDistTag({
+    packageName: args.package,
+    tag: args.tag,
+    maxAttempts: args['max-attempts'],
+    retryDelayMs: args['retry-delay-ms'],
+  });
+}

--- a/scripts/tests/remove-npm-dist-tag.test.js
+++ b/scripts/tests/remove-npm-dist-tag.test.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+const { removeNpmDistTag } = await import('../remove-npm-dist-tag.js');
+
+describe('removeNpmDistTag', () => {
+  beforeEach(() => {
+    vi.spyOn(Atomics, 'wait').mockImplementation(() => 'ok');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('removes the dist-tag on the first attempt', () => {
+    execFileSync.mockReturnValue('');
+
+    removeNpmDistTag({
+      packageName: '@google/gemini-cli-core',
+      tag: 'staging-tmp',
+    });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'npm',
+      ['dist-tag', 'rm', '@google/gemini-cli-core', 'staging-tmp'],
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(Atomics.wait).not.toHaveBeenCalled();
+  });
+
+  it('retries when the registry has not propagated the dist-tag yet', () => {
+    const notReady = Object.assign(new Error('Command failed'), {
+      stderr:
+        'npm error staging-tmp is not a dist-tag on @google/gemini-cli-core',
+      stdout: '',
+    });
+
+    execFileSync
+      .mockImplementationOnce(() => {
+        throw notReady;
+      })
+      .mockImplementationOnce(() => ''); // successful rm
+
+    removeNpmDistTag({
+      packageName: '@google/gemini-cli-core',
+      tag: 'staging-tmp',
+      maxAttempts: 3,
+      retryDelayMs: 1000,
+    });
+
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'npm',
+      ['dist-tag', 'rm', '@google/gemini-cli-core', 'staging-tmp'],
+      expect.any(Object),
+    );
+    expect(Atomics.wait).toHaveBeenCalledWith(
+      expect.any(Int32Array),
+      0,
+      0,
+      1000,
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'npm',
+      ['dist-tag', 'rm', '@google/gemini-cli-core', 'staging-tmp'],
+      expect.any(Object),
+    );
+  });
+
+  it('does not retry on unexpected npm errors', () => {
+    const authError = Object.assign(new Error('Command failed'), {
+      stderr: 'npm error code ENEEDAUTH',
+      stdout: '',
+    });
+    execFileSync.mockImplementation(() => {
+      throw authError;
+    });
+
+    expect(() =>
+      removeNpmDistTag({
+        packageName: '@google/gemini-cli-core',
+        tag: 'staging-tmp',
+        maxAttempts: 3,
+        retryDelayMs: 1000,
+      }),
+    ).toThrow(authError);
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(Atomics.wait).not.toHaveBeenCalled();
+  });
+
+  it('throws after exhausting retries for missing dist-tags', () => {
+    const notReady = Object.assign(new Error('Command failed'), {
+      stderr:
+        'npm error staging-tmp is not a dist-tag on @google/gemini-cli-core',
+      stdout: '',
+    });
+    execFileSync.mockImplementation(() => {
+      throw notReady;
+    });
+
+    expect(() =>
+      removeNpmDistTag({
+        packageName: '@google/gemini-cli-core',
+        tag: 'staging-tmp',
+        maxAttempts: 2,
+        retryDelayMs: 1000,
+      }),
+    ).toThrow(/Failed to remove dist-tag "staging-tmp"/);
+
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+    expect(Atomics.wait).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Nightly release `#28533` failed because Wombat/npm acknowledged publishing the large `@google/gemini-cli-core` package before the `staging-tmp` dist-tag was queryable, so immediate `npm dist-tag rm staging-tmp` exited with `staging-tmp is not a dist-tag`.
- Add `scripts/remove-npm-dist-tag.js` to retry removal until the tag propagates (failing fast on unrelated errors), and use it for core/CLI/a2a publish steps.
- Includes unit coverage for success, retry, non-retryable errors, and exhausted retries.

Fixes #28533

## Test plan
- [x] `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/remove-npm-dist-tag.test.js`
- [ ] Re-run or wait for the next scheduled nightly release and confirm Publish Release gets past core `staging-tmp` removal
- [ ] Confirm leftover `staging-tmp` from the failed run is cleaned up once a successful publish completes (or cleaned manually if needed)


Made with [Cursor](https://cursor.com)