### PR TITLE
fix(docker): upgrade sandbox Dockerfile to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Builder ----
-FROM docker.io/library/node:20-slim AS builder
+FROM docker.io/library/node:22-slim AS builder
 
 # Install git (needed by generate-git-commit-info.js script)
 RUN apt-get update && apt-get install -y --no-install-recommends git \
@@ -39,7 +39,7 @@ RUN HUSKY=0 npm run build && \
     npm pack -w packages/cli --pack-destination packages/cli/dist/
 
 # ---- Stage 2: Runtime ----
-FROM docker.io/library/node:20-slim
+FROM docker.io/library/node:22-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
 ARG CLI_VERSION_ARG


### PR DESCRIPTION
This PR resolves #28584.

### Description
The sandbox Dockerfile (`Dockerfile` in repository root) was previously pinned to `node:20-slim`. Node 20 reached End-of-Life (EOL) on 2026-04-30.

Since the runtime environment in the sandbox executes model-directed commands, running an EOL runtime exposes it to unpatched security vulnerabilities. This PR updates both the `builder` and `runtime` stages of the Dockerfile to `node:22-slim` (Active LTS) to ensure it receives ongoing security updates.
