### PR TITLE
fix(cli): load environment variables before resolving settings placeholders

### DIFF
--- a/integration-tests/settings.test.ts
+++ b/integration-tests/settings.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestRig } from './test-helper.js';
+import { join } from 'node:path';
+import fs from 'node:fs';
+import { loadSettings } from '../packages/cli/src/config/settings.js';
+
+describe('settings', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = new TestRig();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rig.cleanup();
+  });
+
+  describe('environment variables', () => {
+    it('should resolve environment variables loaded from workspace .env file', () => {
+      rig.setup('settings-env-resolution');
+
+      const workspaceDir = rig.testDir!;
+      const geminiDir = join(workspaceDir, '.gemini');
+      fs.mkdirSync(geminiDir, { recursive: true });
+
+      fs.writeFileSync(
+        join(workspaceDir, '.env'),
+        'MY_INTEGRATION_TEST_SECRET=integration-resolved-success\n',
+      );
+
+      fs.writeFileSync(
+        join(geminiDir, 'settings.json'),
+        JSON.stringify({
+          mcpServers: {
+            testServer: {
+              command: 'echo',
+              args: ['$MY_INTEGRATION_TEST_SECRET'],
+            },
+          },
+        }),
+      );
+
+      vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', 'true');
+
+      const settings = loadSettings(workspaceDir);
+
+      expect(settings.merged.mcpServers?.['testServer']?.args).toEqual([
+        'integration-resolved-success',
+      ]);
+    });
+  });
+});

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1378,6 +1378,44 @@ describe('Settings Loading and Merging', () => {
       delete process.env['TEST_API_KEY'];
     });
 
+    it('should resolve environment variables loaded from .env files', () => {
+      vi.stubEnv('TEST_VAR_FROM_DOT_ENV', undefined);
+
+      const workspaceEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+      const userSettingsContent: TestSettings = {
+        apiKey: '$TEST_VAR_FROM_DOT_ENV',
+      };
+
+      (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) => {
+        const normalized = normalizePath(p);
+        return (
+          normalized === normalizePath(USER_SETTINGS_PATH) ||
+          normalized === normalizePath(workspaceEnvPath)
+        );
+      });
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          const normalized = normalizePath(p);
+          if (normalized === normalizePath(USER_SETTINGS_PATH)) {
+            return JSON.stringify(userSettingsContent);
+          }
+          if (normalized === normalizePath(workspaceEnvPath)) {
+            return 'TEST_VAR_FROM_DOT_ENV=resolved_from_dot_env';
+          }
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      expect((settings.user.settings as TestSettings)['apiKey']).toBe(
+        'resolved_from_dot_env',
+      );
+      expect((settings.merged as TestSettings)['apiKey']).toBe(
+        'resolved_from_dot_env',
+      );
+    });
+
     it('should resolve environment variables in workspace settings', () => {
       process.env['WORKSPACE_ENDPOINT'] = 'workspace_endpoint_from_env';
       const workspaceSettingsContent: TestSettings = {
@@ -2103,6 +2141,38 @@ describe('Settings Loading and Merging', () => {
 
       expect(settings.merged.tools?.sandbox).toBe(false); // User setting
       expect(settings.merged.context?.fileName).toBe('USER.md'); // User setting
+    });
+
+    it('should resolve environment variables in security settings using pre-existing process.env before checking trust', () => {
+      vi.stubEnv('ENABLE_FOLDER_TRUST', 'false');
+
+      const spyIsWorkspaceTrusted = vi.spyOn(
+        trustedFolders,
+        'isWorkspaceTrusted',
+      );
+
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettingsContent = {
+        security: {
+          folderTrust: {
+            enabled: '$ENABLE_FOLDER_TRUST',
+          },
+        },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (normalizePath(p) === normalizePath(USER_SETTINGS_PATH))
+            return JSON.stringify(userSettingsContent);
+          return '{}';
+        },
+      );
+
+      loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(spyIsWorkspaceTrusted).toHaveBeenCalled();
+      const passedSettings = spyIsWorkspaceTrusted.mock.calls[0][0];
+      expect(passedSettings.security?.folderTrust?.enabled).toBe(false);
     });
   });
 
