### PR TITLE
fix(core): point ProjectIdRequiredError at current auth docs

### DIFF
--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -307,7 +307,7 @@ Remove-Item Env:\GOOGLE_API_KEY, Env:\GEMINI_API_KEY -ErrorAction Ignore
 
 5.  Select **Vertex AI**.
 
-## Set your Google Cloud project <a id="set-gcp"></a>
+## Set your Google Cloud project <a id="set-gcp"></a><a id="workspace-gca"></a>
 
 > [!IMPORTANT]
 > Most individual Google accounts (free and paid) don't require a

--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -5,6 +5,7 @@
   "/docs/cli/index": "/docs",
   "/docs/cli/keyboard-shortcuts": "/docs/reference/keyboard-shortcuts",
   "/docs/cli/uninstall": "/docs/resources/uninstall",
+  "/docs/cli/authentication": "/docs/get-started/authentication",
   "/docs/core/concepts": "/docs",
   "/docs/core/memport": "/docs/reference/memport",
   "/docs/core/policy-engine": "/docs/reference/policy-engine",

--- a/packages/cli/src/core/auth.test.ts
+++ b/packages/cli/src/core/auth.test.ts
@@ -127,7 +127,7 @@ describe('auth', () => {
     );
     expect(result).toEqual({
       authError:
-        'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
+        'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://geminicli.com/docs/get-started/authentication/#set-gcp',
       accountSuspensionInfo: null,
     });
     expect(result.authError).not.toContain('Failed to login');

--- a/packages/cli/src/ui/auth/useAuth.test.tsx
+++ b/packages/cli/src/ui/auth/useAuth.test.tsx
@@ -326,7 +326,7 @@ describe('useAuth', () => {
       });
 
       expect(result.current.authError).toBe(
-        'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
+        'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://geminicli.com/docs/get-started/authentication/#set-gcp',
       );
       expect(result.current.authError).not.toContain('Failed to login');
       expect(result.current.authState).toBe(AuthState.Updating);

--- a/packages/core/src/code_assist/setup.ts
+++ b/packages/core/src/code_assist/setup.ts
@@ -30,7 +30,7 @@ import {
 export class ProjectIdRequiredError extends Error {
   constructor() {
     super(
-      'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://goo.gle/gemini-cli-auth-docs#workspace-gca',
+      'This account requires setting the GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID env var. See https://geminicli.com/docs/get-started/authentication/#set-gcp',
     );
     this.name = 'ProjectIdRequiredError';
   }


### PR DESCRIPTION
## Summary
- Update `ProjectIdRequiredError` to link to `https://geminicli.com/docs/get-started/authentication/#set-gcp` instead of the broken `goo.gle/gemini-cli-auth-docs#workspace-gca` short link (404 on removed `docs/cli/authentication.md`).
- Add a docs redirect from `/docs/cli/authentication` → `/docs/get-started/authentication`.
- Keep a legacy `#workspace-gca` anchor on the Set your Google Cloud project section for older links.
- Update CLI auth tests that assert the error message URL.

Fixes #26140

## Test plan
- [x] `npm test -w @google/gemini-cli-core -- src/code_assist/setup.test.ts`
- [x] `npm test -w @google/gemini-cli -- src/core/auth.test.ts src/ui/auth/useAuth.test.tsx`
- [x] Docs redirect + updated ProjectIdRequiredError URL included in diff
- [ ] Open https://geminicli.com/docs/get-started/authentication/#set-gcp and confirm it resolves
- [ ] Trigger `/auth` ProjectIdRequiredError path and confirm the shown URL works

