### PR TITLE
fix(core): preserve thoughtSignature in functionCall parts to fix 400 error

### DIFF
--- a/memory-tests/memory-usage.test.ts
+++ b/memory-tests/memory-usage.test.ts
@@ -433,6 +433,9 @@ async function generateSharedLargeChatData(tempDir: string) {
         if (geminiMsg.toolCalls) {
           for (const tc of geminiMsg.toolCalls) {
             parts.push({
+              ...(tc.thoughtSignature && {
+                thoughtSignature: tc.thoughtSignature,
+              }),
               functionCall: {
                 name: tc.name,
                 args: tc.args,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1909,7 +1909,11 @@ export const useGeminiStream = (
               role: 'model',
               parts: [
                 {
+                  ...(tool.request.thoughtSignature && {
+                    thoughtSignature: tool.request.thoughtSignature,
+                  }),
                   functionCall: {
+                    ...(tool.request.id && { id: tool.request.id }), // Good practice to include ID if present
                     name: tool.request.name,
                     args: tool.request.args,
                   },

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1913,7 +1913,7 @@ export const useGeminiStream = (
                     thoughtSignature: tool.request.thoughtSignature,
                   }),
                   functionCall: {
-                    ...(tool.request.id && { id: tool.request.id }), // Good practice to include ID if present
+                    id: tool.request.id ?? tool.request.callId,
                     name: tool.request.name,
                     args: tool.request.args,
                   },

--- a/packages/core/src/scheduler/types.ts
+++ b/packages/core/src/scheduler/types.ts
@@ -35,6 +35,8 @@ export enum CoreToolCallStatus {
 
 export interface ToolCallRequestInfo {
   callId: string;
+  id?: string;
+  thoughtSignature?: string;
   name: string;
   args: Record<string, unknown>;
   /** Tool-controlled display information. */

--- a/packages/core/src/services/chatRecordingTypes.ts
+++ b/packages/core/src/services/chatRecordingTypes.ts
@@ -55,6 +55,7 @@ export interface ToolCallRecord {
   id: string;
   name: string;
   args: Record<string, unknown>;
+  thoughtSignature?: string;
   result?: PartListUnion | null;
   status: Status;
   timestamp: string;

--- a/packages/core/src/utils/sessionUtils.test.ts
+++ b/packages/core/src/utils/sessionUtils.test.ts
@@ -211,4 +211,63 @@ describe('convertSessionToClientHistory', () => {
       },
     ]);
   });
+
+  it('should preserve thoughtSignature when mapping tool calls', () => {
+    const messages: ConversationRecord['messages'] = [
+      {
+        id: 'msg1',
+        type: 'user',
+        timestamp: '2024-01-01T10:00:00Z',
+        content: 'Run parallel tools',
+      },
+      {
+        id: 'msg2',
+        type: 'gemini',
+        timestamp: '2024-01-01T10:01:00Z',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call456',
+            name: 'weather_tool',
+            args: { location: 'New York' },
+            thoughtSignature: 'test-hash-signature-456', // Simulated thought signature
+            status: CoreToolCallStatus.Success,
+            timestamp: '2024-01-01T10:01:05Z',
+            result: 'Sunny',
+          },
+        ],
+      },
+    ];
+
+    const history = convertSessionToClientHistory(messages);
+
+    expect(history.map((h) => h.content)).toEqual([
+      { role: 'user', parts: [{ text: 'Run parallel tools' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            thoughtSignature: 'test-hash-signature-456', // Asserting it is preserved
+            functionCall: {
+              name: 'weather_tool',
+              args: { location: 'New York' },
+              id: 'call456',
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'call456',
+              name: 'weather_tool',
+              response: { output: 'Sunny' },
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/core/src/utils/sessionUtils.ts
+++ b/packages/core/src/utils/sessionUtils.ts
@@ -163,6 +163,9 @@ export function convertSessionToClientHistory(
         if (msg.toolCalls && msg.toolCalls.length > 0) {
           for (const toolCall of msg.toolCalls) {
             modelParts.push({
+              ...(toolCall.thoughtSignature && {
+                thoughtSignature: toolCall.thoughtSignature,
+              }), // ADD THIS LINE
               functionCall: {
                 id: toolCall.id,
                 name: toolCall.name,


### PR DESCRIPTION
### PR Title
fix(core): preserve thoughtSignature in functionCall parts to fix 400 error

---

### PR Body
## Summary

Fixes a regression introduced in version 0.53.0 that causes a 400 Bad Request error during parallel tool calls. The `thoughtSignature` was being inadvertently stripped from `functionCall` parts during history mapping and scrubbing.

## Details

- Updated the `ToolCallRecord` and related interfaces in `packages/core/src/scheduler/types.ts` and `packages/core/src/services/chatRecordingTypes.ts` to include the optional `thoughtSignature` property.
- Modified the mapping logic in `packages/core/src/utils/sessionUtils.ts` to preserve `thoughtSignature` when converting tool calls to parts.
- Added a unit test case in `packages/core/src/utils/sessionUtils.test.ts` to ensure the signature is maintained in the output.

## Related Issues

Fixes #28579

## How to Validate

1. Run the test suite to ensure the new unit test passes:
   `npx vitest run packages/core/src/utils/sessionUtils.test.ts`
2. Start the CLI locally:
   `npm start`
3. Issue a prompt that forces the model to use parallel tool calling (e.g., "Check the weather in New York and London at the same time using your weather tool").
4. Verify that the CLI successfully executes the tools and returns the response without throwing the `400 Bad Request: Function call is missing a thought_signature` API error.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [ ] Docker