### PR TITLE
fix(sdk): keep sendStream alive on malformed tool arguments

### DIFF
--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -22,6 +22,12 @@ const mockClient = {
   updateSystemInstruction: vi.fn(),
 };
 
+const mockToolRegistry = {
+  clone: vi.fn(() => ({
+    getTool: vi.fn().mockReturnValue(null),
+  })),
+};
+
 // Mutable mock config so individual tests can spy on setUserMemory etc.
 const mockConfig = {
   initialize: vi.fn().mockResolvedValue(undefined),
@@ -38,6 +44,7 @@ const mockConfig = {
   getMessageBus: vi.fn().mockReturnValue({}),
   getGeminiClient: vi.fn().mockReturnValue(mockClient),
   geminiClient: mockClient,
+  toolRegistry: mockToolRegistry,
   getSessionId: vi.fn().mockReturnValue('mock-session-id'),
   getWorkingDir: vi.fn().mockReturnValue('/tmp'),
   setUserMemory: vi.fn(),
@@ -251,6 +258,48 @@ describe('GeminiCliSession malformed tool arguments', () => {
       ]);
     },
   );
+
+  it('returns a fallback response when a scheduled call has no result', async () => {
+    const { GeminiEventType } = await import('@google/gemini-cli-core');
+    let callCount = 0;
+    mockClient.sendMessageStream.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return (async function* () {
+          yield {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'missing-result-call',
+              name: '   ',
+              args: {},
+            },
+          } as unknown as ServerGeminiStreamEvent;
+        })();
+      }
+      return (async function* () {})();
+    });
+
+    const session = new GeminiCliSession(
+      baseOptions,
+      'session-missing-result',
+      mockAgent,
+    );
+    for await (const _event of session.sendStream('Use the tool')) {
+      // Consume the stream.
+    }
+
+    expect(mockScheduleAgentTools).toHaveBeenCalledOnce();
+    expect(mockClient.sendMessageStream).toHaveBeenCalledTimes(2);
+    expect(mockClient.sendMessageStream.mock.calls[1]?.[0]).toEqual([
+      {
+        functionResponse: {
+          id: 'missing-result-call',
+          name: 'generic_tool',
+          response: { error: 'Tool execution failed to complete.' },
+        },
+      },
+    ]);
+  });
 });
 
 // TODO(#24999): Update the remaining sendStream mocks and re-enable this suite.

--- a/packages/sdk/src/session.test.ts
+++ b/packages/sdk/src/session.test.ts
@@ -7,12 +7,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GeminiCliSession } from './session.js';
 import type { GeminiCliAgent } from './agent.js';
 import type { GeminiCliAgentOptions } from './types.js';
+import type { ServerGeminiStreamEvent } from '@google/gemini-cli-core';
 
 // Mutable mock client so individual tests can override sendMessageStream
 const mockClient = {
   resumeChat: vi.fn().mockResolvedValue(undefined),
   getHistory: vi.fn().mockReturnValue([]),
-  sendMessageStream: vi.fn().mockReturnValue((async function* () {})()),
+  sendMessageStream: vi
+    .fn(
+      (..._args: unknown[]): AsyncGenerator<ServerGeminiStreamEvent> =>
+        (async function* () {})(),
+    )
+    .mockReturnValue((async function* () {})()),
   updateSystemInstruction: vi.fn(),
 };
 
@@ -31,6 +37,7 @@ const mockConfig = {
   }),
   getMessageBus: vi.fn().mockReturnValue({}),
   getGeminiClient: vi.fn().mockReturnValue(mockClient),
+  geminiClient: mockClient,
   getSessionId: vi.fn().mockReturnValue('mock-session-id'),
   getWorkingDir: vi.fn().mockReturnValue('/tmp'),
   setUserMemory: vi.fn(),
@@ -181,7 +188,72 @@ describe('GeminiCliSession initialize()', () => {
   });
 });
 
