### PR TITLE
fix: use resolveRipgrepPath in perf test global setup

### DIFF
--- a/perf-tests/globalSetup.ts
+++ b/perf-tests/globalSetup.ts
@@ -7,7 +7,7 @@
 import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { canUseRipgrep } from '../packages/core/src/tools/ripGrep.js';
+import { resolveRipgrepPath } from '../packages/core/src/tools/ripGrep.js';
 import { isolateTestEnv } from '../packages/test-utils/src/env-setup.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -23,10 +23,10 @@ export async function setup() {
   // Isolate environment variables
   isolateTestEnv(runDir);
 
-  // Download ripgrep to avoid race conditions
-  const available = await canUseRipgrep();
-  if (!available) {
-    throw new Error('Failed to download ripgrep binary');
+  // Resolve ripgrep binary before running performance tests
+  const ripgrepPath = await resolveRipgrepPath();
+  if (!ripgrepPath) {
+    throw new Error('Failed to resolve ripgrep binary');
   }
 
   // Clean up old test runs, keeping the latest few for debugging


### PR DESCRIPTION
## Summary

Update the performance test global setup to use `resolveRipgrepPath()` instead of the removed `canUseRipgrep()` helper.

This keeps the performance test setup compatible with the current ripgrep resolver API and prevents failures caused by referencing the removed function.

## Details

- Replaced the deprecated `canUseRipgrep()` import with `resolveRipgrepPath()`.
- Updated the setup logic to resolve the ripgrep binary path before running performance tests.
- Updated the error message to reflect the new behavior when the binary cannot be resolved.
- No functional changes beyond adapting to the renamed API.

## Related Issues

Fixes #28417

## How to Validate

1. Check out this branch.
2. Verify that `perf-tests/globalSetup.ts` imports `resolveRipgrepPath`.
3. Run the performance test setup or performance test suite.
4. Confirm that the setup resolves the ripgrep binary successfully instead of calling the removed `canUseRipgrep()` helper.
5. Verify that if the binary cannot be resolved, setup fails with:
   ```
   Failed to resolve ripgrep binary
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
  - No breaking changes.
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run *(local validation blocked by unrelated workspace/dependency issues)*
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker