### PR TITLE
fix(core): don't start voice recording before providers are ready

### DIFF
--- a/packages/core/src/voice/geminiLiveTranscriptionProvider.test.ts
+++ b/packages/core/src/voice/geminiLiveTranscriptionProvider.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import WebSocket from 'ws';
+import { GeminiLiveTranscriptionProvider } from './geminiLiveTranscriptionProvider.js';
+
+vi.mock('ws', () => {
+  const MockWebSocket = vi.fn();
+  Object.assign(MockWebSocket, { OPEN: 1 });
+  return { default: MockWebSocket };
+});
+
+describe('GeminiLiveTranscriptionProvider', () => {
+  function createMockSocket() {
+    const socket = Object.assign(new EventEmitter(), {
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+    });
+    vi.mocked(WebSocket).mockReturnValue(socket as unknown as WebSocket);
+    return socket;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should wait for setup completion after the socket opens', async () => {
+    vi.useFakeTimers();
+    const socket = createMockSocket();
+    const provider = new GeminiLiveTranscriptionProvider('api-key');
+    let connected = false;
+    const connection = provider.connect().then(() => {
+      connected = true;
+    });
+
+    socket.emit('open');
+    await Promise.resolve();
+
+    expect(socket.send).toHaveBeenCalledOnce();
+    expect(JSON.parse(socket.send.mock.calls[0][0])).toMatchObject({
+      setup: {
+        model: 'models/gemini-3.1-flash-live-preview',
+        input_audio_transcription: {},
+      },
+    });
+    expect(connected).toBe(false);
+
+    socket.emit('message', Buffer.from('{"setupComplete":{}}'));
+    await connection;
+    expect(connected).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+
+  it('should reject if the socket closes before setup completes', async () => {
+    const socket = createMockSocket();
+    const provider = new GeminiLiveTranscriptionProvider('api-key');
+    const connection = provider.connect();
+
+    socket.emit('close', 1006, Buffer.from('connection lost'));
+
+    await expect(connection).rejects.toThrow(
+      'Gemini Live connection closed before setup completed (code 1006)',
+    );
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.listenerCount('open')).toBe(0);
+  });
+
+  it('should reject socket errors before setup completes', async () => {
+    const socket = createMockSocket();
+    const provider = new GeminiLiveTranscriptionProvider('api-key');
+    const emittedError = vi.fn();
+    provider.on('error', emittedError);
+    const connection = provider.connect();
+    const error = new Error('socket failed');
+
+    socket.emit('error', error);
+
+    await expect(connection).rejects.toBe(error);
+    expect(emittedError).toHaveBeenCalledWith(error);
+  });
+
+  it('should reject protocol errors received during setup', async () => {
+    const socket = createMockSocket();
+    const provider = new GeminiLiveTranscriptionProvider('api-key');
+    const emittedError = vi.fn();
+    provider.on('error', emittedError);
+    const connection = provider.connect();
+
+    socket.emit('open');
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify({
+          error: {
+            code: 400,
+            message: 'Invalid setup',
+            status: 'INVALID_ARGUMENT',
+          },
+        }),
+      ),
+    );
+
+    await expect(connection).rejects.toThrow('Invalid setup');
+    expect(emittedError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Invalid setup' }),
+    );
+    expect(socket.close).toHaveBeenCalledOnce();
+  });
+
+  it('should reject and close the socket when setup times out', async () => {
+    vi.useFakeTimers();
+    const socket = createMockSocket();
+    const provider = new GeminiLiveTranscriptionProvider('api-key');
+    const connection = provider.connect();
+    const connectionError = connection.catch((error: unknown) => error);
+
+    socket.emit('open');
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(await connectionError).toEqual(
+      expect.objectContaining({
+        message: 'Gemini Live setup did not complete within 10 seconds',
+      }),
+    );
+    expect(socket.close).toHaveBeenCalledOnce();
+    expect(socket.listenerCount('open')).toBe(0);
+  });
+});