-// TODO(#24999): Mock uses getGeminiClient() method but session.ts expects geminiClient property.
+describe('GeminiCliSession malformed tool arguments', () => {
+  it.each([
+    {
+      args: '{"unterminated":',
+      expectedError: 'Failed to parse JSON arguments for tool "testTool"',
+    },
+    {
+      args: '[]',
+      expectedError:
+        'Invalid arguments for tool "testTool": expected a JSON object.',
+    },
+    {
+      args: 'null',
+      expectedError:
+        'Invalid arguments for tool "testTool": expected a JSON object.',
+    },
+  ])(
+    'returns a tool error and continues the loop for $args',
+    async ({ args, expectedError }) => {
+      const { GeminiEventType } = await import('@google/gemini-cli-core');
+      let callCount = 0;
+      mockClient.sendMessageStream.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return (async function* () {
+            yield {
+              type: GeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'malformed-call',
+                name: 'testTool',
+                args,
+              },
+            } as unknown as ServerGeminiStreamEvent;
+          })();
+        }
+        return (async function* () {})();
+      });
+
+      const session = new GeminiCliSession(
+        baseOptions,
+        'session-malformed-args',
+        mockAgent,
+      );
+      const events = [];
+      for await (const event of session.sendStream('Use the tool')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.type).toBe(GeminiEventType.ToolCallRequest);
+      expect(mockScheduleAgentTools).not.toHaveBeenCalled();
+      expect(mockClient.sendMessageStream).toHaveBeenCalledTimes(2);
+      expect(mockClient.sendMessageStream.mock.calls[1]?.[0]).toEqual([
+        {
+          functionResponse: {
+            id: 'malformed-call',
+            name: 'testTool',
+            response: { error: expect.stringContaining(expectedError) },
+          },
+        },
+      ]);
+    },
+  );
+});
+
+// TODO(#24999): Update the remaining sendStream mocks and re-enable this suite.
 describe.skip('GeminiCliSession sendStream()', () => {
   it('auto-initializes if not yet initialized', async () => {
     const session = new GeminiCliSession(
@@ -241,7 +313,7 @@ describe.skip('GeminiCliSession sendStream()', () => {
               name: 'testTool',
               args: { input: 'value' },
             },
-          };
+          } as unknown as ServerGeminiStreamEvent;
         })();
       }
       return (async function* () {})();

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -290,6 +290,7 @@ export class GeminiCliSession {
       const toolCallsToSchedule: ToolCallRequestInfo[] = [];
       const pendingToolResponses: Array<{
         callId: string;
+        name: string;
         errorResponse?: Part;
       }> = [];
 
@@ -297,6 +298,9 @@ export class GeminiCliSession {
         yield event;
         if (event.type === GeminiEventType.ToolCallRequest) {
           const toolCall = event.value;
+          const responseName = toolCall.name.trim()
+            ? toolCall.name
+            : 'generic_tool';
           const { args, error } = parseToolArguments(
             toolCall.name,
             toolCall.args,
@@ -304,10 +308,11 @@ export class GeminiCliSession {
           if (error) {
             pendingToolResponses.push({
               callId: toolCall.callId,
+              name: responseName,
               errorResponse: {
                 functionResponse: {
                   id: toolCall.callId,
-                  name: toolCall.name,
+                  name: responseName,
                   response: { error },
                 },
               },
@@ -320,7 +325,10 @@ export class GeminiCliSession {
             isClientInitiated: false,
             prompt_id: sessionId,
           });
-          pendingToolResponses.push({ callId: toolCall.callId });
+          pendingToolResponses.push({
+            callId: toolCall.callId,
+            name: responseName,
+          });
         }
       }
 
@@ -372,10 +380,18 @@ export class GeminiCliSession {
       }
 
       const functionResponses = pendingToolResponses.flatMap(
-        ({ callId, errorResponse }) =>
+        ({ callId, name, errorResponse }) =>
           errorResponse
             ? [errorResponse]
-            : (completedResponses.get(callId) ?? []),
+            : (completedResponses.get(callId) ?? [
+                {
+                  functionResponse: {
+                    id: callId,
+                    name,
+                    response: { error: 'Tool execution failed to complete.' },
+                  },
+                },
+              ]),
       );
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -15,6 +15,7 @@ import {
   type ServerGeminiStreamEvent,
   type GeminiClient,
   type Content,
+  type Part,
   scheduleAgentTools,
   getAuthTypeFromEnv,
   type ToolRegistry,
@@ -34,6 +35,47 @@ import type {
 } from './types.js';
 import type { SkillReference } from './skills.js';
 import type { GeminiCliAgent } from './agent.js';
+
+interface ParsedToolArguments {
+  args: Record<string, unknown>;
+  error?: string;
+}
+
+function parseToolArguments(
+  toolName: string,
+  rawArgs: unknown,
+): ParsedToolArguments {
+  if (rawArgs === undefined || rawArgs === null) {
+    return { args: {} };
+  }
+
+  let parsedArgs: unknown = rawArgs;
+
+  if (typeof rawArgs === 'string') {
+    try {
+      parsedArgs = JSON.parse(rawArgs) as unknown;
+    } catch {
+      return {
+        args: {},
+        error: `Failed to parse JSON arguments for tool "${toolName}": ${rawArgs}. Ensure you provide a valid JSON object.`,
+      };
+    }
+  }
+
+  if (
+    parsedArgs === null ||
+    typeof parsedArgs !== 'object' ||
+    Array.isArray(parsedArgs)
+  ) {
+    return {
+      args: {},
+      error: `Invalid arguments for tool "${toolName}": expected a JSON object.`,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return { args: parsedArgs as Record<string, unknown> };
+}
 
 /**
  * Represents an interactive conversation session with a Gemini CLI agent.
@@ -246,15 +288,31 @@ export class GeminiCliSession {
       const stream = client.sendMessageStream(request, abortSignal, sessionId);
 
       const toolCallsToSchedule: ToolCallRequestInfo[] = [];
+      const pendingToolResponses: Array<{
+        callId: string;
+        errorResponse?: Part;
+      }> = [];
 
       for await (const event of stream) {
         yield event;
         if (event.type === GeminiEventType.ToolCallRequest) {
           const toolCall = event.value;
-          let args = toolCall.args;
-          if (typeof args === 'string') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            args = JSON.parse(args);
+          const { args, error } = parseToolArguments(
+            toolCall.name,
+            toolCall.args,
+          );
+          if (error) {
+            pendingToolResponses.push({
+              callId: toolCall.callId,
+              errorResponse: {
+                functionResponse: {
+                  id: toolCall.callId,
+                  name: toolCall.name,
+                  response: { error },
+                },
+              },
+            });
+            continue;
           }
           toolCallsToSchedule.push({
             ...toolCall,
@@ -262,49 +320,62 @@ export class GeminiCliSession {
             isClientInitiated: false,
             prompt_id: sessionId,
           });
+          pendingToolResponses.push({ callId: toolCall.callId });
         }
       }
 
-      if (toolCallsToSchedule.length === 0) {
+      if (pendingToolResponses.length === 0) {
         break;
       }
 
-      const transcript: readonly Content[] = client.getHistory();
-      const context: SessionContext = {
-        sessionId,
-        transcript,
-        cwd: this.config.getWorkingDir(),
-        timestamp: new Date().toISOString(),
-        fs,
-        shell,
-        agent: this.agent,
-        session: this,
-      };
+      const completedResponses = new Map<string, Part[]>();
+      if (toolCallsToSchedule.length > 0) {
+        const transcript: readonly Content[] = client.getHistory();
+        const context: SessionContext = {
+          sessionId,
+          transcript,
+          cwd: this.config.getWorkingDir(),
+          timestamp: new Date().toISOString(),
+          fs,
+          shell,
+          agent: this.agent,
+          session: this,
+        };
 
-      const loopContext: AgentLoopContext = this.config;
-      const originalRegistry = loopContext.toolRegistry;
-      const scopedRegistry: ToolRegistry = originalRegistry.clone();
-      const originalGetTool = scopedRegistry.getTool.bind(scopedRegistry);
-      scopedRegistry.getTool = (name: string) => {
-        const tool = originalGetTool(name);
-        if (tool instanceof SdkTool) {
-          return tool.bindContext(context);
+        const loopContext: AgentLoopContext = this.config;
+        const originalRegistry = loopContext.toolRegistry;
+        const scopedRegistry: ToolRegistry = originalRegistry.clone();
+        const originalGetTool = scopedRegistry.getTool.bind(scopedRegistry);
+        scopedRegistry.getTool = (name: string) => {
+          const tool = originalGetTool(name);
+          if (tool instanceof SdkTool) {
+            return tool.bindContext(context);
+          }
+          return tool;
+        };
+
+        const completedCalls = await scheduleAgentTools(
+          this.config,
+          toolCallsToSchedule,
+          {
+            schedulerId: sessionId,
+            toolRegistry: scopedRegistry,
+            signal: abortSignal,
+          },
+        );
+        for (const call of completedCalls) {
+          completedResponses.set(
+            call.request.callId,
+            call.response.responseParts,
+          );
         }
-        return tool;
-      };
+      }
 
-      const completedCalls = await scheduleAgentTools(
-        this.config,
-        toolCallsToSchedule,
-        {
-          schedulerId: sessionId,
-          toolRegistry: scopedRegistry,
-          signal: abortSignal,
-        },
-      );
-
-      const functionResponses = completedCalls.flatMap(
-        (call) => call.response.responseParts,
+      const functionResponses = pendingToolResponses.flatMap(
+        ({ callId, errorResponse }) =>
+          errorResponse
+            ? [errorResponse]
+            : (completedResponses.get(callId) ?? []),
       );
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion


### PR DESCRIPTION
## Summary

- defensively parse string-valued SDK tool arguments instead of allowing `JSON.parse()` failures to escape from `sendStream()`
- validate that decoded arguments are JSON objects, rejecting arrays, primitives, and `null`
- turn invalid arguments into structured `functionResponse` errors so Gemini can correct or explain the failed call on the next turn
- keep malformed calls out of the tool scheduler while preserving the original tool-call event for SDK consumers
- preserve function-response ordering when a model turn contains both valid and malformed tool calls

## Problem

Tool-call arguments are model-generated input. Before this change, the SDK agent loop parsed string arguments with an unguarded `JSON.parse()`. A response such as:

```json
{"unterminated":
```

caused a raw `SyntaxError` after the `ToolCallRequest` event had already been yielded. That terminated the `sendStream()` generator and prevented the model from recovering.

Parsed values also were not checked for the object shape required by tool scheduling, so syntactically valid values such as `[]` or `null` could enter an invalid execution path.

## Implementation

`parseToolArguments()` now returns either validated `Record<string, unknown>` arguments or a contextual error. Invalid calls are converted to the same model-visible function-response shape used by the core executor:

```ts
{
  functionResponse: {
    id: toolCall.callId,
    name: toolCall.name,
    response: { error },
  },
}
```

The request event is still yielded to the SDK caller. The invalid call is not scheduled, and its error response is included in the next model request, allowing the agentic loop to continue normally.

## Tests

Added focused, non-skipped regression coverage for:

- malformed/truncated JSON
- JSON arrays
- JSON `null`
- preserving the yielded `ToolCallRequest`
- bypassing the scheduler for invalid calls
- feeding the structured error response into the next model turn

Validation performed:

- `npm test --workspace @google/gemini-cli-sdk` — 32 passed, 6 pre-existing skipped
- `npm run typecheck --workspace @google/gemini-cli-sdk`
- `npx eslint packages/sdk/src/session.ts packages/sdk/src/session.test.ts`
- `npx prettier --check packages/sdk/src/session.ts packages/sdk/src/session.test.ts`
- `git diff --check`

Closes #28649
