### PR TITLE
fix(core): prevent boolean thought parts leaking as [Thought: true] text

### DIFF
--- a/packages/core/src/code_assist/converter.test.ts
+++ b/packages/core/src/code_assist/converter.test.ts
@@ -416,6 +416,30 @@ describe('converter', () => {
       ]);
     });
 
+    it('should strip boolean thought property and not convert it to [Thought: true]', () => {
+      const contentWithThought: ContentListUnion = {
+        role: 'model',
+        parts: [
+          { text: 'regular text' },
+          {
+            text: 'thinking about the problem',
+            thought: true,
+          } as unknown as Part,
+          { text: 'more text' },
+        ],
+      };
+      expect(toContents(contentWithThought)).toEqual([
+        {
+          role: 'model',
+          parts: [
+            { text: 'regular text' },
+            { text: 'thinking about the problem' },
+            { text: 'more text' },
+          ],
+        },
+      ]);
+    });
+
     it('should combine text and thought for text parts with thoughts', () => {
       const contentWithTextAndThought: ContentListUnion = {
         role: 'model',

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -248,41 +248,39 @@ function toPart(part: PartUnion): Part {
   // The CountToken API expects parts to have certain required "oneof" fields initialized,
   // but thought parts don't conform to this schema and cause API failures
   if ('thought' in part && part.thought) {
-    if (typeof part.thought === 'string') {
-      const thoughtText = `[Thought: ${part.thought}]`;
+    const newPart = { ...part };
+    delete (newPart as Record<string, unknown>)['thought'];
 
-      const newPart = { ...part };
-      delete (newPart as Record<string, unknown>)['thought'];
-
-      const hasApiContent =
-        'functionCall' in newPart ||
-        'functionResponse' in newPart ||
-        'inlineData' in newPart ||
-        'fileData' in newPart;
-
-      if (hasApiContent) {
-        // It's a functionCall or other non-text part. Just strip the thought.
-        return newPart;
-      }
-
-      // If no other valid API content, this must be a text part.
-      // Combine existing text (if any) with the thought, preserving other properties.
-      const text = (newPart as { text?: unknown }).text;
-      const existingText = text ? String(text) : '';
-      const combinedText = existingText
-        ? `${existingText}\n${thoughtText}`
-        : thoughtText;
-
-      return {
-        ...newPart,
-        text: combinedText,
-      };
-    } else {
+    if (typeof part.thought !== 'string') {
       // It's a boolean or other non-string thought. Just strip the thought property.
-      const newPart = { ...part };
-      delete (newPart as Record<string, unknown>)['thought'];
       return newPart;
     }
+
+    const thoughtText = `[Thought: ${part.thought}]`;
+
+    const hasApiContent =
+      'functionCall' in newPart ||
+      'functionResponse' in newPart ||
+      'inlineData' in newPart ||
+      'fileData' in newPart;
+
+    if (hasApiContent) {
+      // It's a functionCall or other non-text part. Just strip the thought.
+      return newPart;
+    }
+
+    // If no other valid API content, this must be a text part.
+    // Combine existing text (if any) with the thought, preserving other properties.
+    const text = (newPart as { text?: unknown }).text;
+    const existingText = text ? String(text) : '';
+    const combinedText = existingText
+      ? `${existingText}\n${thoughtText}`
+      : thoughtText;
+
+    return {
+      ...newPart,
+      text: combinedText,
+    };
   }
 
   return part;

--- a/packages/core/src/code_assist/converter.ts
+++ b/packages/core/src/code_assist/converter.ts
@@ -248,34 +248,41 @@ function toPart(part: PartUnion): Part {
   // The CountToken API expects parts to have certain required "oneof" fields initialized,
   // but thought parts don't conform to this schema and cause API failures
   if ('thought' in part && part.thought) {
-    const thoughtText = `[Thought: ${part.thought}]`;
+    if (typeof part.thought === 'string') {
+      const thoughtText = `[Thought: ${part.thought}]`;
 
-    const newPart = { ...part };
-    delete (newPart as Record<string, unknown>)['thought'];
+      const newPart = { ...part };
+      delete (newPart as Record<string, unknown>)['thought'];
 
-    const hasApiContent =
-      'functionCall' in newPart ||
-      'functionResponse' in newPart ||
-      'inlineData' in newPart ||
-      'fileData' in newPart;
+      const hasApiContent =
+        'functionCall' in newPart ||
+        'functionResponse' in newPart ||
+        'inlineData' in newPart ||
+        'fileData' in newPart;
 
-    if (hasApiContent) {
-      // It's a functionCall or other non-text part. Just strip the thought.
+      if (hasApiContent) {
+        // It's a functionCall or other non-text part. Just strip the thought.
+        return newPart;
+      }
+
+      // If no other valid API content, this must be a text part.
+      // Combine existing text (if any) with the thought, preserving other properties.
+      const text = (newPart as { text?: unknown }).text;
+      const existingText = text ? String(text) : '';
+      const combinedText = existingText
+        ? `${existingText}\n${thoughtText}`
+        : thoughtText;
+
+      return {
+        ...newPart,
+        text: combinedText,
+      };
+    } else {
+      // It's a boolean or other non-string thought. Just strip the thought property.
+      const newPart = { ...part };
+      delete (newPart as Record<string, unknown>)['thought'];
       return newPart;
     }
-
-    // If no other valid API content, this must be a text part.
-    // Combine existing text (if any) with the thought, preserving other properties.
-    const text = (newPart as { text?: unknown }).text;
-    const existingText = text ? String(text) : '';
-    const combinedText = existingText
-      ? `${existingText}\n${thoughtText}`
-      : thoughtText;
-
-    return {
-      ...newPart,
-      text: combinedText,
-    };
   }
 
   return part;


### PR DESCRIPTION
Fixes #23525.

Prevents internal thought parts with a boolean `thought: true` field from leaking into the text representation of model thoughts (appearing as `[Thought: true]`).

### Summary of Changes
- Modified `toPart` in `packages/core/src/code_assist/converter.ts` to check if `part.thought` is a string before formatting it. If it is a boolean `true`, the `thought` property is deleted and the rest of the part is preserved as-is.
- Added a new unit test in `packages/core/src/code_assist/converter.test.ts` to ensure this behavior is correct and to prevent regressions.