--- a/packages/core/src/voice/geminiLiveTranscriptionProvider.ts
+++ b/packages/core/src/voice/geminiLiveTranscriptionProvider.ts
@@ -94,6 +94,7 @@ export class GeminiLiveTranscriptionProvider
       });
       const socket = this.ws;
       let isSettled = false;
+      let connectionTimeout: NodeJS.Timeout | undefined = undefined;
       let resolveConnection: () => void = () => {};
       let rejectConnection: (error: Error) => void = () => {};
       let handleOpen: () => void = () => {};
@@ -210,7 +211,7 @@ export class GeminiLiveTranscriptionProvider
       };
       socket.once('open', handleOpen);
 
-      const connectionTimeout = setTimeout(() => {
+      connectionTimeout = setTimeout(() => {
         const error = new Error(
           `Gemini Live setup did not complete within ${CONNECTION_TIMEOUT_MS / 1000} seconds`,
         );

--- a/packages/core/src/voice/geminiLiveTranscriptionProvider.ts
+++ b/packages/core/src/voice/geminiLiveTranscriptionProvider.ts
@@ -5,7 +5,7 @@
  */
 
 import WebSocket from 'ws';
-import { EventEmitter, once } from 'node:events';
+import { EventEmitter } from 'node:events';
 import { debugLogger } from '../utils/debugLogger.js';
 import type {
   TranscriptionProvider,
@@ -16,6 +16,14 @@ import { z } from 'zod';
 
 const LiveAPIResponseSchema = z.object({
   setupComplete: z.record(z.unknown()).optional(),
+  error: z
+    .object({
+      code: z.number().optional(),
+      message: z.string().optional(),
+      status: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
   serverContent: z
     .object({
       turnComplete: z.boolean().optional(),
@@ -48,6 +56,8 @@ const LiveAPIResponseSchema = z.object({
     })
     .optional(),
 });
+
+const CONNECTION_TIMEOUT_MS = 10_000;
 
 /**
  * Connects to the Gemini Live API using raw WebSockets to support API Key authentication.
@@ -82,14 +92,56 @@ export class GeminiLiveTranscriptionProvider
       this.ws = new WebSocket(url, {
         maxPayload: 1 << 20, // 1MB limit for safety
       });
+      const socket = this.ws;
+      let isSettled = false;
+      let resolveConnection: () => void = () => {};
+      let rejectConnection: (error: Error) => void = () => {};
+      let handleOpen: () => void = () => {};
+      const connectionReady = new Promise<void>((resolve, reject) => {
+        resolveConnection = resolve;
+        rejectConnection = reject;
+      });
 
-      this.ws.on('message', (data) => {
+      const settleConnection = (error?: Error) => {
+        if (isSettled) return;
+        isSettled = true;
+        if (connectionTimeout) {
+          clearTimeout(connectionTimeout);
+        }
+        socket.off('open', handleOpen);
+        if (error) {
+          rejectConnection(error);
+        } else {
+          resolveConnection();
+        }
+      };
+
+      socket.on('message', (data) => {
         try {
           const parsedData: unknown = JSON.parse(data.toString());
           const result = LiveAPIResponseSchema.safeParse(parsedData);
 
           if (result.success) {
             const response = result.data;
+            if (response.error) {
+              const error = new Error(
+                response.error.message ??
+                  response.error.status ??
+                  `Gemini Live setup failed${response.error.code ? ` with code ${response.error.code}` : ''}`,
+              );
+              settleConnection(error);
+              socket.close();
+              this.emit('error', error);
+              return;
+            }
+
+            if (response.setupComplete) {
+              debugLogger.debug(
+                '[GeminiLiveTranscription] Setup complete; ready for audio',
+              );
+              settleConnection();
+            }
+
             if (response.serverContent) {
               const content = response.serverContent;
 
@@ -115,20 +167,26 @@ export class GeminiLiveTranscriptionProvider
         }
       });
 
-      this.ws.on('error', (error) => {
+      socket.on('error', (error) => {
         debugLogger.error('[GeminiLiveTranscription] WebSocket Error:', error);
+        settleConnection(error);
         this.emit('error', error);
       });
 
-      this.ws.on('close', (code, reason) => {
+      socket.on('close', (code, reason) => {
         debugLogger.debug(
           `[GeminiLiveTranscription] Connection Closed. Code: ${code}, Reason: ${reason}`,
         );
+        if (this.ws === socket) {
+          this.ws = null;
+        }
+        settleConnection(
+          new Error(
+            `Gemini Live connection closed before setup completed (code ${code})`,
+          ),
+        );
         this.emit('close');
-        this.ws = null;
       });
-
-      await once(this.ws, 'open');
 
       const setupMessage = {
         setup: {
@@ -140,7 +198,27 @@ export class GeminiLiveTranscriptionProvider
         },
       };
 
-      this.ws.send(JSON.stringify(setupMessage));
+      handleOpen = () => {
+        try {
+          socket.send(JSON.stringify(setupMessage));
+        } catch (error) {
+          settleConnection(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+          socket.close();
+        }
+      };
+      socket.once('open', handleOpen);
+
+      const connectionTimeout = setTimeout(() => {
+        const error = new Error(
+          `Gemini Live setup did not complete within ${CONNECTION_TIMEOUT_MS / 1000} seconds`,
+        );
+        settleConnection(error);
+        socket.close();
+      }, CONNECTION_TIMEOUT_MS);
+
+      await connectionReady;
       this.currentTranscription = '';
     } catch (err) {
       debugLogger.error(

--- a/packages/core/src/voice/transcriptionProvider.ts
+++ b/packages/core/src/voice/transcriptionProvider.ts
@@ -22,7 +22,7 @@ export interface TranscriptionEvents {
  */
 export interface TranscriptionProvider
   extends EventEmitter<TranscriptionEvents> {
-  /** Establish connection to the transcription service. */
+  /** Establish a connection and resolve once the service can accept audio. */
   connect(): Promise<void>;
   /** Send a chunk of raw audio data to the service. */
   sendAudioChunk(chunk: Buffer): void;

--- a/packages/core/src/voice/whisperTranscriptionProvider.test.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.test.ts
@@ -4,17 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WhisperTranscriptionProvider } from './whisperTranscriptionProvider.js';
 import commandExists from 'command-exists';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
 vi.mock('command-exists', () => ({
   default: vi.fn(),
 }));
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
 
 describe('WhisperTranscriptionProvider', () => {
+  function createMockProcess() {
+    const process = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: vi.fn(),
+    }) as unknown as ChildProcessWithoutNullStreams;
+    vi.mocked(spawn).mockReturnValue(process);
+    return process;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(commandExists).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should throw a friendly error if whisper-stream is not available', async () => {
@@ -27,5 +49,81 @@ describe('WhisperTranscriptionProvider', () => {
     await expect(provider.connect()).rejects.toThrow(
       'The `whisper-stream` command is required for local voice mode. Please install it (e.g., `brew install whisper-cpp` on macOS).',
     );
+  });
+
+  it('should resolve only after whisper-stream reports readiness', async () => {
+    vi.useFakeTimers();
+    const process = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    let connected = false;
+
+    const connection = provider.connect().then(() => {
+      connected = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connected).toBe(false);
+
+    process.stderr.emit(
+      'data',
+      Buffer.from('main: processing, press Ctrl+C to stop'),
+    );
+    await connection;
+    expect(connected).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
+  it('should reject if whisper-stream closes before becoming ready', async () => {
+    const process = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const connection = provider.connect();
+    await vi.waitUntil(() => vi.mocked(spawn).mock.calls.length > 0);
+
+    process.emit('close', 1);
+
+    await expect(connection).rejects.toThrow(
+      'whisper-stream exited before becoming ready (code 1)',
+    );
+  });
+
+  it('should reject process errors before readiness', async () => {
+    const process = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const emittedError = vi.fn();
+    provider.on('error', emittedError);
+    const connection = provider.connect();
+    await vi.waitUntil(() => vi.mocked(spawn).mock.calls.length > 0);
+    const error = new Error('spawn failed');
+
+    process.emit('error', error);
+
+    await expect(connection).rejects.toBe(error);
+    expect(emittedError).toHaveBeenCalledWith(error);
+  });
+
+  it('should reject and stop whisper-stream when readiness times out', async () => {
+    vi.useFakeTimers();
+    const process = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const connection = provider.connect();
+    const connectionError = connection.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(await connectionError).toEqual(
+      expect.objectContaining({
+        message: 'whisper-stream did not become ready within 10 seconds',
+      }),
+    );
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM');
   });
 });

--- a/packages/core/src/voice/whisperTranscriptionProvider.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.ts
@@ -20,6 +20,8 @@ export interface WhisperProviderOptions {
   length?: number;
 }
 
+const CONNECTION_TIMEOUT_MS = 10_000;
+
 /**
  * Local transcription provider using `whisper-stream` from whisper.cpp.
  *
@@ -68,7 +70,21 @@ export class WhisperTranscriptionProvider
     );
 
     return new Promise((resolve, reject) => {
-      let isResolved = false;
+      let isSettled = false;
+      let connectionTimeout: NodeJS.Timeout | undefined;
+
+      const settleConnection = (error?: Error) => {
+        if (isSettled) return;
+        isSettled = true;
+        if (connectionTimeout) {
+          clearTimeout(connectionTimeout);
+        }
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
 
       try {
         // whisper-stream -m <model_path> -t <threads> --step 0 --length <length> -vth 0.6
@@ -96,57 +112,52 @@ export class WhisperTranscriptionProvider
           const msg = data.toString();
           if (msg.includes('error')) {
             debugLogger.error(`[WhisperTranscription] stderr: ${msg}`);
-            if (!isResolved) {
-              isResolved = true;
-              reject(new Error(msg));
+            if (!isSettled) {
+              settleConnection(new Error(msg));
             }
           }
 
           // whisper-stream prints "whisper_init_from_file_with_params_no_state: loading model from..."
           // and finally "main: processing, press Ctrl+C to stop" when ready.
-          if (!isResolved && msg.includes('main: processing')) {
+          if (!isSettled && msg.includes('main: processing')) {
             debugLogger.debug('[WhisperTranscription] whisper-stream is ready');
-            isResolved = true;
-            resolve();
+            settleConnection();
           }
         });
 
         this.process.on('error', (err) => {
           debugLogger.error('[WhisperTranscription] Process error:', err);
+          settleConnection(err);
           this.emit('error', err);
-          if (!isResolved) {
-            isResolved = true;
-            reject(err);
-          }
         });
 
         this.process.on('close', (code) => {
           debugLogger.debug(
             `[WhisperTranscription] Process closed with code ${code}`,
           );
-          this.emit('close');
           this.process = null;
+          settleConnection(
+            new Error(
+              `whisper-stream exited before becoming ready (code ${code ?? 'unknown'})`,
+            ),
+          );
+          this.emit('close');
         });
 
-        // Fallback timeout in case "main: processing" is never seen
-        setTimeout(() => {
-          if (!isResolved) {
-            debugLogger.warn(
-              '[WhisperTranscription] Connection timeout (fallback resolve)',
-            );
-            isResolved = true;
-            resolve();
-          }
-        }, 10000);
+        connectionTimeout = setTimeout(() => {
+          const error = new Error(
+            `whisper-stream did not become ready within ${CONNECTION_TIMEOUT_MS / 1000} seconds`,
+          );
+          debugLogger.warn(`[WhisperTranscription] ${error.message}`);
+          settleConnection(error);
+          this.process?.kill('SIGTERM');
+        }, CONNECTION_TIMEOUT_MS);
       } catch (err) {
         debugLogger.error(
           '[WhisperTranscription] Failed to spawn process:',
           err,
         );
-        if (!isResolved) {
-          isResolved = true;
-          reject(err);
-        }
+        settleConnection(err instanceof Error ? err : new Error(String(err)));
       }
     });
   }


### PR DESCRIPTION
## Summary

Make `TranscriptionProvider.connect()` resolve only when the selected backend is actually ready to accept audio, preventing the voice hook from starting recording against a dead Whisper process or a Gemini Live socket whose protocol setup is incomplete.

Previously:

- Whisper resolved after a ten-second fallback even when readiness was never observed, and an early process close left the connection pending until that false success.
- Gemini Live resolved immediately after WebSocket `open` and setup-message send, without waiting for the server's `setupComplete` acknowledgement.

## Details

### Shared contract

- Clarify that `connect()` resolves only once the provider can accept audio.

### Local Whisper

- Resolve only after the `main: processing` readiness marker.
- Reject if `whisper-stream` closes before readiness, including its exit code in the error.
- Reject process errors before readiness while preserving the provider error event.
- Replace the fallback success with a ten-second readiness timeout rejection.
- Stop the child process after a readiness timeout.
- Clear the readiness timer after every success or failure settlement.
- Settle the connection before emitting lifecycle events, so consumer event handlers cannot leave the promise pending.

### Gemini Live

- Treat WebSocket `open` as transport readiness only and send the setup request at that point.
- Resolve `connect()` only after a valid `setupComplete` protocol message.
- Parse structured API error responses and reject setup with the server message/status/code.
- Reject socket errors and pre-setup closes.
- Reject and close the socket when setup is not acknowledged within ten seconds.
- Clear the timeout and pending `open` listener on every terminal path.
- Keep the established message listener for transcription and turn-complete events after readiness.
- Avoid an older socket's close event clearing a newer provider connection.

Dedicated lifecycle tests cover:

- Whisper readiness, early close, process error, and timeout;
- Whisper timer cancellation after successful readiness;
- Gemini transport open remaining pending until setup acknowledgement;
- Gemini setup acknowledgement, protocol rejection, socket error, early close, and timeout;
- Gemini timer cancellation after successful setup; and
- removal of a pending `open` listener after pre-open failure.

## Related Issues

Fixes #28647

## How to Validate

```bash
npm test --workspace @google/gemini-cli-core -- src/voice/whisperTranscriptionProvider.test.ts src/voice/geminiLiveTranscriptionProvider.test.ts
npm test --workspace @google/gemini-cli-core -- src/voice
npm run typecheck --workspace @google/gemini-cli-core
npx eslint packages/core/src/voice/transcriptionProvider.ts packages/core/src/voice/whisperTranscriptionProvider.ts packages/core/src/voice/whisperTranscriptionProvider.test.ts packages/core/src/voice/geminiLiveTranscriptionProvider.ts packages/core/src/voice/geminiLiveTranscriptionProvider.test.ts
npx prettier --check packages/core/src/voice/*.ts
npm run pre-commit
```

Expected results:

- All 10 provider lifecycle tests pass.
- All 47 voice tests pass.
- The core package builds successfully in the test post-step.
- TypeScript, ESLint, Prettier, and staged pre-commit checks pass.
- Neither provider resolves before its backend-specific readiness signal.
- Early close/error and readiness timeout reject without a later fallback resolution.

## Pre-Merge Checklist

- [x] Updated the provider contract documentation.
- [x] Added dedicated lifecycle regression tests for both providers.
- [x] No breaking API changes; `connect()` now fulfills its intended readiness semantics.
- [x] Validated with npm on macOS.
