### PR TITLE
fix(core): skip merged function-response turns when finding the active loop

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2447,6 +2447,37 @@ describe('GeminiChat', () => {
       expect(newContents[5]?.parts?.[1]).not.toHaveProperty('thoughtSignature');
     });
 
+    it('should skip a user turn that has text alongside a functionResponse when locating the active loop', () => {
+      const chat = new GeminiChat(mockConfig, '', [], []);
+      // `coalesceConsecutiveRoles` can merge a function response turn with the
+      // prompt that follows it, producing a user turn holding both.
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'First prompt' }] },
+        {
+          role: 'model',
+          parts: [
+            { text: 'Working on it' },
+            { functionCall: { name: 'some_tool', args: {} } },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            { functionResponse: { name: 'some_tool', response: {} } },
+            { text: 'Second prompt' },
+          ],
+        },
+      ];
+
+      const newContents = chat.ensureActiveLoopHasThoughtSignatures(history);
+
+      // The merged turn must not be taken as the loop start, otherwise the
+      // model turn before it is left unsigned while the API still validates it.
+      expect(newContents[1]?.parts?.[1]?.thoughtSignature).toBe(
+        SYNTHETIC_THOUGHT_SIGNATURE,
+      );
+    });
+
     it('should not modify contents if there is no user text message', () => {
       const chat = new GeminiChat(mockConfig, '', [], []);
       const history: Content[] = [

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1044,11 +1044,19 @@ export class GeminiChat {
     requestContents: readonly Content[],
   ): readonly Content[] {
     // First, find the start of the active loop by finding the last user turn
-    // with a text message, i.e. that is not a function response.
+    // with a text message, i.e. that is not a function response. Testing for
+    // text alone is not enough: `coalesceConsecutiveRoles` can merge a function
+    // response turn with the prompt that follows it, and starting the loop at
+    // such a turn starts it later than the API starts the turn, leaving earlier
+    // function calls unsigned but still validated.
     let activeLoopStartIndex = -1;
     for (let i = requestContents.length - 1; i >= 0; i--) {
       const content = requestContents[i];
-      if (content.role === 'user' && content.parts?.some((part) => part.text)) {
+      if (
+        content.role === 'user' &&
+        content.parts?.some((part) => part.text) &&
+        !content.parts?.some((part) => part.functionResponse)
+      ) {
         activeLoopStartIndex = i;
         break;
       }


### PR DESCRIPTION
## Summary

Tool calls can be sent to the API without a thought signature, which the API
rejects with `400 INVALID_ARGUMENT`. The bad turn stays in history, so once it
happens the session cannot recover. Skill activation triggers it on every use,
because that call is generated client-side and carries no signature of its own.

Regression from #28407, first shipped in `v0.52.0-nightly.20260716`. Not in
`v0.51.0`.

## Details

`ensureActiveLoopHasThoughtSignatures` finds the start of the active loop by
looking for the last `user` turn containing text. Its comment already describes
the correct rule:

```ts
// ...the last user turn with a text message, i.e. that is not a function response.
if (content.role === 'user' && content.parts?.some((part) => part.text)) {
```

The code never checked for a function response. That was equivalent only while a
user turn was either pure text or pure function response.

#28407 added `coalesceConsecutiveRoles`, which merges adjacent same-role turns —
so a function response turn can now be merged with the prompt that follows it.
Starting the loop at such a turn starts it _later_ than the API starts the turn,
so model turns in between are validated by the API but never receive a synthetic
signature.

The fix adds the missing condition, making the code match its comment and the
API's own turn boundary. One condition, one regression test.

## Related Issues

Regression from #28407.

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/core/geminiChat.test.ts
```

The new test builds the merged `functionResponse` + text turn and asserts the
preceding call is signed. It fails on `main`
(`expected undefined to be 'skip_thought_signature_validator'`) and passes with
this change.

Manually: send a prompt, let the model reply, then activate a skill with
`/<skill-name>` and send a follow-up. Before this change the follow-up returns
`400`; after it, it succeeds.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
