### PR TITLE
fix(core): guard formatTruncatedToolOutput against non-positive maxChars

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1348,5 +1348,38 @@ describe('fileUtils', () => {
       expect(formatted).toContain('For full output see: /tmp/out.txt');
       expect(formatted).toContain('[46,000 characters omitted]'); // 50000 - 800 - 3200
     });
+
+    it('should return content unchanged when maxChars is 0 (disable truncation)', () => {
+      const content = 'a'.repeat(50000);
+      const formatted = formatTruncatedToolOutput(content, '/tmp/out.txt', 0);
+
+      expect(formatted).toBe(content);
+      expect(formatted.length).toBe(content.length);
+    });
+
+    it('should return content unchanged when maxChars is negative', () => {
+      const content = 'a'.repeat(50000);
+      const formatted = formatTruncatedToolOutput(
+        content,
+        '/tmp/out.txt',
+        -1000,
+      );
+
+      expect(formatted).toBe(content);
+      expect(formatted.length).toBe(content.length);
+      expect(formatted).not.toContain('Output too large');
+    });
+
+    it('should return content unchanged when maxChars is NaN', () => {
+      const content = 'a'.repeat(50000);
+      const formatted = formatTruncatedToolOutput(
+        content,
+        '/tmp/out.txt',
+        Number.NaN,
+      );
+
+      expect(formatted).toBe(content);
+      expect(formatted).not.toContain('Output too large');
+    });
   });
 });

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -657,13 +657,18 @@ export function sanitizeFilenamePart(part: string): string {
 /**
  * Formats a truncated message for tool output.
  * Shows the first 20% and last 80% of the allowed characters with a marker in between.
+ *
+ * A non-positive (or non-finite) `maxChars` disables truncation and returns
+ * `contentStr` unchanged. Without that guard, `String.prototype.slice` treats
+ * negative indices as offsets from the end, which can concatenate nearly the
+ * whole string twice (~2x inflation). `!(maxChars > 0)` also covers `NaN`.
  */
 export function formatTruncatedToolOutput(
   contentStr: string,
   outputFile: string,
   maxChars: number,
 ): string {
-  if (contentStr.length <= maxChars) return contentStr;
+  if (!(maxChars > 0) || contentStr.length <= maxChars) return contentStr;
 
   const headChars = Math.floor(maxChars * 0.2);
   const tailChars = maxChars - headChars;


### PR DESCRIPTION
## Summary
- Guard `formatTruncatedToolOutput` so `maxChars <= 0` returns content unchanged instead of inflating output ~2x via `String.prototype.slice` negative-index behavior.
- Add regression tests for `maxChars = 0` and negative `maxChars`.

Fixes #28620

## Test plan
- [x] `npm test -w @google/gemini-cli-core -- src/utils/fileUtils.test.ts` (95 tests passed)
- [x] New regression cases for `maxChars = 0` and negative `maxChars` (content returned unchanged)
- [ ] Spot-check positive `maxChars` truncation still shows head 20% / tail 80%

