### PR TITLE
fix(core): make Whisper model downloads failure-atomic

### DIFF
--- a/packages/core/src/voice/whisperModelManager.test.ts
+++ b/packages/core/src/voice/whisperModelManager.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { WhisperModelManager } from './whisperModelManager.js';
+
+const { homeDirectory } = vi.hoisted(() => ({
+  homeDirectory: { value: '' },
+}));
+
+vi.mock('../utils/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/paths.js')>();
+  return {
+    ...actual,
+    homedir: () => homeDirectory.value,
+  };
+});
+
+describe('WhisperModelManager', () => {
+  const modelName = 'ggml-tiny.en.bin';
+  let testHome: string;
+  let modelsDirectory: string;
+  let modelPath: string;
+
+  beforeEach(async () => {
+    testHome = await fs.mkdtemp(path.join(os.tmpdir(), 'whisper-model-test-'));
+    homeDirectory.value = testHome;
+    modelsDirectory = path.join(testHome, '.gemini', 'whisper_models');
+    modelPath = path.join(modelsDirectory, modelName);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await fs.rm(testHome, { recursive: true, force: true });
+  });
+
+  async function listTemporaryDownloads(): Promise<string[]> {
+    try {
+      return (await fs.readdir(modelsDirectory)).filter((file) =>
+        file.endsWith('.downloading'),
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  it('publishes a model only after the complete response is written', async () => {
+    const firstChunk = new Uint8Array([1, 2, 3]);
+    const secondChunk = new Uint8Array([4, 5]);
+    let releaseResponse: () => void = () => {};
+    const responseGate = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    let firstChunkSent = false;
+    const responseBody = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (!firstChunkSent) {
+          firstChunkSent = true;
+          controller.enqueue(firstChunk);
+          return;
+        }
+
+        await responseGate;
+        controller.enqueue(secondChunk);
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(responseBody, {
+          headers: { 'content-length': '5' },
+        }),
+      ),
+    );
+    const manager = new WhisperModelManager();
+    const progress = vi.fn();
+    manager.on('progress', progress);
+    const firstProgress = new Promise<void>((resolve) => {
+      manager.once('progress', () => resolve());
+    });
+
+    const download = manager.downloadModel(modelName);
+    await firstProgress;
+
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+    expect(await listTemporaryDownloads()).toHaveLength(1);
+
+    releaseResponse();
+    await download;
+
+    expect(await fs.readFile(modelPath)).toEqual(Buffer.from([1, 2, 3, 4, 5]));
+    expect(await listTemporaryDownloads()).toEqual([]);
+    expect(progress).toHaveBeenLastCalledWith({
+      modelName,
+      transferred: 5,
+      total: 5,
+      percentage: 1,
+    });
+    expect(manager.isModelInstalled(modelName)).toBe(true);
+  });
+
+  it('rejects a response shorter than its content length and removes the temporary file', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { 'content-length': '10' },
+        }),
+      ),
+    );
+    const manager = new WhisperModelManager();
+
+    await expect(manager.downloadModel(modelName)).rejects.toThrow(
+      'Incomplete model download: expected 10 bytes, received 3',
+    );
+
+    await expect(fs.stat(modelPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await listTemporaryDownloads()).toEqual([]);
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+  });
+
+  it('removes partial output when the response stream fails', async () => {
+    const responseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.error(new Error('connection interrupted'));
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(responseBody)),
+    );
+    const manager = new WhisperModelManager();
+
+    await expect(manager.downloadModel(modelName)).rejects.toThrow(
+      'connection interrupted',
+    );
+
+    await expect(fs.stat(modelPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await listTemporaryDownloads()).toEqual([]);
+  });
+
+  it('preserves an installed model when a replacement download fails', async () => {
+    await fs.mkdir(modelsDirectory, { recursive: true });
+    await fs.writeFile(modelPath, 'installed model');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2]), {
+          headers: { 'content-length': '20' },
+        }),
+      ),
+    );
+    const manager = new WhisperModelManager();
+
+    await expect(manager.downloadModel(modelName)).rejects.toThrow(
+      'Incomplete model download',
+    );
+
+    expect(await fs.readFile(modelPath, 'utf8')).toBe('installed model');
+    expect(await listTemporaryDownloads()).toEqual([]);
+    expect(manager.isModelInstalled(modelName)).toBe(true);
+  });
+
+  it('does not treat a leftover temporary download as an installed model', async () => {
+    await fs.mkdir(modelsDirectory, { recursive: true });
+    await fs.writeFile(`${modelPath}.old.downloading`, 'partial model');
+
+    const manager = new WhisperModelManager();
+
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+  });
+});

