### PR TITLE
fix(cli): make session retention collision-safe—protect unrelated chats

### DIFF
--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -489,6 +489,90 @@ describe('Session Cleanup (Refactored)', () => {
       );
     });
 
+    it('should preserve a recent unrelated session with the same shortId', async () => {
+      const now = new Date();
+      const twoWeeksAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+      const sharedShortId = 'deadbeef';
+      const expiredSessionId = `${sharedShortId}-expired-session`;
+      const recentSessionId = `${sharedShortId}-recent-session`;
+      const expiredFileName = `session-20250110-${sharedShortId}.json`;
+      const recentFileName = `session-20250111-${sharedShortId}.json`;
+
+      await writeSessionFile({
+        id: expiredSessionId,
+        fileName: expiredFileName,
+        lastUpdated: twoWeeksAgo.toISOString(),
+      });
+      await writeArtifacts(expiredSessionId);
+
+      await writeSessionFile({
+        id: recentSessionId,
+        fileName: recentFileName,
+        lastUpdated: now.toISOString(),
+      });
+      await writeArtifacts(recentSessionId);
+
+      const config = createMockConfig();
+      const settings: Settings = {
+        general: { sessionRetention: { enabled: true, maxAge: '10d' } },
+      };
+
+      const result = await cleanupExpiredSessions(config, settings);
+
+      expect(result).toMatchObject({
+        scanned: 2,
+        deleted: 1,
+        skipped: 1,
+        failed: 0,
+      });
+      expect(existsSync(path.join(chatsDir, expiredFileName))).toBe(false);
+      expect(existsSync(path.join(chatsDir, recentFileName))).toBe(true);
+      expect(
+        existsSync(path.join(logsDir, `session-${expiredSessionId}.jsonl`)),
+      ).toBe(false);
+      expect(
+        existsSync(path.join(logsDir, `session-${recentSessionId}.jsonl`)),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(toolOutputsDir, `session-${recentSessionId}`)),
+      ).toBe(true);
+    });
+
+    it('should identify the current session by full ID after a shortId collision', async () => {
+      const now = new Date();
+      const twoWeeksAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+      const sharedShortId = 'cafebabe';
+      const currentSessionId = `${sharedShortId}-current-session`;
+      const expiredSessionId = `${sharedShortId}-expired-session`;
+      const currentFileName = `session-20250111-${sharedShortId}.json`;
+      const expiredFileName = `session-20250110-${sharedShortId}.json`;
+
+      await writeSessionFile({
+        id: currentSessionId,
+        fileName: currentFileName,
+        lastUpdated: now.toISOString(),
+      });
+      await writeSessionFile({
+        id: expiredSessionId,
+        fileName: expiredFileName,
+        lastUpdated: twoWeeksAgo.toISOString(),
+      });
+
+      const config = createMockConfig({
+        getSessionId: () => currentSessionId,
+      });
+      const settings: Settings = {
+        general: { sessionRetention: { enabled: true, maxAge: '10d' } },
+      };
+
+      const result = await cleanupExpiredSessions(config, settings);
+
+      expect(result.deleted).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(existsSync(path.join(chatsDir, expiredFileName))).toBe(false);
+      expect(existsSync(path.join(chatsDir, currentFileName))).toBe(true);
+    });
+
     it('should delete corrupted session files', async () => {
       // Write a corrupted file (invalid JSON)
       const corruptPath = path.join(chatsDir, 'session-corrupt.json');

--- a/packages/cli/src/utils/sessionCleanup.test.ts
+++ b/packages/cli/src/utils/sessionCleanup.test.ts
@@ -363,7 +363,10 @@ describe('Session Cleanup (Refactored)', () => {
 
       await fs.writeFile(filePath, 'completely invalid json');
 
-      const config = createMockConfig();
+      const config = createMockConfig({
+        // Cleanup can run before an active session has been assigned.
+        getSessionId: () => undefined as unknown as string,
+      });
       const settings: Settings = {
         general: { sessionRetention: { enabled: true, maxAge: '10d' } },
       };

--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -170,8 +170,7 @@ export async function cleanupExpiredSessions(
 
         // A malformed or non-resumable current session may have been classified
         // as corrupted. Always use its persisted full ID as the final safeguard.
-        if (sessionId === config.getSessionId()) {
-          result.skipped++;
+        if (sessionId && sessionId === config.getSessionId()) {
           continue;
         }
 

--- a/packages/cli/src/utils/sessionCleanup.ts
+++ b/packages/cli/src/utils/sessionCleanup.ts
@@ -9,7 +9,6 @@ import * as path from 'node:path';
 import {
   debugLogger,
   sanitizeFilenamePart,
-  SESSION_FILE_PREFIX,
   Storage,
   TOOL_OUTPUTS_DIR,
   type Config,
@@ -28,12 +27,6 @@ const MULTIPLIERS = {
   w: 7 * 24 * 60 * 60 * 1000, // weeks to ms
   m: 30 * 24 * 60 * 60 * 1000, // months (30 days) to ms
 };
-
-/**
- * Matches a trailing hyphen followed by exactly 8 alphanumeric characters before the .json or .jsonl extension.
- * Example: session-20250110-abcdef12.json -> captures "abcdef12"
- */
-const SHORT_ID_REGEX = /-([a-zA-Z0-9]{8})\.jsonl?$/;
 
 function hasProperty<T extends string>(
   obj: unknown,
@@ -68,18 +61,42 @@ export interface CleanupResult {
  * Helpers for session cleanup.
  */
 
-/**
- * Derives an 8-character shortId from a session filename.
- */
-function deriveShortIdFromFileName(fileName: string): string | null {
-  if (
-    fileName.startsWith(SESSION_FILE_PREFIX) &&
-    (fileName.endsWith('.json') || fileName.endsWith('.jsonl'))
-  ) {
-    const match = fileName.match(SHORT_ID_REGEX);
-    return match ? match[1] : null;
+async function readSessionId(filePath: string): Promise<string | undefined> {
+  try {
+    const chunkSize = 4096;
+    const buffer = Buffer.alloc(chunkSize);
+    let fd: fs.FileHandle | undefined;
+
+    try {
+      fd = await fs.open(filePath, 'r');
+      const { bytesRead } = await fd.read(buffer, 0, chunkSize, 0);
+      if (bytesRead > 0) {
+        const contentChunk = buffer.toString('utf8', 0, bytesRead);
+        const newlineIndex = contentChunk.indexOf('\n');
+        const firstLine =
+          newlineIndex !== -1
+            ? contentChunk.substring(0, newlineIndex)
+            : contentChunk;
+
+        try {
+          const record: unknown = JSON.parse(firstLine);
+          if (isSessionIdRecord(record)) {
+            return record.sessionId;
+          }
+        } catch {
+          // Try a full read below for legacy pretty-printed JSON.
+        }
+      }
+    } finally {
+      await fd?.close();
+    }
+
+    const fileContent = await fs.readFile(filePath, 'utf8');
+    const content: unknown = JSON.parse(fileContent);
+    return isSessionIdRecord(content) ? content.sessionId : undefined;
+  } catch {
+    return undefined;
   }
-  return null;
 }
 
 /**
@@ -144,119 +161,29 @@ export async function cleanupExpiredSessions(
       retentionConfig,
     );
 
-    const processedShortIds = new Set<string>();
-
     // Delete all sessions that need to be deleted
     for (const sessionToDelete of sessionsToDelete) {
       try {
-        const shortId = deriveShortIdFromFileName(sessionToDelete.fileName);
+        const sessionPath = path.join(chatsDir, sessionToDelete.fileName);
+        const sessionId =
+          sessionToDelete.sessionInfo?.id ?? (await readSessionId(sessionPath));
 
-        if (shortId) {
-          if (processedShortIds.has(shortId)) {
-            continue;
-          }
-          processedShortIds.add(shortId);
-
-          const matchingFiles = allFiles
-            .map((f) => f.fileName)
-            .filter(
-              (f) =>
-                f.startsWith(SESSION_FILE_PREFIX) &&
-                (f.endsWith(`-${shortId}.json`) ||
-                  f.endsWith(`-${shortId}.jsonl`)),
-            );
-
-          for (const file of matchingFiles) {
-            const filePath = path.join(chatsDir, file);
-            let fullSessionId: string | undefined;
-
-            try {
-              // Try to read file to get full sessionId
-              try {
-                const CHUNK_SIZE = 4096;
-                const buffer = Buffer.alloc(CHUNK_SIZE);
-                let fd: fs.FileHandle | undefined;
-                try {
-                  fd = await fs.open(filePath, 'r');
-                  const { bytesRead } = await fd.read(buffer, 0, CHUNK_SIZE, 0);
-                  if (bytesRead > 0) {
-                    const contentChunk = buffer.toString('utf8', 0, bytesRead);
-                    const newlineIndex = contentChunk.indexOf('\n');
-                    const firstLine =
-                      newlineIndex !== -1
-                        ? contentChunk.substring(0, newlineIndex)
-                        : contentChunk;
-
-                    try {
-                      const record: unknown = JSON.parse(firstLine);
-                      if (isSessionIdRecord(record)) {
-                        fullSessionId = record.sessionId;
-                      }
-                    } catch {
-                      // Ignore first line parse error, try full parse for legacy pretty-printed JSON
-                    }
-                  }
-                } finally {
-                  if (fd !== undefined) {
-                    await fd.close();
-                  }
-                }
-
-                if (!fullSessionId) {
-                  const fileContent = await fs.readFile(filePath, 'utf8');
-                  const content: unknown = JSON.parse(fileContent);
-                  if (isSessionIdRecord(content)) {
-                    fullSessionId = content.sessionId;
-                  }
-                }
-              } catch {
-                // If read/parse fails, skip getting sessionId, just delete the file below
-              }
-
-              // Delete the session file
-              if (!fullSessionId || fullSessionId !== config.getSessionId()) {
-                await fs.unlink(filePath);
-
-                if (fullSessionId) {
-                  await cleanupSessionAndSubagentsAsync(fullSessionId, config);
-                }
-                result.deleted++;
-              } else {
-                result.skipped++;
-              }
-            } catch (error) {
-              // Ignore ENOENT (file already deleted)
-              if (
-                error instanceof Error &&
-                'code' in error &&
-                error.code === 'ENOENT'
-              ) {
-                // File already deleted, do nothing.
-              } else {
-                debugLogger.warn(
-                  `Failed to delete matching file ${file}: ${error instanceof Error ? error.message : 'Unknown error'}`,
-                );
-                result.failed++;
-              }
-            }
-          }
-        } else {
-          // Fallback to old logic
-          const sessionPath = path.join(chatsDir, sessionToDelete.fileName);
-          await fs.unlink(sessionPath);
-
-          const sessionId = sessionToDelete.sessionInfo?.id;
-          if (sessionId) {
-            await cleanupSessionAndSubagentsAsync(sessionId, config);
-          }
-
-          if (config.getDebugMode()) {
-            debugLogger.debug(
-              `Deleted fallback session: ${sessionToDelete.fileName}`,
-            );
-          }
-          result.deleted++;
+        // A malformed or non-resumable current session may have been classified
+        // as corrupted. Always use its persisted full ID as the final safeguard.
+        if (sessionId === config.getSessionId()) {
+          result.skipped++;
+          continue;
         }
+
+        // Retention decisions are made per file. A short filename ID is not
+        // unique enough to establish that another file belongs to this session.
+        await fs.unlink(sessionPath);
+
+        if (sessionId) {
+          await cleanupSessionAndSubagentsAsync(sessionId, config);
+        }
+
+        result.deleted++;
       } catch (error) {
         // Ignore ENOENT (file already deleted)
         if (

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -295,7 +295,7 @@ export const getAllSessionFiles = async (
             ? cleanMessage(content.firstUserMessage)
             : extractFirstUserMessage(content.messages);
           const isCurrentSession = currentSessionId
-            ? file.includes(currentSessionId.slice(0, 8))
+            ? content.sessionId === currentSessionId
             : false;
 
           let fullContent: string | undefined;


### PR DESCRIPTION
## Summary

Prevents session retention from deleting unrelated conversations that happen to share the same eight-character filename ID.

The previous cleanup path expanded one expired session into every file with the same short suffix. Because the suffix contains only eight characters, a collision could turn routine retention into permanent deletion of a recent session and its artifacts.

This change makes cleanup collision-safe: the files selected by the retention policy are now the only files deleted.

## Details

- Removes suffix-wide deletion and the `processedShortIds` grouping from startup retention cleanup.
- Deletes each `SessionFileEntry` selected by `identifySessionsToDelete()` by its exact filename.
- Reads the persisted full session ID before deletion when `sessionInfo` is unavailable, preserving artifact cleanup for corrupted, non-resumable, and legacy records.
- Keeps the full-ID safeguard for the active session.
- Changes active-session detection from a filename substring check to equality with the persisted full session ID.
- Preserves nested subagent cleanup: deleting an expired parent still removes the subagent directory and each subagent's artifacts through the existing full-ID cleanup helpers.

### Before

Given these two files:

- expired: `session-20250110-deadbeef.json` → `deadbeef-expired-session`
- recent: `session-20250111-deadbeef.json` → `deadbeef-recent-session`

Selecting the expired file caused both files and both artifact trees to be removed.

### After

Only the expired file and its artifacts are removed. The recent session, log, and tool-output directory remain intact.

## Related Issues

Fixes #28643

## How to Validate

```bash
# Collision and session-discovery unit coverage (95 tests)
npm test --workspace @google/gemini-cli -- \
  src/utils/sessionCleanup.test.ts \
  src/utils/sessionUtils.test.ts

# Filesystem-level cleanup integration coverage (6 tests)
npx vitest run --root packages/cli \
  src/utils/sessionCleanup.integration.test.ts

# Static checks
npm run typecheck --workspace @google/gemini-cli
npx eslint \
  packages/cli/src/utils/sessionCleanup.ts \
  packages/cli/src/utils/sessionCleanup.test.ts \
  packages/cli/src/utils/sessionUtils.ts \
  --max-warnings 0
npx prettier --check \
  packages/cli/src/utils/sessionCleanup.ts \
  packages/cli/src/utils/sessionCleanup.test.ts \
  packages/cli/src/utils/sessionUtils.ts
```

Expected results:

- An expired session is deleted normally.
- A recent unrelated session sharing its short filename ID survives with its artifacts.
- A colliding expired session is not incorrectly protected as the current session.
- Existing legacy, corrupt-record, nested-subagent, age-based, and count-based cleanup tests continue to pass.

## Pre-Merge Checklist

- [x] Documentation is not affected; this restores the documented retention behavior.
- [x] Added regression tests for unrelated short-ID collisions and full-ID active-session detection.
- [x] No breaking changes.
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