@@ -3528,6 +3598,51 @@ MALICIOUS_VAR=allowed-because-trusted
         expect(process.env['GOOGLE_CLOUD_PROJECT']).toBe(
           'attacker-projectinject',
         );
+      });
+
+      it('should resolve placeholders in selected auth type during loadSettings and skip Cloud Shell override', () => {
+        vi.stubEnv('CLOUD_SHELL', 'true');
+        vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'my-vertex-project');
+        vi.stubEnv('MOCK_AUTH_TYPE', undefined);
+
+        vi.mocked(isWorkspaceTrusted).mockReturnValue({
+          isTrusted: true,
+          source: 'file',
+        });
+
+        const workspaceEnvPath = path.join(MOCK_WORKSPACE_DIR, '.env');
+        (mockFsExistsSync as Mock).mockImplementation((p: fs.PathLike) => {
+          const norm = normalizePath(p);
+          return (
+            norm === normalizePath(USER_SETTINGS_PATH) ||
+            norm === normalizePath(workspaceEnvPath)
+          );
+        });
+
+        const userSettingsContent = {
+          security: {
+            auth: {
+              selectedType: '$MOCK_AUTH_TYPE',
+            },
+          },
+        };
+
+        (fs.readFileSync as Mock).mockImplementation(
+          (p: fs.PathOrFileDescriptor) => {
+            const norm = normalizePath(p);
+            if (norm === normalizePath(USER_SETTINGS_PATH)) {
+              return JSON.stringify(userSettingsContent);
+            }
+            if (norm === normalizePath(workspaceEnvPath)) {
+              return 'MOCK_AUTH_TYPE=vertex-ai';
+            }
+            return '{}';
+          },
+        );
+
+        loadSettings(MOCK_WORKSPACE_DIR);
+
+        expect(process.env['GOOGLE_CLOUD_PROJECT']).toBe('my-vertex-project');
       });
     });
   });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -46,7 +46,10 @@ export {
   getSettingsSchema,
 };
 
-import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
+import {
+  resolveEnvVarsInObject,
+  resolveEnvVarsInString,
+} from '../utils/envVarResolver.js';
 import { customDeepMerge } from '../utils/deepMerge.js';
 import { updateSettingsFilePreservingFormat } from '../utils/commentJson.js';
 import {
@@ -679,17 +682,7 @@ export function loadEnvironment(
 
   const envFilePath = findEnvFile(workspaceDir, isTrusted, shouldIgnoreEnv);
 
-  // Cloud Shell environment variable handling
-  if (process.env['CLOUD_SHELL'] === 'true') {
-    const selectedAuthType = settings.security?.auth?.selectedType;
-    setUpCloudShellEnvironment(
-      envFilePath,
-      isTrusted,
-      isSandboxed,
-      selectedAuthType,
-    );
-  }
-
+  // 1. Load variables from `.env` file first so they are available in process.env
   if (envFilePath) {
     // Manually parse and load environment variables to handle exclusions correctly.
     // This avoids modifying environment variables that were already set from the shell.
@@ -727,6 +720,22 @@ export function loadEnvironment(
     } catch {
       // Errors are ignored to match the behavior of `dotenv.config({ quiet: true })`.
     }
+  }
+
+  // 2. Now that process.env is fully populated, expand the selected auth type
+  const rawAuthType = settings.security?.auth?.selectedType;
+  const selectedAuthType = rawAuthType
+    ? resolveEnvVarsInString(rawAuthType)
+    : undefined;
+
+  // 3. Cloud Shell environment variable handling (using the fully expanded auth type)
+  if (process.env['CLOUD_SHELL'] === 'true') {
+    setUpCloudShellEnvironment(
+      envFilePath,
+      isTrusted,
+      isSandboxed,
+      selectedAuthType,
+    );
   }
 }
 
@@ -778,7 +787,7 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
 
   const load = (
     filePath: string,
-  ): { settings: Settings; rawSettings: Settings; rawJson?: string } => {
+  ): { rawSettings: Settings; rawJson?: string } => {
     try {
       if (fs.existsSync(filePath)) {
         const content = fs.readFileSync(filePath, 'utf-8');
@@ -794,43 +803,11 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
             path: filePath,
             severity: 'error',
           });
-          return { settings: {}, rawSettings: {} };
+          return { rawSettings: {} };
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        const settingsObject = rawSettings as Record<string, unknown>;
-
-        // Expand environment variables
-        const expandedSettings = resolveEnvVarsInObject(
-          settingsObject as Settings,
-        );
-
-        // Validate settings structure with Zod after environment variable expansion
-        const validationResult = validateSettings(expandedSettings);
-        if (!validationResult.success && validationResult.error) {
-          const errorMessage = formatValidationError(
-            validationResult.error,
-            filePath,
-          );
-          settingsErrors.push({
-            message: errorMessage,
-            path: filePath,
-            severity: 'warning',
-          });
-          return {
-            settings: expandedSettings,
-            rawSettings: settingsObject as Settings,
-            rawJson: content,
-          };
-        }
-
-        // Return the successfully cast and validated data
         return {
-          // Since we've successfully validated expandedSettings against settingsZodSchema,
-          // it's safe to cast the resulting data to the Settings type.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          settings: (validationResult.data as Settings) ?? expandedSettings,
-          rawSettings: settingsObject as Settings,
+          rawSettings: rawSettings as Settings,
           rawJson: content,
         };
       }
@@ -841,42 +818,136 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
         severity: 'error',
       });
     }
-    return { settings: {}, rawSettings: {} };
+    return { rawSettings: {} };
   };
 
-  const systemResult = load(systemSettingsPath);
-  const systemDefaultsResult = load(systemDefaultsPath);
-  const userResult = load(USER_SETTINGS_PATH);
+  const systemRawResult = load(systemSettingsPath);
+  const systemDefaultsRawResult = load(systemDefaultsPath);
+  const userRawResult = load(USER_SETTINGS_PATH);
 
-  let workspaceResult: {
-    settings: Settings;
+  let workspaceRawResult: {
     rawSettings: Settings;
     rawJson?: string;
   } = {
-    settings: {} as Settings,
     rawSettings: {} as Settings,
     rawJson: undefined,
   };
   if (!storage.isWorkspaceHomeDir()) {
-    workspaceResult = load(workspaceSettingsPath);
+    workspaceRawResult = load(workspaceSettingsPath);
   }
 
-  const systemOriginalSettings = structuredClone(systemResult.rawSettings);
+  // Support legacy theme names in the raw settings
+  if (userRawResult.rawSettings.ui?.theme === 'VS') {
+    userRawResult.rawSettings.ui.theme = DefaultLight.name;
+  } else if (userRawResult.rawSettings.ui?.theme === 'VS2015') {
+    userRawResult.rawSettings.ui.theme = DefaultDark.name;
+  }
+  if (workspaceRawResult.rawSettings.ui?.theme === 'VS') {
+    workspaceRawResult.rawSettings.ui.theme = DefaultLight.name;
+  } else if (workspaceRawResult.rawSettings.ui?.theme === 'VS2015') {
+    workspaceRawResult.rawSettings.ui.theme = DefaultDark.name;
+  }
+
+  // Helper to expand environment variables and coerce types using Zod schema validation
+  const expandAndCast = (settings: Settings): Settings => {
+    const expanded = resolveEnvVarsInObject(settings);
+    const validated = validateSettings(expanded);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return (validated.data as Settings) ?? expanded;
+  };
+
+  // For the initial trust check, we can only use user and system settings.
+  const initialTrustCheckSettings = expandAndCast(
+    customDeepMerge(
+      getMergeStrategyForPath,
+      getDefaultsFromSchema(),
+      systemDefaultsRawResult.rawSettings,
+      userRawResult.rawSettings,
+      systemRawResult.rawSettings,
+    ) as Settings,
+  );
+  const isTrusted =
+    isWorkspaceTrusted(initialTrustCheckSettings, workspaceDir).isTrusted ??
+    false;
+
+  // Create a temporary merged settings object to pass to loadEnvironment.
+  const tempMergedSettings = expandAndCast(
+    mergeSettings(
+      systemRawResult.rawSettings,
+      systemDefaultsRawResult.rawSettings,
+      userRawResult.rawSettings,
+      workspaceRawResult.rawSettings,
+      isTrusted,
+    ),
+  );
+
+  // loadEnvironment depends on settings so we have to create a temp version of
+  // the settings to avoid a cycle. This loads environment variables from .env files!
+  loadEnvironment(tempMergedSettings, workspaceDir);
+
+  // Now process (expand environment variables and validate) each settings scope
+  const resolveAndValidate = (
+    filePath: string,
+    rawSettings: Settings,
+    rawJson?: string,
+  ): Settings => {
+    if (!rawJson) {
+      return {} as Settings;
+    }
+
+    // Expand environment variables (now with .env files fully loaded in process.env!)
+    const expandedSettings = resolveEnvVarsInObject(rawSettings);
+
+    // Validate settings structure with Zod after environment variable expansion
+    const validationResult = validateSettings(expandedSettings);
+    if (!validationResult.success && validationResult.error) {
+      const errorMessage = formatValidationError(
+        validationResult.error,
+        filePath,
+      );
+      settingsErrors.push({
+        message: errorMessage,
+        path: filePath,
+        severity: 'warning',
+      });
+      return expandedSettings;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return (validationResult.data as Settings) ?? expandedSettings;
+  };
+
+  systemSettings = resolveAndValidate(
+    systemSettingsPath,
+    systemRawResult.rawSettings,
+    systemRawResult.rawJson,
+  );
+  systemDefaultSettings = resolveAndValidate(
+    systemDefaultsPath,
+    systemDefaultsRawResult.rawSettings,
+    systemDefaultsRawResult.rawJson,
+  );
+  userSettings = resolveAndValidate(
+    USER_SETTINGS_PATH,
+    userRawResult.rawSettings,
+    userRawResult.rawJson,
+  );
+  workspaceSettings = resolveAndValidate(
+    workspaceSettingsPath,
+    workspaceRawResult.rawSettings,
+    workspaceRawResult.rawJson,
+  );
+
+  const systemOriginalSettings = structuredClone(systemRawResult.rawSettings);
   const systemDefaultsOriginalSettings = structuredClone(
-    systemDefaultsResult.rawSettings,
+    systemDefaultsRawResult.rawSettings,
   );
-  const userOriginalSettings = structuredClone(userResult.rawSettings);
+  const userOriginalSettings = structuredClone(userRawResult.rawSettings);
   const workspaceOriginalSettings = structuredClone(
-    workspaceResult.rawSettings,
+    workspaceRawResult.rawSettings,
   );
 
-  // Environment variables for runtime use are already resolved and validated in load()
-  systemSettings = systemResult.settings;
-  systemDefaultSettings = systemDefaultsResult.settings;
-  userSettings = userResult.settings;
-  workspaceSettings = workspaceResult.settings;
-
-  // Support legacy theme names
+  // Support legacy theme names in processed settings
   if (userSettings.ui?.theme === 'VS') {
     userSettings.ui.theme = DefaultLight.name;
   } else if (userSettings.ui?.theme === 'VS2015') {
@@ -887,31 +958,6 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
   } else if (workspaceSettings.ui?.theme === 'VS2015') {
     workspaceSettings.ui.theme = DefaultDark.name;
   }
-
-  // For the initial trust check, we can only use user and system settings.
-  const initialTrustCheckSettings = customDeepMerge(
-    getMergeStrategyForPath,
-    getDefaultsFromSchema(),
-    systemDefaultSettings,
-    userSettings,
-    systemSettings,
-  );
-  const isTrusted =
-    isWorkspaceTrusted(initialTrustCheckSettings as Settings, workspaceDir)
-      .isTrusted ?? false;
-
-  // Create a temporary merged settings object to pass to loadEnvironment.
-  const tempMergedSettings = mergeSettings(
-    systemSettings,
-    systemDefaultSettings,
-    userSettings,
-    workspaceSettings,
-    isTrusted,
-  );
-
-  // loadEnvironment depends on settings so we have to create a temp version of
-  // the settings to avoid a cycle
-  loadEnvironment(tempMergedSettings, workspaceDir);
 
   // Check for any fatal errors before proceeding
   const fatalErrors = settingsErrors.filter((e) => e.severity === 'error');
@@ -929,28 +975,28 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
       path: systemSettingsPath,
       settings: systemSettings,
       originalSettings: systemOriginalSettings,
-      rawJson: systemResult.rawJson,
+      rawJson: systemRawResult.rawJson,
       readOnly: true,
     },
     {
       path: systemDefaultsPath,
       settings: systemDefaultSettings,
       originalSettings: systemDefaultsOriginalSettings,
-      rawJson: systemDefaultsResult.rawJson,
+      rawJson: systemDefaultsRawResult.rawJson,
       readOnly: true,
     },
     {
       path: USER_SETTINGS_PATH,
       settings: userSettings,
       originalSettings: userOriginalSettings,
-      rawJson: userResult.rawJson,
+      rawJson: userRawResult.rawJson,
       readOnly: false,
     },
     {
       path: storage.isWorkspaceHomeDir() ? '' : workspaceSettingsPath,
       settings: workspaceSettings,
       originalSettings: workspaceOriginalSettings,
-      rawJson: workspaceResult.rawJson,
+      rawJson: workspaceRawResult.rawJson,
       readOnly: storage.isWorkspaceHomeDir(),
     },
     isTrusted,


### PR DESCRIPTION
## Summary

This PR resolves a load-order race condition in the settings lifecycle. Previously, settings files (system, user, workspace) were parsed, immediately expanded against `process.env`, and validated in a single monolithic step inside the `load` helper upon startup. However, the local `.env` files (which populate `process.env` from the project workspace) were only loaded after this step had already finished. This caused settings mapped to environment variables defined only in `.env` (such as `$GITHUB_MCP_PAT`) to remain unexpanded, leading to downstream authorization failures (e.g., a 400 Bad Format Authorization Header when communicating with GitHub Copilot's MCP server).

## Details

The settings lifecycle inside `_doLoadSettings` has been refactored to decouple loading from variable expansion and validation:
- **Parse Raw Files:** The `load` helper now strictly reads files from disk and parses the JSON content to produce raw, unexpanded configurations.
- **Initialize Environment:** `loadEnvironment` executes using these raw settings to load and inject `.env` file variables into `process.env`.
- **Resolve & Validate:** A new `resolveAndValidate` helper executes after environment variables have been fully initialized. This helper expands environment variable placeholders (now with fully loaded `.env` variables) and validates their final shapes against Zod schemas.

### Before the Fix (Race Condition Bug)

Upon CLI initialization, the internal `load()` helper executes for all settings files:
1. Settings files are parsed and immediately expanded against `process.env`.
2. The placeholder `$GITHUB_MCP_PAT` is evaluated against `process.env`. Because the local workspace `.env` file **has not been loaded yet**, the variable is not found.
3. The placeholder remains unexpanded:
   ```json
   "headers": {
     "Authorization": "Bearer $GITHUB_MCP_PAT"
   }
   ```
4. Only after this initial settings evaluation is completed does `loadEnvironment()` run to parse the `.env` file and populate `process.env`.
5. The CLI attempts to establish a connection to the GitHub Copilot MCP server using the literal string `Bearer $GITHUB_MCP_PAT`, resulting in a **400 Bad Format Authorization Header** error.

### After the Fix (Decoupled Pipeline)

The settings loading sequence is refactored into a decoupled, multi-stage pipeline:
1. **Load Raw Files:** The CLI loads and parses the settings files but defers environment variable resolution.
2. **Initialize Environment:** `loadEnvironment()` runs using the raw configurations. It parses the local `.env` file and populates the process environment:
   ```bash
   process.env['GITHUB_MCP_PAT'] = 'ghp_secretTokenVal123'
   ```
3. **Resolve & Validate:** The `resolveAndValidate()` helper executes. It resolves settings placeholders now that `GITHUB_MCP_PAT` is fully initialized in the environment.
4. The header expands cleanly to:
   ```json
   "headers": {
     "Authorization": "Bearer ghp_secretTokenVal123"
   }
   ```
5. The CLI connects to the GitHub Copilot MCP server, authorizes successfully, and launches without error.

## Related Issues

Fixes #28684

## How to Validate

This change has been covered with both unit and integration-level tests:

1. **Unit tests:**
   Run the modified settings unit test suite:
   ```bash
   npx vitest run packages/cli/src/config/settings.test.ts
   ```
   *Expected: All 115 unit tests pass cleanly.*

2. **Integration tests:**
   Run the newly added integration test covering E2E `.env` resolution:
   ```bash
   npx vitest run integration-tests/settings.test.ts
   ```
   *Expected: The test passes cleanly in a sandboxed, isolated environment.*

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker