### PR TITLE
fix(mcp): disclose that Plan Mode read-only status is a server claim

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -480,6 +480,10 @@ export const ToolConfirmationMessage: React.FC<
       if (containsRedirection && !isAutoEdit) {
         extraInfoLines = 1; // Warning line
       }
+    } else if (confirmationDetails.type === 'mcp') {
+      if (confirmationDetails.serverDeclaredReadOnly) {
+        extraInfoLines = 1; // Unverified read-only claim notice
+      }
     }
 
     const surroundingElementsHeight =
@@ -823,7 +827,22 @@ export const ToolConfirmationMessage: React.FC<
         );
       } else if (confirmationDetails.type === 'mcp') {
         const mcpProps = confirmationDetails;
-        question = `Allow execution of MCP tool "${sanitizeForDisplay(mcpProps.toolName)}" from server "${sanitizeForDisplay(mcpProps.serverName)}"?`;
+        const mcpAllowQuestion = (
+          <Text color={theme.text.primary}>
+            {`Allow execution of MCP tool "${sanitizeForDisplay(mcpProps.toolName)}" from server "${sanitizeForDisplay(mcpProps.serverName)}"?`}
+          </Text>
+        );
+        question = mcpProps.serverDeclaredReadOnly ? (
+          <Box flexDirection="column">
+            {mcpAllowQuestion}
+            <Text color={theme.status.warning}>
+              This server declares this tool read-only. Gemini CLI has not
+              verified that claim.
+            </Text>
+          </Box>
+        ) : (
+          mcpAllowQuestion
+        );
 
         bodyContent = (
           <Box flexDirection="column">

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -877,6 +877,90 @@ describe('DiscoveredMCPTool', () => {
   });
 
   describe('shouldConfirmExecute', () => {
+
+    it('should flag a tool the server declared read-only', async () => {
+      const bus = createMockMessageBus();
+      getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+      const annotatedTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        bus,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { readOnlyHint: true },
+      );
+      const invocation = annotatedTool.build({ param: 'mock' });
+      const details = (await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      )) as { serverDeclaredReadOnly?: boolean } | false;
+      expect(details).not.toBe(false);
+      expect(
+        (details as { serverDeclaredReadOnly?: boolean }).serverDeclaredReadOnly,
+      ).toBe(true);
+    });
+
+    it('should not flag a tool the server declared not read-only', async () => {
+      const bus = createMockMessageBus();
+      getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+      const annotatedTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        bus,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { readOnlyHint: false },
+      );
+      const invocation = annotatedTool.build({ param: 'mock' });
+      const details = (await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      )) as { serverDeclaredReadOnly?: boolean } | false;
+      expect(details).not.toBe(false);
+      expect(
+        (details as { serverDeclaredReadOnly?: boolean }).serverDeclaredReadOnly,
+      ).toBe(false);
+    });
+
+    it('should not flag a tool with no annotations', async () => {
+      const bus = createMockMessageBus();
+      getMockMessageBusInstance(bus).defaultToolDecision = 'ask_user';
+      const annotatedTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        bus,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+      const invocation = annotatedTool.build({ param: 'mock' });
+      const details = (await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      )) as { serverDeclaredReadOnly?: boolean } | false;
+      expect(details).not.toBe(false);
+      expect(
+        (details as { serverDeclaredReadOnly?: boolean }).serverDeclaredReadOnly,
+      ).toBe(false);
+    });
     it('should return false if trust is true', async () => {
       const trustedTool = new DiscoveredMCPTool(
         mockCallableToolInstance,

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -224,6 +224,7 @@ export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
       toolArgs: this.params,
       toolDescription: this.toolDescription,
       toolParameterSchema: this.toolParameterSchema,
+      serverDeclaredReadOnly: this._toolAnnotations?.['readOnlyHint'] === true,
       onConfirm: async (outcome: ToolConfirmationOutcome) => {
         if (outcome === ToolConfirmationOutcome.ProceedAlwaysServer) {
           DiscoveredMCPToolInvocation.allowlist.add(serverAllowListKey);

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -1045,6 +1045,13 @@ export interface ToolMcpConfirmationDetails {
   toolArgs?: Record<string, unknown>;
   toolDescription?: string;
   toolParameterSchema?: unknown;
+  /**
+   * True when the MCP server declared this tool read-only via the
+   * `readOnlyHint` annotation. The value comes from the server and is not
+   * verified by Gemini CLI, so it is surfaced to the user at the point of
+   * approval rather than treated as a guarantee.
+   */
+  serverDeclaredReadOnly?: boolean;
   onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
 }
 


### PR DESCRIPTION
Closes #28548.

## Summary

Plan Mode presents itself as read-only, and for MCP tools that decision rests on the `readOnlyHint` annotation the MCP server supplies about itself. Gemini CLI does not verify it, and `plan.toml` promotes any tool carrying it out of the Plan Mode deny-all into `ask_user`. A server therefore decides which of its own tools Plan Mode will surface, including a destructive one.

The confirmation prompt still fires, so this is not silent execution. But the prompt never tells the user that the read-only status is a server claim, while Plan Mode's own messaging tells them Plan Mode is read-only. The approval prompt is the control that catches this case, so it should carry the doubt.

Reported to Google VRP as b/524448710 (closed Won't Fix / Infeasible, P2 / S4). Triage confirmed on 2026-07-27 that a public PR is welcome.

## What this changes

When an MCP tool is presented for confirmation and the server declared it read-only, the prompt now says so and states that Gemini CLI has not verified the claim. One extra line, shown only when the annotation is present.

- `packages/core/src/tools/tools.ts`: adds optional `serverDeclaredReadOnly` to `ToolMcpConfirmationDetails`.
- `packages/core/src/tools/mcp-tool.ts`: populates it from the server-supplied `readOnlyHint` annotation.
- `packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx`: renders the disclosure. This mirrors the existing `exec` redirection-warning pattern, including the `extraInfoLines` height accounting so the layout math stays correct.
- `packages/core/src/tools/mcp-tool.test.ts`: asserts the flag tracks the annotation and nothing else (true when declared, false when declared false, false when absent).

## What this deliberately does not change

The `plan.toml` promotion stays. Removing it would deny all MCP tools in Plan Mode and undo the MCP-in-Plan-Mode support from #18229 and the annotation matching from #19671 / #20029 / #20083. No defaults change, no new config surface, no behavior change for servers that do not send the annotation.

## Follow-up available on request

Gate the promotion on user-side trust: honor `readOnlyHint` in Plan Mode only for servers the user has explicitly marked trusted, and treat MCP tools as non-read-only in Plan Mode otherwise. Stronger boundary, but it changes default behavior for existing MCP users, so I kept it out of this PR. Happy to build it if you prefer that shape.

For context, #27156 and #27163 asked for the opposite, trusting `readOnlyHint` enough to auto-allow annotated tools in Plan Mode, and both were closed. This change is consistent with that outcome.

## Testing note

Unit tests are included. I do not have a full local build of the monorepo, so CI here is the first complete typecheck, lint, and test run. Happy to fix up anything it flags.
