### PR TITLE
fix(vscode-ide-companion): track both Disposables in each activate() push

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -165,8 +165,13 @@ describe('activate', () => {
       );
     });
 
+    // Only the stubs above carry a `tag`. IDEServer.start also pushes its own
+    // untagged Disposables onto context.subscriptions, so filter to the tagged
+    // ones rather than assuming every entry is one of ours.
     const subscribedTags = () =>
-      context.subscriptions.map((d) => (d as unknown as { tag: string }).tag);
+      context.subscriptions
+        .map((d) => (d as unknown as { tag?: unknown } | undefined)?.tag)
+        .filter((tag): tag is string => typeof tag === 'string');
 
     it('tracks every registration made during activation', async () => {
       await activate(context);

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -131,6 +131,86 @@ describe('activate', () => {
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
   });
 
+  describe('disposable tracking', () => {
+    // Each registration returns a Disposable tagged with what produced it, so
+    // the assertions below can tell *which* Disposables reached
+    // context.subscriptions rather than merely that the registration ran.
+    //
+    // Asserting the call happened is not enough: a comma expression
+    // `(regA(), regB())` still evaluates both operands, so both mocks are
+    // called while only regB's Disposable becomes the argument to push().
+    // These tests read context.subscriptions for that reason.
+    const tagged = (tag: string) => ({ tag, dispose: vi.fn() });
+
+    beforeEach(() => {
+      vi.mocked(context.globalState.get).mockReturnValue(true);
+      vi.mocked(vscode.workspace.onDidCloseTextDocument).mockImplementation(
+        () => tagged('onDidCloseTextDocument') as never,
+      );
+      vi.mocked(
+        vscode.workspace.registerTextDocumentContentProvider,
+      ).mockImplementation(
+        () => tagged('registerTextDocumentContentProvider') as never,
+      );
+      vi.mocked(
+        vscode.workspace.onDidChangeWorkspaceFolders,
+      ).mockImplementation(
+        () => tagged('onDidChangeWorkspaceFolders') as never,
+      );
+      vi.mocked(vscode.workspace.onDidGrantWorkspaceTrust).mockImplementation(
+        () => tagged('onDidGrantWorkspaceTrust') as never,
+      );
+      vi.mocked(vscode.commands.registerCommand).mockImplementation(
+        (command: string) => tagged(`command:${command}`) as never,
+      );
+    });
+
+    const subscribedTags = () =>
+      context.subscriptions.map((d) => (d as unknown as { tag: string }).tag);
+
+    it('tracks every registration made during activation', async () => {
+      await activate(context);
+
+      expect(subscribedTags()).toEqual(
+        expect.arrayContaining([
+          'onDidCloseTextDocument',
+          'registerTextDocumentContentProvider',
+          'command:gemini.diff.accept',
+          'command:gemini.diff.cancel',
+          'onDidChangeWorkspaceFolders',
+          'onDidGrantWorkspaceTrust',
+          'command:gemini-cli.runGeminiCLI',
+          'command:gemini-cli.showNotices',
+        ]),
+      );
+    });
+
+    it('tracks the gemini.diff.accept command so re-activation does not collide', async () => {
+      // Left untracked, the command stays registered after deactivation and a
+      // re-activate in the same extension host throws
+      // "command 'gemini.diff.accept' already exists".
+      await activate(context);
+
+      expect(subscribedTags()).toContain('command:gemini.diff.accept');
+    });
+
+    it('tracks the onDidChangeWorkspaceFolders listener so it stops on deactivation', async () => {
+      // Left untracked, the listener outlives the IDEServer it calls and keeps
+      // firing syncEnvVars() against a stopped server.
+      await activate(context);
+
+      expect(subscribedTags()).toContain('onDidChangeWorkspaceFolders');
+    });
+
+    it('pushes one Disposable per registration', async () => {
+      await activate(context);
+
+      const tags = subscribedTags();
+      expect(tags).toHaveLength(new Set(tags).size);
+      expect(tags).toHaveLength(8);
+    });
+  });
+
   it('should launch the Gemini CLI when the user clicks the button', async () => {
     const showInformationMessageMock = vi
       .mocked(vscode.window.showInformationMessage)

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

Two of the eight registrations in `activate()` are wrapped in parentheses together with the registration that follows them:

```ts
context.subscriptions.push(
  ...
  (vscode.commands.registerCommand('gemini.diff.accept', ...),
   vscode.commands.registerCommand('gemini.diff.cancel', ...)),
);
```

That is a **comma expression**, not two arguments. Both operands are evaluated, so both commands do get registered -- but the expression's *value* is only the last operand, so only `gemini.diff.cancel` ever reaches `context.subscriptions`. The second `push()` has the same shape, where `onDidChangeWorkspaceFolders` is swallowed by `onDidGrantWorkspaceTrust`.

Net effect: 6 of 8 Disposables are tracked.

```
Disposables actually pushed into context.subscriptions:
  - onDidCloseTextDocument
  - registerTextDocumentContentProvider
  - registerCommand:gemini.diff.cancel
  - onDidGrantWorkspaceTrust
  - registerCommand:gemini-cli.runGeminiCLI
  - registerCommand:gemini-cli.showNotices

Expected 8 disposables; got 6
MISSING (registered but never pushed -> leaked):
  - registerCommand:gemini.diff.accept
  - onDidChangeWorkspaceFolders
```

Observable consequences:

- **`gemini.diff.accept` stays registered after `deactivate()`.** Re-activating in the same extension host throws `command 'gemini.diff.accept' already exists` -- this is what a user hits on extension update / reload without a full window restart.
- **The `onDidChangeWorkspaceFolders` listener outlives the `IDEServer`** it closes over, and keeps calling `syncEnvVars()` against a stopped server.

Fixes #27790

## Changes

`packages/vscode-ide-companion/src/extension.ts` -- removed the two stray sets of wrapping parentheses so all eight registrations are real arguments to `push()`. No behavioural change beyond the Disposables now being tracked.

`packages/vscode-ide-companion/src/extension.test.ts` -- added a `describe('disposable tracking')` block with four regression tests.

## Why the tests are shaped this way

The pre-existing test

```ts
expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
```

**passes either way** -- a comma expression still evaluates both operands, so every registration mock is called regardless of which Disposable becomes the argument to `push()`. Any "was it called?" assertion is structurally blind to this class of bug.

So the new tests make each mocked registration return a Disposable tagged with what produced it, and assert on the *contents* of `context.subscriptions`.

## Verification

Full package suite, with the fix:

```
 ✓ src/open-files-manager.test.ts (17 tests)
 ✓ src/extension.test.ts (15 tests)
 ✓ src/ide-server.test.ts (13 tests)

 Test Files  3 passed (3)
      Tests  45 passed (45)
```

`eslint src` exits 0; `prettier --check` clean on both files.

Control experiment -- reverting **only** `extension.ts` and keeping the new tests:

```
 ✗ tracks every registration made during activation
 ✗ tracks the gemini.diff.accept command so re-activation does not collide
     -> expected [ 'onDidCloseTextDocument', ...(5) ] to include 'command:gemini.diff.accept'
 ✗ tracks the onDidChangeWorkspaceFolders listener so it stops on deactivation
     -> expected [ 'onDidCloseTextDocument', ...(5) ] to include 'onDidChangeWorkspaceFolders'
 ✗ pushes one Disposable per registration
     -> expected [ 'onDidCloseTextDocument', ...(5) ] to have a length of 8 but got 6

 Tests  4 failed | 11 passed (15)
```

The 11 pre-existing tests still pass with the bug present, which is exactly the blindness described above.
