### PR TITLE
fix(cli): make extension release downloads failure-atomic

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -23,7 +23,7 @@ import * as https from 'node:https';
 import * as tar from 'tar';
 import * as extract from 'extract-zip';
 import type { ExtensionManager } from '../extension-manager.js';
-import { fetchJson } from './github_fetch.js';
+import { fetchJson, getGitHubToken } from './github_fetch.js';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type {
@@ -591,10 +591,11 @@ describe('github.ts', () => {
     });
 
     it('should follow redirects', async () => {
+      vi.mocked(getGitHubToken).mockReturnValue('github-token');
       const mockReq = new EventEmitter();
       const mockResRedirect = Object.assign(new PassThrough(), {
         statusCode: 302,
-        headers: { location: 'new-url' },
+        headers: { location: '/new-url' },
       }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       const mockResSuccess = Object.assign(new PassThrough(), {
@@ -617,14 +618,68 @@ describe('github.ts', () => {
       const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
-      const promise = downloadFile('url', '/dest');
+      const promise = downloadFile('https://api.github.com/releases', '/dest');
       mockResSuccess.end('archive');
 
       await expect(promise).resolves.toBeUndefined();
       expect(https.get).toHaveBeenCalledTimes(2);
       expect(https.get).toHaveBeenLastCalledWith(
-        'new-url',
+        'https://api.github.com/new-url',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'token github-token',
+          }),
+        }),
         expect.anything(),
+      );
+    });
+
+    it('should strip authorization when redirecting to another origin', async () => {
+      vi.mocked(getGitHubToken).mockReturnValue('github-token');
+      const mockReq = new EventEmitter();
+      const mockResRedirect = Object.assign(new PassThrough(), {
+        statusCode: 302,
+        headers: { location: 'https://downloads.example.com/archive' },
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
+      const mockResSuccess = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
+      vi.mocked(https.get)
+        .mockImplementationOnce((_url, _options, callback) => {
+          callback?.(mockResRedirect);
+          return mockReq as unknown as import('node:http').ClientRequest;
+        })
+        .mockImplementationOnce((_url, _options, callback) => {
+          callback?.(mockResSuccess);
+          return mockReq as unknown as import('node:http').ClientRequest;
+        });
+      vi.mocked(fs.createWriteStream).mockReturnValue(
+        new PassThrough() as unknown as fs.WriteStream,
+      );
+
+      const promise = downloadFile('https://api.github.com/releases', '/dest');
+      mockResSuccess.end('archive');
+      await promise;
+
+      expect(https.get).toHaveBeenNthCalledWith(
+        1,
+        'https://api.github.com/releases',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'token github-token',
+          }),
+        }),
+        expect.anything(),
+      );
+      expect(https.get).toHaveBeenNthCalledWith(
+        2,
+        'https://downloads.example.com/archive',
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Authorization: expect.any(String),
+          }),
+        }),
         expect.anything(),
       );
     });
