### PR TITLE
refactor(core): replace tree-sitter Bash parser with unbash

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -8,7 +8,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { writeFileSync } from 'node:fs';
-import { wasmLoader } from 'esbuild-plugin-wasm';
 
 let esbuild;
 try {
@@ -22,37 +21,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 const pkg = require(path.resolve(__dirname, 'package.json'));
-
-function createWasmPlugins() {
-  const wasmBinaryPlugin = {
-    name: 'wasm-binary',
-    setup(build) {
-      build.onResolve({ filter: /\.wasm\?binary$/ }, (args) => {
-        const specifier = args.path.replace(/\?binary$/, '');
-        const resolveDir = args.resolveDir || '';
-        const isBareSpecifier =
-          !path.isAbsolute(specifier) &&
-          !specifier.startsWith('./') &&
-          !specifier.startsWith('../');
-
-        let resolvedPath;
-        if (isBareSpecifier) {
-          resolvedPath = require.resolve(specifier, {
-            paths: resolveDir ? [resolveDir, __dirname] : [__dirname],
-          });
-        } else {
-          resolvedPath = path.isAbsolute(specifier)
-            ? specifier
-            : path.join(resolveDir, specifier);
-        }
-
-        return { path: resolvedPath, namespace: 'wasm-embedded' };
-      });
-    },
-  };
-
-  return [wasmBinaryPlugin, wasmLoader({ mode: 'embedded' })];
-}
 
 const external = [
   '@lydell/node-pty',
@@ -98,7 +66,6 @@ const cliConfig = {
     ),
     'process.env.DEV': JSON.stringify(process.env.DEV || 'false'),
   },
-  plugins: createWasmPlugins(),
   alias: {
     'is-in-ci': path.resolve(__dirname, 'packages/cli/src/patches/is-in-ci.ts'),
     'https-proxy-agent': path.resolve(
@@ -137,7 +104,6 @@ const workerConfig = {
       process.env.NODE_ENV || 'production',
     ),
   },
-  plugins: createWasmPlugins(),
   alias: commonAliases,
 };
 
@@ -157,7 +123,6 @@ const a2aServerConfig = {
     ),
     'process.env.DEV': JSON.stringify(process.env.DEV || 'false'),
   },
-  plugins: createWasmPlugins(),
   alias: commonAliases,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "depcheck": "1.4.7",
         "domexception": "4.0.0",
         "esbuild": "0.25.0",
-        "esbuild-plugin-wasm": "1.1.0",
         "eslint": "9.24.0",
         "eslint-config-prettier": "10.1.2",
         "eslint-plugin-headers": "1.3.3",
@@ -7700,20 +7699,6 @@
         "@esbuild/win32-x64": "0.25.0"
       }
     },
-    "node_modules/esbuild-plugin-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-wasm/-/esbuild-plugin-wasm-1.1.0.tgz",
-      "integrity": "sha512-0bQ6+1tUbySSnxzn5jnXHMDvYnT0cN/Wd4Syk8g/sqAIJUg7buTIi22svS3Qz6ssx895NT+TgLPb33xi1OkZig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://ko-fi.com/tschrock"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -12149,17 +12134,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-pty": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
@@ -15790,34 +15764,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/tree-sitter-bash": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.0.tgz",
-      "integrity": "sha512-gZtlj9+qFS81qKxpLfD6H0UssQ3QBc/F0nKkPsiFDyfQF2YBqYvglFJUzchrPpVhZe9kLZTrJ9n2J6lmka69Vg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.25.0"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tree-sitter-bash/node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -16342,6 +16288,15 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unbash": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.5.tgz",
+      "integrity": "sha512-EE9xv9cr93DSppe086Rnbq0jwG7MBCEe22JZ4UQ8Bn9RyUwDSoUpBmzdb5+7PzocdqBEb/K73FGPaQUMmLxTQQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -17206,20 +17161,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/web-tree-sitter": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
-      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/emscripten": "^1.40.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/emscripten": {
-          "optional": true
-        }
       }
     },
     "node_modules/webidl-conversions": {
@@ -18524,10 +18465,9 @@
         "strip-ansi": "7.1.0",
         "strip-json-comments": "3.1.1",
         "systeminformation": "5.25.11",
-        "tree-sitter-bash": "0.25.0",
+        "unbash": "4.0.5",
         "undici": "7.10.0",
         "uuid": "13.0.0",
-        "web-tree-sitter": "0.25.10",
         "zod": "3.25.76",
         "zod-to-json-schema": "3.25.1"
       },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "depcheck": "1.4.7",
     "domexception": "4.0.0",
     "esbuild": "0.25.0",
-    "esbuild-plugin-wasm": "1.1.0",
     "eslint": "9.24.0",
     "eslint-config-prettier": "10.1.2",
     "eslint-plugin-headers": "1.3.3",

--- a/packages/cli/src/ui/components/messages/RedirectionConfirmation.test.tsx
+++ b/packages/cli/src/ui/components/messages/RedirectionConfirmation.test.tsx
@@ -4,20 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
 import type {
   SerializableConfirmationDetails,
   Config,
 } from '@google/gemini-cli-core';
-import { initializeShellParsers } from '@google/gemini-cli-core';
 import { renderWithProviders } from '../../../test-utils/render.js';
 
 describe('ToolConfirmationMessage Redirection', () => {
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
-
   const mockConfig = {
     isTrustedFolder: () => true,
     getIdeMode: () => false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,10 +86,9 @@
     "strip-ansi": "7.1.0",
     "strip-json-comments": "3.1.1",
     "systeminformation": "5.25.11",
-    "tree-sitter-bash": "0.25.0",
+    "unbash": "4.0.5",
     "undici": "7.10.0",
     "uuid": "13.0.0",
-    "web-tree-sitter": "0.25.10",
     "zod": "3.25.76",
     "zod-to-json-schema": "3.25.1"
   },

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PolicyEngine } from './policy-engine.js';
 import {
   PolicyDecision,
@@ -20,10 +20,7 @@ import {
 import type { FunctionCall } from '@google/genai';
 import { SafetyCheckDecision } from '../safety/protocol.js';
 import type { CheckerRunner } from '../safety/checker-runner.js';
-import {
-  initializeShellParsers,
-  parseCommandDetails,
-} from '../utils/shell-utils.js';
+import { parseCommandDetails } from '../utils/shell-utils.js';
 import { buildArgsPatterns } from './utils.js';
 import {
   NoopSandboxManager,
@@ -38,7 +35,6 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
     await importOriginal<typeof import('../utils/shell-utils.js')>();
   return {
     ...actual,
-    initializeShellParsers: vi.fn().mockResolvedValue(undefined),
     splitCommands: vi.fn().mockImplementation((command: string) => {
       // Simple mock splitting logic for test cases
       if (command.includes('&&')) {
@@ -123,10 +119,6 @@ vi.mock('../tools/tool-names.js', async (importOriginal) => {
 describe('PolicyEngine', () => {
   let engine: PolicyEngine;
   let mockCheckerRunner: CheckerRunner;
-
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
 
   beforeEach(() => {
     mockCheckerRunner = {
@@ -1762,7 +1754,6 @@ describe('PolicyEngine', () => {
       engine = new PolicyEngine({ rules });
 
       // In this case, we mock splitCommands to keep the redirection in the sub-command
-      vi.mocked(initializeShellParsers).mockResolvedValue(undefined);
       const { splitCommands } = await import('../utils/shell-utils.js');
       vi.mocked(splitCommands).mockReturnValueOnce([
         'mkdir bar',

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -8,7 +8,6 @@ import { type FunctionCall } from '@google/genai';
 import {
   SHELL_TOOL_NAMES,
   REDIRECTION_NAMES,
-  initializeShellParsers,
   parseCommandDetails,
   stripShellWrapper,
   hasRedirection,
@@ -307,7 +306,6 @@ export class PolicyEngine {
     command: string,
     decision: PolicyDecision,
   ): Promise<PolicyDecision> {
-    await initializeShellParsers();
     try {
       const parsedObjArgs = shellParse(command);
       const parsedArgs = parsedObjArgs.map(extractStringFromParseEntry);
@@ -359,7 +357,6 @@ export class PolicyEngine {
       };
     }
 
-    await initializeShellParsers();
     const parsed = parseCommandDetails(command);
     const subCommands = parsed?.details ?? [];
 

--- a/packages/core/src/policy/shell-safety-regression.test.ts
+++ b/packages/core/src/policy/shell-safety-regression.test.ts
@@ -4,18 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { PolicyEngine } from './policy-engine.js';
 import { PolicyDecision, ApprovalMode } from './types.js';
-import { initializeShellParsers } from '../utils/shell-utils.js';
 import { buildArgsPatterns } from './utils.js';
 
 describe('PolicyEngine - Shell Safety Regression Suite', () => {
   let engine: PolicyEngine;
-
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
 
   const setupEngine = (allowedCommands: string[]) => {
     const rules = allowedCommands.map((cmd) => ({

--- a/packages/core/src/policy/shell-safety.test.ts
+++ b/packages/core/src/policy/shell-safety.test.ts
@@ -6,7 +6,6 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Mock shell-utils to avoid relying on tree-sitter WASM which is flaky in CI on Windows
 vi.mock('../utils/shell-utils.js', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('../utils/shell-utils.js')>();
@@ -58,7 +57,6 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
 
   return {
     ...actual,
-    initializeShellParsers: vi.fn(),
     parseCommandDetails: (command: string) => {
       if (Object.prototype.hasOwnProperty.call(commandMap, command)) {
         const subcommands = commandMap[command];

--- a/packages/core/src/policy/shell-substitution.test.ts
+++ b/packages/core/src/policy/shell-substitution.test.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect, describe, it, beforeAll, vi } from 'vitest';
+import { expect, describe, it, vi } from 'vitest';
 import { PolicyEngine } from './policy-engine.js';
 import { PolicyDecision } from './types.js';
-import { initializeShellParsers } from '../utils/shell-utils.js';
 
 // Mock node:os to ensure shell-utils logic always thinks it's on a POSIX-like system.
 // This ensures that internal calls to getShellConfiguration() and isWindows()
@@ -40,10 +39,6 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
 });
 
 describe('PolicyEngine Command Substitution Validation', () => {
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
-
   const setupEngine = (blockedCmd: string) =>
     new PolicyEngine({
       defaultDecision: PolicyDecision.ALLOW,

--- a/packages/core/src/sandbox/linux/LinuxSandboxManager.test.ts
+++ b/packages/core/src/sandbox/linux/LinuxSandboxManager.test.ts
@@ -52,7 +52,6 @@ vi.mock('../../utils/shell-utils.js', async (importOriginal) => {
     spawnAsync: vi.fn(() =>
       Promise.resolve({ status: 0, stdout: Buffer.from('') }),
     ),
-    initializeShellParsers: vi.fn(),
     isStrictlyApproved: vi.fn().mockResolvedValue(true),
   };
 });

--- a/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
+++ b/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
@@ -39,11 +39,7 @@ import {
 import { isErrnoException } from '../utils/fsUtils.js';
 import { handleReadWriteCommands } from '../utils/sandboxReadWriteUtils.js';
 import { buildBwrapArgs } from './bwrapArgsBuilder.js';
-import {
-  getCommandRoots,
-  initializeShellParsers,
-  stripShellWrapper,
-} from '../../utils/shell-utils.js';
+import { getCommandRoots, stripShellWrapper } from '../../utils/shell-utils.js';
 
 let cachedBpfPath: string | undefined;
 
@@ -222,7 +218,6 @@ export class LinuxSandboxManager implements SandboxManager {
       args = ['-c', 'cat > "$1"', '_', ...args];
     }
 
-    await initializeShellParsers();
     const fullCmd = [command, ...args].join(' ');
     const stripped = stripShellWrapper(fullCmd);
     const roots = getCommandRoots(stripped).filter(

--- a/packages/core/src/sandbox/linux/bwrapArgsBuilder.test.ts
+++ b/packages/core/src/sandbox/linux/bwrapArgsBuilder.test.ts
@@ -54,7 +54,6 @@ vi.mock('../../utils/shell-utils.js', async (importOriginal) => {
     spawnAsync: vi.fn(() =>
       Promise.resolve({ status: 0, stdout: Buffer.from('') }),
     ),
-    initializeShellParsers: vi.fn(),
     isStrictlyApproved: vi.fn().mockResolvedValue(true),
   };
 });

--- a/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
+++ b/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
@@ -22,11 +22,7 @@ import {
   getSecureSanitizationConfig,
 } from '../../services/environmentSanitization.js';
 import { buildSeatbeltProfile } from './seatbeltArgsBuilder.js';
-import {
-  initializeShellParsers,
-  getCommandRoots,
-  stripShellWrapper,
-} from '../../utils/shell-utils.js';
+import { getCommandRoots, stripShellWrapper } from '../../utils/shell-utils.js';
 import {
   isKnownSafeCommand,
   isDangerousCommand,
@@ -74,7 +70,6 @@ export class MacOsSandboxManager implements SandboxManager {
   }
 
   async prepareCommand(req: SandboxRequest): Promise<SandboxedCommand> {
-    await initializeShellParsers();
     const sanitizationConfig = getSecureSanitizationConfig(
       req.policy?.sanitizationConfig,
     );

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -7,7 +7,6 @@ import path from 'node:path';
 import { parse as shellParse } from 'shell-quote';
 import {
   extractStringFromParseEntry,
-  initializeShellParsers,
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
@@ -46,8 +45,6 @@ export async function isStrictlyApproved(
   approvedTools?: string[],
 ): Promise<boolean> {
   const tools = approvedTools ?? [];
-
-  await initializeShellParsers();
 
   const fullCmd = [command, ...args].join(' ');
   const stripped = stripShellWrapper(fullCmd);

--- a/packages/core/src/sandbox/utils/commandUtils.ts
+++ b/packages/core/src/sandbox/utils/commandUtils.ts
@@ -7,7 +7,6 @@
 import { type SandboxRequest } from '../../services/sandboxManager.js';
 import {
   getCommandRoots,
-  initializeShellParsers,
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
@@ -22,8 +21,6 @@ export async function isStrictlyApproved(
   if (!approvedTools || approvedTools.length === 0) {
     return false;
   }
-
-  await initializeShellParsers();
 
   const fullCmd = [req.command, ...req.args].join(' ');
   const stripped = stripShellWrapper(fullCmd);
@@ -50,7 +47,6 @@ export async function isStrictlyApproved(
 }
 
 export async function getCommandName(req: SandboxRequest): Promise<string> {
-  await initializeShellParsers();
   const fullCmd = [req.command, ...req.args].join(' ');
   const stripped = stripShellWrapper(fullCmd);
   const roots = getCommandRoots(stripped).filter(

--- a/packages/core/src/sandbox/windows/WindowsSandboxManager.test.ts
+++ b/packages/core/src/sandbox/windows/WindowsSandboxManager.test.ts
@@ -20,7 +20,6 @@ vi.mock('../../utils/shell-utils.js', async (importOriginal) => {
   return {
     ...actual,
     spawnAsync: vi.fn(),
-    initializeShellParsers: vi.fn(),
     isStrictlyApproved: vi.fn().mockResolvedValue(true),
   };
 });

--- a/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
+++ b/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
@@ -28,7 +28,6 @@ import { debugLogger } from '../../utils/debugLogger.js';
 import {
   spawnAsync,
   getCommandName,
-  initializeShellParsers,
   getCommandRoots,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
@@ -267,7 +266,6 @@ export class WindowsSandboxManager implements SandboxManager {
       this.options.modeConfig?.network ?? req.policy?.networkAccess ?? false;
     const networkAccess = defaultNetwork || mergedAdditional.network;
 
-    await initializeShellParsers();
     const fullCmd = [command, ...args].join(' ');
     const stripped = stripShellWrapper(fullCmd);
     const roots = getCommandRoots(stripped).filter(

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -6,7 +6,6 @@
 import { parse as shellParse } from 'shell-quote';
 import {
   extractStringFromParseEntry,
-  initializeShellParsers,
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
@@ -27,8 +26,6 @@ export async function isStrictlyApproved(
   approvedTools?: string[],
 ): Promise<boolean> {
   const tools = approvedTools ?? [];
-
-  await initializeShellParsers();
 
   const fullCmd = [command, ...args].join(' ');
   const stripped = stripShellWrapper(fullCmd);

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -9,7 +9,6 @@ import {
   describe,
   it,
   expect,
-  beforeAll,
   beforeEach,
   afterEach,
   type Mock,
@@ -44,7 +43,6 @@ vi.mock('node:os', async (importOriginal) => {
 vi.mock('crypto');
 vi.mock('../utils/summarizer.js');
 
-import { initializeShellParsers } from '../utils/shell-utils.js';
 import {
   ShellTool,
   OUTPUT_UPDATE_INTERVAL_MS,
@@ -91,10 +89,6 @@ const originalComSpec = process.env['ComSpec'];
 const itWindowsOnly = process.platform === 'win32' ? it : it.skip;
 
 describe('ShellTool', () => {
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
-
   let shellTool: ShellTool;
   let mockConfig: Config;
   let mockSandboxManager: SandboxManager;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -36,7 +36,6 @@ import { formatBytes } from '../utils/formatters.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import {
   getCommandRoots,
-  initializeShellParsers,
   stripShellWrapper,
   parseCommandDetails,
   hasRedirection,
@@ -1097,9 +1096,6 @@ export class ShellTool extends BaseDeclarativeTool<
     private readonly context: AgentLoopContext,
     messageBus: MessageBus,
   ) {
-    void initializeShellParsers().catch(() => {
-      // Errors are surfaced when parsing commands.
-    });
     const definition = getShellDefinition(
       context.config.isInteractiveShellEnabled(),
       context.config.getEnableShellOutputEfficiency(),

--- a/packages/core/src/tools/shell_proactive.test.ts
+++ b/packages/core/src/tools/shell_proactive.test.ts
@@ -4,23 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  vi,
-  describe,
-  it,
-  expect,
-  beforeEach,
-  beforeAll,
-  afterEach,
-} from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import os from 'node:os';
 import type _fs from 'node:fs';
 import { ShellTool } from './shell.js';
 import { type Config } from '../config/config.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import * as proactivePermissions from '../sandbox/utils/proactivePermissions.js';
-
-import { initializeShellParsers } from '../utils/shell-utils.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
@@ -54,10 +44,6 @@ const mockPlatform = (platform: string) => {
 describe('ShellTool Proactive Expansion', () => {
   let mockConfig: Config;
   let shellTool: ShellTool;
-
-  beforeAll(async () => {
-    await initializeShellParsers();
-  });
 
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/packages/core/src/utils/__fixtures__/dummy.wasm
+++ b/packages/core/src/utils/__fixtures__/dummy.wasm
@@ -1,1 +1,0 @@
-This is a wasm fixture.

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -19,7 +19,6 @@ import * as actualNodeFs from 'node:fs'; // For setup/teardown
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { fileURLToPath } from 'node:url';
 
 import mime from 'mime/lite';
 
@@ -31,7 +30,6 @@ import {
   detectBOM,
   readFileWithEncoding,
   fileExists,
-  readWasmBinaryFromDisk,
   saveTruncatedToolOutput,
   formatTruncatedToolOutput,
   getRealPath,
@@ -86,23 +84,6 @@ describe('fileUtils', () => {
     }
     process.cwd = originalProcessCwd;
     vi.restoreAllMocks(); // Restore any spies
-  });
-
-  describe('readWasmBinaryFromDisk', () => {
-    it('loads a WASM binary from disk as a Uint8Array', async () => {
-      const wasmFixtureUrl = new URL(
-        './__fixtures__/dummy.wasm',
-        import.meta.url,
-      );
-      const wasmFixturePath = fileURLToPath(wasmFixtureUrl);
-      const result = await readWasmBinaryFromDisk(wasmFixturePath);
-      const expectedBytes = new Uint8Array(
-        await fsPromises.readFile(wasmFixturePath),
-      );
-
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result).toStrictEqual(expectedBytes);
-    });
   });
 
   describe('isWithinRoot', () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -13,7 +13,6 @@ import mime from 'mime/lite';
 import type { FileSystemService } from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
-import { createRequire as createModuleRequire } from 'node:module';
 import { debugLogger } from './debugLogger.js';
 
 import {
@@ -21,42 +20,6 @@ import {
   MAX_LINE_LENGTH_TEXT_FILE,
   MAX_FILE_SIZE_MB,
 } from './constants.js';
-
-const requireModule = createModuleRequire(import.meta.url);
-
-export async function readWasmBinaryFromDisk(
-  specifier: string,
-): Promise<Uint8Array> {
-  const resolvedPath = requireModule.resolve(specifier);
-  const buffer = await fsPromises.readFile(resolvedPath);
-  return new Uint8Array(buffer);
-}
-
-export async function loadWasmBinary(
-  dynamicImport: () => Promise<{ default: Uint8Array }>,
-  fallbackSpecifier: string,
-): Promise<Uint8Array> {
-  try {
-    const module = await dynamicImport();
-    if (module?.default instanceof Uint8Array) {
-      return module.default;
-    }
-  } catch (error) {
-    try {
-      return await readWasmBinaryFromDisk(fallbackSpecifier);
-    } catch {
-      throw error;
-    }
-  }
-
-  try {
-    return await readWasmBinaryFromDisk(fallbackSpecifier);
-  } catch (error) {
-    throw new Error('WASM binary module did not provide a Uint8Array export', {
-      cause: error,
-    });
-  }
-}
 
 // Default values for encoding and separator format
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -4,20 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  expect,
-  describe,
-  it,
-  beforeEach,
-  beforeAll,
-  vi,
-  afterEach,
-} from 'vitest';
+import { expect, describe, it, beforeEach, vi, afterEach } from 'vitest';
 import {
   escapeShellArg,
   getCommandRoots,
   getShellConfiguration,
-  initializeShellParsers,
   parseCommandDetails,
   splitCommands,
   stripShellWrapper,
@@ -75,11 +66,6 @@ vi.mock('./debugLogger.js', () => ({
 
 const isWindowsRuntime = process.platform === 'win32';
 const describeWindowsOnly = isWindowsRuntime ? describe : describe.skip;
-
-beforeAll(async () => {
-  mockPlatform.mockReturnValue('linux');
-  await initializeShellParsers();
-});
 
 beforeEach(() => {
   mockPlatform.mockReturnValue('linux');
@@ -153,6 +139,32 @@ describe('getCommandRoots', () => {
     expect(result).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
+  it('should not treat test syntax as an executable command', () => {
+    const result = getCommandRoots('if [[ -f package.json ]]; then npm ci; fi');
+    expect(result).toEqual(['npm']);
+  });
+
+  it('should return the command inside a named coprocess', () => {
+    const result = getCommandRoots('coproc mycop { sleep 1; }');
+    expect(result).toEqual(['sleep']);
+  });
+
+  it('should include command substitutions inside arithmetic syntax', () => {
+    expect(getCommandRoots('echo $((1 + $(danger)))')).toEqual([
+      'echo',
+      'danger',
+    ]);
+    expect(getCommandRoots('((x=$(danger)))')).toEqual(['danger']);
+    expect(
+      getCommandRoots('for ((i=$(init); i<$(limit); i++)); do echo "$i"; done'),
+    ).toEqual(['init', 'limit', 'echo']);
+  });
+
+  it('should fail closed on parse errors inside command substitutions', () => {
+    const result = getCommandRoots('echo "$(if true; then echo ok)"');
+    expect(result).toEqual([]);
+  });
+
   it('should correctly parse a chained command with quotes', () => {
     const result = getCommandRoots('echo "hello" && git commit -m "feat"');
     expect(result).toEqual(['echo', 'git']);
@@ -202,48 +214,6 @@ describe('getCommandRoots', () => {
     expect(getCommandRoots('cat < input.txt')).toEqual(['cat']);
     expect(getCommandRoots('ls 2> error.log')).toEqual(['ls']);
     expect(getCommandRoots('exec 3<&0')).toEqual(['exec']);
-  });
-
-  it('should handle parser initialization failures gracefully', async () => {
-    // Reset modules to clear singleton state
-    vi.resetModules();
-
-    // Mock fileUtils to fail Wasm loading
-    vi.doMock('./fileUtils.js', () => ({
-      loadWasmBinary: vi.fn().mockRejectedValue(new Error('Wasm load failed')),
-    }));
-
-    // Re-import shell-utils with mocked dependencies
-    const shellUtils = await import('./shell-utils.js');
-
-    // Should catch the error and not throw
-    await expect(shellUtils.initializeShellParsers()).resolves.not.toThrow();
-
-    // Fallback: splitting commands depends on parser, so if parser fails, it returns empty
-    const roots = shellUtils.getCommandRoots('ls -la');
-    expect(roots).toEqual([]);
-  });
-
-  it('should handle bash parser timeouts', () => {
-    const nowSpy = vi.spyOn(performance, 'now');
-    // Mock performance.now() to trigger timeout:
-    // 1st call: start time = 0. deadline = 0 + 1000ms.
-    // 2nd call (and onwards): inside progressCallback, return 2000ms.
-    nowSpy.mockReturnValueOnce(0).mockReturnValue(2000);
-
-    // Use a very complex command to ensure progressCallback is triggered at least once
-    const complexCommand =
-      'ls -la && ' + Array(100).fill('echo "hello"').join(' && ');
-    const roots = getCommandRoots(complexCommand);
-    expect(roots).toEqual([]);
-    expect(nowSpy).toHaveBeenCalled();
-
-    expect(mockDebugLogger.error).toHaveBeenCalledWith(
-      'Bash command parsing timed out for command:',
-      complexCommand,
-    );
-
-    nowSpy.mockRestore();
   });
 });
 
@@ -341,8 +311,6 @@ describe('splitCommands', () => {
 
     // Heredoc/Herestring
     expect(splitCommands('cat << EOF\nhello\nEOF')).toEqual(['cat']);
-    // Note: The Tree-sitter bash parser includes the herestring in the main
-    // command node's text, unlike standard redirections which are siblings.
     expect(splitCommands('grep "foo" <<< "foobar"')).toEqual([
       'grep "foo" <<< "foobar"',
     ]);

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -322,16 +322,22 @@ function collectWordPart(
     case 'ArithmeticExpansion':
       collectArithmeticExpression(part.expression, source, result);
       return;
-    case 'ParameterExpansion':
-      if (part.operator === '@' && part.operand?.value.toLowerCase() === 'p') {
+    case 'ParameterExpansion': {
+      const operand = part.operand;
+      if (
+        part.operator === '@' &&
+        operand !== undefined &&
+        (operand.value === 'P' || operand.value === 'p')
+      ) {
         result.hasPromptCommandTransform = true;
       }
-      collectWord(part.operand, source, result);
+      collectWord(operand, source, result);
       collectWord(part.slice?.offset, source, result);
       collectWord(part.slice?.length, source, result);
       collectWord(part.replace?.pattern, source, result);
       collectWord(part.replace?.replacement, source, result);
       return;
+    }
     case 'DoubleQuoted':
     case 'LocaleString':
       for (const child of part.parts) {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -9,6 +9,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { quote, parse, type ParseEntry } from 'shell-quote';
 import {
+  parse as parseBash,
+  type ArithmeticExpression,
+  type Command as BashCommand,
+  type Node as BashNode,
+  type Redirect,
+  type TestExpression,
+  type Word,
+  type WordPart,
+} from 'unbash';
+import {
   spawn,
   spawnSync,
   type SpawnOptionsWithoutStdio,
@@ -26,7 +36,6 @@ export async function getCommandName(
   command: string,
   args: string[],
 ): Promise<string> {
-  await initializeShellParsers();
   const fullCmd = [command, ...args].join(' ');
   const stripped = stripShellWrapper(fullCmd);
   const roots = getCommandRoots(stripped).filter(
@@ -49,8 +58,6 @@ export function extractStringFromParseEntry(entry: ParseEntry): string {
   return '';
 }
 import * as readline from 'node:readline';
-import { Language, Parser, Query, type Node, type Tree } from 'web-tree-sitter';
-import { loadWasmBinary } from './fileUtils.js';
 import { debugLogger } from './debugLogger.js';
 import type { SandboxManager } from '../services/sandboxManager.js';
 import { NoopSandboxManager } from '../services/sandboxManager.js';
@@ -106,76 +113,6 @@ export function resolveExecutable(exe: string): string | undefined {
   return undefined;
 }
 
-let bashLanguage: Language | null = null;
-let treeSitterInitialization: Promise<void> | null = null;
-let treeSitterInitializationError: Error | null = null;
-
-class ShellParserInitializationError extends Error {
-  constructor(cause: Error) {
-    super(`Failed to initialize bash parser: ${cause.message}`, { cause });
-    this.name = 'ShellParserInitializationError';
-  }
-}
-
-function toError(value: unknown): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === 'string') {
-    return new Error(value);
-  }
-  return new Error('Unknown tree-sitter initialization error', {
-    cause: value,
-  });
-}
-
-async function loadBashLanguage(): Promise<void> {
-  try {
-    treeSitterInitializationError = null;
-    const [treeSitterBinary, bashBinary] = await Promise.all([
-      loadWasmBinary(
-        () =>
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore resolved by esbuild-plugin-wasm during bundling
-          import('web-tree-sitter/tree-sitter.wasm?binary'),
-        'web-tree-sitter/tree-sitter.wasm',
-      ),
-      loadWasmBinary(
-        () =>
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore resolved by esbuild-plugin-wasm during bundling
-          import('tree-sitter-bash/tree-sitter-bash.wasm?binary'),
-        'tree-sitter-bash/tree-sitter-bash.wasm',
-      ),
-    ]);
-
-    await Parser.init({ wasmBinary: treeSitterBinary });
-    bashLanguage = await Language.load(bashBinary);
-  } catch (error) {
-    bashLanguage = null;
-    const normalized = toError(error);
-    const initializationError =
-      normalized instanceof ShellParserInitializationError
-        ? normalized
-        : new ShellParserInitializationError(normalized);
-    treeSitterInitializationError = initializationError;
-    throw initializationError;
-  }
-}
-
-export async function initializeShellParsers(): Promise<void> {
-  if (!treeSitterInitialization) {
-    treeSitterInitialization = loadBashLanguage().catch((error) => {
-      treeSitterInitialization = null;
-      // Log the error but don't throw, allowing the application to fall back to safe defaults (ASK_USER)
-      // or regex checks where appropriate.
-      debugLogger.debug('Failed to initialize shell parsers:', error);
-    });
-  }
-
-  await treeSitterInitialization;
-}
-
 export interface ParsedCommandDetail {
   name: string;
   text: string;
@@ -190,7 +127,6 @@ interface CommandParseResult {
 }
 
 const POWERSHELL_COMMAND_ENV = '__GCLI_POWERSHELL_COMMAND__';
-const PARSE_TIMEOUT_MICROS = 1000 * 1000; // 1 second
 
 // Encode the parser script as UTF-16LE base64 so we can pass it via PowerShell's -EncodedCommand flag;
 // this avoids brittle quoting/escaping when spawning PowerShell and ensures the script is received byte-for-byte.
@@ -252,58 +188,6 @@ export const REDIRECTION_NAMES = new Set([
   'subshell',
 ]);
 
-function createParser(): Parser | null {
-  if (!bashLanguage) {
-    if (treeSitterInitializationError) {
-      throw treeSitterInitializationError;
-    }
-    return null;
-  }
-
-  try {
-    const parser = new Parser();
-    parser.setLanguage(bashLanguage);
-    return parser;
-  } catch {
-    return null;
-  }
-}
-
-function parseCommandTree(
-  command: string,
-  timeoutMicros: number = PARSE_TIMEOUT_MICROS,
-): Tree | null {
-  const parser = createParser();
-  if (!parser || !command.trim()) {
-    return null;
-  }
-
-  const deadline = performance.now() + timeoutMicros / 1000;
-  let timedOut = false;
-
-  try {
-    const tree = parser.parse(command, null, {
-      progressCallback: () => {
-        if (performance.now() > deadline) {
-          timedOut = true;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          return true as unknown as void; // Returning true cancels parsing, but type says void
-        }
-      },
-    });
-
-    if (timedOut) {
-      debugLogger.error('Bash command parsing timed out for command:', command);
-      // Returning a partial tree could be risky so we return null to be safe.
-      return null;
-    }
-
-    return tree;
-  } catch {
-    return null;
-  }
-}
-
 function normalizeCommandName(raw: string): string {
   if (raw.length >= 2) {
     const first = raw[0];
@@ -329,196 +213,363 @@ export function normalizeCommand(commandName: string): string {
   return base.toLowerCase().replace(/\.exe$/, '');
 }
 
-function extractNameFromNode(node: Node): string | null {
-  switch (node.type) {
-    case 'command': {
-      const nameNode = node.childForFieldName('name');
-      if (!nameNode) {
-        return null;
-      }
-      return normalizeCommandName(nameNode.text);
-    }
-    case 'declaration_command':
-    case 'unset_command':
-    case 'test_command': {
-      const firstChild = node.child(0);
-      if (!firstChild) {
-        return null;
-      }
-      return normalizeCommandName(firstChild.text);
-    }
-    case 'file_redirect': {
-      // The first child might be a file descriptor (e.g., '2>').
-      // We iterate to find the actual operator token.
-      for (let i = 0; i < node.childCount; i++) {
-        const child = node.child(i);
-        if (child && child.text.includes('<')) {
-          return 'redirection (<)';
-        }
-        if (child && child.text.includes('>')) {
-          return 'redirection (>)';
-        }
-      }
-      return 'redirection (>)';
-    }
-    case 'heredoc_redirect':
-      return 'heredoc (<<)';
-    case 'herestring_redirect':
-      return 'herestring (<<<)';
-    case 'command_substitution':
-      return 'command substitution';
-    case 'backtick_substitution':
-      return 'backtick substitution';
-    case 'process_substitution':
-      return 'process substitution';
-    case 'subshell':
-      return 'subshell';
-    default:
-      return null;
-  }
+interface BashCollection {
+  details: ParsedCommandDetail[];
+  hasParseError: boolean;
+  hasPromptCommandTransform: boolean;
+  hasRedirection: boolean;
 }
 
-function collectCommandDetails(
-  root: Node,
+type ParsedBashScript = ReturnType<typeof parseBash>;
+
+function collectScript(
+  script: ParsedBashScript | undefined,
   source: string,
-): ParsedCommandDetail[] {
-  const stack: Node[] = [root];
-  const details: ParsedCommandDetail[] = [];
-
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-
-    const name = extractNameFromNode(current);
-    if (name) {
-      const detail: ParsedCommandDetail = {
-        name,
-        text: source.slice(current.startIndex, current.endIndex).trim(),
-        startIndex: current.startIndex,
-      };
-
-      if (current.type === 'command') {
-        const args: string[] = [];
-        const nameNode = current.childForFieldName('name');
-        for (let i = 0; i < current.childCount; i += 1) {
-          const child = current.child(i);
-          if (
-            child &&
-            child.type === 'word' &&
-            child.startIndex !== nameNode?.startIndex
-          ) {
-            args.push(child.text);
-          }
-        }
-        if (args.length > 0) {
-          detail.args = args;
-        }
-      }
-
-      details.push(detail);
-    }
-
-    // Traverse all children to find all sub-components (commands, redirections, etc.)
-    for (let i = current.childCount - 1; i >= 0; i -= 1) {
-      const child = current.child(i);
-      if (child) {
-        stack.push(child);
-      }
-    }
+  result: BashCollection,
+): void {
+  if (!script) return;
+  if (script.errors?.length) result.hasParseError = true;
+  for (const statement of script.commands) {
+    collectBashNode(statement, source, result);
   }
-
-  return details;
 }
 
-function hasPromptCommandTransform(root: Node): boolean {
-  const stack: Node[] = [root];
+function collectSubstitution(
+  name: string,
+  text: string,
+  script: ParsedBashScript | undefined,
+  startIndex: number,
+  source: string,
+  result: BashCollection,
+): void {
+  result.details.push({ name, text, startIndex });
+  collectScript(script, source, result);
+}
 
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current) {
-      continue;
+function collectArithmeticExpression(
+  expression: ArithmeticExpression | undefined,
+  source: string,
+  result: BashCollection,
+): void {
+  if (!expression) return;
+  switch (expression.type) {
+    case 'ArithmeticBinary':
+      collectArithmeticExpression(expression.left, source, result);
+      collectArithmeticExpression(expression.right, source, result);
+      return;
+    case 'ArithmeticUnary':
+      collectArithmeticExpression(expression.operand, source, result);
+      return;
+    case 'ArithmeticTernary':
+      collectArithmeticExpression(expression.test, source, result);
+      collectArithmeticExpression(expression.consequent, source, result);
+      collectArithmeticExpression(expression.alternate, source, result);
+      return;
+    case 'ArithmeticGroup':
+      collectArithmeticExpression(expression.expression, source, result);
+      return;
+    case 'ArithmeticCommandExpansion':
+      collectSubstitution(
+        expression.text.startsWith('`')
+          ? 'backtick substitution'
+          : 'command substitution',
+        expression.text,
+        expression.script,
+        expression.pos,
+        source,
+        result,
+      );
+      return;
+    case 'ArithmeticWord':
+    default:
+      return;
+  }
+}
+
+function collectWordPart(
+  part: WordPart,
+  word: Word,
+  source: string,
+  result: BashCollection,
+): void {
+  switch (part.type) {
+    case 'CommandExpansion': {
+      const startIndex = part.script
+        ? part.script.pos - (part.text.startsWith('`') ? 1 : 2)
+        : word.pos;
+      collectSubstitution(
+        part.text.startsWith('`')
+          ? 'backtick substitution'
+          : 'command substitution',
+        part.text,
+        part.script,
+        startIndex,
+        source,
+        result,
+      );
+      return;
     }
-
-    if (current.type === 'expansion') {
-      for (let i = 0; i < current.childCount - 1; i += 1) {
-        const operatorNode = current.child(i);
-        const transformNode = current.child(i + 1);
-
-        if (
-          operatorNode?.text === '@' &&
-          transformNode?.text?.toLowerCase() === 'p'
-        ) {
-          return true;
-        }
+    case 'ProcessSubstitution':
+      collectSubstitution(
+        'process substitution',
+        part.text,
+        part.script,
+        part.script ? part.script.pos - 2 : word.pos,
+        source,
+        result,
+      );
+      return;
+    case 'ArithmeticExpansion':
+      collectArithmeticExpression(part.expression, source, result);
+      return;
+    case 'ParameterExpansion':
+      if (part.operator === '@' && part.operand?.value.toLowerCase() === 'p') {
+        result.hasPromptCommandTransform = true;
       }
-    }
-
-    for (let i = current.namedChildCount - 1; i >= 0; i -= 1) {
-      const child = current.namedChild(i);
-      if (child) {
-        stack.push(child);
+      collectWord(part.operand, source, result);
+      collectWord(part.slice?.offset, source, result);
+      collectWord(part.slice?.length, source, result);
+      collectWord(part.replace?.pattern, source, result);
+      collectWord(part.replace?.replacement, source, result);
+      return;
+    case 'DoubleQuoted':
+    case 'LocaleString':
+      for (const child of part.parts) {
+        collectWordPart(child, word, source, result);
       }
-    }
+      return;
+    case 'Literal':
+    case 'SingleQuoted':
+    case 'AnsiCQuoted':
+    case 'SimpleExpansion':
+    case 'ExtendedGlob':
+    case 'BraceExpansion':
+    default:
+      return;
+  }
+}
+
+function collectWord(
+  word: Word | undefined,
+  source: string,
+  result: BashCollection,
+): void {
+  if (!word) return;
+  for (const part of word.parts ?? []) {
+    collectWordPart(part, word, source, result);
+  }
+}
+
+function collectTestExpression(
+  expression: TestExpression,
+  source: string,
+  result: BashCollection,
+): void {
+  switch (expression.type) {
+    case 'TestUnary':
+      collectWord(expression.operand, source, result);
+      return;
+    case 'TestBinary':
+      collectWord(expression.left, source, result);
+      collectWord(expression.right, source, result);
+      return;
+    case 'TestLogical':
+      collectTestExpression(expression.left, source, result);
+      collectTestExpression(expression.right, source, result);
+      return;
+    case 'TestNot':
+      collectTestExpression(expression.operand, source, result);
+      return;
+    case 'TestGroup':
+      collectTestExpression(expression.expression, source, result);
+      return;
+    default:
+      return;
+  }
+}
+
+function redirectName(redirect: Redirect): string {
+  if (redirect.operator === '<<' || redirect.operator === '<<-') {
+    return 'heredoc (<<)';
+  }
+  if (redirect.operator === '<<<') return 'herestring (<<<)';
+  return redirect.operator.includes('<')
+    ? 'redirection (<)'
+    : 'redirection (>)';
+}
+
+function collectRedirect(
+  redirect: Redirect,
+  source: string,
+  result: BashCollection,
+): void {
+  result.hasRedirection = true;
+  result.details.push({
+    name: redirectName(redirect),
+    text: source.slice(redirect.pos, redirect.end).trim(),
+    startIndex: redirect.pos,
+  });
+  collectWord(redirect.target, source, result);
+  collectWord(redirect.body, source, result);
+}
+
+function commandText(command: BashCommand, source: string): string {
+  const redirects = command.redirects
+    .filter((redirect) => redirect.operator !== '<<<')
+    .sort((a, b) => a.pos - b.pos);
+  if (redirects.length === 0) {
+    return source.slice(command.pos, command.end).trim();
   }
 
-  return false;
+  let text = '';
+  let pos = command.pos;
+  for (const redirect of redirects) {
+    text += source.slice(pos, redirect.pos);
+    pos = redirect.end;
+  }
+  return (text + source.slice(pos, command.end)).trim();
+}
+
+function collectCommand(
+  command: BashCommand,
+  source: string,
+  result: BashCollection,
+): void {
+  if (command.name) {
+    const detail: ParsedCommandDetail = {
+      name: normalizeCommandName(command.name.text),
+      text: commandText(command, source),
+      startIndex: command.pos,
+    };
+    if (command.suffix.length > 0) {
+      detail.args = command.suffix.map((word) => word.text);
+    }
+    result.details.push(detail);
+  }
+
+  collectWord(command.name, source, result);
+  for (const prefix of command.prefix) {
+    collectWord(prefix.value, source, result);
+    for (const word of prefix.array ?? []) collectWord(word, source, result);
+  }
+  for (const word of command.suffix) collectWord(word, source, result);
+  for (const redirect of command.redirects) {
+    collectRedirect(redirect, source, result);
+  }
+}
+
+function collectBashNode(
+  node: BashNode | undefined,
+  source: string,
+  result: BashCollection,
+): void {
+  if (!node) return;
+  switch (node.type) {
+    case 'Command':
+      collectCommand(node, source, result);
+      return;
+    case 'Statement':
+      collectBashNode(node.command, source, result);
+      for (const redirect of node.redirects) {
+        collectRedirect(redirect, source, result);
+      }
+      return;
+    case 'Pipeline':
+    case 'AndOr':
+    case 'CompoundList':
+      for (const child of node.commands) {
+        collectBashNode(child, source, result);
+      }
+      return;
+    case 'If':
+      collectBashNode(node.clause, source, result);
+      collectBashNode(node.then, source, result);
+      collectBashNode(node.else, source, result);
+      return;
+    case 'For':
+    case 'Select':
+      for (const word of node.wordlist) collectWord(word, source, result);
+      collectBashNode(node.body, source, result);
+      return;
+    case 'ArithmeticFor':
+      collectArithmeticExpression(node.initialize, source, result);
+      collectArithmeticExpression(node.test, source, result);
+      collectArithmeticExpression(node.update, source, result);
+      collectBashNode(node.body, source, result);
+      return;
+    case 'While':
+      collectBashNode(node.clause, source, result);
+      collectBashNode(node.body, source, result);
+      return;
+    case 'Function':
+      collectBashNode(node.body, source, result);
+      for (const redirect of node.redirects) {
+        collectRedirect(redirect, source, result);
+      }
+      return;
+    case 'Subshell':
+      result.details.push({
+        name: 'subshell',
+        text: source.slice(node.pos, node.end).trim(),
+        startIndex: node.pos,
+      });
+      collectBashNode(node.body, source, result);
+      return;
+    case 'BraceGroup':
+      collectBashNode(node.body, source, result);
+      return;
+    case 'Case':
+      collectWord(node.word, source, result);
+      for (const item of node.items) {
+        for (const word of item.pattern) collectWord(word, source, result);
+        collectBashNode(item.body, source, result);
+      }
+      return;
+    case 'Coproc':
+      collectBashNode(node.body, source, result);
+      for (const redirect of node.redirects) {
+        collectRedirect(redirect, source, result);
+      }
+      return;
+    case 'TestCommand':
+      collectTestExpression(node.expression, source, result);
+      return;
+    case 'ArithmeticCommand':
+      collectArithmeticExpression(node.expression, source, result);
+      return;
+    default:
+      return;
+  }
 }
 
 export function parseBashCommandDetails(
   command: string,
 ): CommandParseResult | null {
-  if (treeSitterInitializationError) {
-    debugLogger.debug(
-      'Bash parser not initialized:',
-      treeSitterInitializationError,
-    );
+  let script: ReturnType<typeof parseBash>;
+  try {
+    script = parseBash(command);
+  } catch (error) {
+    debugLogger.debug('Failed to parse Bash command:', error);
     return null;
   }
 
-  if (!bashLanguage) {
-    initializeShellParsers().catch(() => {
-      // The failure path is surfaced via treeSitterInitializationError.
-    });
-    return null;
-  }
-
-  const tree = parseCommandTree(command);
-  if (!tree) {
-    return null;
-  }
-
-  const details = collectCommandDetails(tree.rootNode, command);
+  const result: BashCollection = {
+    details: [],
+    hasParseError: false,
+    hasPromptCommandTransform: false,
+    hasRedirection: false,
+  };
+  collectScript(script, command, result);
 
   const hasError =
-    tree.rootNode.hasError ||
-    details.length === 0 ||
-    hasPromptCommandTransform(tree.rootNode);
+    result.hasParseError ||
+    result.details.length === 0 ||
+    result.hasPromptCommandTransform;
 
-  if (hasError) {
-    let query = null;
-    try {
-      query = new Query(bashLanguage, '(ERROR) @error (MISSING) @missing');
-      const captures = query.captures(tree.rootNode);
-      const syntaxErrors = captures.map((capture) => {
-        const { node, name } = capture;
-        const type = name === 'missing' ? 'Missing' : 'Error';
-        return `${type} node: "${node.text}" at ${node.startPosition.row}:${node.startPosition.column}`;
-      });
-
-      debugLogger.log(
-        'Bash command parsing error detected for command:',
-        command,
-        'Syntax Errors:',
-        syntaxErrors,
-      );
-    } catch {
-      // Ignore query errors
-    } finally {
-      query?.delete();
-    }
-  }
   return {
-    details: details.sort((a, b) => a.startIndex - b.startIndex),
+    details: result.details.sort((a, b) => a.startIndex - b.startIndex),
     hasError,
+    hasRedirection: result.hasRedirection,
   };
 }
 
@@ -768,27 +819,11 @@ export function hasRedirection(command: string): boolean {
       : fallbackCheck();
   }
 
-  if (configuration.shell === 'bash' && bashLanguage) {
-    const tree = parseCommandTree(command);
-    if (!tree) return fallbackCheck();
-
-    const stack: Node[] = [tree.rootNode];
-    while (stack.length > 0) {
-      const current = stack.pop()!;
-      if (
-        current.type === 'redirected_statement' ||
-        current.type === 'file_redirect' ||
-        current.type === 'heredoc_redirect' ||
-        current.type === 'herestring_redirect'
-      ) {
-        return true;
-      }
-      for (let i = current.childCount - 1; i >= 0; i -= 1) {
-        const child = current.child(i);
-        if (child) stack.push(child);
-      }
-    }
-    return false;
+  if (configuration.shell === 'bash') {
+    const parsed = parseBashCommandDetails(command);
+    return parsed && !parsed.hasError
+      ? !!parsed.hasRedirection
+      : fallbackCheck();
   }
 
   return fallbackCheck();


### PR DESCRIPTION
## Summary

Replace the tree-sitter Bash parser with the synchronous `unbash` parser. This removes the WASM runtime, Bash grammar, asynchronous initialization and fallback plumbing while preserving the command-detail API and the native PowerShell AST path.

A fresh bundle comparison from the same `origin/main` commit reduced top-level JavaScript from 26,808,108 to 24,665,148 bytes (8.0%) and gzip size from 4,834,570 to 4,452,446 bytes (7.9%). The two tree-sitter chunks and all tree-sitter references are gone.

## Details

The Bash command collector now walks structured commands, compound syntax, redirections, substitutions, tests and arithmetic expressions from the unbash AST. It preserves the existing command details used by policy and sandbox callers, including source text and offsets.

The replacement also corrects two command-root results from the previous parser:

| Input                                       | Previous roots | New roots |
| ------------------------------------------- | -------------- | --------- |
| `if [[ -f package.json ]]; then npm ci; fi` | `[[`, `npm`    | `npm`     |
| `coproc mycop { sleep 1; }`                 | `coproc`, `}`  | `sleep`   |

Command substitutions inside arithmetic syntax are collected as executable roots. Parse errors from both the root script and nested substitutions continue to fail closed.

This removes `web-tree-sitter`, `tree-sitter-bash` and `esbuild-plugin-wasm`, along with the WASM loader utilities and parser lifecycle calls. It also addresses the loading overhead discussed in #12135 and removes the published `?binary` WASM imports reported in #25651. Both issues were closed by stale automation rather than a code change.

Disclosure: I maintain [unbash](https://github.com/webpro-nl/unbash) and [knip](https://github.com/webpro-nl/knip), which depends on it. For npm's 2026-07-27 through 2026-08-02 reporting window, unbash recorded 9,056,581 downloads and knip recorded 12,240,135. unbash is an ISC-licensed, zero-dependency, synchronous package and supports every Node.js version supported by Gemini CLI.

## Related Issues

Related to #12135 and #25651.

## How to Validate

- `npm test -w @google/gemini-cli-core -- src/utils/shell-utils.test.ts`
  - 67 passed, 2 skipped
- Affected policy, sandbox, shell and utility tests
  - 472 passed, 5 skipped across 11 files
- Full core test suite
  - 7,765 passed, 50 skipped across 408 files
- `npm run typecheck`
  - Passed for all workspaces, evals, integration tests and memory tests
- `npm run lint`
  - Passed with zero warnings
- `npm run bundle`
  - Completed successfully with no tree-sitter chunks or references

## Pre-Merge Checklist

- [x] Documentation is not needed because this changes an internal parser backend
- [x] Added and updated tests
- [x] Breaking changes: none
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