--- a/packages/core/src/voice/whisperModelManager.test.ts
+++ b/packages/core/src/voice/whisperModelManager.test.ts
@@ -134,10 +134,13 @@ describe('WhisperModelManager', () => {
   });
 
   it('removes partial output when the response stream fails', async () => {
+    let interruptResponse: () => void = () => {};
     const responseBody = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new Uint8Array([1, 2, 3]));
-        controller.error(new Error('connection interrupted'));
+        interruptResponse = () => {
+          controller.error(new Error('connection interrupted'));
+        };
       },
     });
     vi.stubGlobal(
@@ -145,10 +148,18 @@ describe('WhisperModelManager', () => {
       vi.fn().mockResolvedValue(new Response(responseBody)),
     );
     const manager = new WhisperModelManager();
+    const firstProgress = new Promise<void>((resolve) => {
+      manager.once('progress', () => resolve());
+    });
 
-    await expect(manager.downloadModel(modelName)).rejects.toThrow(
-      'connection interrupted',
-    );
+    const download = manager.downloadModel(modelName);
+    await firstProgress;
+
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+    expect(await listTemporaryDownloads()).toHaveLength(1);
+    interruptResponse();
+
+    await expect(download).rejects.toThrow('connection interrupted');
 
     await expect(fs.stat(modelPath)).rejects.toMatchObject({ code: 'ENOENT' });
     expect(await listTemporaryDownloads()).toEqual([]);

--- a/packages/core/src/voice/whisperModelManager.ts
+++ b/packages/core/src/voice/whisperModelManager.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import { homedir, GEMINI_DIR } from '../utils/paths.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
@@ -30,29 +31,6 @@ const ALLOWED_MODELS = [
   'ggml-large-v3-turbo-q5_0.bin',
   'ggml-large-v3-turbo-q8_0.bin',
 ];
-
-async function* readResponseBody(
-  body: ReadableStream<Uint8Array>,
-): AsyncGenerator<Uint8Array> {
-  const reader = body.getReader();
-  let completed = false;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        completed = true;
-        return;
-      }
-      yield value;
-    }
-  } finally {
-    if (!completed) {
-      await reader.cancel().catch(() => undefined);
-    }
-    reader.releaseLock();
-  }
-}
 
 /**
  * Manages Whisper models (checking existence, downloading).
@@ -104,6 +82,10 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
     if (!response.body) {
       throw new Error('Response body is not readable');
     }
+    // TypeScript's DOM ReadableStream omits Node's values() extension, but
+    // fetch returns the same runtime Web Streams API consumed by fromWeb().
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const responseBody = response.body as NodeReadableStream;
 
     const progressTracker = new Transform({
       transform: (chunk: Buffer, _encoding, callback) => {
@@ -123,7 +105,7 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
 
     try {
       await pipeline(
-        Readable.from(readResponseBody(response.body), { objectMode: false }),
+        Readable.fromWeb(responseBody),
         progressTracker,
         fs.createWriteStream(temporaryDestination, { flags: 'wx' }),
       );

--- a/packages/core/src/voice/whisperModelManager.ts
+++ b/packages/core/src/voice/whisperModelManager.ts
@@ -6,7 +6,10 @@
 
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { homedir, GEMINI_DIR } from '../utils/paths.js';
 import { debugLogger } from '../utils/debugLogger.js';
 
@@ -27,6 +30,29 @@ const ALLOWED_MODELS = [
   'ggml-large-v3-turbo-q5_0.bin',
   'ggml-large-v3-turbo-q8_0.bin',
 ];
+
+async function* readResponseBody(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const reader = body.getReader();
+  let completed = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        completed = true;
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    if (!completed) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
+  }
+}
 
 /**
  * Manages Whisper models (checking existence, downloading).
@@ -52,11 +78,10 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
   async downloadModel(modelName: string): Promise<void> {
     this.validateModelName(modelName);
 
-    if (!fs.existsSync(this.modelsDir)) {
-      fs.mkdirSync(this.modelsDir, { recursive: true });
-    }
+    await fs.promises.mkdir(this.modelsDir, { recursive: true });
 
     const destination = path.join(this.modelsDir, modelName);
+    const temporaryDestination = `${destination}.${randomUUID()}.downloading`;
     const url = `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${modelName}`;
 
     debugLogger.debug(
@@ -68,23 +93,21 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
       throw new Error(`Failed to download model: ${response.statusText}`);
     }
 
-    const total = parseInt(response.headers.get('content-length') || '0', 10);
+    const contentLength = response.headers.get('content-length');
+    const expectedSize = contentLength ? Number(contentLength) : undefined;
+    const total =
+      expectedSize !== undefined && Number.isSafeInteger(expectedSize)
+        ? expectedSize
+        : 0;
     let transferred = 0;
 
-    const reader = response.body?.getReader();
-    if (!reader) {
+    if (!response.body) {
       throw new Error('Response body is not readable');
     }
 
-    const writer = fs.createWriteStream(destination);
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        transferred += value.length;
-        writer.write(value);
+    const progressTracker = new Transform({
+      transform: (chunk: Buffer, _encoding, callback) => {
+        transferred += chunk.length;
 
         const percentage = total > 0 ? transferred / total : 0;
         this.emit('progress', {
@@ -93,9 +116,45 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
           total,
           percentage,
         });
+
+        callback(null, chunk);
+      },
+    });
+
+    try {
+      await pipeline(
+        Readable.from(readResponseBody(response.body), { objectMode: false }),
+        progressTracker,
+        fs.createWriteStream(temporaryDestination, { flags: 'wx' }),
+      );
+
+      if (transferred === 0) {
+        throw new Error('Downloaded model is empty');
       }
-    } finally {
-      writer.end();
+
+      if (total > 0 && transferred !== total) {
+        throw new Error(
+          `Incomplete model download: expected ${total} bytes, received ${transferred}`,
+        );
+      }
+
+      const temporaryFile = await fs.promises.open(temporaryDestination, 'r+');
+      try {
+        await temporaryFile.sync();
+      } finally {
+        await temporaryFile.close();
+      }
+
+      await fs.promises.rename(temporaryDestination, destination);
+    } catch (error) {
+      try {
+        await fs.promises.rm(temporaryDestination, { force: true });
+      } catch (cleanupError) {
+        debugLogger.warn(
+          `[WhisperModelManager] Failed to remove incomplete download ${temporaryDestination}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+        );
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

Make Whisper model downloads failure-atomic so an interrupted or failed download can never appear at the installed model path.

Previously, `downloadModel()` streamed bytes directly into the final `.bin` file and returned without awaiting the write stream. A network interruption, disk write failure, or short response could therefore leave a partial file that `isModelInstalled()` accepted on the next startup.

## Details

- Stream each response into a unique sibling `.downloading` file.
- Use Node's promise-based stream pipeline so file writes honor backpressure and source/destination errors reject the download.
- Keep progress events while bytes pass through the pipeline.
- Reject empty downloads and responses whose byte count does not match a valid `Content-Length`.
- Flush the completed temporary file with `fsync` before publication.
- Atomically rename the temporary file to the final model path only after all validation succeeds.
- Remove temporary output on every caught stream, validation, flush, or rename failure.
- Preserve an existing installed model if a replacement attempt fails.
- Cancel the web response reader if the destination pipeline terminates early.

A dedicated `WhisperModelManager` test suite now covers:

- the final path remaining invisible while a download is in progress;
- successful atomic publication and progress reporting;
- cleanly truncated responses;
- response-stream interruption;
- preservation of an existing installed model after failure; and
- exclusion of `.downloading` files from installation detection.

## Related Issues

Fixes #28644

## How to Validate

```bash
npm test --workspace @google/gemini-cli-core -- src/voice/whisperModelManager.test.ts
npm run typecheck --workspace @google/gemini-cli-core
npx eslint packages/core/src/voice/whisperModelManager.ts packages/core/src/voice/whisperModelManager.test.ts
npm run pre-commit
```

Expected results:

- 5 Whisper model manager tests pass.
- The core package builds successfully in the test post-step.
- TypeScript, ESLint, Prettier, and the staged pre-commit checks pass.
- During the gated success test, only a temporary file exists until the final response chunk arrives.
- On truncation or stream failure, neither a final model nor temporary output remains.

## Pre-Merge Checklist

- [x] Documentation is not required; this corrects internal download semantics without changing user-facing configuration.
- [x] Added dedicated regression tests.
- [x] No breaking changes.
- [x] Validated with npm on macOS.
