### PR TITLE
fix(cli): skip diff hunk markers during @ processing

### DIFF
--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -204,6 +204,59 @@ describe('handleAtCommand', () => {
     });
   });
 
+  it('should preserve diff hunk markers without searching for files', async () => {
+    const query = [
+      'Review this diff:',
+      '--- a/example.ts',
+      '+++ b/example.ts',
+      '@@ -1,2 +1,2 @@',
+      '-const oldValue = 1;',
+      '+const newValue = 2;',
+      '@@@ -10,2 -10,2 +10,2 @@@',
+    ].join('\n');
+    const globTool = mockConfig.getToolRegistry().getTool('glob');
+    const globSpy = vi.spyOn(globTool!, 'buildAndExecute');
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 125,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [{ text: query }],
+    });
+    expect(globSpy).not.toHaveBeenCalled();
+  });
+
+  it('should still process file paths that start with @', async () => {
+    const fileContent = 'scoped file content';
+    await createTestFile(path.join(testRootDir, '@scope.ts'), fileContent);
+    const query = '@@scope.ts';
+
+    const result = await handleAtCommand({
+      query,
+      config: mockConfig,
+      addItem: mockAddItem,
+      onDebugMessage: mockOnDebugMessage,
+      messageId: 126,
+      signal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      processedQuery: [
+        { text: query },
+        { text: '\n--- Content from referenced files ---' },
+        { text: '\nContent from @@scope.ts:\n' },
+        { text: fileContent },
+        { text: '\n--- End of content ---' },
+      ],
+    });
+  });
+
   it('should process a valid text file path', async () => {
     const fileContent = 'This is the file content.';
     const filePath = await createTestFile(

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -54,12 +54,13 @@ export function unescapeLiteralAt(text: string): string {
  * It uses strict ASCII whitespace delimiters to allow Unicode characters like NNBSP in filenames.
  *
  * 1. "(?:[^"]*)" matches a double-quoted string (for Windows paths with spaces).
- * 2. \\. matches any escaped character (e.g., \ ).
- * 3. [^ \t\n\r,;!?()\[\]{}.] matches any character that is NOT a delimiter and NOT a period.
- * 4. \.(?!$|[ \t\n\r]) matches a period ONLY if it is NOT followed by whitespace or end-of-string.
+ * 2. (?!@+(?=$|[ \t\n\r])) excludes bare @ runs, such as unified diff hunk markers.
+ * 3. \\. matches any escaped character (e.g., \ ).
+ * 4. [^ \t\n\r,;!?()\[\]{}.] matches any character that is NOT a delimiter and NOT a period.
+ * 5. \.(?!$|[ \t\n\r]) matches a period ONLY if it is NOT followed by whitespace or end-of-string.
  */
 export const AT_COMMAND_PATH_REGEX_SOURCE =
-  '(?:(?:"(?:[^"]*)")|(?:\\\\.|[^ \\t\\n\\r,;!?()\\[\\]{}.]|\\.(?!$|[ \\t\\n\\r])))+';
+  '(?!@+(?=$|[ \\t\\n\\r]))(?:(?:"(?:[^"]*)")|(?:\\\\.|[^ \\t\\n\\r,;!?()\\[\\]{}.]|\\.(?!$|[ \\t\\n\\r])))+';
 
 interface HandleAtCommandParams {
   query: string;

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -194,6 +194,15 @@ describe('commandUtils', () => {
       expect(isAtCommand('\\@file')).toBe(false);
     });
 
+    it('should not treat unified diff hunk markers as @ commands', () => {
+      expect(isAtCommand('@@ -1,2 +1,2 @@')).toBe(false);
+      expect(isAtCommand('@@@ -10,2 -10,2 +10,2 @@@')).toBe(false);
+    });
+
+    it('should still detect paths that start with @', () => {
+      expect(isAtCommand('@@scope.ts')).toBe(true);
+    });
+
     it('should return true for multi-line external editor prompts with @-references', () => {
       expect(isAtCommand('Please review:\n@src/main.py\nand fix bugs.')).toBe(
         true,


### PR DESCRIPTION
## Summary

Prevent unified and combined diff hunk markers from being interpreted as `@file` references. This removes two recursive workspace-wide glob searches per hunk, preventing `minimatch`/`path-scurry` heap growth on large diff prompts.

## Details

- Reject only bare runs of `@` bounded by ASCII whitespace or end of input.
- Preserve the prompt byte-for-byte when it contains `@@ ... @@` or `@@@ ... @@@` markers.
- Preserve real paths beginning with `@`, such as `@@scope.ts`.
- A two-hunk regression case made four glob calls before this change and zero after it.

## Related Issues

Fixes #28550

## How to Validate

- `npm test -w @google/gemini-cli -- src/ui/hooks/atCommandProcessor.test.ts src/ui/utils/commandUtils.test.ts` — 101 tests passed.
- Preflight format, lint, build, typecheck, CLI, core, and SDK suites passed. The VS Code companion suite also passed separately: 40 passed, 1 skipped.
- `npm run test:memory` — 6/7 scenarios passed; the remaining unrelated baseline is already unstable on this exact upstream SHA, whose Nightly job is red: https://github.com/google-gemini/gemini-cli/actions/runs/30418799040
- `npm run test:perf` — blocked before collection by the existing `canUseRipgrep is not a function` fixture regression, reproduced identically by the upstream Nightly job on this SHA: https://github.com/google-gemini/gemini-cli/actions/runs/30421363714

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (not needed; internal parser fix)
- [x] Added/updated tests
- [x] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker