### PR TITLE
fix(core): classify capacity exhaustion as terminal to prevent retry hangs

### DIFF
--- a/packages/core/src/utils/googleQuotaErrors.test.ts
+++ b/packages/core/src/utils/googleQuotaErrors.test.ts
@@ -107,6 +107,44 @@ describe('classifyGoogleError', () => {
     expect((result as RetryableQuotaError).retryDelayMs).toBe(9000);
   });
 
+  it('should return TerminalQuotaError for MODEL_CAPACITY_EXHAUSTED when no retry delay is specified', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message:
+        'No capacity available for model gemini-3.1-pro-preview on the server',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+          reason: 'MODEL_CAPACITY_EXHAUSTED',
+          domain: 'cloudcode-pa.googleapis.com',
+          metadata: { model: 'gemini-3.1-pro-preview' },
+        },
+      ],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(new Error());
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
+  it('should return TerminalQuotaError for MODEL_CAPACITY_EXCEEDED when no retry delay is specified', () => {
+    const apiError: GoogleApiError = {
+      code: 429,
+      message:
+        'No capacity available for model gemini-3.1-pro-preview on the server',
+      details: [
+        {
+          '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+          reason: 'MODEL_CAPACITY_EXCEEDED',
+          domain: 'cloudcode-pa.googleapis.com',
+          metadata: { model: 'gemini-3.1-pro-preview' },
+        },
+      ],
+    };
+    vi.spyOn(errorParser, 'parseGoogleApiError').mockReturnValue(apiError);
+    const result = classifyGoogleError(new Error());
+    expect(result).toBeInstanceOf(TerminalQuotaError);
+  });
+
   it('should return original error if code is not 429, 499 or 503', () => {
     const apiError: GoogleApiError = {
       code: 500,

--- a/packages/core/src/utils/googleQuotaErrors.ts
+++ b/packages/core/src/utils/googleQuotaErrors.ts
@@ -357,6 +357,22 @@ export function classifyGoogleError(error: unknown): unknown {
             errorInfo.reason,
           );
         }
+        if (
+          errorInfo.reason === 'MODEL_CAPACITY_EXHAUSTED' ||
+          errorInfo.reason === 'MODEL_CAPACITY_EXCEEDED'
+        ) {
+          // If no server backoff delay is specified, treat capacity exhaustion as a terminal error
+          // to trigger immediate model fallback without retrying on the same exhausted model.
+          if (delaySeconds === undefined) {
+            return new TerminalQuotaError(
+              googleApiError.message,
+              googleApiError,
+              delaySeconds,
+              errorInfo.reason,
+            );
+          }
+          // Otherwise, fall through to RetryableQuotaError to honor the server's requested delay.
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR resolves a client-side hang that occurs when the backend returns a
`MODEL_CAPACITY_EXHAUSTED` error (HTTP 429) for preview models. By explicitly
classifying this error as a terminal limit when no retry delay is specified, the
client immediately triggers the fallback chain instead of entering an unhandled
retry loop.

## Details

When the backend experiences capacity constraints, it returns an HTTP 429 error
with the reason `MODEL_CAPACITY_EXHAUSTED`. Currently, this error is not matched
by the Cloud Code domain checks in `classifyGoogleError`, causing it to fall
through and be classified as a generic `RetryableQuotaError`. 

This forces the retry utility (`retryWithBackoff`) to perform 10 retry attempts
with exponential backoff on the exact same exhausted model, freezing the VS Code
UI for approximately 4 minutes.

To resolve this, we update `classifyGoogleError` to explicitly map
`MODEL_CAPACITY_EXHAUSTED` to `TerminalQuotaError` when no explicit retry delay
is specified (`delaySeconds === undefined`). This breaks the retry loop
immediately on the first attempt, allowing the client to instantly trigger the
fallback handler (`onPersistent429`) and seamlessly switch to Gemini Flash using
the session ID rotation mechanism introduced in PR #28469.

We also add a unit test to verify this behavior while preserving the existing
test case for 503 errors with explicit `RetryInfo` delays.

## Related Issues

## How to Validate

1. Run the unit test suite for `googleQuotaErrors` to verify that the new
   classification is fully covered and no regressions are introduced:
   ```bash
   npx vitest run packages/core/src/utils/googleQuotaErrors.test.ts
   ```
2. Run the linting and type-checking commands to ensure code quality and type
   safety:
   ```bash
   npm run lint
   npm run typecheck
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker