### PR TITLE
fix(core): make Whisper output parsing chunk-boundary safe

### DIFF
--- a/packages/core/src/voice/whisperTranscriptionProvider.test.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.test.ts
@@ -4,17 +4,55 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WhisperTranscriptionProvider } from './whisperTranscriptionProvider.js';
 import commandExists from 'command-exists';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
 vi.mock('command-exists', () => ({
   default: vi.fn(),
 }));
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
 
 describe('WhisperTranscriptionProvider', () => {
+  function createMockProcess() {
+    const process = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: vi.fn(),
+    }) as unknown as ChildProcessWithoutNullStreams;
+    vi.mocked(spawn).mockReturnValue(process);
+    return process;
+  }
+
+  async function connectProvider() {
+    const process = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const connection = provider.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    process.stderr.emit(
+      'data',
+      Buffer.from('main: processing, press Ctrl+C to stop'),
+    );
+    await connection;
+    return { process, provider };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(commandExists).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should throw a friendly error if whisper-stream is not available', async () => {
@@ -27,5 +65,85 @@ describe('WhisperTranscriptionProvider', () => {
     await expect(provider.connect()).rejects.toThrow(
       'The `whisper-stream` command is required for local voice mode. Please install it (e.g., `brew install whisper-cpp` on macOS).',
     );
+  });
+
+  it('should preserve a timestamped record split across stdout chunks', async () => {
+    const { process, provider } = await connectProvider();
+    const transcription = vi.fn();
+    provider.on('transcription', transcription);
+
+    process.stdout.emit('data', Buffer.from('[00:00:00.000 --> 00:00:'));
+    expect(transcription).not.toHaveBeenCalled();
+
+    process.stdout.emit('data', Buffer.from('02.000] Hello world.\n'));
+
+    expect(transcription).toHaveBeenCalledOnce();
+    expect(transcription).toHaveBeenCalledWith('Hello world.');
+    expect(provider.getTranscription()).toBe('Hello world.');
+  });
+
+  it('should preserve transcribed text split across stdout chunks', async () => {
+    const { process, provider } = await connectProvider();
+    const transcription = vi.fn();
+    provider.on('transcription', transcription);
+
+    process.stdout.emit(
+      'data',
+      Buffer.from('[00:00:00.000 --> 00:00:02.000] Hello'),
+    );
+    process.stdout.emit('data', Buffer.from(' world.\n'));
+
+    expect(transcription).toHaveBeenCalledWith('Hello world.');
+  });
+
+  it('should parse complete records while buffering the final partial record', async () => {
+    const { process, provider } = await connectProvider();
+    const transcription = vi.fn();
+    provider.on('transcription', transcription);
+
+    process.stdout.emit(
+      'data',
+      Buffer.from(
+        '[00:00:00.000 --> 00:00:01.000] First.\n[00:00:01.000 --> 00:00:02.000] Sec',
+      ),
+    );
+    expect(transcription).toHaveBeenLastCalledWith('First.');
+
+    process.stdout.emit('data', Buffer.from('ond.\n'));
+
+    expect(transcription).toHaveBeenLastCalledWith('First. Second.');
+    expect(transcription).toHaveBeenCalledTimes(2);
+  });
+
+  it('should preserve UTF-8 characters split across byte chunks', async () => {
+    const { process, provider } = await connectProvider();
+    const transcription = vi.fn();
+    provider.on('transcription', transcription);
+    const output = Buffer.from(
+      '[00:00:00.000 --> 00:00:02.000] Un café.\n',
+      'utf8',
+    );
+    const splitAt = output.indexOf(Buffer.from('é')) + 1;
+
+    process.stdout.emit('data', output.subarray(0, splitAt));
+    process.stdout.emit('data', output.subarray(splitAt));
+
+    expect(transcription).toHaveBeenCalledWith('Un café.');
+  });
+
+  it('should flush a final unterminated record when the process closes', async () => {
+    const { process, provider } = await connectProvider();
+    const transcription = vi.fn();
+    provider.on('transcription', transcription);
+
+    process.stdout.emit(
+      'data',
+      Buffer.from('[00:00:00.000 --> 00:00:02.000] Final words.'),
+    );
+    expect(transcription).not.toHaveBeenCalled();
+
+    process.emit('close', 0);
+
+    expect(transcription).toHaveBeenCalledWith('Final words.');
   });
 });

--- a/packages/core/src/voice/whisperTranscriptionProvider.test.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.test.ts
@@ -146,4 +146,44 @@ describe('WhisperTranscriptionProvider', () => {
 
     expect(transcription).toHaveBeenCalledWith('Final words.');
   });
+
+  it('should ignore late data and close events from a replaced process', async () => {
+    const firstProcess = createMockProcess();
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const transcription = vi.fn();
+    const closed = vi.fn();
+    provider.on('transcription', transcription);
+    provider.on('close', closed);
+    const firstConnection = provider.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    firstProcess.stderr.emit('data', Buffer.from('main: processing'));
+    await firstConnection;
+    firstProcess.stdout.emit(
+      'data',
+      Buffer.from('[00:00:00.000 --> 00:00:01.000] Stale'),
+    );
+
+    provider.disconnect();
+    const secondProcess = createMockProcess();
+    const secondConnection = provider.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    secondProcess.stderr.emit('data', Buffer.from('main: processing'));
+    await secondConnection;
+
+    firstProcess.stdout.emit('data', Buffer.from(' transcription.\n'));
+    firstProcess.emit('close', 0);
+    secondProcess.stdout.emit(
+      'data',
+      Buffer.from('[00:00:00.000 --> 00:00:01.000] Current.\n'),
+    );
+
+    expect(transcription).toHaveBeenCalledOnce();
+    expect(transcription).toHaveBeenCalledWith('Current.');
+    expect(closed).not.toHaveBeenCalled();
+
+    provider.disconnect();
+    expect(secondProcess.kill).toHaveBeenCalledWith('SIGTERM');
+  });
 });

--- a/packages/core/src/voice/whisperTranscriptionProvider.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.ts
@@ -6,6 +6,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { StringDecoder } from 'node:string_decoder';
 import commandExists from 'command-exists';
 import { debugLogger } from '../utils/debugLogger.js';
 import type {
@@ -32,6 +33,8 @@ export class WhisperTranscriptionProvider
 {
   private process: ChildProcessWithoutNullStreams | null = null;
   private currentTranscription = '';
+  private stdoutDecoder = new StringDecoder('utf8');
+  private pendingOutput = '';
 
   constructor(private readonly options: WhisperProviderOptions) {
     super();
@@ -53,6 +56,8 @@ export class WhisperTranscriptionProvider
     const { modelPath, threads = 4, step = 0, length = 5000 } = this.options;
 
     this.currentTranscription = '';
+    this.stdoutDecoder = new StringDecoder('utf8');
+    this.pendingOutput = '';
 
     const available = await WhisperTranscriptionProvider.isAvailable();
     if (!available) {
@@ -88,8 +93,7 @@ export class WhisperTranscriptionProvider
         ]);
 
         this.process.stdout.on('data', (data: Buffer) => {
-          const output = data.toString();
-          this.parseOutput(output);
+          this.consumeOutput(data);
         });
 
         this.process.stderr.on('data', (data: Buffer) => {
@@ -121,6 +125,7 @@ export class WhisperTranscriptionProvider
         });
 
         this.process.on('close', (code) => {
+          this.flushOutput();
           debugLogger.debug(
             `[WhisperTranscription] Process closed with code ${code}`,
           );
@@ -151,33 +156,47 @@ export class WhisperTranscriptionProvider
     });
   }
 
-  private parseOutput(output: string): void {
-    // whisper-stream output format: "[00:00:00.000 --> 00:00:02.000]   Hello world."
+  private consumeOutput(data: Buffer): void {
+    const output = this.pendingOutput + this.stdoutDecoder.write(data);
     const lines = output.split('\n');
+    this.pendingOutput = lines.pop() ?? '';
 
     for (const line of lines) {
-      const match = line.match(/\[.* --> .*\]\s+(.*)/);
-      if (match && match[1]) {
-        let text = match[1].trim();
+      this.parseOutputLine(line);
+    }
+  }
 
-        // Filter out [Silence], [music], (laughter), etc.
-        text = text
-          .replace(/\[[^\]]*\]/g, '')
-          .replace(/\([^)]*\)/g, '')
-          .trim();
+  private flushOutput(): void {
+    this.pendingOutput += this.stdoutDecoder.end();
+    if (this.pendingOutput) {
+      this.parseOutputLine(this.pendingOutput);
+    }
+    this.pendingOutput = '';
+  }
 
-        if (text) {
-          // In VAD mode (step=0), each line is a completed speech block.
-          // Append it to the buffer to ensure it doesn't disappear.
-          this.currentTranscription = this.currentTranscription
-            ? `${this.currentTranscription} ${text}`
-            : text;
+  private parseOutputLine(line: string): void {
+    // whisper-stream output format: "[00:00:00.000 --> 00:00:02.000]   Hello world."
+    const match = line.match(/\[.* --> .*\]\s+(.*)/);
+    if (match && match[1]) {
+      let text = match[1].trim();
 
-          debugLogger.debug(
-            `[WhisperTranscription] Transcription updated (Local-VAD): "${this.currentTranscription}"`,
-          );
-          this.emit('transcription', this.currentTranscription);
-        }
+      // Filter out [Silence], [music], (laughter), etc.
+      text = text
+        .replace(/\[[^\]]*\]/g, '')
+        .replace(/\([^)]*\)/g, '')
+        .trim();
+
+      if (text) {
+        // In VAD mode (step=0), each line is a completed speech block.
+        // Append it to the buffer to ensure it doesn't disappear.
+        this.currentTranscription = this.currentTranscription
+          ? `${this.currentTranscription} ${text}`
+          : text;
+
+        debugLogger.debug(
+          `[WhisperTranscription] Transcription updated (Local-VAD): "${this.currentTranscription}"`,
+        );
+        this.emit('transcription', this.currentTranscription);
       }
     }
   }

--- a/packages/core/src/voice/whisperTranscriptionProvider.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.ts
@@ -79,7 +79,7 @@ export class WhisperTranscriptionProvider
         // whisper-stream -m <model_path> -t <threads> --step 0 --length <length> -vth 0.6
         // Setting step == 0 enables sliding window mode with VAD, which outputs
         // non-overlapping transcription blocks suitable for appending.
-        this.process = spawn('whisper-stream', [
+        const proc = spawn('whisper-stream', [
           '-m',
           modelPath,
           '-t',
@@ -91,12 +91,16 @@ export class WhisperTranscriptionProvider
           '-vth',
           '0.6',
         ]);
+        this.process = proc;
 
-        this.process.stdout.on('data', (data: Buffer) => {
-          this.consumeOutput(data);
+        proc.stdout.on('data', (data: Buffer) => {
+          if (this.process === proc) {
+            this.consumeOutput(data);
+          }
         });
 
-        this.process.stderr.on('data', (data: Buffer) => {
+        proc.stderr.on('data', (data: Buffer) => {
+          if (this.process !== proc) return;
           const msg = data.toString();
           if (msg.includes('error')) {
             debugLogger.error(`[WhisperTranscription] stderr: ${msg}`);
@@ -115,7 +119,8 @@ export class WhisperTranscriptionProvider
           }
         });
 
-        this.process.on('error', (err) => {
+        proc.on('error', (err) => {
+          if (this.process !== proc) return;
           debugLogger.error('[WhisperTranscription] Process error:', err);
           this.emit('error', err);
           if (!isResolved) {
@@ -124,13 +129,14 @@ export class WhisperTranscriptionProvider
           }
         });
 
-        this.process.on('close', (code) => {
+        proc.on('close', (code) => {
+          if (this.process !== proc) return;
           this.flushOutput();
           debugLogger.debug(
             `[WhisperTranscription] Process closed with code ${code}`,
           );
-          this.emit('close');
           this.process = null;
+          this.emit('close');
         });
 
         // Fallback timeout in case "main: processing" is never seen


### PR DESCRIPTION
## Summary

Make local Whisper transcription parsing independent of arbitrary Node.js stdout chunk boundaries, preventing timestamped records, words, and multibyte characters from being silently dropped or corrupted.

Previously, every `data` event was converted independently to a string and split into lines. A valid record divided between two OS-level chunks could not match the timestamp pattern in either call, and decoding each chunk independently could replace a UTF-8 character split between bytes.

## Details

- Decode stdout with Node's `StringDecoder`, preserving incomplete UTF-8 byte sequences between chunks.
- Keep a pending text buffer across `data` events.
- Parse only newline-terminated records during normal streaming.
- Retain the final incomplete segment for the next stdout chunk.
- Flush the decoder and parse a final valid unterminated record when `whisper-stream` closes.
- Reset both decoder and pending-record state for every new connection.
- Bind stream and lifecycle callbacks to the child process that created them, ignoring late events after disconnect or reconnect.
- Clear the active process reference before emitting `close`, preventing a synchronous reconnect from being overwritten.
- Keep the existing timestamp parsing, annotation filtering, cumulative transcription, and event behavior unchanged for complete records.

Regression tests cover:

- the exact timestamp split reported in #28648;
- a split inside transcribed text;
- complete and partial records arriving in the same chunk;
- a split between the two bytes of a UTF-8 `é`;
- a final valid record without a trailing newline, flushed on process close; and
- late stdout and close events from a replaced child, including verification that the replacement process remains active and killable.

## Related Issues

Fixes #28648

## How to Validate

```bash
npm test --workspace @google/gemini-cli-core -- src/voice/whisperTranscriptionProvider.test.ts
npm test --workspace @google/gemini-cli-core -- src/voice
npm run typecheck --workspace @google/gemini-cli-core
npx eslint packages/core/src/voice/whisperTranscriptionProvider.ts packages/core/src/voice/whisperTranscriptionProvider.test.ts
npx prettier --check packages/core/src/voice/whisperTranscriptionProvider.ts packages/core/src/voice/whisperTranscriptionProvider.test.ts
npm run pre-commit
```

Expected results:

- All 7 dedicated Whisper provider tests pass.
- All 44 current voice tests pass.
- The core package builds successfully in the test post-step.
- TypeScript, ESLint, Prettier, and staged pre-commit checks pass.
- Each valid logical record produces the same transcription regardless of chunk or UTF-8 byte boundaries.

## Pre-Merge Checklist

- [x] Documentation is not required; this preserves the public API and corrects internal stream parsing.
- [x] Added regression tests for record and byte boundary splits.
- [x] No breaking changes.
- [x] Validated with npm on macOS.
