### PR TITLE
fix(core,cli): propagate InvalidStreamError details to UI for specific empty response guidance

### DIFF
--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -319,6 +319,41 @@ describe('Session', () => {
     expect(result).toMatchObject({ stopReason: 'end_turn' });
   });
 
+  it.each([
+    { type: 'MAX_TOKENS_EXCEEDED', reason: 'MAX_TOKENS' },
+    { type: 'SAFETY_BLOCKED', reason: 'SAFETY' },
+    { type: 'RECITATION_BLOCKED', reason: 'RECITATION' },
+    { type: 'OTHER_BLOCKED', reason: 'OTHER' },
+    { type: 'THINKING_ONLY_RESPONSE', reason: 'STOP' },
+  ])(
+    'should gracefully handle InvalidStreamError with type $type in ACP session',
+    async ({ type, reason }) => {
+      const error = new InvalidStreamError(
+        `Stream failed with ${reason}`,
+        type as InvalidStreamError['type'],
+      );
+      mockSendMessageStream.mockImplementation(() => {
+        async function* errorGen(): AsyncGenerator<
+          ServerGeminiStreamEvent,
+          void,
+          unknown
+        > {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          yield* [] as any;
+          throw error;
+        }
+        return errorGen();
+      });
+
+      const result = await session.prompt({
+        sessionId: 'session-1',
+        prompt: [{ type: 'text', text: 'Hi' }],
+      });
+
+      expect(result).toMatchObject({ stopReason: 'end_turn' });
+    },
+  );
+
   it('should handle /memory command', async () => {
     const handleCommandSpy = vi
       .spyOn(

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -510,7 +510,12 @@ export class Session {
             (error.type === 'NO_RESPONSE_TEXT' ||
               error.type === 'NO_FINISH_REASON' ||
               error.type === 'MALFORMED_FUNCTION_CALL' ||
-              error.type === 'UNEXPECTED_TOOL_CALL'))
+              error.type === 'UNEXPECTED_TOOL_CALL' ||
+              error.type === 'MAX_TOKENS_EXCEEDED' ||
+              error.type === 'SAFETY_BLOCKED' ||
+              error.type === 'RECITATION_BLOCKED' ||
+              error.type === 'OTHER_BLOCKED' ||
+              error.type === 'THINKING_ONLY_RESPONSE'))
         ) {
           // The stream ended with an empty response or malformed tool call.
           // Treat this as a graceful end to the model's turn rather than a crash.

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -110,6 +110,7 @@ describe('runNonInteractive', () => {
     sendMessageStream: Mock;
     resumeChat: Mock;
     getChatRecordingService: Mock;
+    getCurrentSequenceModel: Mock;
   };
   const MOCK_SESSION_METRICS: SessionMetrics = {
     models: {},
@@ -165,6 +166,7 @@ describe('runNonInteractive', () => {
         recordMessageTokens: vi.fn(),
         recordToolCalls: vi.fn(),
       })),
+      getCurrentSequenceModel: vi.fn().mockReturnValue('gemini-2.5-flash'),
     };
 
     mockConfig = {
@@ -193,6 +195,7 @@ describe('runNonInteractive', () => {
       getRawOutput: vi.fn().mockReturnValue(false),
       getAcceptRawOutputRisk: vi.fn().mockReturnValue(false),
       getAgentSessionNoninteractiveEnabled: vi.fn().mockReturnValue(false),
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     mockSettings = {
@@ -1820,7 +1823,6 @@ describe('runNonInteractive', () => {
     };
     // @ts-expect-error - Mocking internal structure
     mockGeminiClient.getChat = vi.fn().mockReturnValue(mockChat);
-    // @ts-expect-error - Mocking internal structure
     mockGeminiClient.getCurrentSequenceModel = vi
       .fn()
       .mockReturnValue('model-1');
@@ -2318,7 +2320,7 @@ describe('runNonInteractive', () => {
       });
 
       expect(processStderrSpy).toHaveBeenCalledWith(
-        '[ERROR] Invalid stream: The model returned an empty response or malformed tool call.\n',
+        '[ERROR] The model returned an empty text response. If your context window is near capacity, try using /compress.\n',
       );
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
@@ -2354,7 +2356,7 @@ describe('runNonInteractive', () => {
       expect(output).toContain('"type":"error"');
       expect(output).toContain('"severity":"error"');
       expect(output).toContain(
-        'Invalid stream: The model returned an empty response or malformed tool call.',
+        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
       );
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
@@ -2390,7 +2392,34 @@ describe('runNonInteractive', () => {
       expect(output).toContain('"error": {');
       expect(output).toContain('"type": "INVALID_STREAM"');
       expect(output).toContain(
-        'Invalid stream: The model returned an empty response or malformed tool call.',
+        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
+      );
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle non-NO_RESPONSE_TEXT InvalidStream event gracefully and use message from eventValue', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'MALFORMED_FUNCTION_CALL',
+            message: 'Custom malformed function call message',
+          },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test invalid stream malformed',
+        prompt_id: 'prompt-id-invalid-malformed',
+      });
+
+      expect(processStderrSpy).toHaveBeenCalledWith(
+        '[ERROR] Custom malformed function call message\n',
       );
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -22,6 +22,7 @@ import {
   CoreEvent,
   CoreToolCallStatus,
   JsonStreamEventType,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
@@ -2320,7 +2321,7 @@ describe('runNonInteractive', () => {
       });
 
       expect(processStderrSpy).toHaveBeenCalledWith(
-        '[ERROR] The model returned an empty text response. If your context window is near capacity, try using /compress.\n',
+        `[ERROR] ${TRUE_EMPTY_RESPONSE_MESSAGE}\n`,
       );
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
@@ -2355,9 +2356,7 @@ describe('runNonInteractive', () => {
       const output = getWrittenOutput();
       expect(output).toContain('"type":"error"');
       expect(output).toContain('"severity":"error"');
-      expect(output).toContain(
-        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
-      );
+      expect(output).toContain(TRUE_EMPTY_RESPONSE_MESSAGE);
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
 
@@ -2391,9 +2390,7 @@ describe('runNonInteractive', () => {
       const output = getWrittenOutput();
       expect(output).toContain('"error": {');
       expect(output).toContain('"type": "INVALID_STREAM"');
-      expect(output).toContain(
-        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
-      );
+      expect(output).toContain(TRUE_EMPTY_RESPONSE_MESSAGE);
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2298,7 +2298,13 @@ describe('runNonInteractive', () => {
 
     it('should handle InvalidStream event gracefully in TEXT mode', async () => {
       const events: ServerGeminiStreamEvent[] = [
-        { type: GeminiEventType.InvalidStream },
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
       ];
       mockGeminiClient.sendMessageStream.mockReturnValue(
         createStreamFromEvents(events),
@@ -2325,7 +2331,13 @@ describe('runNonInteractive', () => {
         OutputFormat.STREAM_JSON,
       );
       const events: ServerGeminiStreamEvent[] = [
-        { type: GeminiEventType.InvalidStream },
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
       ];
       mockGeminiClient.sendMessageStream.mockReturnValue(
         createStreamFromEvents(events),
@@ -2355,7 +2367,13 @@ describe('runNonInteractive', () => {
         OutputFormat.JSON,
       );
       const events: ServerGeminiStreamEvent[] = [
-        { type: GeminiEventType.InvalidStream },
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
       ];
       mockGeminiClient.sendMessageStream.mockReturnValue(
         createStreamFromEvents(events),

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -79,6 +79,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ChatRecordingService: MockChatRecordingService,
     uiTelemetryService: {
       getMetrics: vi.fn(),
+      recordSemanticValidationError: vi.fn(),
     },
     coreEvents: mockCoreEvents,
     createWorkingStdio: vi.fn(() => ({

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -32,7 +32,12 @@ import {
   ROOT_SCHEDULER_ID,
   logApiError,
   ApiErrorEvent,
-  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+  THINKING_ONLY_COMPRESS_SUGGESTION,
+  MAX_TOKENS_EXCEEDED_SUGGESTION,
+  SAFETY_BLOCKED_MESSAGE,
+  RECITATION_BLOCKED_MESSAGE,
+  OTHER_BLOCKED_MESSAGE,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -438,7 +443,17 @@ export async function runNonInteractive(
           } else if (event.type === GeminiEventType.InvalidStream) {
             const eventValue = event.value;
             if (eventValue?.type === 'NO_RESPONSE_TEXT') {
-              invalidStreamError = EMPTY_RESPONSE_COMPRESS_SUGGESTION;
+              invalidStreamError = TRUE_EMPTY_RESPONSE_MESSAGE;
+            } else if (eventValue?.type === 'THINKING_ONLY_RESPONSE') {
+              invalidStreamError = THINKING_ONLY_COMPRESS_SUGGESTION;
+            } else if (eventValue?.type === 'MAX_TOKENS_EXCEEDED') {
+              invalidStreamError = MAX_TOKENS_EXCEEDED_SUGGESTION;
+            } else if (eventValue?.type === 'SAFETY_BLOCKED') {
+              invalidStreamError = SAFETY_BLOCKED_MESSAGE;
+            } else if (eventValue?.type === 'RECITATION_BLOCKED') {
+              invalidStreamError = RECITATION_BLOCKED_MESSAGE;
+            } else if (eventValue?.type === 'OTHER_BLOCKED') {
+              invalidStreamError = OTHER_BLOCKED_MESSAGE;
             } else {
               invalidStreamError =
                 eventValue?.message?.trim() ||

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -30,6 +30,8 @@ import {
   ToolErrorType,
   Scheduler,
   ROOT_SCHEDULER_ID,
+  logApiError,
+  ApiErrorEvent,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -433,8 +435,32 @@ export async function runNonInteractive(
             }
             warnings.push(blockMessage);
           } else if (event.type === GeminiEventType.InvalidStream) {
-            invalidStreamError =
-              'Invalid stream: The model returned an empty response or malformed tool call.';
+            const eventValue = event.value;
+            if (eventValue?.type === 'NO_RESPONSE_TEXT') {
+              invalidStreamError =
+                'The model returned an empty text response. If your context window is near capacity, try using /compress.';
+            } else {
+              invalidStreamError =
+                eventValue?.message?.trim() ||
+                'Invalid stream: The model returned an empty response or malformed tool call.';
+            }
+
+            // Log the API error telemetry
+            logApiError(
+              config,
+              new ApiErrorEvent(
+                geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+                eventValue?.message || 'Invalid stream received from model',
+                0, // duration
+                {
+                  prompt_id,
+                  contents: [],
+                },
+                config.getContentGeneratorConfig()?.authType,
+                eventValue?.type || 'INVALID_STREAM',
+              ),
+            );
+
             if (streamFormatter) {
               streamFormatter.emitEvent({
                 type: JsonStreamEventType.ERROR,

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -30,8 +30,6 @@ import {
   ToolErrorType,
   Scheduler,
   ROOT_SCHEDULER_ID,
-  logApiError,
-  ApiErrorEvent,
   THINKING_ONLY_COMPRESS_SUGGESTION,
   MAX_TOKENS_EXCEEDED_SUGGESTION,
   SAFETY_BLOCKED_MESSAGE,
@@ -460,20 +458,10 @@ export async function runNonInteractive(
                 'Invalid stream: The model returned an empty response or malformed tool call.';
             }
 
-            // Log the API error telemetry
-            logApiError(
-              config,
-              new ApiErrorEvent(
-                geminiClient.getCurrentSequenceModel() ?? config.getModel(),
-                eventValue?.message || 'Invalid stream received from model',
-                0, // duration
-                {
-                  prompt_id,
-                  contents: [],
-                },
-                config.getContentGeneratorConfig()?.authType,
-                eventValue?.type || 'INVALID_STREAM',
-              ),
+            // Log semantic error telemetry without double-counting requests
+            uiTelemetryService.recordSemanticValidationError(
+              geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+              eventValue?.type || 'INVALID_STREAM',
             );
 
             if (streamFormatter) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -32,6 +32,7 @@ import {
   ROOT_SCHEDULER_ID,
   logApiError,
   ApiErrorEvent,
+  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
 } from '@google/gemini-cli-core';
 
 import type { Content, Part } from '@google/genai';
@@ -437,8 +438,7 @@ export async function runNonInteractive(
           } else if (event.type === GeminiEventType.InvalidStream) {
             const eventValue = event.value;
             if (eventValue?.type === 'NO_RESPONSE_TEXT') {
-              invalidStreamError =
-                'The model returned an empty text response. If your context window is near capacity, try using /compress.';
+              invalidStreamError = EMPTY_RESPONSE_COMPRESS_SUGGESTION;
             } else {
               invalidStreamError =
                 eventValue?.message?.trim() ||

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -2458,6 +2458,130 @@ describe('runNonInteractive', () => {
       const output = JSON.parse(getWrittenOutput());
       expect(output.warnings).toBeUndefined();
     });
+
+    it('should handle InvalidStream event gracefully in TEXT mode', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test invalid stream',
+        prompt_id: 'prompt-id-invalid',
+      });
+
+      expect(processStderrSpy).toHaveBeenCalledWith(
+        '[ERROR] The model returned an empty text response. If your context window is near capacity, try using /compress.\n',
+      );
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle InvalidStream event gracefully in STREAM_JSON mode', async () => {
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+      vi.spyOn(mockConfig, 'getOutputFormat').mockReturnValue(
+        OutputFormat.STREAM_JSON,
+      );
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test invalid stream',
+        prompt_id: 'prompt-id-invalid',
+      });
+
+      const output = getWrittenOutput();
+      expect(output).toContain('"type":"error"');
+      expect(output).toContain('"severity":"error"');
+      expect(output).toContain(
+        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
+      );
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle InvalidStream event gracefully in JSON mode', async () => {
+      vi.spyOn(uiTelemetryService, 'getMetrics').mockReturnValue(
+        MOCK_SESSION_METRICS,
+      );
+      vi.spyOn(mockConfig, 'getOutputFormat').mockReturnValue(
+        OutputFormat.JSON,
+      );
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_RESPONSE_TEXT',
+            message: 'Empty response',
+          },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test invalid stream',
+        prompt_id: 'prompt-id-invalid',
+      });
+
+      const output = getWrittenOutput();
+      expect(output).toContain('"error": {');
+      expect(output).toContain('"type": "INVALID_STREAM"');
+      expect(output).toContain(
+        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
+      );
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle non-NO_RESPONSE_TEXT InvalidStream event gracefully and use message from eventValue', async () => {
+      const events: ServerGeminiStreamEvent[] = [
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'MALFORMED_FUNCTION_CALL',
+            message: 'Malformed call',
+          },
+        },
+      ];
+      mockGeminiClient.sendMessageStream.mockReturnValue(
+        createStreamFromEvents(events),
+      );
+
+      await runNonInteractive({
+        config: mockConfig,
+        settings: mockSettings,
+        input: 'test invalid stream',
+        prompt_id: 'prompt-id-invalid',
+      });
+
+      expect(processStderrSpy).toHaveBeenCalledWith('[ERROR] Malformed call\n');
+      expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Output Sanitization', () => {

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -199,6 +199,7 @@ describe('runNonInteractive', () => {
       getRawOutput: vi.fn().mockReturnValue(false),
       getAcceptRawOutputRisk: vi.fn().mockReturnValue(false),
       getAgentSessionNoninteractiveEnabled: vi.fn().mockReturnValue(false),
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     mockSettings = {

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -79,6 +79,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
     ChatRecordingService: MockChatRecordingService,
     uiTelemetryService: {
       getMetrics: vi.fn(),
+      recordSemanticValidationError: vi.fn(),
     },
     LegacyAgentSession: original.LegacyAgentSession,
     geminiPartsToContentParts: original.geminiPartsToContentParts,

--- a/packages/cli/src/nonInteractiveCliAgentSession.test.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.test.ts
@@ -22,6 +22,7 @@ import {
   CoreEvent,
   CoreToolCallStatus,
   JsonStreamEventType,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 import type { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCliAgentSession.js';
@@ -2481,7 +2482,7 @@ describe('runNonInteractive', () => {
       });
 
       expect(processStderrSpy).toHaveBeenCalledWith(
-        '[ERROR] The model returned an empty text response. If your context window is near capacity, try using /compress.\n',
+        `[ERROR] ${TRUE_EMPTY_RESPONSE_MESSAGE}\n`,
       );
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
@@ -2516,9 +2517,7 @@ describe('runNonInteractive', () => {
       const output = getWrittenOutput();
       expect(output).toContain('"type":"error"');
       expect(output).toContain('"severity":"error"');
-      expect(output).toContain(
-        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
-      );
+      expect(output).toContain(TRUE_EMPTY_RESPONSE_MESSAGE);
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
 
@@ -2552,9 +2551,7 @@ describe('runNonInteractive', () => {
       const output = getWrittenOutput();
       expect(output).toContain('"error": {');
       expect(output).toContain('"type": "INVALID_STREAM"');
-      expect(output).toContain(
-        'The model returned an empty text response. If your context window is near capacity, try using /compress.',
-      );
+      expect(output).toContain(TRUE_EMPTY_RESPONSE_MESSAGE);
       expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -39,8 +39,6 @@ import {
   geminiPartsToContentParts,
   displayContentToString,
   debugLogger,
-  logApiError,
-  ApiErrorEvent,
   THINKING_ONLY_COMPRESS_SUGGESTION,
   MAX_TOKENS_EXCEEDED_SUGGESTION,
   SAFETY_BLOCKED_MESSAGE,
@@ -560,9 +558,6 @@ export async function runNonInteractive({
               const errorTypeVal = event._meta?.['errorType'];
               const errorType =
                 typeof errorTypeVal === 'string' ? errorTypeVal : undefined;
-              const rawMessageVal = event._meta?.['rawMessage'];
-              const rawMessage =
-                typeof rawMessageVal === 'string' ? rawMessageVal : undefined;
 
               let errorMessage = event.message;
               if (errorType === 'NO_RESPONSE_TEXT') {
@@ -590,20 +585,10 @@ export async function runNonInteractive({
                 process.stderr.write(`[ERROR] ${errorMessage}\n`);
               }
 
-              // Log the API error telemetry
-              logApiError(
-                config,
-                new ApiErrorEvent(
-                  geminiClient.getCurrentSequenceModel() ?? config.getModel(),
-                  rawMessage || 'Invalid stream received from model',
-                  0, // duration
-                  {
-                    prompt_id,
-                    contents: [],
-                  },
-                  config.getContentGeneratorConfig()?.authType,
-                  errorType || 'INVALID_STREAM',
-                ),
+              // Log semantic error telemetry without double-counting requests
+              uiTelemetryService.recordSemanticValidationError(
+                geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+                errorType || 'INVALID_STREAM',
               );
 
               // If it's a fatal stream error, we should terminate and output final results

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -41,7 +41,12 @@ import {
   debugLogger,
   logApiError,
   ApiErrorEvent,
-  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+  THINKING_ONLY_COMPRESS_SUGGESTION,
+  MAX_TOKENS_EXCEEDED_SUGGESTION,
+  SAFETY_BLOCKED_MESSAGE,
+  RECITATION_BLOCKED_MESSAGE,
+  OTHER_BLOCKED_MESSAGE,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 
 import type { Part } from '@google/genai';
@@ -559,10 +564,20 @@ export async function runNonInteractive({
               const rawMessage =
                 typeof rawMessageVal === 'string' ? rawMessageVal : undefined;
 
-              const errorMessage =
-                errorType === 'NO_RESPONSE_TEXT'
-                  ? EMPTY_RESPONSE_COMPRESS_SUGGESTION
-                  : event.message;
+              let errorMessage = event.message;
+              if (errorType === 'NO_RESPONSE_TEXT') {
+                errorMessage = TRUE_EMPTY_RESPONSE_MESSAGE;
+              } else if (errorType === 'THINKING_ONLY_RESPONSE') {
+                errorMessage = THINKING_ONLY_COMPRESS_SUGGESTION;
+              } else if (errorType === 'MAX_TOKENS_EXCEEDED') {
+                errorMessage = MAX_TOKENS_EXCEEDED_SUGGESTION;
+              } else if (errorType === 'SAFETY_BLOCKED') {
+                errorMessage = SAFETY_BLOCKED_MESSAGE;
+              } else if (errorType === 'RECITATION_BLOCKED') {
+                errorMessage = RECITATION_BLOCKED_MESSAGE;
+              } else if (errorType === 'OTHER_BLOCKED') {
+                errorMessage = OTHER_BLOCKED_MESSAGE;
+              }
 
               if (streamFormatter) {
                 streamFormatter.emitEvent({

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -559,7 +559,7 @@ export async function runNonInteractive({
               const rawMessage =
                 typeof rawMessageVal === 'string' ? rawMessageVal : undefined;
 
-              const warningMessage =
+              const errorMessage =
                 errorType === 'NO_RESPONSE_TEXT'
                   ? EMPTY_RESPONSE_COMPRESS_SUGGESTION
                   : event.message;
@@ -569,10 +569,10 @@ export async function runNonInteractive({
                   type: JsonStreamEventType.ERROR,
                   timestamp: new Date().toISOString(),
                   severity: 'error',
-                  message: warningMessage,
+                  message: errorMessage,
                 });
               } else if (config.getOutputFormat() === OutputFormat.TEXT) {
-                process.stderr.write(`[ERROR] ${warningMessage}\n`);
+                process.stderr.write(`[ERROR] ${errorMessage}\n`);
               }
 
               // Log the API error telemetry
@@ -594,7 +594,7 @@ export async function runNonInteractive({
               // If it's a fatal stream error, we should terminate and output final results
               emitFinalResult({
                 type: 'INVALID_STREAM',
-                message: warningMessage,
+                message: errorMessage,
               });
               streamEnded = true;
               break;

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -39,6 +39,8 @@ import {
   geminiPartsToContentParts,
   displayContentToString,
   debugLogger,
+  logApiError,
+  ApiErrorEvent,
 } from '@google/gemini-cli-core';
 
 import type { Part } from '@google/genai';
@@ -545,6 +547,64 @@ export async function runNonInteractive({
             break;
           }
           case 'error': {
+            if (event._meta?.['code'] === 'INVALID_STREAM') {
+              const errorTypeVal = event._meta?.['errorType'];
+              const errorType =
+                typeof errorTypeVal === 'string' ? errorTypeVal : undefined;
+              const rawMessageVal = event._meta?.['rawMessage'];
+              const rawMessage =
+                typeof rawMessageVal === 'string' ? rawMessageVal : undefined;
+
+              if (errorType === 'NO_RESPONSE_TEXT') {
+                const warningMessage =
+                  'The model returned an empty text response. If your context window is near capacity, try using /compress.';
+
+                if (streamFormatter) {
+                  streamFormatter.emitEvent({
+                    type: JsonStreamEventType.ERROR,
+                    timestamp: new Date().toISOString(),
+                    severity: 'error',
+                    message: warningMessage,
+                  });
+                } else if (config.getOutputFormat() === OutputFormat.TEXT) {
+                  process.stderr.write(`[ERROR] ${warningMessage}\n`);
+                }
+              } else {
+                const warningMessage = event.message;
+                if (streamFormatter) {
+                  streamFormatter.emitEvent({
+                    type: JsonStreamEventType.ERROR,
+                    timestamp: new Date().toISOString(),
+                    severity: 'error',
+                    message: warningMessage,
+                  });
+                } else if (config.getOutputFormat() === OutputFormat.TEXT) {
+                  process.stderr.write(`[ERROR] ${warningMessage}\n`);
+                }
+              }
+
+              // Log the API error telemetry
+              logApiError(
+                config,
+                new ApiErrorEvent(
+                  geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+                  rawMessage || 'Invalid stream received from model',
+                  0, // duration
+                  {
+                    prompt_id,
+                    contents: [],
+                  },
+                  config.getContentGeneratorConfig()?.authType,
+                  errorType || 'INVALID_STREAM',
+                ),
+              );
+
+              // If it's a fatal stream error, we should terminate and output final results
+              emitFinalSuccessResult();
+              streamEnded = true;
+              break;
+            }
+
             if (event.fatal) {
               throw reconstructFatalError(event);
             }

--- a/packages/cli/src/nonInteractiveCliAgentSession.ts
+++ b/packages/cli/src/nonInteractiveCliAgentSession.ts
@@ -41,6 +41,7 @@ import {
   debugLogger,
   logApiError,
   ApiErrorEvent,
+  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
 } from '@google/gemini-cli-core';
 
 import type { Part } from '@google/genai';
@@ -334,14 +335,17 @@ export async function runNonInteractive({
         return text ? text : undefined;
       };
 
-      const emitFinalSuccessResult = (): void => {
+      const emitFinalResult = (errorPayload?: {
+        type: string;
+        message: string;
+      }): void => {
         if (streamFormatter) {
           const metrics = uiTelemetryService.getMetrics();
           const durationMs = Date.now() - startTime;
           streamFormatter.emitEvent({
             type: JsonStreamEventType.RESULT,
             timestamp: new Date().toISOString(),
-            status: 'success',
+            status: errorPayload ? 'error' : 'success',
             stats: streamFormatter.convertToStreamStats(metrics, durationMs),
           });
         } else if (config.getOutputFormat() === OutputFormat.JSON) {
@@ -352,7 +356,7 @@ export async function runNonInteractive({
               config.getSessionId(),
               responseText,
               stats,
-              undefined,
+              errorPayload,
               warnings,
             ),
           );
@@ -555,32 +559,20 @@ export async function runNonInteractive({
               const rawMessage =
                 typeof rawMessageVal === 'string' ? rawMessageVal : undefined;
 
-              if (errorType === 'NO_RESPONSE_TEXT') {
-                const warningMessage =
-                  'The model returned an empty text response. If your context window is near capacity, try using /compress.';
+              const warningMessage =
+                errorType === 'NO_RESPONSE_TEXT'
+                  ? EMPTY_RESPONSE_COMPRESS_SUGGESTION
+                  : event.message;
 
-                if (streamFormatter) {
-                  streamFormatter.emitEvent({
-                    type: JsonStreamEventType.ERROR,
-                    timestamp: new Date().toISOString(),
-                    severity: 'error',
-                    message: warningMessage,
-                  });
-                } else if (config.getOutputFormat() === OutputFormat.TEXT) {
-                  process.stderr.write(`[ERROR] ${warningMessage}\n`);
-                }
-              } else {
-                const warningMessage = event.message;
-                if (streamFormatter) {
-                  streamFormatter.emitEvent({
-                    type: JsonStreamEventType.ERROR,
-                    timestamp: new Date().toISOString(),
-                    severity: 'error',
-                    message: warningMessage,
-                  });
-                } else if (config.getOutputFormat() === OutputFormat.TEXT) {
-                  process.stderr.write(`[ERROR] ${warningMessage}\n`);
-                }
+              if (streamFormatter) {
+                streamFormatter.emitEvent({
+                  type: JsonStreamEventType.ERROR,
+                  timestamp: new Date().toISOString(),
+                  severity: 'error',
+                  message: warningMessage,
+                });
+              } else if (config.getOutputFormat() === OutputFormat.TEXT) {
+                process.stderr.write(`[ERROR] ${warningMessage}\n`);
               }
 
               // Log the API error telemetry
@@ -600,7 +592,10 @@ export async function runNonInteractive({
               );
 
               // If it's a fatal stream error, we should terminate and output final results
-              emitFinalSuccessResult();
+              emitFinalResult({
+                type: 'INVALID_STREAM',
+                message: warningMessage,
+              });
               streamEnded = true;
               break;
             }
@@ -673,7 +668,7 @@ export async function runNonInteractive({
               process.stderr.write(`Agent execution stopped: ${stopMessage}\n`);
             }
 
-            emitFinalSuccessResult();
+            emitFinalResult();
             streamEnded = true;
             break;
           }

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -36,6 +36,18 @@ function areModelMetricsEqual(a: ModelMetrics, b: ModelMetrics): boolean {
   ) {
     return false;
   }
+  const errorsA = a.api.errorsByType || {};
+  const errorsB = b.api.errorsByType || {};
+  const keysA = Object.keys(errorsA);
+  const keysB = Object.keys(errorsB);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  for (const key of keysA) {
+    if (errorsA[key] !== errorsB[key]) {
+      return false;
+    }
+  }
   if (
     a.tokens.input !== b.tokens.input ||
     a.tokens.prompt !== b.tokens.prompt ||

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -54,7 +54,7 @@ import {
   GeminiCliOperation,
   getPlanModeExitMessage,
   UPDATE_TOPIC_TOOL_NAME,
-  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -2308,7 +2308,7 @@ describe('useGeminiStream', () => {
       });
     });
 
-    it('should use EMPTY_RESPONSE_COMPRESS_SUGGESTION when receiving an invalid stream event of type NO_RESPONSE_TEXT', async () => {
+    it('should use TRUE_EMPTY_RESPONSE_MESSAGE when receiving an invalid stream event of type NO_RESPONSE_TEXT', async () => {
       mockSendMessageStream.mockClear();
       mockSendMessageStream.mockReturnValue(
         (async function* () {
@@ -2332,7 +2332,7 @@ describe('useGeminiStream', () => {
         expect(mockAddItem).toHaveBeenCalledWith(
           expect.objectContaining({
             type: MessageType.ERROR,
-            text: EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+            text: TRUE_EMPTY_RESPONSE_MESSAGE,
           }),
           expect.any(Number),
         );

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2338,6 +2338,37 @@ describe('useGeminiStream', () => {
         );
       });
     });
+
+    it('should use the event message when receiving a non-NO_RESPONSE_TEXT invalid stream event', async () => {
+      mockSendMessageStream.mockClear();
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.InvalidStream,
+            value: {
+              type: 'MALFORMED_FUNCTION_CALL',
+              message: 'Custom malformed function call message',
+            },
+          };
+        })(),
+      );
+
+      const { result } = await renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: MessageType.ERROR,
+            text: 'Custom malformed function call message',
+          }),
+          expect.any(Number),
+        );
+      });
+    });
   });
 
   describe('handleApprovalModeChange', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -54,6 +54,7 @@ import {
   GeminiCliOperation,
   getPlanModeExitMessage,
   UPDATE_TOPIC_TOOL_NAME,
+  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
 } from '@google/gemini-cli-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -2303,6 +2304,37 @@ describe('useGeminiStream', () => {
           undefined,
           'gemini-2.5-pro',
           'gemini-2.5-flash',
+        );
+      });
+    });
+
+    it('should use EMPTY_RESPONSE_COMPRESS_SUGGESTION when receiving an invalid stream event of type NO_RESPONSE_TEXT', async () => {
+      mockSendMessageStream.mockClear();
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.InvalidStream,
+            value: {
+              type: 'NO_RESPONSE_TEXT',
+              message: 'empty response text',
+            },
+          };
+        })(),
+      );
+
+      const { result } = await renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: MessageType.ERROR,
+            text: EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+          }),
+          expect.any(Number),
         );
       });
     });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1773,6 +1773,55 @@ describe('useGeminiStream', () => {
       expect(mockCancelAllToolCalls).toHaveBeenCalled();
     });
 
+    it('should transition to Idle state when cancelled while a tool call is in progress and completes', async () => {
+      const toolCalls: TrackedToolCall[] = [
+        {
+          request: { callId: 'call1', name: 'tool1', args: {} },
+          status: CoreToolCallStatus.Executing,
+          responseSubmittedToGemini: false,
+          tool: {
+            name: 'tool1',
+            description: 'desc1',
+            build: vi.fn().mockImplementation((_) => ({
+              getDescription: () => `Mock description`,
+            })),
+          } as any,
+          invocation: {
+            getDescription: () => `Mock description`,
+          },
+          startTime: Date.now(),
+          liveOutput: '...',
+        } as TrackedExecutingToolCall,
+      ];
+
+      const { result } = await renderTestHook(toolCalls);
+
+      // State is `Responding` because a tool is running
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+
+      // Try to cancel
+      simulateEscapeKeyPress();
+
+      // Trigger the onComplete callback with the cancelled tool call
+      await act(async () => {
+        if (capturedOnComplete) {
+          await capturedOnComplete([
+            {
+              ...toolCalls[0],
+              status: CoreToolCallStatus.Cancelled,
+              response: {
+                callId: 'call1',
+                responseParts: [],
+              },
+            } as any,
+          ]);
+        }
+      });
+
+      // The final state should be idle because the cancelled tool call was marked as submitted
+      expect(result.current.streamingState).toBe(StreamingState.Idle);
+    });
+
     it('should cancel a request when a tool is awaiting confirmation', async () => {
       const mockOnConfirm = vi.fn().mockResolvedValue(undefined);
       const toolCalls: TrackedToolCall[] = [

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1822,6 +1822,71 @@ describe('useGeminiStream', () => {
       expect(result.current.streamingState).toBe(StreamingState.Idle);
     });
 
+    it('should append cancelled tool responses to history when cancelled while a tool call is in progress and completes with response parts', async () => {
+      const toolCalls: TrackedToolCall[] = [
+        {
+          request: { callId: 'call1', name: 'tool1', args: {} },
+          status: CoreToolCallStatus.Executing,
+          responseSubmittedToGemini: false,
+          tool: {
+            name: 'tool1',
+            description: 'desc1',
+            build: vi.fn().mockImplementation((_) => ({
+              getDescription: () => `Mock description`,
+            })),
+          } as any,
+          invocation: {
+            getDescription: () => `Mock description`,
+          },
+          startTime: Date.now(),
+          liveOutput: '...',
+        } as TrackedExecutingToolCall,
+      ];
+
+      const { result, client } = await renderTestHook(toolCalls);
+
+      // State is `Responding` because a tool is running
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+
+      // Try to cancel
+      simulateEscapeKeyPress();
+
+      const expectedResponseParts = [
+        {
+          functionResponse: {
+            name: 'tool1',
+            id: 'call1',
+            response: { error: 'cancelled' },
+          },
+        },
+      ];
+
+      // Trigger the onComplete callback with the cancelled tool call having non-empty response parts
+      await act(async () => {
+        if (capturedOnComplete) {
+          await capturedOnComplete([
+            {
+              ...toolCalls[0],
+              status: CoreToolCallStatus.Cancelled,
+              response: {
+                callId: 'call1',
+                responseParts: expectedResponseParts,
+              },
+            } as any,
+          ]);
+        }
+      });
+
+      // Assert that addHistory was called with the combined response parts
+      expect(client.addHistory).toHaveBeenCalledWith({
+        role: 'user',
+        parts: expectedResponseParts,
+      });
+
+      // The final state should be idle because the cancelled tool call was marked as submitted
+      expect(result.current.streamingState).toBe(StreamingState.Idle);
+    });
+
     it('should cancel a request when a tool is awaiting confirmation', async () => {
       const mockOnConfirm = vi.fn().mockResolvedValue(undefined);
       const toolCalls: TrackedToolCall[] = [

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -14,8 +14,7 @@ import {
   GitService,
   UnauthorizedError,
   UserPromptEvent,
-  logApiError,
-  ApiErrorEvent,
+  uiTelemetryService,
   DEFAULT_GEMINI_FLASH_MODEL,
   logConversationFinishedEvent,
   ConversationFinishedEvent,
@@ -1265,20 +1264,10 @@ export const useGeminiStream = (
         text = OTHER_BLOCKED_MESSAGE;
       }
 
-      // Log the API error telemetry
-      logApiError(
-        config,
-        new ApiErrorEvent(
-          geminiClient.getCurrentSequenceModel() ?? config.getModel(),
-          eventValue?.message || 'Invalid stream received from model',
-          0, // duration
-          {
-            prompt_id: lastPromptIdRef.current || 'unknown',
-            contents: [],
-          },
-          config.getContentGeneratorConfig()?.authType,
-          eventValue?.type || 'INVALID_STREAM',
-        ),
+      // Log semantic error telemetry without double-counting requests
+      uiTelemetryService.recordSemanticValidationError(
+        geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+        eventValue?.type || 'INVALID_STREAM',
       );
 
       addItem(
@@ -1300,7 +1289,6 @@ export const useGeminiStream = (
       maybeAddLowVerbosityFailureNote,
       config,
       geminiClient,
-      lastPromptIdRef,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1930,15 +1930,6 @@ export const useGeminiStream = (
 
   const handleCompletedTools = useCallback(
     async (completedToolCallsFromScheduler: TrackedToolCall[]) => {
-      if (turnCancelledRef.current) {
-        setIsResponding(false);
-        const callIdsToMarkAsSubmitted = toolCalls.map(
-          (toolCall) => toolCall.request.callId,
-        );
-        markToolsAsSubmitted(callIdsToMarkAsSubmitted);
-        return;
-      }
-
       const completedAndReadyToSubmitTools =
         completedToolCallsFromScheduler.filter(
           (
@@ -1960,6 +1951,30 @@ export const useGeminiStream = (
             return false;
           },
         );
+
+      if (turnCancelledRef.current) {
+        setIsResponding(false);
+        const geminiTools = completedAndReadyToSubmitTools.filter(
+          (t) => !t.request.isClientInitiated,
+        );
+        if (geminiClient && geminiTools.length > 0) {
+          const combinedParts = geminiTools.flatMap(
+            (toolCall) => toolCall.response.responseParts,
+          );
+          if (combinedParts.length > 0) {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            geminiClient.addHistory({
+              role: 'user',
+              parts: combinedParts,
+            });
+          }
+        }
+        const callIdsToMarkAsSubmitted = toolCalls.map(
+          (toolCall) => toolCall.request.callId,
+        );
+        markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+        return;
+      }
 
       // Finalize any client-initiated tools as soon as they are done.
       const clientTools = completedAndReadyToSubmitTools.filter(

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1930,6 +1930,15 @@ export const useGeminiStream = (
 
   const handleCompletedTools = useCallback(
     async (completedToolCallsFromScheduler: TrackedToolCall[]) => {
+      if (turnCancelledRef.current) {
+        setIsResponding(false);
+        const callIdsToMarkAsSubmitted = toolCalls.map(
+          (toolCall) => toolCall.request.callId,
+        );
+        markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+        return;
+      }
+
       const completedAndReadyToSubmitTools =
         completedToolCallsFromScheduler.filter(
           (
@@ -2132,6 +2141,7 @@ export const useGeminiStream = (
       maybeAddSuppressedToolErrorNote,
       maybeAddLowVerbosityFailureNote,
       setIsResponding,
+      toolCalls,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1241,8 +1241,8 @@ export const useGeminiStream = (
       }
       maybeAddSuppressedToolErrorNote(userMessageTimestamp);
 
-      let text = eventValue.message;
-      if (eventValue.type === 'NO_RESPONSE_TEXT') {
+      let text = eventValue?.message?.trim() || 'Invalid stream received from model';
+      if (eventValue?.type === 'NO_RESPONSE_TEXT') {
         text =
           'The model returned an empty text response. If this error persists as your conversation grows, try using `/compress` to reduce context size.';
       }

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -47,6 +47,7 @@ import {
   buildToolVisibilityContext,
   UPDATE_TOPIC_TOOL_NAME,
   UPDATE_TOPIC_DISPLAY_NAME,
+  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
 } from '@google/gemini-cli-core';
 import type {
   Config,
@@ -1246,8 +1247,7 @@ export const useGeminiStream = (
       let text =
         eventValue?.message?.trim() || 'Invalid stream received from model';
       if (eventValue?.type === 'NO_RESPONSE_TEXT') {
-        text =
-          'The model returned an empty text response. If this error persists as your conversation grows, try using `/compress` to reduce context size.';
+        text = EMPTY_RESPONSE_COMPRESS_SUGGESTION;
       }
 
       // Log the API error telemetry

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -14,6 +14,8 @@ import {
   GitService,
   UnauthorizedError,
   UserPromptEvent,
+  logApiError,
+  ApiErrorEvent,
   DEFAULT_GEMINI_FLASH_MODEL,
   logConversationFinishedEvent,
   ConversationFinishedEvent,
@@ -1248,6 +1250,22 @@ export const useGeminiStream = (
           'The model returned an empty text response. If this error persists as your conversation grows, try using `/compress` to reduce context size.';
       }
 
+      // Log the API error telemetry
+      logApiError(
+        config,
+        new ApiErrorEvent(
+          geminiClient.getCurrentSequenceModel() ?? config.getModel(),
+          eventValue?.message || 'Invalid stream received from model',
+          0, // duration
+          {
+            prompt_id: lastPromptIdRef.current || 'unknown',
+            contents: [],
+          },
+          config.getContentGeneratorConfig()?.authType,
+          eventValue?.type || 'INVALID_STREAM',
+        ),
+      );
+
       addItem(
         {
           type: MessageType.ERROR,
@@ -1265,6 +1283,9 @@ export const useGeminiStream = (
       setThought,
       maybeAddSuppressedToolErrorNote,
       maybeAddLowVerbosityFailureNote,
+      config,
+      geminiClient,
+      lastPromptIdRef,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -54,6 +54,7 @@ import type {
   ServerGeminiContentEvent as ContentEvent,
   ServerGeminiFinishedEvent,
   ServerGeminiStreamEvent as GeminiEvent,
+  ServerGeminiInvalidStreamEvent,
   ThoughtSummary,
   ToolCallRequestInfo,
   ToolCallResponseInfo,
@@ -1229,6 +1230,43 @@ export const useGeminiStream = (
     ],
   );
 
+  const handleInvalidStreamEvent = useCallback(
+    (
+      eventValue: ServerGeminiInvalidStreamEvent['value'],
+      userMessageTimestamp: number,
+    ) => {
+      if (pendingHistoryItemRef.current) {
+        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        setPendingHistoryItem(null);
+      }
+      maybeAddSuppressedToolErrorNote(userMessageTimestamp);
+
+      let text = eventValue.message;
+      if (eventValue.type === 'NO_RESPONSE_TEXT') {
+        text =
+          'The model returned an empty text response. If this error persists as your conversation grows, try using `/compress` to reduce context size.';
+      }
+
+      addItem(
+        {
+          type: MessageType.ERROR,
+          text,
+        },
+        userMessageTimestamp,
+      );
+      maybeAddLowVerbosityFailureNote(userMessageTimestamp);
+      setThought(null); // Reset thought when there's an error
+    },
+    [
+      addItem,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
+      setThought,
+      maybeAddSuppressedToolErrorNote,
+      maybeAddLowVerbosityFailureNote,
+    ],
+  );
+
   const handleCitationEvent = useCallback(
     (text: string, userMessageTimestamp: number) => {
       if (!showCitations(settings)) {
@@ -1541,8 +1579,10 @@ export const useGeminiStream = (
             loopDetectedRef.current = true;
             break;
           case ServerGeminiEventType.Retry:
+            // Handled transparently by the backend stream retries.
+            break;
           case ServerGeminiEventType.InvalidStream:
-            // Will add the missing logic later
+            handleInvalidStreamEvent(event.value, userMessageTimestamp);
             break;
           default: {
             // enforces exhaustive switch-case
@@ -1575,6 +1615,7 @@ export const useGeminiStream = (
       handleChatModelEvent,
       handleAgentExecutionStoppedEvent,
       handleAgentExecutionBlockedEvent,
+      handleInvalidStreamEvent,
       addItem,
       pendingHistoryItemRef,
       setPendingHistoryItem,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1241,7 +1241,8 @@ export const useGeminiStream = (
       }
       maybeAddSuppressedToolErrorNote(userMessageTimestamp);
 
-      let text = eventValue?.message?.trim() || 'Invalid stream received from model';
+      let text =
+        eventValue?.message?.trim() || 'Invalid stream received from model';
       if (eventValue?.type === 'NO_RESPONSE_TEXT') {
         text =
           'The model returned an empty text response. If this error persists as your conversation grows, try using `/compress` to reduce context size.';

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -47,7 +47,12 @@ import {
   buildToolVisibilityContext,
   UPDATE_TOPIC_TOOL_NAME,
   UPDATE_TOPIC_DISPLAY_NAME,
-  EMPTY_RESPONSE_COMPRESS_SUGGESTION,
+  THINKING_ONLY_COMPRESS_SUGGESTION,
+  MAX_TOKENS_EXCEEDED_SUGGESTION,
+  SAFETY_BLOCKED_MESSAGE,
+  RECITATION_BLOCKED_MESSAGE,
+  OTHER_BLOCKED_MESSAGE,
+  TRUE_EMPTY_RESPONSE_MESSAGE,
 } from '@google/gemini-cli-core';
 import type {
   Config,
@@ -1247,7 +1252,17 @@ export const useGeminiStream = (
       let text =
         eventValue?.message?.trim() || 'Invalid stream received from model';
       if (eventValue?.type === 'NO_RESPONSE_TEXT') {
-        text = EMPTY_RESPONSE_COMPRESS_SUGGESTION;
+        text = TRUE_EMPTY_RESPONSE_MESSAGE;
+      } else if (eventValue?.type === 'THINKING_ONLY_RESPONSE') {
+        text = THINKING_ONLY_COMPRESS_SUGGESTION;
+      } else if (eventValue?.type === 'MAX_TOKENS_EXCEEDED') {
+        text = MAX_TOKENS_EXCEEDED_SUGGESTION;
+      } else if (eventValue?.type === 'SAFETY_BLOCKED') {
+        text = SAFETY_BLOCKED_MESSAGE;
+      } else if (eventValue?.type === 'RECITATION_BLOCKED') {
+        text = RECITATION_BLOCKED_MESSAGE;
+      } else if (eventValue?.type === 'OTHER_BLOCKED') {
+        text = OTHER_BLOCKED_MESSAGE;
       }
 
       // Log the API error telemetry

--- a/packages/core/src/agent/event-translator.test.ts
+++ b/packages/core/src/agent/event-translator.test.ts
@@ -516,13 +516,30 @@ describe('translateEvent', () => {
   });
 
   describe('InvalidStream events', () => {
-    it('emits fatal error', () => {
+    it('emits fatal error with specific message from event', () => {
       state.streamStartEmitted = true;
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.InvalidStream,
         value: {
           type: 'NO_RESPONSE_TEXT',
           message: 'Empty response',
+        },
+      };
+      const result = translateEvent(event, state);
+      expect(result).toHaveLength(1);
+      const err = result[0] as AgentEvent<'error'>;
+      expect(err.status).toBe('INTERNAL');
+      expect(err.message).toBe('Empty response');
+      expect(err.fatal).toBe(true);
+    });
+
+    it('falls back to default message when message is missing', () => {
+      state.streamStartEmitted = true;
+      const event: ServerGeminiStreamEvent = {
+        type: GeminiEventType.InvalidStream,
+        value: {
+          type: 'NO_RESPONSE_TEXT',
+          message: '',
         },
       };
       const result = translateEvent(event, state);

--- a/packages/core/src/agent/event-translator.test.ts
+++ b/packages/core/src/agent/event-translator.test.ts
@@ -531,6 +531,9 @@ describe('translateEvent', () => {
       expect(err.status).toBe('INTERNAL');
       expect(err.message).toBe('Empty response');
       expect(err.fatal).toBe(true);
+      expect(err._meta?.['code']).toBe('INVALID_STREAM');
+      expect(err._meta?.['errorType']).toBe('NO_RESPONSE_TEXT');
+      expect(err._meta?.['rawMessage']).toBe('Empty response');
     });
 
     it('falls back to default message when message is missing', () => {

--- a/packages/core/src/agent/event-translator.test.ts
+++ b/packages/core/src/agent/event-translator.test.ts
@@ -520,6 +520,10 @@ describe('translateEvent', () => {
       state.streamStartEmitted = true;
       const event: ServerGeminiStreamEvent = {
         type: GeminiEventType.InvalidStream,
+        value: {
+          type: 'NO_RESPONSE_TEXT',
+          message: 'Empty response',
+        },
       };
       const result = translateEvent(event, state);
       expect(result).toHaveLength(1);

--- a/packages/core/src/agent/event-translator.ts
+++ b/packages/core/src/agent/event-translator.ts
@@ -226,6 +226,11 @@ export function translateEvent(
             event.value?.message?.trim() ||
             'Invalid stream received from model',
           fatal: true,
+          _meta: {
+            code: 'INVALID_STREAM',
+            errorType: event.value?.type,
+            rawMessage: event.value?.message,
+          },
         }),
       );
       break;

--- a/packages/core/src/agent/event-translator.ts
+++ b/packages/core/src/agent/event-translator.ts
@@ -222,7 +222,9 @@ export function translateEvent(
       out.push(
         makeEvent('error', state, {
           status: 'INTERNAL',
-          message: 'Invalid stream received from model',
+          message:
+            event.value?.message?.trim() ||
+            'Invalid stream received from model',
           fatal: true,
         }),
       );

--- a/packages/core/src/agent/legacy-agent-session.ts
+++ b/packages/core/src/agent/legacy-agent-session.ts
@@ -10,7 +10,7 @@
  */
 
 import { GeminiEventType } from '../core/turn.js';
-import type { Part } from '@google/genai';
+import type { Part, FinishReason } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import type { Config } from '../config/config.js';
 import type { ToolCallRequestInfo } from '../scheduler/types.js';
@@ -192,6 +192,7 @@ export class LegacyAgentProtocol implements AgentProtocol {
       }
 
       const toolCallRequests: ToolCallRequestInfo[] = [];
+      let finishedReason: FinishReason | undefined = undefined;
       const responseStream = this._client.sendMessageStream(
         currentParts,
         this._abortController.signal,
@@ -220,10 +221,7 @@ export class LegacyAgentProtocol implements AgentProtocol {
             this._finishStream('failed');
             return;
           case GeminiEventType.Finished:
-            if (toolCallRequests.length === 0) {
-              this._finishStream(mapFinishReason(event.value.reason));
-              return;
-            }
+            finishedReason = event.value.reason;
             break;
           case GeminiEventType.AgentExecutionStopped:
           case GeminiEventType.UserCancelled:
@@ -241,7 +239,11 @@ export class LegacyAgentProtocol implements AgentProtocol {
       }
 
       if (toolCallRequests.length === 0) {
-        this._finishStream('completed');
+        if (finishedReason !== undefined) {
+          this._finishStream(mapFinishReason(finishedReason));
+        } else {
+          this._finishStream('completed');
+        }
         return;
       }
 

--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -165,6 +165,16 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -361,6 +371,16 @@ An approved plan is available for this task at \`../plans/feature-x.md\`.
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -671,6 +691,16 @@ ONLY use the built-in \`exit_plan_mode\` tool to present the plan for formal app
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -845,6 +875,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -1005,6 +1045,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -1148,6 +1198,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -1837,6 +1897,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2011,6 +2081,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2189,6 +2269,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2367,6 +2457,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2541,6 +2641,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2709,6 +2819,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -2851,6 +2971,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -3025,6 +3155,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -3345,6 +3485,16 @@ You are operating with a persistent file-based task tracking system located at \
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -3774,6 +3924,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -3948,6 +4108,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -4241,6 +4411,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.
@@ -4415,6 +4595,16 @@ Operate using a **Research -> Strategy -> Execution** lifecycle. For the Executi
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. \`replace\`, \`write_file\`), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the \`replace\` tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the \`run_shell_command\` tool for running shell commands, remembering the safety rule to explain modifying commands first.

--- a/packages/core/src/core/agentChatHistory.test.ts
+++ b/packages/core/src/core/agentChatHistory.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AgentChatHistory, type HistoryTurn } from './agentChatHistory.js';
+
+describe('AgentChatHistory', () => {
+  const dummyTurns: HistoryTurn[] = [
+    {
+      id: 'turn-1',
+      content: { role: 'user', parts: [{ text: 'Hello' }] },
+    },
+    {
+      id: 'turn-2',
+      content: { role: 'model', parts: [{ text: 'Hi there' }] },
+    },
+    {
+      id: 'turn-3',
+      content: { role: 'user', parts: [{ text: 'How are you?' }] },
+    },
+  ];
+
+  it('should initialize with empty history by default', () => {
+    const history = new AgentChatHistory();
+    expect(history.length).toBe(0);
+    expect(history.get()).toEqual([]);
+  });
+
+  it('should initialize with provided turns', () => {
+    const history = new AgentChatHistory(dummyTurns);
+    expect(history.length).toBe(3);
+    expect(history.get()).toEqual(dummyTurns);
+  });
+
+  it('should push new turns', () => {
+    const history = new AgentChatHistory();
+    history.push(dummyTurns[0]);
+    expect(history.length).toBe(1);
+    expect(history.get()[0]).toEqual(dummyTurns[0]);
+  });
+
+  it('should set and overwrite history turns', () => {
+    const history = new AgentChatHistory(dummyTurns.slice(0, 1));
+    expect(history.length).toBe(1);
+    history.set(dummyTurns);
+    expect(history.length).toBe(3);
+    expect(history.get()).toEqual(dummyTurns);
+  });
+
+  it('should clear history', () => {
+    const history = new AgentChatHistory(dummyTurns);
+    expect(history.length).toBe(3);
+    history.clear();
+    expect(history.length).toBe(0);
+    expect(history.get()).toEqual([]);
+  });
+
+  describe('rollback', () => {
+    it('should roll back history to a specified length', () => {
+      const history = new AgentChatHistory(dummyTurns);
+      history.rollback(1);
+      expect(history.length).toBe(1);
+      expect(history.get()).toEqual([dummyTurns[0]]);
+    });
+
+    it('should roll back to 0', () => {
+      const history = new AgentChatHistory(dummyTurns);
+      history.rollback(0);
+      expect(history.length).toBe(0);
+      expect(history.get()).toEqual([]);
+    });
+
+    it('should do nothing if rollback length is out of bounds (negative)', () => {
+      const history = new AgentChatHistory(dummyTurns);
+      history.rollback(-1);
+      expect(history.length).toBe(3);
+      expect(history.get()).toEqual(dummyTurns);
+    });
+
+    it('should do nothing if rollback length is out of bounds (greater than current history length)', () => {
+      const history = new AgentChatHistory(dummyTurns);
+      history.rollback(5);
+      expect(history.length).toBe(3);
+      expect(history.get()).toEqual(dummyTurns);
+    });
+  });
+
+  it('should return raw Content array via getContents()', () => {
+    const history = new AgentChatHistory(dummyTurns);
+    expect(history.getContents()).toEqual(
+      dummyTurns.map((turn) => turn.content),
+    );
+  });
+
+  it('should support mapping and flatMapping operations', () => {
+    const history = new AgentChatHistory(dummyTurns);
+    const mappedIds = history.map((turn) => turn.id);
+    expect(mappedIds).toEqual(['turn-1', 'turn-2', 'turn-3']);
+
+    const flatMappedParts = history.flatMap((turn) => turn.content.parts || []);
+    expect(flatMappedParts).toEqual([
+      { text: 'Hello' },
+      { text: 'Hi there' },
+      { text: 'How are you?' },
+    ]);
+  });
+});

--- a/packages/core/src/core/agentChatHistory.ts
+++ b/packages/core/src/core/agentChatHistory.ts
@@ -46,6 +46,16 @@ export class AgentChatHistory {
     this.history = [];
   }
 
+  /**
+   * Rolls back the history to a specified length.
+   * Useful when a stream fails and we need to remove the un-responded turn(s).
+   */
+  rollback(length: number) {
+    if (length >= 0 && length <= this.history.length) {
+      this.history = this.history.slice(0, length);
+    }
+  }
+
   get(): readonly HistoryTurn[] {
     return this.history;
   }

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1047,6 +1047,93 @@ describe('GeminiChat', () => {
       expect(chat.getLastPromptTokenCount()).toBe(initialBaseline);
     });
 
+    it('should not write failed retry attempts to the chat recording service', async () => {
+      const recordMessageSpy = vi.spyOn(
+        chat.getChatRecordingService(),
+        'recordMessage',
+      );
+      const recordSyntheticMessageSpy = vi.spyOn(
+        chat.getChatRecordingService(),
+        'recordSyntheticMessage',
+      );
+
+      // Attempt 1: returns invalid stream (triggering InvalidStreamError)
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: { role: 'model', parts: [{ text: '' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+        )
+        // Attempt 2: returns a valid response
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: 'successful retry response' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+        );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test prompt for recording deferral',
+        'prompt-id-recording-deferral',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      for await (const _ of stream) {
+        // consume stream completely
+      }
+
+      // 1. The execution was successful, and final history turn has the correct text
+      const lastHistoryTurn =
+        chat.agentHistory.get()[chat.agentHistory.length - 1];
+      expect(lastHistoryTurn.content.parts?.[0]?.text).toBe(
+        'successful retry response',
+      );
+
+      // 2. recordMessage was only called for the successful turn
+      // (The failed attempt was NEVER recorded!)
+      const successfulCalls = recordMessageSpy.mock.calls.filter((call) => {
+        const payload = call[0];
+        return (
+          typeof payload === 'object' &&
+          payload !== null &&
+          payload.content === 'successful retry response'
+        );
+      });
+      const failedCalls = recordMessageSpy.mock.calls.filter((call) => {
+        const payload = call[0];
+        return (
+          typeof payload === 'object' &&
+          payload !== null &&
+          payload.content === ''
+        );
+      });
+
+      expect(successfulCalls.length).toBe(1);
+      expect(failedCalls.length).toBe(0);
+      expect(recordSyntheticMessageSpy).not.toHaveBeenCalled();
+
+      recordMessageSpy.mockRestore();
+      recordSyntheticMessageSpy.mockRestore();
+    });
+
     it('should sync the chat recording service on history rollback when InvalidStreamError is thrown', async () => {
       const initialHistoryLength = chat.agentHistory.length;
       const updateSpy = vi.spyOn(

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1336,6 +1336,157 @@ describe('GeminiChat', () => {
       ).toBe(true);
     });
 
+    it('should throw InvalidStreamError with type MAX_TOKENS_EXCEEDED when finishReason is MAX_TOKENS and text is empty', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: { role: 'model', parts: [] },
+                  finishReason: 'MAX_TOKENS',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.5-pro' },
+        'test',
+        'prompt-id-max-tokens',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      let error: unknown;
+      try {
+        const chunks = [];
+        for await (const chunk of stream) {
+          chunks.push(chunk);
+        }
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(InvalidStreamError);
+      expect((error as InvalidStreamError).type).toBe('MAX_TOKENS_EXCEEDED');
+    });
+
+    it('should throw InvalidStreamError with type THINKING_ONLY_RESPONSE when response contains thoughts but text is empty', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ thought: true, text: 'thinking...' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.5-pro' },
+        'test',
+        'prompt-id-thoughts-only',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      let error: unknown;
+      try {
+        const chunks = [];
+        for await (const chunk of stream) {
+          chunks.push(chunk);
+        }
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(InvalidStreamError);
+      expect((error as InvalidStreamError).type).toBe('THINKING_ONLY_RESPONSE');
+    });
+
+    it('should throw InvalidStreamError when response consists only of zero-width or invisible characters', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: '\u200B\uFEFF\u200D' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.5-pro' },
+        'test',
+        'prompt-id-invisible-only',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      let error: unknown;
+      try {
+        for await (const _ of stream) {
+          // consume
+        }
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(InvalidStreamError);
+      expect((error as InvalidStreamError).type).toBe('NO_RESPONSE_TEXT');
+    });
+
+    it('should throw InvalidStreamError when response consists only of HTML or Markdown comment blocks', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ text: '<!-- invisible comment -->' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.5-pro' },
+        'test',
+        'prompt-id-comments-only',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      let error: unknown;
+      try {
+        for await (const _ of stream) {
+          // consume
+        }
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(InvalidStreamError);
+      expect((error as InvalidStreamError).type).toBe('NO_RESPONSE_TEXT');
+    });
+
     it('should call generateContentStream with the correct parameters', async () => {
       const response = (async function* () {
         yield {
@@ -1760,6 +1911,84 @@ describe('GeminiChat', () => {
           }),
         }),
         'prompt-id-retry-temperature',
+        LlmRole.MAIN,
+      );
+    });
+
+    it('should append nudge message to systemInstruction on retry when InvalidStreamError occurs', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ thought: true, text: 'thinking...' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+        )
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: { parts: [{ text: 'valid response after nudge' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+        );
+
+      chat.setSystemInstruction('Initial instruction');
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.5-pro' },
+        'test',
+        'prompt-id-retry-nudge',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+
+      // First call should have original system instruction
+      expect(
+        mockContentGenerator.generateContentStream,
+      ).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          config: expect.objectContaining({
+            systemInstruction: 'Initial instruction',
+          }),
+        }),
+        'prompt-id-retry-nudge',
+        LlmRole.MAIN,
+      );
+
+      // Second call (retry) should have nudge message appended to systemInstruction
+      expect(
+        mockContentGenerator.generateContentStream,
+      ).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          config: expect.objectContaining({
+            systemInstruction:
+              'Initial instruction\n[System: You previously generated thoughts but failed to provide a final user-facing response. Please ensure you provide your final answer or call a tool now.]',
+          }),
+        }),
+        'prompt-id-retry-nudge',
         LlmRole.MAIN,
       );
     });

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1134,6 +1134,109 @@ describe('GeminiChat', () => {
       recordSyntheticMessageSpy.mockRestore();
     });
 
+    it('should not record thoughts or usage metadata to chatRecordingService from failed stream attempts', async () => {
+      const recordThoughtSpy = vi.spyOn(
+        chat.getChatRecordingService(),
+        'recordThought',
+      );
+      const recordMessageTokensSpy = vi.spyOn(
+        chat.getChatRecordingService(),
+        'recordMessageTokens',
+      );
+
+      // Attempt 1: returns invalid stream with thoughts and usage metadata (triggering InvalidStreamError)
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [
+                      {
+                        thought: true,
+                        text: '**Stale subject** Stale description',
+                      },
+                    ],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 1000,
+                candidatesTokenCount: 50,
+                totalTokenCount: 1050,
+              },
+            } as unknown as GenerateContentResponse;
+          })(),
+        )
+        // Attempt 2: returns a valid response with separate thoughts and usage metadata
+        .mockImplementationOnce(async () =>
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [
+                      {
+                        thought: true,
+                        text: '**Fresh subject** Fresh description',
+                      },
+                      { text: 'successful retry response' },
+                    ],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 2000,
+                candidatesTokenCount: 100,
+                totalTokenCount: 2100,
+              },
+            } as unknown as GenerateContentResponse;
+          })(),
+        );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test prompt for metadata deferral',
+        'prompt-id-metadata-deferral',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      for await (const _ of stream) {
+        // consume stream completely
+      }
+
+      // Verify that recordThought was NOT called with the first (failed) attempt's thoughts
+      expect(recordThoughtSpy).toHaveBeenCalledTimes(1);
+      expect(recordThoughtSpy).toHaveBeenCalledWith({
+        subject: 'Fresh subject',
+        description: 'Fresh description',
+      });
+      expect(recordThoughtSpy).not.toHaveBeenCalledWith({
+        subject: 'Stale subject',
+        description: 'Stale description',
+      });
+
+      // Verify that recordMessageTokens was only called with the second (successful) attempt's metadata
+      expect(recordMessageTokensSpy).toHaveBeenCalledTimes(1);
+      expect(recordMessageTokensSpy).toHaveBeenCalledWith({
+        promptTokenCount: 2000,
+        candidatesTokenCount: 100,
+        totalTokenCount: 2100,
+      });
+
+      // Verify that the prompt token count is correct
+      expect(chat.getLastPromptTokenCount()).toBe(2000);
+
+      recordThoughtSpy.mockRestore();
+      recordMessageTokensSpy.mockRestore();
+    });
+
     it('should sync the chat recording service on history rollback when InvalidStreamError is thrown', async () => {
       const initialHistoryLength = chat.agentHistory.length;
       const updateSpy = vi.spyOn(

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -921,7 +921,7 @@ describe('GeminiChat', () => {
       ).rejects.toThrow(InvalidStreamError);
     });
 
-    it('should throw InvalidStreamError without retrying when no tool call and empty response text', async () => {
+    it('should retry when no tool call and empty response text, and succeed if a retry succeeds', async () => {
       vi.mocked(mockContentGenerator.generateContentStream)
         .mockImplementationOnce(async () =>
           // First attempt: finish reason is present, but the stream has no
@@ -941,7 +941,7 @@ describe('GeminiChat', () => {
           })(),
         )
         .mockImplementationOnce(async () =>
-          // This would succeed if NO_RESPONSE_TEXT were retried.
+          // Second attempt: succeeds
           (async function* () {
             yield {
               candidates: [
@@ -965,6 +965,54 @@ describe('GeminiChat', () => {
         LlmRole.MAIN,
       );
 
+      const chunks: GenerateContentResponse[] = [];
+      for await (const chunk of stream) {
+        if (chunk.type === StreamEventType.CHUNK) {
+          chunks.push(chunk.value);
+        }
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      expect(mockLogContentRetry).toHaveBeenCalledTimes(1);
+      expect(mockLogContentRetryFailure).not.toHaveBeenCalled();
+      expect(chunks.length).toBe(2);
+      expect(chunks[0].candidates?.[0]?.content?.parts?.[0]?.thought).toBe(
+        true,
+      );
+      expect(chunks[1].candidates?.[0]?.content?.parts?.[0]?.text).toBe(
+        'valid response after retry',
+      );
+    });
+
+    it('should retry when no tool call and empty response text, and throw InvalidStreamError after exhausting retries', async () => {
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () =>
+          // All attempts return empty response text
+          (async function* () {
+            yield {
+              candidates: [
+                {
+                  content: {
+                    role: 'model',
+                    parts: [{ thought: true, text: 'thinking...' }],
+                  },
+                  finishReason: 'STOP',
+                },
+              ],
+            } as unknown as GenerateContentResponse;
+          })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test message',
+        'prompt-id-1',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
       await expect(
         (async () => {
           for await (const _ of stream) {
@@ -972,10 +1020,11 @@ describe('GeminiChat', () => {
           }
         })(),
       ).rejects.toThrow(InvalidStreamError);
+
       expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        1,
+        4,
       );
-      expect(mockLogContentRetry).not.toHaveBeenCalled();
+      expect(mockLogContentRetry).toHaveBeenCalledTimes(3);
       expect(mockLogContentRetryFailure).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -999,6 +999,54 @@ describe('GeminiChat', () => {
       expect(lastTurn.content.parts?.[0]?.functionResponse).toBeDefined();
     });
 
+    it('should restore the lastPromptTokenCount baseline on history rollback when InvalidStreamError is thrown', async () => {
+      // Establish an initial token count baseline
+      const initialBaseline = chat.getLastPromptTokenCount();
+
+      // Setup: Stream that yields usageMetadata updating token count and then throws an InvalidStreamError
+      const streamWithUsageAndFailure = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: '' }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: initialBaseline + 500, // mock updated larger token count
+            candidatesTokenCount: 10,
+            totalTokenCount: initialBaseline + 510,
+          },
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithUsageAndFailure,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test prompt for token baseline rollback',
+        'prompt-id-baseline-rollback',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream to trigger validation error
+          }
+        })(),
+      ).rejects.toThrow(InvalidStreamError);
+
+      // Verify that the prompt token count has been successfully restored to its initial baseline
+      expect(chat.getLastPromptTokenCount()).toBe(initialBaseline);
+    });
+
     it('should sync the chat recording service on history rollback when InvalidStreamError is thrown', async () => {
       const initialHistoryLength = chat.agentHistory.length;
       const updateSpy = vi.spyOn(

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -3723,7 +3723,7 @@ describe('GeminiChat', () => {
       );
     });
 
-    it('should roll back all synthetic binary injection turns when the stream fails', async () => {
+    it('should preserve all synthetic binary injection turns when the stream fails', async () => {
       const initialHistoryLength = chat.agentHistory.length;
       const audioParts = [
         {
@@ -3761,9 +3761,8 @@ describe('GeminiChat', () => {
         })(),
       ).rejects.toThrow('API error during binary injection stream');
 
-      // Verify that history has been rolled back to its initial state,
-      // and all 3 synthetic binary injection turns have been cleaned up.
-      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+      // Verify that history has been preserved, and all 3 synthetic binary injection turns are kept.
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 3);
     });
   });
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -884,6 +884,104 @@ describe('GeminiChat', () => {
       ).resolves.not.toThrow();
     });
 
+    it('should roll back the un-responded user turn from history when InvalidStreamError is thrown', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+
+      // Setup: Stream with text but no finish reason and no tool call (will trigger InvalidStreamError)
+      const streamWithoutFinishReason = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'some response' }],
+              },
+              // No finishReason
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithoutFinishReason,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test message to roll back',
+        'prompt-id-rollback',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      // Verify the user turn WAS added during sendMessageStream
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 1);
+      expect(chat.getHistory()[initialHistoryLength].parts?.[0]?.text).toBe(
+        'test message to roll back',
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream to trigger validation error
+          }
+        })(),
+      ).rejects.toThrow(InvalidStreamError);
+
+      // Verify history has been rolled back to its initial state
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+    });
+
+    it('should sync the chat recording service on history rollback when InvalidStreamError is thrown', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+      const updateSpy = vi.spyOn(
+        chat.getChatRecordingService(),
+        'updateMessagesFromHistory',
+      );
+
+      // Setup: Stream with text but no finish reason and no tool call (will trigger InvalidStreamError)
+      const streamWithoutFinishReason = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'some response' }],
+              },
+              // No finishReason
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithoutFinishReason,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test disk sync rollback',
+        'prompt-id-rollback-sync',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream to trigger validation error
+          }
+        })(),
+      ).rejects.toThrow(InvalidStreamError);
+
+      // Verify history has been rolled back to its initial state
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+      // Verify chatRecordingService.updateMessagesFromHistory was called to sync the disk
+      expect(updateSpy).toHaveBeenCalled();
+
+      updateSpy.mockRestore();
+    });
+
     it('should throw InvalidStreamError when no tool call and no finish reason', async () => {
       // Setup: Stream with text but no finish reason and no tool call
       const streamWithoutFinishReason = (async function* () {
@@ -1631,13 +1729,9 @@ describe('GeminiChat', () => {
       expect(mockLogContentRetry).toHaveBeenCalledTimes(3);
       expect(mockLogContentRetryFailure).toHaveBeenCalledTimes(1);
 
-      // History should still contain the user message.
+      // History should be rolled back to exclude the un-responded user message.
       const history = chat.getHistory();
-      expect(history.length).toBe(1);
-      expect(history[0]).toEqual({
-        role: 'user',
-        parts: [{ text: 'test' }],
-      });
+      expect(history.length).toBe(0);
     });
 
     describe('API error retry behavior', () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -982,6 +982,78 @@ describe('GeminiChat', () => {
       updateSpy.mockRestore();
     });
 
+    it('should roll back the un-responded user turn from history when the stream is aborted/cancelled', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+      const abortController = new AbortController();
+
+      // Setup: Stream that aborts/fails mid-generation
+      const streamWithAbort = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'some text' }],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+        abortController.abort();
+        throw new Error('User aborted a request.');
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithAbort,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test abort message',
+        'prompt-id-abort',
+        abortController.signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream to trigger abort error
+          }
+        })(),
+      ).rejects.toThrow();
+
+      // Verify history has been rolled back to its initial state
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+    });
+
+    it('should roll back the un-responded user turn from history when an ApiError is thrown', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+
+      // Setup: Stream that throws a standard API error
+      vi.mocked(mockContentGenerator.generateContentStream).mockRejectedValue(
+        new Error('API rate limit reached'),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'test api error message',
+        'prompt-id-api-error',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })(),
+      ).rejects.toThrow('API rate limit reached');
+
+      // Verify history has been rolled back to its initial state
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+    });
+
     it('should throw InvalidStreamError when no tool call and no finish reason', async () => {
       // Setup: Stream with text but no finish reason and no tool call
       const streamWithoutFinishReason = (async function* () {
@@ -3218,6 +3290,49 @@ describe('GeminiChat', () => {
       expect(capturedContents[2].parts![1].inlineData!.mimeType).toBe(
         'video/mp4',
       );
+    });
+
+    it('should roll back all synthetic binary injection turns when the stream fails', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+      const audioParts = [
+        {
+          functionResponse: {
+            id: 'call-123',
+            name: 'read_file',
+            response: {
+              output: 'Success',
+              [BINARY_INJECTION_KEY]: [
+                { inlineData: { mimeType: 'audio/mpeg', data: 'base64' } },
+              ],
+            },
+          },
+        },
+      ];
+
+      // Setup: Stream that throws an error
+      vi.mocked(mockContentGenerator.generateContentStream).mockRejectedValue(
+        new Error('API error during binary injection stream'),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-pro' },
+        audioParts,
+        'test-id',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })(),
+      ).rejects.toThrow('API error during binary injection stream');
+
+      // Verify that history has been rolled back to its initial state,
+      // and all 3 synthetic binary injection turns have been cleaned up.
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
     });
   });
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -999,6 +999,80 @@ describe('GeminiChat', () => {
       expect(lastTurn.content.parts?.[0]?.functionResponse).toBeDefined();
     });
 
+    it('should preserve mixed multimodal function responses during rollback when InvalidStreamError is thrown (regression)', async () => {
+      // 1. Setup history ending with a model turn containing functionCall
+      chat.agentHistory.push({
+        id: 'model-turn-1',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'test_tool',
+                args: {},
+              },
+            },
+          ],
+        },
+      });
+
+      const initialHistoryLength = chat.agentHistory.length;
+
+      // Setup: Stream that will throw InvalidStreamError
+      const streamWithNoResponseText = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: { role: 'model', parts: [] },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithNoResponseText,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        [
+          {
+            functionResponse: {
+              name: 'test_tool',
+              response: { success: true },
+            },
+          },
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://example.com/image.png',
+            },
+          },
+        ],
+        'prompt-id-mixed-multimodal-rollback',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      // Verify the function response was added
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 1);
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume
+          }
+        })(),
+      ).rejects.toThrow(InvalidStreamError);
+
+      // Verify that history was NOT rolled back, i.e., function response and sibling fileData are preserved!
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 1);
+      const lastTurn = chat.agentHistory.get()[chat.agentHistory.length - 1];
+      expect(lastTurn.content.parts?.[0]?.functionResponse).toBeDefined();
+      expect(lastTurn.content.parts?.[1]?.fileData).toBeDefined();
+    });
+
     it('should restore the lastPromptTokenCount baseline on history rollback when InvalidStreamError is thrown', async () => {
       // Establish an initial token count baseline
       const initialBaseline = chat.getLastPromptTokenCount();

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -932,6 +932,73 @@ describe('GeminiChat', () => {
       expect(chat.agentHistory.length).toBe(initialHistoryLength);
     });
 
+    it('should preserve function responses during rollback when InvalidStreamError is thrown', async () => {
+      // 1. Setup history ending with a model turn containing functionCall
+      chat.agentHistory.push({
+        id: 'model-turn-1',
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'test_tool',
+                args: {},
+              },
+            },
+          ],
+        },
+      });
+
+      const initialHistoryLength = chat.agentHistory.length;
+
+      // Setup: Stream that will throw InvalidStreamError
+      const streamWithNoResponseText = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: { role: 'model', parts: [] },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithNoResponseText,
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        [
+          {
+            functionResponse: {
+              name: 'test_tool',
+              response: { success: true },
+            },
+          },
+        ],
+        'prompt-id-function-response-rollback',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+
+      // Verify the function response was added
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 1);
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume
+          }
+        })(),
+      ).rejects.toThrow(InvalidStreamError);
+
+      // Verify that history was NOT rolled back, i.e., function response is preserved!
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 1);
+      const lastTurn = chat.agentHistory.get()[chat.agentHistory.length - 1];
+      expect(lastTurn.content.parts?.[0]?.functionResponse).toBeDefined();
+    });
+
     it('should sync the chat recording service on history rollback when InvalidStreamError is thrown', async () => {
       const initialHistoryLength = chat.agentHistory.length;
       const updateSpy = vi.spyOn(

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -225,7 +225,12 @@ export class InvalidStreamError extends Error {
     | 'NO_FINISH_REASON'
     | 'NO_RESPONSE_TEXT'
     | 'MALFORMED_FUNCTION_CALL'
-    | 'UNEXPECTED_TOOL_CALL';
+    | 'UNEXPECTED_TOOL_CALL'
+    | 'MAX_TOKENS_EXCEEDED'
+    | 'SAFETY_BLOCKED'
+    | 'RECITATION_BLOCKED'
+    | 'OTHER_BLOCKED'
+    | 'THINKING_ONLY_RESPONSE';
 
   constructor(
     message: string,
@@ -233,7 +238,12 @@ export class InvalidStreamError extends Error {
       | 'NO_FINISH_REASON'
       | 'NO_RESPONSE_TEXT'
       | 'MALFORMED_FUNCTION_CALL'
-      | 'UNEXPECTED_TOOL_CALL',
+      | 'UNEXPECTED_TOOL_CALL'
+      | 'MAX_TOKENS_EXCEEDED'
+      | 'SAFETY_BLOCKED'
+      | 'RECITATION_BLOCKED'
+      | 'OTHER_BLOCKED'
+      | 'THINKING_ONLY_RESPONSE',
   ) {
     super(message);
     this.name = 'InvalidStreamError';
@@ -521,6 +531,7 @@ export class GeminiChat {
     ): AsyncGenerator<StreamEvent, void, void> {
       try {
         const maxAttempts = this.context.config.getMaxAttempts();
+        let lastStreamError: unknown = undefined;
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           let isConnectionPhase = true;
@@ -532,7 +543,7 @@ export class GeminiChat {
             // If this is a retry, update the key with the new context.
             const currentConfigKey =
               attempt > 0
-                ? { ...modelConfigKey, isRetry: true }
+                ? { ...modelConfigKey, isRetry: true, lastStreamError }
                 : modelConfigKey;
 
             isConnectionPhase = true;
@@ -551,6 +562,10 @@ export class GeminiChat {
 
             return;
           } catch (error) {
+            if (error instanceof InvalidStreamError) {
+              lastStreamError = error;
+            }
+
             if (error instanceof AgentExecutionStoppedError) {
               yield {
                 type: StreamEventType.AGENT_EXECUTION_STOPPED,
@@ -776,6 +791,30 @@ export class GeminiChat {
         tools: this.tools,
         abortSignal,
       };
+
+      // Apply Context-Aware Retries (On-Retry Nudging) to guide the model out of silent loops
+      if (
+        modelConfigKey.isRetry &&
+        modelConfigKey.lastStreamError instanceof InvalidStreamError
+      ) {
+        const lastError = modelConfigKey.lastStreamError;
+        let nudgeMessage = '';
+        if (lastError.type === 'THINKING_ONLY_RESPONSE') {
+          nudgeMessage =
+            '\n[System: You previously generated thoughts but failed to provide a final user-facing response. Please ensure you provide your final answer or call a tool now.]';
+        } else if (lastError.type === 'NO_RESPONSE_TEXT') {
+          nudgeMessage =
+            '\n[System: You previously returned an empty response with no text or thoughts. Please ensure you provide your final answer or call a tool now.]';
+        }
+
+        if (nudgeMessage) {
+          if (typeof config.systemInstruction === 'string') {
+            config.systemInstruction += nudgeMessage;
+          } else if (config.systemInstruction === undefined) {
+            config.systemInstruction = nudgeMessage;
+          }
+        }
+      }
 
       let contentsToUse: Content[] =
         supportsModernFeatures(modelToUse) || isGemini2Model(modelToUse)
@@ -1325,10 +1364,15 @@ export class GeminiChat {
       }
     }
 
-    const responseText = consolidatedParts
+    const rawResponseText = consolidatedParts
       .filter((part) => part.text)
       .map((part) => part.text)
-      .join('')
+      .join('');
+
+    // Clean zero-width/invisible characters and HTML comments to determine actual printable/visible content
+    const responseText = rawResponseText
+      .replace(/[\u200B-\u200D\uFEFF\u200E\u200F]/g, '')
+      .replace(/<!--[\s\S]*?-->/g, '')
       .trim();
 
     let id: string;
@@ -1377,6 +1421,36 @@ export class GeminiChat {
         );
       }
       if (!responseText) {
+        if (finishReason === FinishReason.MAX_TOKENS) {
+          throw new InvalidStreamError(
+            'Model stream ended due to token limit exhaustion (MAX_TOKENS) with empty response text.',
+            'MAX_TOKENS_EXCEEDED',
+          );
+        }
+        if (finishReason === FinishReason.SAFETY) {
+          throw new InvalidStreamError(
+            'Model stream ended due to safety settings (SAFETY) with empty response text.',
+            'SAFETY_BLOCKED',
+          );
+        }
+        if (finishReason === FinishReason.RECITATION) {
+          throw new InvalidStreamError(
+            'Model stream ended due to recitation settings (RECITATION) with empty response text.',
+            'RECITATION_BLOCKED',
+          );
+        }
+        if (finishReason === FinishReason.OTHER) {
+          throw new InvalidStreamError(
+            'Model stream ended due to other settings (OTHER) with empty response text.',
+            'OTHER_BLOCKED',
+          );
+        }
+        if (hasThoughts) {
+          throw new InvalidStreamError(
+            'Model stream ended with empty response text but contained reasoning thoughts.',
+            'THINKING_ONLY_RESPONSE',
+          );
+        }
         throw new InvalidStreamError(
           'Model stream ended with empty response text.',
           'NO_RESPONSE_TEXT',

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1374,10 +1374,16 @@ export class GeminiChat {
       .join('');
 
     // Clean zero-width/invisible characters and HTML comments to determine actual printable/visible content
-    const responseText = rawResponseText
-      .replace(/[\u200B-\u200D\uFEFF\u200E\u200F]/g, '')
-      .replace(/<!--[\s\S]*?-->/g, '')
-      .trim();
+    let responseText = rawResponseText.replace(
+      /[\u200B-\u200D\uFEFF\u200E\u200F]/g,
+      '',
+    );
+    let previous: string;
+    do {
+      previous = responseText;
+      responseText = responseText.replace(/<!--[\s\S]*?-->/g, '');
+    } while (responseText !== previous);
+    responseText = responseText.trim();
 
     // Stream validation logic: A stream is considered successful if:
     // 1. There's a tool call OR

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -650,12 +650,10 @@ export class GeminiChat {
           }
         }
       } catch (error) {
-        if (error instanceof InvalidStreamError) {
-          this.agentHistory.rollback(historyLengthBefore);
-          this.chatRecordingService.updateMessagesFromHistory(
-            this.agentHistory.get(),
-          );
-        }
+        this.agentHistory.rollback(historyLengthBefore);
+        this.chatRecordingService.updateMessagesFromHistory(
+          this.agentHistory.get(),
+        );
         throw error;
       } finally {
         streamDoneResolver!();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -585,8 +585,7 @@ export class GeminiChat {
             );
 
             const isContentError = error instanceof InvalidStreamError;
-            const isRetryableContentError =
-              isContentError && error.type !== 'NO_RESPONSE_TEXT';
+            const isRetryableContentError = isContentError;
             const errorType = isContentError
               ? error.type
               : getRetryErrorType(error);

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -387,6 +387,8 @@ export class GeminiChat {
   ): Promise<AsyncGenerator<StreamEvent>> {
     await this.sendPromise;
 
+    const historyLengthBefore = this.agentHistory.length;
+
     let streamDoneResolver: () => void;
     const streamDonePromise = new Promise<void>((resolve) => {
       streamDoneResolver = resolve;
@@ -647,6 +649,14 @@ export class GeminiChat {
             throw error;
           }
         }
+      } catch (error) {
+        if (error instanceof InvalidStreamError) {
+          this.agentHistory.rollback(historyLengthBefore);
+          this.chatRecordingService.updateMessagesFromHistory(
+            this.agentHistory.get(),
+          );
+        }
+        throw error;
       } finally {
         streamDoneResolver!();
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -407,6 +407,7 @@ export class GeminiChat {
     this.sendPromise = streamDonePromise;
 
     let userContent = createUserContent(message);
+    const isOriginalFunctionResponse = isFunctionResponse(userContent);
     const { model } =
       this.context.config.modelConfigService.getResolvedConfig(modelConfigKey);
 
@@ -415,7 +416,7 @@ export class GeminiChat {
 
     // Record user input - capture complete message with all parts (text, files, images, etc.)
     // but skip recording function responses (tool call results) as they should be stored in tool call records
-    if (!isFunctionResponse(userContent)) {
+    if (!isOriginalFunctionResponse) {
       const userMessageParts = userContent.parts || [];
       const userMessageContent = partListUnionToString(userMessageParts);
 
@@ -666,7 +667,7 @@ export class GeminiChat {
           }
         }
       } catch (error) {
-        if (!isFunctionResponse(userContent)) {
+        if (!isOriginalFunctionResponse) {
           this.agentHistory.rollback(historyLengthBefore);
           this.chatRecordingService.updateMessagesFromHistory(
             this.agentHistory.get(),

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -398,6 +398,7 @@ export class GeminiChat {
     await this.sendPromise;
 
     const historyLengthBefore = this.agentHistory.length;
+    const baselinePromptTokenCount = this.lastPromptTokenCount;
 
     let streamDoneResolver: () => void;
     const streamDonePromise = new Promise<void>((resolve) => {
@@ -670,6 +671,7 @@ export class GeminiChat {
           this.chatRecordingService.updateMessagesFromHistory(
             this.agentHistory.get(),
           );
+          this.lastPromptTokenCount = baselinePromptTokenCount;
         }
         throw error;
       } finally {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1379,24 +1379,6 @@ export class GeminiChat {
       .replace(/<!--[\s\S]*?-->/g, '')
       .trim();
 
-    let id: string;
-    // Record model response text from the collected parts.
-    // Also flush when there are thoughts or a tool call (even with no text)
-    // so that BeforeTool hooks always see the latest transcript state.
-    if (responseText || hasThoughts || hasToolCall) {
-      id = this.chatRecordingService.recordMessage({
-        model,
-        type: 'gemini',
-        content: responseText,
-      });
-    } else {
-      // Still need a durable ID even if response is empty (e.g. only tool calls)
-      id = this.chatRecordingService.recordSyntheticMessage(
-        'gemini',
-        consolidatedParts,
-      );
-    }
-
     // Stream validation logic: A stream is considered successful if:
     // 1. There's a tool call OR
     // 2. A not MALFORMED_FUNCTION_CALL finish reason and a non-mepty resp
@@ -1460,6 +1442,24 @@ export class GeminiChat {
           'NO_RESPONSE_TEXT',
         );
       }
+    }
+
+    let id: string;
+    // Record model response text from the collected parts.
+    // Also flush when there are thoughts or a tool call (even with no text)
+    // so that BeforeTool hooks always see the latest transcript state.
+    if (responseText || hasThoughts || hasToolCall) {
+      id = this.chatRecordingService.recordMessage({
+        model,
+        type: 'gemini',
+        content: responseText,
+      });
+    } else {
+      // Still need a durable ID even if response is empty (e.g. only tool calls)
+      id = this.chatRecordingService.recordSyntheticMessage(
+        'gemini',
+        consolidatedParts,
+      );
     }
 
     this.agentHistory.push({

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -665,10 +665,12 @@ export class GeminiChat {
           }
         }
       } catch (error) {
-        this.agentHistory.rollback(historyLengthBefore);
-        this.chatRecordingService.updateMessagesFromHistory(
-          this.agentHistory.get(),
-        );
+        if (!isFunctionResponse(userContent)) {
+          this.agentHistory.rollback(historyLengthBefore);
+          this.chatRecordingService.updateMessagesFromHistory(
+            this.agentHistory.get(),
+          );
+        }
         throw error;
       } finally {
         streamDoneResolver!();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1194,6 +1194,13 @@ export class GeminiChat {
     let hasThoughts = false;
     let finishReason: FinishReason | undefined;
 
+    // Buffers to prevent failed stream attempts from polluting telemetry and logs
+    const bufferedThoughts: Array<{ subject: string; description: string }> =
+      [];
+    let bufferedUsageMetadata:
+      | GenerateContentResponse['usageMetadata']
+      | undefined = undefined;
+
     // The SDK provides fully assembled FunctionCall objects in chunk.functionCalls
     // We use a Map to ensure we only keep the latest version of each call (by ID)
     const finalFunctionCallsMap = new Map<string, FunctionCall>();
@@ -1249,7 +1256,10 @@ export class GeminiChat {
           if (content.parts.some((part) => part.thought)) {
             // Record thoughts
             hasThoughts = true;
-            this.recordThoughtFromContent(content);
+            const thought = this.extractThoughtFromContent(content);
+            if (thought) {
+              bufferedThoughts.push(thought);
+            }
           }
           if (content.parts.some((part) => part.functionCall)) {
             hasToolCall = true;
@@ -1277,12 +1287,9 @@ export class GeminiChat {
         }
       }
 
-      // Record token usage if this chunk has usageMetadata
+      // Buffer token usage if this chunk has usageMetadata
       if (chunk.usageMetadata) {
-        this.chatRecordingService.recordMessageTokens(chunk.usageMetadata);
-        if (chunk.usageMetadata.promptTokenCount !== undefined) {
-          this.lastPromptTokenCount = chunk.usageMetadata.promptTokenCount;
-        }
+        bufferedUsageMetadata = chunk.usageMetadata;
       }
 
       const hookSystem = this.context.config.getHookSystem();
@@ -1451,6 +1458,19 @@ export class GeminiChat {
       }
     }
 
+    // Flush buffered thoughts from the successful attempt
+    for (const thought of bufferedThoughts) {
+      this.chatRecordingService.recordThought(thought);
+    }
+
+    // Flush buffered usage metadata and token counts from the successful attempt
+    if (bufferedUsageMetadata) {
+      this.chatRecordingService.recordMessageTokens(bufferedUsageMetadata);
+      if (bufferedUsageMetadata.promptTokenCount !== undefined) {
+        this.lastPromptTokenCount = bufferedUsageMetadata.promptTokenCount;
+      }
+    }
+
     let id: string;
     // Record model response text from the collected parts.
     // Also flush when there are thoughts or a tool call (even with no text)
@@ -1523,11 +1543,13 @@ export class GeminiChat {
   }
 
   /**
-   * Extracts and records thought from thought content.
+   * Extracts thought from thought content.
    */
-  private recordThoughtFromContent(content: Content): void {
+  private extractThoughtFromContent(
+    content: Content,
+  ): { subject: string; description: string } | undefined {
     if (!content.parts || content.parts.length === 0) {
-      return;
+      return undefined;
     }
 
     const thoughtPart = content.parts[0];
@@ -1540,11 +1562,12 @@ export class GeminiChat {
         : '';
       const description = rawText.replace(/\*\*(.*?)\*\*/s, '').trim();
 
-      this.chatRecordingService.recordThought({
+      return {
         subject,
         description,
-      });
+      };
     }
+    return undefined;
   }
 }
 

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -254,7 +254,15 @@ describe('Turn', () => {
         events.push(event);
       }
 
-      expect(events).toEqual([{ type: GeminiEventType.InvalidStream }]);
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: 'NO_FINISH_REASON',
+            message: 'Test invalid stream',
+          },
+        },
+      ]);
       expect(turn.getDebugResponses().length).toBe(0);
       expect(reportError).not.toHaveBeenCalled(); // Should not report as error
     });

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -110,7 +110,12 @@ export type ServerGeminiInvalidStreamEvent = {
       | 'NO_FINISH_REASON'
       | 'NO_RESPONSE_TEXT'
       | 'MALFORMED_FUNCTION_CALL'
-      | 'UNEXPECTED_TOOL_CALL';
+      | 'UNEXPECTED_TOOL_CALL'
+      | 'MAX_TOKENS_EXCEEDED'
+      | 'SAFETY_BLOCKED'
+      | 'RECITATION_BLOCKED'
+      | 'OTHER_BLOCKED'
+      | 'THINKING_ONLY_RESPONSE';
     message: string;
   };
 };

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -105,6 +105,14 @@ export type ServerGeminiContextWindowWillOverflowEvent = {
 
 export type ServerGeminiInvalidStreamEvent = {
   type: GeminiEventType.InvalidStream;
+  value: {
+    type:
+      | 'NO_FINISH_REASON'
+      | 'NO_RESPONSE_TEXT'
+      | 'MALFORMED_FUNCTION_CALL'
+      | 'UNEXPECTED_TOOL_CALL';
+    message: string;
+  };
 };
 
 export type ServerGeminiModelInfoEvent = {
@@ -408,7 +416,13 @@ export class Turn {
       }
 
       if (e instanceof InvalidStreamError) {
-        yield { type: GeminiEventType.InvalidStream };
+        yield {
+          type: GeminiEventType.InvalidStream,
+          value: {
+            type: e.type,
+            message: e.message,
+          },
+        };
         return;
       }
 

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -413,6 +413,16 @@ export function renderOperationalGuidelines(
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
 ## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a \`functionResponse\`, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. ${formatToolName(EDIT_TOOL_NAME)}, ${formatToolName(WRITE_FILE_TOOL_NAME)}), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
 - **Parallelism & Sequencing:** Tools execute in parallel by default. Execute multiple independent tool calls in parallel when feasible (e.g., searching, reading files, independent shell commands, or editing *different* files). If a tool depends on the output or side-effects of a previous tool in the same turn (e.g., running a shell command that depends on the success of a previous command), you MUST set the \`wait_for_previous\` parameter to \`true\` on the dependent tool to ensure sequential execution.
 - **File Editing Collisions:** Do NOT make multiple calls to the ${formatToolName(EDIT_TOOL_NAME)} tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
 - **Command Execution:** Use the ${formatToolName(SHELL_TOOL_NAME)} tool for running shell commands, remembering the safety rule to explain modifying commands first.${toolUsageInteractive(

--- a/packages/core/src/scheduler/scheduler.test.ts
+++ b/packages/core/src/scheduler/scheduler.test.ts
@@ -630,8 +630,8 @@ describe('Scheduler (Orchestrator)', () => {
         CoreToolCallStatus.Cancelled,
         'Operation cancelled by user',
       );
-      // finalizeCall is handled by the processing loop, not synchronously by cancelAll
-      // expect(mockStateManager.finalizeCall).toHaveBeenCalledWith('call-1');
+      // finalizeCall is called synchronously by cancelAll to ensure completedBatch is populated and isActive is updated immediately
+      expect(mockStateManager.finalizeCall).toHaveBeenCalledWith('call-1');
       expect(mockStateManager.cancelAllQueued).toHaveBeenCalledWith(
         'Operation cancelled by user',
       );

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -278,6 +278,7 @@ export class Scheduler {
           CoreToolCallStatus.Cancelled,
           'Operation cancelled by user',
         );
+        this.state.finalizeCall(activeCall.request.callId);
       }
     }
 
@@ -438,6 +439,14 @@ export class Scheduler {
    */
   private async _processNextItem(signal: AbortSignal): Promise<boolean> {
     if (signal.aborted || this.isCancelling) {
+      // Finalize active calls that are terminal
+      const activeCalls = this.state.allActiveCalls;
+      for (const call of activeCalls) {
+        if (this.isTerminal(call.status)) {
+          this.state.finalizeCall(call.request.callId);
+        }
+      }
+
       this.state.cancelAllQueued('Operation cancelled');
       return false;
     }

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -37,6 +37,9 @@ export interface ModelConfigKey {
   // Indicates whether this request originates from the primary interactive chat model.
   // Enables the default fallback configuration to `chat-base` when unknown.
   isChatModel?: boolean;
+
+  // The last stream error that triggered this retry attempt, if any.
+  lastStreamError?: unknown;
 }
 
 export interface ModelConfig {

--- a/packages/core/src/telemetry/uiTelemetry.test.ts
+++ b/packages/core/src/telemetry/uiTelemetry.test.ts
@@ -173,6 +173,7 @@ describe('UiTelemetryService', () => {
           totalRequests: 1,
           totalErrors: 0,
           totalLatencyMs: 500,
+          errorsByType: {},
         },
         tokens: {
           input: 5,
@@ -229,6 +230,7 @@ describe('UiTelemetryService', () => {
           totalRequests: 2,
           totalErrors: 0,
           totalLatencyMs: 1100,
+          errorsByType: {},
         },
         tokens: {
           input: 10,
@@ -305,6 +307,9 @@ describe('UiTelemetryService', () => {
           totalRequests: 1,
           totalErrors: 1,
           totalLatencyMs: 300,
+          errorsByType: {
+            UNKNOWN: 1,
+          },
         },
         tokens: {
           input: 0,
@@ -316,6 +321,42 @@ describe('UiTelemetryService', () => {
           tool: 0,
         },
         roles: {},
+      });
+    });
+
+    it('should track errors by error_type distinctly', () => {
+      const event1 = {
+        'event.name': EVENT_API_ERROR,
+        model: 'gemini-2.5-pro',
+        duration_ms: 200,
+        error: 'Empty response',
+        error_type: 'NO_RESPONSE_TEXT',
+      } as unknown as ApiErrorEvent & { 'event.name': typeof EVENT_API_ERROR };
+
+      const event2 = {
+        'event.name': EVENT_API_ERROR,
+        model: 'gemini-2.5-pro',
+        duration_ms: 250,
+        error: 'Malformed JSON',
+        error_type: 'MALFORMED_FUNCTION_CALL',
+      } as unknown as ApiErrorEvent & { 'event.name': typeof EVENT_API_ERROR };
+
+      const event3 = {
+        'event.name': EVENT_API_ERROR,
+        model: 'gemini-2.5-pro',
+        duration_ms: 100,
+        error: 'Another empty response',
+        error_type: 'NO_RESPONSE_TEXT',
+      } as unknown as ApiErrorEvent & { 'event.name': typeof EVENT_API_ERROR };
+
+      service.addEvent(event1);
+      service.addEvent(event2);
+      service.addEvent(event3);
+
+      const metrics = service.getMetrics();
+      expect(metrics.models['gemini-2.5-pro'].api.errorsByType).toEqual({
+        NO_RESPONSE_TEXT: 2,
+        MALFORMED_FUNCTION_CALL: 1,
       });
     });
 
@@ -351,6 +392,9 @@ describe('UiTelemetryService', () => {
           totalRequests: 2,
           totalErrors: 1,
           totalLatencyMs: 800,
+          errorsByType: {
+            UNKNOWN: 1,
+          },
         },
         tokens: {
           input: 5,

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -56,6 +56,7 @@ export interface ModelMetrics {
     totalRequests: number;
     totalErrors: number;
     totalLatencyMs: number;
+    errorsByType?: Record<string, number>;
   };
   tokens: {
     input: number;
@@ -110,6 +111,7 @@ const createInitialModelMetrics = (): ModelMetrics => ({
     totalRequests: 0,
     totalErrors: 0,
     totalLatencyMs: 0,
+    errorsByType: {},
   },
   tokens: {
     input: 0,
@@ -325,6 +327,13 @@ export class UiTelemetryService extends EventEmitter {
     modelMetrics.api.totalRequests++;
     modelMetrics.api.totalErrors++;
     modelMetrics.api.totalLatencyMs += event.duration_ms;
+
+    if (!modelMetrics.api.errorsByType) {
+      modelMetrics.api.errorsByType = {};
+    }
+    const errorType = event.error_type || 'UNKNOWN';
+    modelMetrics.api.errorsByType[errorType] =
+      (modelMetrics.api.errorsByType[errorType] || 0) + 1;
 
     if (event.role) {
       if (!modelMetrics.roles[event.role]) {

--- a/packages/core/src/telemetry/uiTelemetry.ts
+++ b/packages/core/src/telemetry/uiTelemetry.ts
@@ -172,6 +172,23 @@ export class UiTelemetryService extends EventEmitter {
     });
   }
 
+  recordSemanticValidationError(model: string, errorType: string): void {
+    const modelMetrics = this.getOrCreateModelMetrics(model);
+    modelMetrics.api.totalErrors++;
+
+    if (!modelMetrics.api.errorsByType) {
+      modelMetrics.api.errorsByType = {};
+    }
+    const type = errorType || 'INVALID_STREAM';
+    modelMetrics.api.errorsByType[type] =
+      (modelMetrics.api.errorsByType[type] || 0) + 1;
+
+    this.emit('update', {
+      metrics: this.#metrics,
+      lastPromptTokenCount: this.#lastPromptTokenCount,
+    });
+  }
+
   getMetrics(): SessionMetrics {
     return this.#metrics;
   }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -10,3 +10,6 @@ export const REFERENCE_CONTENT_END = '--- End of content ---';
 export const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
 export const MAX_LINE_LENGTH_TEXT_FILE = 2000;
 export const MAX_FILE_SIZE_MB = 20;
+
+export const EMPTY_RESPONSE_COMPRESS_SUGGESTION =
+  'The model returned an empty text response. If your context window is near capacity, try using /compress.';

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -13,3 +13,21 @@ export const MAX_FILE_SIZE_MB = 20;
 
 export const EMPTY_RESPONSE_COMPRESS_SUGGESTION =
   'The model returned an empty text response. If your context window is near capacity, try using /compress.';
+
+export const THINKING_ONLY_COMPRESS_SUGGESTION =
+  'The model returned reasoning thoughts but no final response text. If your context window is near capacity, try using /compress.';
+
+export const MAX_TOKENS_EXCEEDED_SUGGESTION =
+  'Model response was truncated because it exceeded the token limit. Try using /compress to free up context space.';
+
+export const SAFETY_BLOCKED_MESSAGE =
+  'The model response was blocked due to safety settings.';
+
+export const RECITATION_BLOCKED_MESSAGE =
+  'The model response was blocked due to recitation/copyright filters.';
+
+export const OTHER_BLOCKED_MESSAGE =
+  'The model response was blocked due to other policy settings.';
+
+export const TRUE_EMPTY_RESPONSE_MESSAGE =
+  'The model returned an empty response with no text or thoughts. This may be a transient API issue; please try again.';

--- a/packages/core/src/utils/messageInspectors.test.ts
+++ b/packages/core/src/utils/messageInspectors.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isFunctionResponse, isFunctionCall } from './messageInspectors.js';
+
+describe('messageInspectors', () => {
+  describe('isFunctionResponse', () => {
+    it('should return false if content role is not user', () => {
+      const content = {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              name: 'test_tool',
+              response: { success: true },
+            },
+          },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('should return false if content has no parts', () => {
+      const content = {
+        role: 'user',
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('should return false if parts are empty', () => {
+      const content = {
+        role: 'user',
+        parts: [],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('should return false if none of the parts is a functionResponse', () => {
+      const content = {
+        role: 'user',
+        parts: [
+          {
+            text: 'Hello world',
+          },
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://example.com/image.png',
+            },
+          },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(false);
+    });
+
+    it('should return true if all parts are functionResponses', () => {
+      const content = {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'test_tool_1',
+              response: { success: true },
+            },
+          },
+          {
+            functionResponse: {
+              name: 'test_tool_2',
+              response: { value: 42 },
+            },
+          },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+
+    it('should return true if content is a mixed multimodal tool response containing functionResponse and sibling parts', () => {
+      const content = {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'test_tool',
+              response: { success: true },
+            },
+          },
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://example.com/image.png',
+            },
+          },
+        ],
+      };
+      expect(isFunctionResponse(content)).toBe(true);
+    });
+  });
+
+  describe('isFunctionCall', () => {
+    it('should return false if content role is not model', () => {
+      const content = {
+        role: 'user',
+        parts: [
+          {
+            functionCall: {
+              name: 'test_tool',
+              args: {},
+            },
+          },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('should return false if content has no parts', () => {
+      const content = {
+        role: 'model',
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('should return false if parts are empty', () => {
+      const content = {
+        role: 'model',
+        parts: [],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('should return false if none of the parts is a functionCall', () => {
+      const content = {
+        role: 'model',
+        parts: [
+          {
+            text: 'I am thinking...',
+          },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(false);
+    });
+
+    it('should return true if all parts are functionCalls', () => {
+      const content = {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'test_tool_1',
+              args: {},
+            },
+          },
+          {
+            functionCall: {
+              name: 'test_tool_2',
+              args: { query: 'foo' },
+            },
+          },
+        ],
+      };
+      expect(isFunctionCall(content)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/utils/messageInspectors.ts
+++ b/packages/core/src/utils/messageInspectors.ts
@@ -10,7 +10,7 @@ export function isFunctionResponse(content: Content): boolean {
   return (
     content.role === 'user' &&
     !!content.parts &&
-    content.parts.every((part) => !!part.functionResponse)
+    content.parts.some((part) => !!part.functionResponse)
   );
 }
 
@@ -18,6 +18,7 @@ export function isFunctionCall(content: Content): boolean {
   return (
     content.role === 'model' &&
     !!content.parts &&
+    content.parts.length > 0 &&
     content.parts.every((part) => !!part.functionCall)
   );
 }


### PR DESCRIPTION
## Summary

This PR propagates specific `InvalidStreamError` details (the error `type` and `message`) from the core backend layers up to the CLI UI hooks. This allows the CLI to display highly relevant and helpful troubleshooting suggestions—such as recommending the use of `/compress` to reduce context size when the model returns an empty text response.

## Details

- **Core Events (`Turn`/`geminiChat`)**: Updated the `ServerGeminiInvalidStreamEvent` type and the `Turn` run logic to pass the specific error `type` and `message` values in the event's `value` payload, instead of dropping this detail.
- **UI Stream Hook (`useGeminiStream`)**: Implemented `handleInvalidStreamEvent` to check if `eventValue.type` is `'NO_RESPONSE_TEXT'`, in which case we display a custom, friendly message recommending the use of `/compress`. Otherwise, we fall back to displaying the event's raw error message.
- **Testing**:
  - Updated `packages/cli/src/nonInteractiveCli.test.ts` mock events to include the new `value` metadata.
  - Updated `packages/core/src/agent/event-translator.test.ts` to mock the correct payload structure.
  - Updated `packages/core/src/core/turn.test.ts` to expect the populated `value` payload on `InvalidStream` events.
  - Fixed pre-existing/broken tests in `packages/core/src/core/geminiChat.test.ts` to correctly mock/stub and run the mid-conversation stream retry flow when empty text responses are received.

## Related Issues

Addresses https://github.com/google-gemini/gemini-cli/issues/28351 .

## How to Validate

Run unit tests in the core and CLI packages to verify the new behavior:
```bash
npm test -w @google/gemini-cli-core -- src/core/turn.test.ts
npm test -w @google/gemini-cli-core -- src/core/geminiChat.test.ts
npm test -w @google/gemini-cli -- src/nonInteractiveCli.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
