### PR TITLE
fix(cli): prevent malformed GitHub JSON from crashing extensions

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -151,6 +151,24 @@ describe('fetchJson', () => {
     ).resolves.toEqual({ permanent: true });
   });
 
+  it('should reject malformed redirect URLs with context', async () => {
+    const resume = vi.fn();
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 302;
+      res.headers = { location: 'https://[' };
+      res.resume = resume;
+      (callback as (res: IncomingMessage) => void)(res);
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://api.github.com/releases')).rejects.toThrow(
+      'Failed to parse redirect URL from https://api.github.com/releases',
+    );
+    expect(resume).toHaveBeenCalledOnce();
+    expect(getMock).toHaveBeenCalledOnce();
+  });
+
   it('should reject on non-200/30x status code', async () => {
     const resume = vi.fn();
     getMock.mockImplementationOnce((_url, _options, callback) => {

--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -56,6 +56,51 @@ describe('fetchJson', () => {
     });
   });
 
+  it('should reject malformed JSON with response context', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{"truncated":'));
+      res.emit('end');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://api.github.com/releases')).rejects.toThrow(
+      'Failed to parse GitHub response from https://api.github.com/releases (status 200)',
+    );
+  });
+
+  it('should reject response stream errors with response context', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{"partial":'));
+      res.emit('error', new Error('connection reset'));
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://api.github.com/releases')).rejects.toThrow(
+      'Failed to read GitHub response from https://api.github.com/releases (status 200): connection reset',
+    );
+  });
+
+  it('should reject aborted responses with response context', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{"partial":'));
+      res.emit('aborted');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://api.github.com/releases')).rejects.toThrow(
+      'GitHub response was aborted for https://api.github.com/releases (status 200)',
+    );
+  });
+
   it('should handle redirects (301 and 302)', async () => {
     // Test 302
     getMock.mockImplementationOnce((_url, _options, callback) => {
@@ -107,17 +152,19 @@ describe('fetchJson', () => {
   });
 
   it('should reject on non-200/30x status code', async () => {
+    const resume = vi.fn();
     getMock.mockImplementationOnce((_url, _options, callback) => {
       const res = new EventEmitter() as IncomingMessage;
       res.statusCode = 404;
+      res.resume = resume;
       (callback as (res: IncomingMessage) => void)(res);
-      res.emit('end');
       return new EventEmitter() as ClientRequest;
     });
 
     await expect(fetchJson('https://example.com/error')).rejects.toThrow(
       'Request failed with status code 404',
     );
+    expect(resume).toHaveBeenCalledOnce();
   });
 
   it('should reject on request error', async () => {
@@ -164,6 +211,37 @@ describe('fetchJson', () => {
       await expect(fetchJson('https://api.github.com/user')).resolves.toEqual({
         foo: 'bar',
       });
+    });
+
+    it('should strip Authorization on cross-origin redirects', async () => {
+      getMock.mockImplementationOnce((_url, options, callback) => {
+        expect(options.headers).toEqual({
+          'User-Agent': 'gemini-cli',
+          Authorization: 'token my-secret-token',
+        });
+        const res = new EventEmitter() as IncomingMessage;
+        res.statusCode = 302;
+        res.headers = { location: 'https://downloads.example.com/release' };
+        res.resume = vi.fn();
+        (callback as (res: IncomingMessage) => void)(res);
+        return new EventEmitter() as ClientRequest;
+      });
+      getMock.mockImplementationOnce((url, options, callback) => {
+        expect(url).toBe('https://downloads.example.com/release');
+        expect(options.headers).toEqual({
+          'User-Agent': 'gemini-cli',
+        });
+        const res = new EventEmitter() as IncomingMessage;
+        res.statusCode = 200;
+        (callback as (res: IncomingMessage) => void)(res);
+        res.emit('data', Buffer.from('{"redirected": true}'));
+        res.emit('end');
+        return new EventEmitter() as ClientRequest;
+      });
+
+      await expect(
+        fetchJson('https://api.github.com/releases'),
+      ).resolves.toEqual({ redirected: true });
     });
   });
 

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -14,26 +14,45 @@ export async function fetchJson<T>(
   url: string,
   redirectCount: number = 0,
 ): Promise<T> {
-  const headers: { 'User-Agent': string; Authorization?: string } = {
+  const headers: Record<string, string> = {
     'User-Agent': 'gemini-cli',
   };
   const token = getGitHubToken();
   if (token) {
-    headers.Authorization = `token ${token}`;
+    headers['Authorization'] = `token ${token}`;
   }
+  return fetchJsonResponse<T>(url, headers, redirectCount);
+}
+
+function fetchJsonResponse<T>(
+  url: string,
+  headers: Record<string, string>,
+  redirectCount: number,
+): Promise<T> {
   return new Promise((resolve, reject) => {
     https
       .get(url, { headers }, (res) => {
         if (res.statusCode === 302 || res.statusCode === 301) {
+          drainResponse(res);
           if (redirectCount >= 10) {
             return reject(new Error('Too many redirects'));
           }
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          res.resume();
-          fetchJson<T>(
-            new URL(res.headers.location, url).toString(),
+          const currentUrl = new URL(url);
+          const redirectUrl = new URL(res.headers.location, currentUrl);
+          const redirectHeaders = { ...headers };
+          if (currentUrl.origin !== redirectUrl.origin) {
+            for (const header of Object.keys(redirectHeaders)) {
+              if (header.toLowerCase() === 'authorization') {
+                delete redirectHeaders[header];
+              }
+            }
+          }
+          fetchJsonResponse<T>(
+            redirectUrl.toString(),
+            redirectHeaders,
             redirectCount + 1,
           )
             .then(resolve)
@@ -41,18 +60,60 @@ export async function fetchJson<T>(
           return;
         }
         if (res.statusCode !== 200) {
+          drainResponse(res);
           return reject(
             new Error(`Request failed with status code ${res.statusCode}`),
           );
         }
+
         const chunks: Buffer[] = [];
-        res.on('data', (chunk) => chunks.push(chunk));
+        let settled = false;
+        res.on('data', (chunk: Buffer) => {
+          if (!settled) {
+            chunks.push(chunk);
+          }
+        });
+        res.once('error', (error) => {
+          if (settled) return;
+          settled = true;
+          reject(
+            new Error(
+              `Failed to read GitHub response from ${url} (status 200): ${error.message}`,
+              { cause: error },
+            ),
+          );
+        });
+        res.once('aborted', () => {
+          if (settled) return;
+          settled = true;
+          reject(
+            new Error(`GitHub response was aborted for ${url} (status 200)`),
+          );
+        });
         res.on('end', () => {
+          if (settled) return;
+          settled = true;
           const data = Buffer.concat(chunks).toString();
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          resolve(JSON.parse(data) as T);
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            resolve(JSON.parse(data) as T);
+          } catch (error) {
+            reject(
+              new Error(
+                `Failed to parse GitHub response from ${url} (status 200): ${error instanceof Error ? error.message : String(error)}`,
+                { cause: error },
+              ),
+            );
+          }
         });
       })
       .on('error', reject);
   });
+}
+
+function drainResponse(response: import('node:http').IncomingMessage): void {
+  // Drained responses can still fail mid-stream. Absorb that error because the
+  // caller has already received the status/redirect failure for this response.
+  response.on('error', () => undefined);
+  response.resume();
 }

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -40,8 +40,19 @@ function fetchJsonResponse<T>(
           if (!res.headers.location) {
             return reject(new Error('No location header in redirect response'));
           }
-          const currentUrl = new URL(url);
-          const redirectUrl = new URL(res.headers.location, currentUrl);
+          let currentUrl: URL;
+          let redirectUrl: URL;
+          try {
+            currentUrl = new URL(url);
+            redirectUrl = new URL(res.headers.location, currentUrl);
+          } catch (error) {
+            return reject(
+              new Error(
+                `Failed to parse redirect URL from ${url}: ${error instanceof Error ? error.message : String(error)}`,
+                { cause: error },
+              ),
+            );
+          }
           const redirectHeaders = { ...headers };
           if (currentUrl.origin !== redirectUrl.origin) {
             for (const header of Object.keys(redirectHeaders)) {


### PR DESCRIPTION
## Summary

Prevent malformed or truncated GitHub API responses from escaping `fetchJson()` as uncaught exceptions and crashing extension operations.

Previously, `JSON.parse()` ran inside an asynchronous `end` callback without error handling, and the response stream had no `error` or `aborted` listeners. A malformed HTTP 200 body could throw outside the promise contract, while a mid-response failure could become unhandled or leave the operation pending.

## Details

- Catch JSON parsing failures and reject `fetchJson()` with the request URL and HTTP status while preserving the original error as `cause`.
- Reject response-stream `error` events with URL/status context.
- Reject explicit `aborted` responses rather than waiting indefinitely or attempting to parse partial content.
- Guard response settlement so an `error`, `aborted`, or `end` sequence can resolve or reject only once.
- Stop collecting chunks after the response has settled.
- Drain redirect and non-success response bodies so their connections can be released.
- Install a defensive error listener on drained responses to avoid a late unhandled stream error after the caller has already received the status failure.
- Keep redirect handling within one internal request chain.
- Resolve relative redirect locations and strip all case variants of `Authorization` on cross-origin redirects, preventing GitHub token disclosure to redirect targets.
- Reject malformed redirect locations with source-URL context instead of allowing `URL` parsing errors to escape the asynchronous response callback.
- Preserve the existing public API, success behavior, redirect limit, and token handling for the initial request.

Tests add coverage for:

- malformed/truncated JSON returned with HTTP 200;
- response-stream errors after partial data;
- explicitly aborted responses;
- draining non-success responses;
- removing authorization from cross-origin redirects; and
- malformed redirect locations, including response draining and suppression of follow-up requests.

## Related Issues

Fixes #28646

## How to Validate

```bash
npm test --workspace @google/gemini-cli -- src/config/extensions/github_fetch.test.ts
npm test --workspace @google/gemini-cli -- src/config/extensions/github.test.ts src/config/extensions/github_fetch.test.ts
npm run typecheck --workspace @google/gemini-cli
npx eslint packages/cli/src/config/extensions/github_fetch.ts packages/cli/src/config/extensions/github_fetch.test.ts
npx prettier --check packages/cli/src/config/extensions/github_fetch.ts packages/cli/src/config/extensions/github_fetch.test.ts
npm run pre-commit
```

Expected results:

- All 13 focused `fetchJson()` tests pass.
- All 47 related GitHub extension tests pass.
- The CLI package builds successfully in the test post-step.
- TypeScript, ESLint, Prettier, and staged pre-commit checks pass.
- Malformed, errored, and aborted HTTP 200 responses reject with contextual errors instead of throwing or hanging.

## Pre-Merge Checklist

- [x] Documentation is not required; this preserves the public API and improves internal error handling.
- [x] Added focused regression tests for malformed and failed responses.
- [x] No breaking changes.
- [x] Validated with npm on macOS.
