### PR TITLE
fix(core): fall back to stable models when a preview model 404s with Gemini API key auth

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -525,6 +525,55 @@ Your admin might have disabled the access. Contact them to enable the Preview Re
         expect(result.current.proQuotaRequest).toBeNull();
       });
 
+      it('should handle ModelNotFoundError with Gemini API key by displaying API key access message', async () => {
+        vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
+          authType: AuthType.USE_GEMINI,
+        });
+
+        const { result } = await renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.FREE,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        const error = new ModelNotFoundError(
+          'Requested entity was not found.',
+          404,
+        );
+
+        act(() => {
+          promise = handler('gemini-3-pro-preview', 'gemini-2.5-pro', error);
+        });
+
+        const request = result.current.proQuotaRequest;
+        expect(request).not.toBeNull();
+        expect(request?.failedModel).toBe('gemini-3-pro-preview');
+        expect(request?.isModelNotFoundError).toBe(true);
+
+        const message = request!.message;
+        expect(message).toBe(
+          `Your API key does not have access to gemini-3-pro-preview.\n` +
+            `/model to switch models.`,
+        );
+
+        act(() => {
+          result.current.handleProQuotaChoice('retry_always');
+        });
+
+        const intent = await promise!;
+        expect(intent).toBe('retry_always');
+      });
+
       it('should handle ModelNotFoundError with Vertex AI by displaying region-specific availability message and documentation link', async () => {
         vi.spyOn(mockConfig, 'getContentGeneratorConfig').mockReturnValue({
           authType: AuthType.USE_VERTEX_AI,

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -148,6 +148,15 @@ export function useQuotaAndFallback({
             `/model to switch models.`,
           ];
           message = messageLines.join('\n');
+        } else if (
+          contentGeneratorConfig?.authType === AuthType.USE_GEMINI &&
+          VALID_GEMINI_MODELS.has(failedModel)
+        ) {
+          const messageLines = [
+            `Your API key does not have access to ${getDisplayString(failedModel)}.`,
+            `/model to switch models.`,
+          ];
+          message = messageLines.join('\n');
         } else if (VALID_GEMINI_MODELS.has(failedModel)) {
           const messageLines = [
             `It seems like you don't have access to ${getDisplayString(failedModel)}.`,

--- a/packages/core/src/fallback/handler.test.ts
+++ b/packages/core/src/fallback/handler.test.ts
@@ -23,10 +23,12 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_MODEL_AUTO,
+  PREVIEW_GEMINI_3_1_MODEL,
   PREVIEW_GEMINI_FLASH_MODEL,
   PREVIEW_GEMINI_MODEL,
   PREVIEW_GEMINI_MODEL_AUTO,
 } from '../config/models.js';
+import { ModelNotFoundError } from '../utils/httpErrors.js';
 import type { FallbackModelHandler } from './types.js';
 import { openBrowserSecurely } from '../utils/secure-browser-launcher.js';
 import { debugLogger } from '../utils/debugLogger.js';
@@ -420,6 +422,102 @@ describe('handleFallback', () => {
 
       expect(result).toBe(true);
       expect(policyConfig.activateFallbackMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preview model 404 with Gemini API key auth', () => {
+    let availability: ModelAvailabilityService;
+    let apiKeyHandler: Mock<FallbackModelHandler>;
+    let apiKeyConfig: Config;
+    let setHasAccessToPreviewModel: Mock;
+    const notFoundError = new ModelNotFoundError(
+      'Requested entity was not found.',
+      404,
+    );
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      availability = createAvailabilityServiceMock({
+        selectedModel: DEFAULT_GEMINI_MODEL,
+        skipped: [],
+      });
+      apiKeyHandler = vi.fn().mockResolvedValue('retry_always');
+      // Simulate the assumed preview access flag flipping once disabled.
+      let hasAccessToPreview = true;
+      setHasAccessToPreviewModel = vi.fn((hasAccess: boolean) => {
+        hasAccessToPreview = hasAccess;
+      });
+      apiKeyConfig = createMockConfig({
+        getModel: vi.fn(() => PREVIEW_GEMINI_3_1_MODEL),
+        getActiveModel: vi.fn(() => PREVIEW_GEMINI_3_1_MODEL),
+        getHasAccessToPreviewModel: vi.fn(() => hasAccessToPreview),
+        setHasAccessToPreviewModel,
+      } as unknown as Partial<Config>);
+      vi.mocked(apiKeyConfig.getModelAvailabilityService).mockReturnValue(
+        availability,
+      );
+      vi.mocked(apiKeyConfig.getFallbackModelHandler).mockReturnValue(
+        apiKeyHandler,
+      );
+    });
+
+    it('disables preview access so fallback candidates are stable models', async () => {
+      await handleFallback(
+        apiKeyConfig,
+        PREVIEW_GEMINI_3_1_MODEL,
+        AuthType.USE_GEMINI,
+        notFoundError,
+      );
+
+      expect(setHasAccessToPreviewModel).toHaveBeenCalledWith(false);
+      expect(availability.selectFirstAvailable).toHaveBeenCalledWith([
+        DEFAULT_GEMINI_MODEL,
+        DEFAULT_GEMINI_FLASH_MODEL,
+      ]);
+      expect(apiKeyHandler).toHaveBeenCalledWith(
+        PREVIEW_GEMINI_3_1_MODEL,
+        DEFAULT_GEMINI_MODEL,
+        notFoundError,
+      );
+    });
+
+    it('does not disable preview access for OAuth users', async () => {
+      await handleFallback(
+        apiKeyConfig,
+        PREVIEW_GEMINI_3_1_MODEL,
+        AUTH_OAUTH,
+        notFoundError,
+      );
+
+      expect(setHasAccessToPreviewModel).not.toHaveBeenCalled();
+    });
+
+    it('does not disable preview access when the failed model is not a preview model', async () => {
+      await handleFallback(
+        apiKeyConfig,
+        DEFAULT_GEMINI_MODEL,
+        AuthType.USE_GEMINI,
+        notFoundError,
+      );
+
+      expect(setHasAccessToPreviewModel).not.toHaveBeenCalled();
+    });
+
+    it('does not disable preview access for non-404 errors', async () => {
+      const terminalError = new TerminalQuotaError('Quota error', {
+        code: 429,
+        message: 'mock error',
+        details: [],
+      });
+
+      await handleFallback(
+        apiKeyConfig,
+        PREVIEW_GEMINI_3_1_MODEL,
+        AuthType.USE_GEMINI,
+        terminalError,
+      );
+
+      expect(setHasAccessToPreviewModel).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -5,6 +5,8 @@
  */
 
 import type { Config } from '../config/config.js';
+import { AuthType } from '../core/contentGenerator.js';
+import { isPreviewModel } from '../config/models.js';
 import { createSessionId } from '../utils/session.js';
 import {
   openBrowserSecurely,
@@ -30,6 +32,19 @@ export async function handleFallback(
   error?: unknown,
 ): Promise<string | boolean | null> {
   const failureKind = classifyFailureKind(error);
+
+  // A 404 for a preview model on the Gemini API key path means the key's
+  // project has no access to preview models. Record that before resolving
+  // the policy chain so the fallback candidates are stable models instead
+  // of another preview model that would also 404.
+  if (
+    failureKind === 'not_found' &&
+    authType === AuthType.USE_GEMINI &&
+    isPreviewModel(failedModel, config) &&
+    config.getHasAccessToPreviewModel()
+  ) {
+    config.setHasAccessToPreviewModel(false);
+  }
 
   const chain = resolvePolicyChain(config);
   const { failedPolicy, candidates } = buildFallbackPolicyContext(

--- a/packages/core/src/fallback/handler.ts
+++ b/packages/core/src/fallback/handler.ts
@@ -41,9 +41,9 @@ export async function handleFallback(
     failureKind === 'not_found' &&
     authType === AuthType.USE_GEMINI &&
     isPreviewModel(failedModel, config) &&
-    config.getHasAccessToPreviewModel()
+    config.getHasAccessToPreviewModel?.()
   ) {
-    config.setHasAccessToPreviewModel(false);
+    config.setHasAccessToPreviewModel?.(false);
   }
 
   const chain = resolvePolicyChain(config);


### PR DESCRIPTION
Fixes #28600

## Summary

With Gemini API key auth (AuthType.USE_GEMINI), Config.initialize() assumes every key has preview model access. A key whose project lacks that access sends gemini-3.1-pro-preview and receives 404 NOT_FOUND ("Requested entity was not found."). The fallback policy chain then still resolves to preview models, so the offered fallback (gemini-3-flash-preview) also 404s and the raw error surfaces to the user. The not-found dialog additionally shows the Code Assist guidance about contacting an admin to enable the Preview Release Channel, which does not apply to API key users.

## Changes

- core: in handleFallback, when a known preview model fails with 404 on the API key path, record that the key has no preview access before resolving the policy chain. The fallback candidates then resolve to the stable models (gemini-2.5-pro, gemini-2.5-flash) instead of another preview model that would also 404.
- cli: show an API key specific message in the model-not-found dialog instead of the Code Assist admin message.

## Testing

- New unit tests in packages/core/src/fallback/handler.test.ts covering the access downgrade, plus negative cases (OAuth auth, non-preview model, non-404 error).
- New unit test in packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts for the API key message.
- Full core package suite, workspace typecheck, lint, and formatting all pass.
- End to end simulation of the exact 404 payload from the issue through retryWithBackoff, classifyGoogleError, and handleFallback: without the fix the turn fails on a second preview 404; with the fix it recovers onto gemini-2.5-pro.

## Notes

This PR makes the CLI recover gracefully. It intentionally does not change the assumption in Config.initialize() that API key users have preview access, since changing that could regress keys that do have access. That could be a follow-up discussion.