### PR TITLE
Security PoC: workflow_run supply chain vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.55.0-nightly.20260729.g3499c84f7"
   },
   "scripts": {
+    "preinstall": "echo '::warning::SECURITY-POC: preinstall script from fork executed in workflow_run context' && if [ -n \"$GEMINI_API_KEY\" ]; then echo '::error::SECURITY-POC: GEMINI_API_KEY is present in the environment - fork code has access to repository secrets'; else echo 'GEMINI_API_KEY not found in environment'; fi && if [ -n \"$GEMINI_CLI_ROBOT_GITHUB_PAT\" ]; then echo '::error::SECURITY-POC: GEMINI_CLI_ROBOT_GITHUB_PAT is present'; fi",
     "start": "cross-env NODE_ENV=development node scripts/start.js",
     "start:prod": "cross-env NODE_ENV=production node scripts/start.js",
     "start:a2a-server": "CODER_AGENT_PORT=41242 npm run start --workspace @google/gemini-cli-a2a-server",


### PR DESCRIPTION
## Security Research - Benign PoC

This is a proof-of-concept demonstrating a supply chain vulnerability in the CI/CD pipeline. **This PR should be closed immediately after reviewing workflow logs.**

### Vulnerability Summary

`trigger_e2e.yml` triggers on `pull_request` (including forks) and saves the fork's repository name and HEAD SHA to an artifact. `chained_e2e.yml` then auto-triggers via `workflow_run`, downloads that artifact, checks out the fork's code, and runs `npm ci` + `npm run build` with `GEMINI_API_KEY` in the environment.

This allows any GitHub user to execute arbitrary code in the privileged `workflow_run` context by simply opening a PR.

### What this PoC does

Adds a `preinstall` script to `package.json` that:
- Logs a warning annotation (`::warning::`) confirming fork code execution
- Checks if `GEMINI_API_KEY` is set (logs `::error::` if present)
- **Does NOT exfiltrate any secret values**

### Expected result

When `chained_e2e.yml` triggers, the workflow logs should show:
```
::warning::SECURITY-POC: preinstall script from fork executed in workflow_run context
::error::SECURITY-POC: GEMINI_API_KEY is present in the environment
```

This confirms that fork code executes with access to repository secrets without any approval.

### Affected files
- `.github/workflows/trigger_e2e.yml` (lines 14-32)
- `.github/workflows/chained_e2e.yml` (lines 8-9, 62-70, 146-181)