@@ -634,7 +689,7 @@ describe('github.ts', () => {
       mockReq.setMaxListeners(20);
       const mockResRedirect = Object.assign(new PassThrough(), {
         statusCode: 302,
-        headers: { location: 'new-url' },
+        headers: { location: 'https://example.com/new-url' },
       }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
@@ -643,9 +698,9 @@ describe('github.ts', () => {
         return mockReq as unknown as import('node:http').ClientRequest;
       });
 
-      await expect(downloadFile('url', '/dest')).rejects.toThrow(
-        'Too many redirects',
-      );
+      await expect(
+        downloadFile('https://example.com/start', '/dest'),
+      ).rejects.toThrow('Too many redirects');
     }, 10000); // Increase timeout for this test if needed, though with mocks it should be fast
 
     it('should fail if redirect location is missing', async () => {

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -25,6 +25,7 @@ import * as extract from 'extract-zip';
 import type { ExtensionManager } from '../extension-manager.js';
 import { fetchJson } from './github_fetch.js';
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import type {
   GeminiCLIExtension,
   ExtensionInstallMetadata,
@@ -335,9 +336,10 @@ describe('github.ts', () => {
 
       // Mock https.get and fs.createWriteStream for downloadFile
       const mockReq = new EventEmitter();
-      const mockRes =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockRes, { statusCode: 200, pipe: vi.fn() });
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') {
@@ -347,8 +349,7 @@ describe('github.ts', () => {
         return mockReq as unknown as import('node:http').ClientRequest;
       });
 
-      const mockStream = new EventEmitter() as unknown as fs.WriteStream;
-      Object.assign(mockStream, { close: vi.fn((cb) => cb && cb()) });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
       // Mock fs.promises.readdir to return empty array (no cleanup needed)
@@ -372,8 +373,7 @@ describe('github.ts', () => {
       );
 
       // Trigger stream events to complete download
-      mockRes.emit('end');
-      mockStream.emit('finish');
+      mockRes.end('archive');
 
       await promise;
 
@@ -397,9 +397,10 @@ describe('github.ts', () => {
 
       // Mock https.get and fs.createWriteStream for downloadFile
       const mockReq = new EventEmitter();
-      const mockRes =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockRes, { statusCode: 200, pipe: vi.fn() });
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') {
@@ -409,8 +410,7 @@ describe('github.ts', () => {
         return mockReq as unknown as import('node:http').ClientRequest;
       });
 
-      const mockStream = new EventEmitter() as unknown as fs.WriteStream;
-      Object.assign(mockStream, { close: vi.fn((cb) => cb && cb()) });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
       // Mock fs.promises.readdir to return empty array
@@ -434,8 +434,7 @@ describe('github.ts', () => {
       );
 
       // Trigger stream events to complete download
-      mockRes.emit('end');
-      mockStream.emit('finish');
+      mockRes.end('archive');
 
       await promise;
 
@@ -472,9 +471,10 @@ describe('github.ts', () => {
   describe('downloadFile', () => {
     it('should download file successfully', async () => {
       const mockReq = new EventEmitter();
-      const mockRes =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockRes, { statusCode: 200, pipe: vi.fn() });
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') {
@@ -484,22 +484,98 @@ describe('github.ts', () => {
         return mockReq as unknown as import('node:http').ClientRequest;
       });
 
-      const mockStream = new EventEmitter() as unknown as fs.WriteStream;
-      Object.assign(mockStream, { close: vi.fn((cb) => cb && cb()) });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
       const promise = downloadFile('url', '/dest');
-      mockRes.emit('end');
-      mockStream.emit('finish');
+      mockRes.end('archive');
 
       await expect(promise).resolves.toBeUndefined();
+      expect(fs.createWriteStream).toHaveBeenCalledWith('/dest.downloading');
+      expect(fs.promises.rename).toHaveBeenCalledWith(
+        '/dest.downloading',
+        '/dest',
+      );
+    });
+
+    it('should reject request errors and remove temporary output', async () => {
+      const mockReq = new EventEmitter();
+      vi.mocked(https.get).mockReturnValue(
+        mockReq as unknown as import('node:http').ClientRequest,
+      );
+
+      const promise = downloadFile('url', '/dest');
+      await vi.waitUntil(() => vi.mocked(https.get).mock.calls.length > 0);
+      mockReq.emit('error', new Error('request failed'));
+
+      await expect(promise).rejects.toThrow('request failed');
+      expect(fs.promises.rm).toHaveBeenLastCalledWith('/dest.downloading', {
+        force: true,
+      });
+      expect(fs.promises.rename).not.toHaveBeenCalled();
+    });
+
+    it('should reject response stream errors and remove partial output', async () => {
+      const mockReq = new EventEmitter();
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
+      vi.mocked(https.get).mockImplementation((_url, _options, callback) => {
+        callback?.(mockRes);
+        return mockReq as unknown as import('node:http').ClientRequest;
+      });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
+
+      const promise = downloadFile('url', '/dest');
+      await vi.waitUntil(
+        () => vi.mocked(fs.createWriteStream).mock.calls.length > 0,
+      );
+      mockRes.write('partial archive');
+      mockRes.destroy(new Error('response interrupted'));
+
+      await expect(promise).rejects.toThrow('response interrupted');
+      expect(mockStream.destroyed).toBe(true);
+      expect(fs.promises.rm).toHaveBeenLastCalledWith('/dest.downloading', {
+        force: true,
+      });
+      expect(fs.promises.rename).not.toHaveBeenCalled();
+    });
+
+    it('should reject file stream errors and remove partial output', async () => {
+      const mockReq = new EventEmitter();
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
+      vi.mocked(https.get).mockImplementation((_url, _options, callback) => {
+        callback?.(mockRes);
+        return mockReq as unknown as import('node:http').ClientRequest;
+      });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
+
+      const promise = downloadFile('url', '/dest');
+      await vi.waitUntil(
+        () => vi.mocked(fs.createWriteStream).mock.calls.length > 0,
+      );
+      mockStream.destroy(new Error('disk full'));
+
+      await expect(promise).rejects.toThrow('disk full');
+      expect(mockRes.destroyed).toBe(true);
+      expect(fs.promises.rm).toHaveBeenLastCalledWith('/dest.downloading', {
+        force: true,
+      });
+      expect(fs.promises.rename).not.toHaveBeenCalled();
     });
 
     it('should fail on non-200 status', async () => {
       const mockReq = new EventEmitter();
-      const mockRes =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockRes, { statusCode: 404 });
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 404,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') {
@@ -516,16 +592,15 @@ describe('github.ts', () => {
 
     it('should follow redirects', async () => {
       const mockReq = new EventEmitter();
-      const mockResRedirect =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockResRedirect, {
+      const mockResRedirect = Object.assign(new PassThrough(), {
         statusCode: 302,
         headers: { location: 'new-url' },
-      });
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
-      const mockResSuccess =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockResSuccess, { statusCode: 200, pipe: vi.fn() });
+      const mockResSuccess = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get)
         .mockImplementationOnce((url, options, cb) => {
@@ -539,13 +614,11 @@ describe('github.ts', () => {
           return mockReq as unknown as import('node:http').ClientRequest;
         });
 
-      const mockStream = new EventEmitter() as unknown as fs.WriteStream;
-      Object.assign(mockStream, { close: vi.fn((cb) => cb && cb()) });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
       const promise = downloadFile('url', '/dest');
-      mockResSuccess.emit('end');
-      mockStream.emit('finish');
+      mockResSuccess.end('archive');
 
       await expect(promise).resolves.toBeUndefined();
       expect(https.get).toHaveBeenCalledTimes(2);
@@ -558,12 +631,11 @@ describe('github.ts', () => {
 
     it('should fail after too many redirects', async () => {
       const mockReq = new EventEmitter();
-      const mockResRedirect =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockResRedirect, {
+      mockReq.setMaxListeners(20);
+      const mockResRedirect = Object.assign(new PassThrough(), {
         statusCode: 302,
         headers: { location: 'new-url' },
-      });
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') cb = options;
@@ -578,12 +650,10 @@ describe('github.ts', () => {
 
     it('should fail if redirect location is missing', async () => {
       const mockReq = new EventEmitter();
-      const mockResRedirect =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockResRedirect, {
+      const mockResRedirect = Object.assign(new PassThrough(), {
         statusCode: 302,
         headers: {}, // No location
-      });
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') cb = options;
@@ -598,9 +668,10 @@ describe('github.ts', () => {
 
     it('should pass custom headers', async () => {
       const mockReq = new EventEmitter();
-      const mockRes =
-        new EventEmitter() as unknown as import('node:http').IncomingMessage;
-      Object.assign(mockRes, { statusCode: 200, pipe: vi.fn() });
+      const mockRes = Object.assign(new PassThrough(), {
+        statusCode: 200,
+        headers: {},
+      }) as unknown as PassThrough & import('node:http').IncomingMessage;
 
       vi.mocked(https.get).mockImplementation((url, options, cb) => {
         if (typeof options === 'function') cb = options;
@@ -608,15 +679,13 @@ describe('github.ts', () => {
         return mockReq as unknown as import('node:http').ClientRequest;
       });
 
-      const mockStream = new EventEmitter() as unknown as fs.WriteStream;
-      Object.assign(mockStream, { close: vi.fn((cb) => cb && cb()) });
+      const mockStream = new PassThrough() as unknown as fs.WriteStream;
       vi.mocked(fs.createWriteStream).mockReturnValue(mockStream);
 
       const promise = downloadFile('url', '/dest', {
         headers: { 'X-Custom': 'value' },
       });
-      mockRes.emit('end');
-      mockStream.emit('finish');
+      mockRes.end('archive');
 
       await expect(promise).resolves.toBeUndefined();
       expect(https.get).toHaveBeenCalledWith(

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -569,10 +569,20 @@ async function downloadResponse(
     if (!response.headers.location) {
       throw new Error('Redirect response missing Location header');
     }
+    const currentUrl = new URL(url);
+    const redirectUrl = new URL(response.headers.location, currentUrl);
+    const redirectHeaders = { ...headers };
+    if (currentUrl.origin !== redirectUrl.origin) {
+      for (const header of Object.keys(redirectHeaders)) {
+        if (header.toLowerCase() === 'authorization') {
+          delete redirectHeaders[header];
+        }
+      }
+    }
     return downloadResponse(
-      response.headers.location,
+      redirectUrl.toString(),
       temporaryDest,
-      headers,
+      redirectHeaders,
       redirectCount + 1,
     );
   }

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -16,6 +16,7 @@ import * as os from 'node:os';
 import * as https from 'node:https';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
 import extract from 'extract-zip';
 import { fetchJson, getGitHubToken } from './github_fetch.js';
@@ -530,35 +531,58 @@ export async function downloadFile(
     headers['Authorization'] = `token ${token}`;
   }
 
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, { headers }, (res) => {
-        if (res.statusCode === 302 || res.statusCode === 301) {
-          if (redirectCount >= 10) {
-            return reject(new Error('Too many redirects'));
-          }
+  const temporaryDest = `${dest}.downloading`;
+  await fs.promises.rm(temporaryDest, { force: true });
 
-          if (!res.headers.location) {
-            return reject(
-              new Error('Redirect response missing Location header'),
-            );
-          }
-          downloadFile(res.headers.location, dest, options, redirectCount + 1)
-            .then(resolve)
-            .catch(reject);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          return reject(
-            new Error(`Request failed with status code ${res.statusCode}`),
-          );
-        }
-        const file = fs.createWriteStream(dest);
-        res.pipe(file);
-        file.on('finish', () => file.close(resolve as () => void));
-      })
-      .on('error', reject);
-  });
+  try {
+    await downloadResponse(url, temporaryDest, headers, redirectCount);
+    await fs.promises.rename(temporaryDest, dest);
+  } catch (error) {
+    try {
+      await fs.promises.rm(temporaryDest, { force: true });
+    } catch (cleanupError) {
+      debugLogger.warn(
+        `Failed to remove incomplete extension download ${temporaryDest}: ${getErrorMessage(cleanupError)}`,
+      );
+    }
+    throw error;
+  }
+}
+
+async function downloadResponse(
+  url: string,
+  temporaryDest: string,
+  headers: Record<string, string>,
+  redirectCount: number,
+): Promise<void> {
+  const response = await new Promise<import('node:http').IncomingMessage>(
+    (resolve, reject) => {
+      https.get(url, { headers }, resolve).once('error', reject);
+    },
+  );
+
+  if (response.statusCode === 302 || response.statusCode === 301) {
+    response.destroy();
+    if (redirectCount >= 10) {
+      throw new Error('Too many redirects');
+    }
+    if (!response.headers.location) {
+      throw new Error('Redirect response missing Location header');
+    }
+    return downloadResponse(
+      response.headers.location,
+      temporaryDest,
+      headers,
+      redirectCount + 1,
+    );
+  }
+
+  if (response.statusCode !== 200) {
+    response.destroy();
+    throw new Error(`Request failed with status code ${response.statusCode}`);
+  }
+
+  await pipeline(response, fs.createWriteStream(temporaryDest));
 }
 
 export async function extractFile(file: string, dest: string): Promise<void> {


### PR DESCRIPTION
## Summary

Make GitHub-release extension downloads failure-atomic so request, response-stream, and filesystem failures reject cleanly without crashing the CLI or leaving a partial archive at the extraction path.

Previously, `downloadFile()` piped the HTTP response directly to the final destination and listened only for `finish`. Errors emitted after headers arrived or by the destination stream had no coordinated handler, allowing unhandled `error` events, hung installs, and incomplete archives.

## Details

- Download into a sibling `<destination>.downloading` file instead of the final archive path.
- Coordinate the HTTP response and file writer with `node:stream/promises.pipeline()` so backpressure, stream errors, closure, and teardown are handled together.
- Atomically rename the completed temporary archive to the requested destination only after the pipeline succeeds.
- Remove stale temporary output before a new attempt and incomplete output after request, response, writer, or rename failures.
- Preserve the original transfer error if temporary-file cleanup itself fails, while logging the cleanup failure.
- Keep redirect handling inside the same transfer operation so recursive redirects cannot independently publish or clean up the archive.
- Resolve relative redirects and strip every case variant of the `Authorization` header before following a cross-origin redirect, including protocol or port changes.
- Destroy redirect and non-200 responses that will not be consumed.
- Preserve the existing redirect limit, request headers, GitHub token handling, and public API.

The tests now use real `PassThrough` stream behavior and add regressions for:

- request errors before a response is received;
- response errors after a partial transfer;
- destination write errors;
- same-origin credential retention and cross-origin credential stripping;
- bidirectional pipeline teardown;
- partial temporary-file removal; and
- atomic rename only after successful completion.

## Related Issues

Fixes #28645

## How to Validate

```bash
npm test --workspace @google/gemini-cli -- src/config/extensions/github.test.ts
npm run typecheck --workspace @google/gemini-cli
npx eslint packages/cli/src/config/extensions/github.ts packages/cli/src/config/extensions/github.test.ts
npx prettier --check packages/cli/src/config/extensions/github.ts packages/cli/src/config/extensions/github.test.ts
npm run pre-commit
```

Expected results:

- All 38 extension GitHub tests pass, including stream-failure and redirect-security regressions.
- The CLI package build passes in the test post-step.
- TypeScript, ESLint, Prettier, and staged pre-commit checks pass.
- Successful transfers write only to `.downloading` until atomic publication.
- Request, response, and writer errors reject and trigger temporary-file cleanup without renaming the archive.

## Pre-Merge Checklist

- [x] Documentation is not required; this corrects internal download behavior without changing user-facing configuration.
- [x] Added regression tests for all reported failure sources.
- [x] No breaking changes.
- [x] Validated with npm on macOS.
