### PR TITLE
fix(cli): prevent ghost text wrapping infinite loop at narrow widths

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -5394,6 +5394,41 @@ describe('InputPrompt', () => {
     });
   });
 
+  describe('ghost text wrapping', () => {
+    it('does not freeze when ghost text contains wide chars and inputWidth is narrow', async () => {
+      // Regression for #19985: when inputWidth is smaller than a wide
+      // character's rendered width, the hard-split loop must still advance.
+      // buffer.text must be non-empty so getGhostTextLines does not early-return.
+      props.inputWidth = 1;
+      props.suggestionsWidth = 1;
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        promptCompletion: {
+          text: 'a' + '好'.repeat(10),
+          accept: vi.fn(),
+          clear: vi.fn(),
+          isLoading: false,
+          isActive: true,
+          markSelected: vi.fn(),
+        },
+      });
+      mockBuffer.text = 'a';
+      mockBuffer.lines = ['a'];
+      mockBuffer.cursor = [0, 1];
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} />,
+        { uiState: {} },
+      );
+
+      // Without the guard this hang pegs CPU and the wait times out.
+      await waitFor(() => {
+        expect(lastFrame()).toBeDefined();
+      });
+      unmount();
+    });
+  });
+
   describe('terminal buffer rendering', () => {
     it('does not clip the last char of a visual line whose width equals inputWidth', async () => {
       const fullLine = '1234567890'; // 10 chars, exactly props.inputWidth

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1515,6 +1515,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 partWidth += charWidth;
                 splitIndex = i + 1;
               }
+              // When inputWidth is narrower than a single codepoint, nothing
+              // fits and splitIndex stays 0, causing an infinite loop. Force-
+              // advance by one codepoint so the loop always terminates.
+              if (splitIndex === 0 && wordCP.length > 0) {
+                part = wordCP[0];
+                splitIndex = 1;
+              }
               additionalLines.push(part);
               wordToProcess = cpSlice(wordToProcess, splitIndex);
             }


### PR DESCRIPTION
## Summary
- Fix infinite loop in `getGhostTextLines` (`InputPrompt.tsx`) when `inputWidth` is narrower than a single wide codepoint (CJK/emoji): force-advance `splitIndex` so wrapping always terminates.
- Add a regression test that would hang without the guard.

Fixes #19985

This issue already has the `help wanted` label. Several prior fix attempts were closed for process/CLA/inactivity reasons; the hang is still present on `main`.

## Test plan
- [x] `npx vitest run --root packages/cli src/ui/components/InputPrompt.test.tsx -t "does not freeze when ghost text"`
- [x] Regression test would hang without the `splitIndex` force-advance guard
- [ ] Manual: shrink terminal to ~9 columns with wide-character ghost text; UI stays responsive

