### PR TITLE
chore(docker): update Docker base image to node:24-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Builder ----
-FROM docker.io/library/node:20-slim AS builder
+FROM docker.io/library/node:24-slim AS builder
 
 # Install git (needed by generate-git-commit-info.js script)
 RUN apt-get update && apt-get install -y --no-install-recommends git \
@@ -39,7 +39,7 @@ RUN HUSKY=0 npm run build && \
     npm pack -w packages/cli --pack-destination packages/cli/dist/
 
 # ---- Stage 2: Runtime ----
-FROM docker.io/library/node:20-slim
+FROM docker.io/library/node:24-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
 ARG CLI_VERSION_ARG
@@ -81,8 +81,13 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 USER node
 
 # install gemini-cli and clean up
-COPY --chown=node:node packages/cli/dist/google-gemini-cli-*.tgz /tmp/gemini-cli.tgz
-COPY --chown=node:node packages/core/dist/google-gemini-cli-core-*.tgz /tmp/gemini-core.tgz
+COPY --from=builder --chown=node:node \
+    /build/packages/cli/dist/google-gemini-cli-*.tgz \
+    /tmp/gemini-cli.tgz
+
+COPY --from=builder --chown=node:node \
+    /build/packages/core/dist/google-gemini-cli-core-*.tgz \
+    /tmp/gemini-core.tgz
 RUN npm install -g /tmp/gemini-core.tgz \
   && npm install -g /tmp/gemini-cli.tgz \
   && node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli/package.json','utf8')); JSON.parse(fs.readFileSync('/usr/local/share/npm-global/lib/node_modules/@google/gemini-cli-core/package.json','utf8'));" \


### PR DESCRIPTION
## Summary

Updates the Docker image to use `node:24-slim` and fixes the runtime stage to copy the generated CLI packages from the builder stage.

## Details

This PR makes the following changes:

- Updates the builder image from `node:20-slim` to `node:24-slim`.
- Updates the runtime image from `node:20-slim` to `node:24-slim`.
- Changes the runtime stage to copy the generated package tarballs using `COPY --from=builder` instead of copying them from the build context.

These changes allow the Docker image to build successfully while using Node.js 24.


## How to Validate

1. Build the Docker image:
   ```bash
   docker build -t gemini-cli .
   ```

2. Verify that the build completes successfully without missing tarball errors.

3. Run the project's validation commands:

   ```bash
   npm run lint
   npm test
   ```

4. Confirm that the Docker image is built successfully using the updated Node.js 24 base image.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed) *(No code changes requiring new tests.)*
- [x] Noted breaking changes (if any) *(No breaking changes.)*
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [x] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker