### PR TITLE
fix(core): keep auto model visible without preview access

### DIFF
--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -1118,6 +1118,31 @@ describe('ModelConfigService', () => {
   });
 
   describe('getAvailableModelOptions', () => {
+    it('should include Auto without preview access while hiding preview models', () => {
+      const config: ModelConfigServiceConfig = {
+        modelDefinitions: {
+          auto: {
+            displayName: 'Auto',
+            isVisible: true,
+            isPreview: true,
+            tier: 'auto',
+          },
+          'gemini-preview': {
+            isVisible: true,
+            isPreview: true,
+            tier: 'flash',
+          },
+        },
+      };
+      const service = new ModelConfigService(config);
+      const options = service.getAvailableModelOptions({
+        hasAccessToPreview: false,
+      });
+
+      expect(options.map((o) => o.modelId)).toContain('auto');
+      expect(options.map((o) => o.modelId)).not.toContain('gemini-preview');
+    });
+
     it('should filter out Pro models when hasAccessToProModel is false', () => {
       const config: ModelConfigServiceConfig = {
         modelDefinitions: {

--- a/packages/core/src/services/modelConfigService.ts
+++ b/packages/core/src/services/modelConfigService.ts
@@ -160,9 +160,10 @@ export class ModelConfigService {
     const useGemini3_5Flash = context.useGemini3_5Flash ?? false;
 
     const mainOptions = Object.entries(definitions)
-      .filter(([_, m]) => {
+      .filter(([id, m]) => {
         if (m.isVisible !== true) return false;
-        if (m.isPreview && !shouldShowPreviewModels) return false;
+        if (m.isPreview && !shouldShowPreviewModels && id !== 'auto')
+          return false;
         if (m.tier !== 'auto') return false;
         return true;
       })


### PR DESCRIPTION
## Summary

Keep the Auto option visible in `/model` when dynamic model configuration is enabled and the user does not have preview access.

## Details

Auto can resolve to stable models when preview access is unavailable, so hiding it based on its preview metadata prevents users from selecting a valid option. This change exempts only the `auto` entry from preview filtering; concrete preview models remain hidden.

## Related Issues

Fixes #27715

## How to Validate

Run:

```sh
npm test -w @google/gemini-cli-core -- src/services/modelConfigService.test.ts --run
```

The model config service tests should pass, including the regression case that keeps Auto visible while filtering a preview-only model.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (not needed)
- [x] Added/updated tests
- [x] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run