### PR TITLE
fix(core): honor model-config tools and system instructions

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1927,6 +1927,56 @@ describe('GeminiChat', () => {
       );
     });
 
+    it('should preserve system instruction and tools from resolved model config', async () => {
+      const configuredTools = [
+        { functionDeclarations: [{ name: 'configured_tool' }] },
+      ];
+      vi.mocked(
+        mockConfig.modelConfigService.getResolvedConfig,
+      ).mockReturnValue(
+        makeResolvedModelConfig('test-model', {
+          systemInstruction: 'Configured system instruction',
+          tools: configuredTools,
+        }),
+      );
+      chat.setSystemInstruction('Chat system instruction');
+      chat.setTools([{ functionDeclarations: [{ name: 'chat_tool' }] }]);
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: { parts: [{ text: 'response' }], role: 'model' },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'test-model' },
+        'hello',
+        'prompt-resolved-config',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            systemInstruction: 'Configured system instruction',
+            tools: configuredTools,
+          }),
+        }),
+        'prompt-resolved-config',
+        LlmRole.MAIN,
+      );
+    });
+
     it('should use thinkingLevel and remove thinkingBudget for gemini-3 models', async () => {
       const response = (async function* () {
         yield {
@@ -3514,19 +3564,41 @@ describe('GeminiChat', () => {
         activeModel = model;
       });
 
+      const modelATools = [
+        { functionDeclarations: [{ name: 'model_a_tool' }] },
+      ];
+      const modelBTools = [
+        { functionDeclarations: [{ name: 'model_b_tool' }] },
+      ];
+
       // Different configs per model
       vi.mocked(
         mockConfig.modelConfigService.getResolvedConfig,
       ).mockImplementation((key) => {
         if (key.model === 'model-a') {
-          return makeResolvedModelConfig('model-a', { temperature: 0.1 });
+          return makeResolvedModelConfig('model-a', {
+            temperature: 0.1,
+            systemInstruction: 'Model A instruction',
+            tools: modelATools,
+          });
         }
         if (key.model === 'model-b') {
-          return makeResolvedModelConfig('model-b', { temperature: 0.9 });
+          return makeResolvedModelConfig('model-b', {
+            temperature: 0.9,
+            systemInstruction: 'Model B instruction',
+            tools: modelBTools,
+          });
         }
         // Default for the initial requested model in this test
-        return makeResolvedModelConfig('model-a', { temperature: 0.1 });
+        return makeResolvedModelConfig('model-a', {
+          temperature: 0.1,
+          systemInstruction: 'Model A instruction',
+          tools: modelATools,
+        });
       });
+
+      chat.setSystemInstruction('Chat instruction');
+      chat.setTools([{ functionDeclarations: [{ name: 'chat_tool' }] }]);
 
       // First attempt uses model-a, then simulate availability switching to model-b
       mockRetryWithBackoff.mockImplementation(async (apiCall) => {
@@ -3580,6 +3652,8 @@ describe('GeminiChat', () => {
           model: 'model-a',
           config: expect.objectContaining({
             temperature: 0.1,
+            systemInstruction: 'Model A instruction',
+            tools: modelATools,
           }),
         }),
         expect.any(String),
@@ -3593,6 +3667,8 @@ describe('GeminiChat', () => {
           model: 'model-b',
           config: expect.objectContaining({
             temperature: 0.9,
+            systemInstruction: 'Model B instruction',
+            tools: modelBTools,
           }),
         }),
         expect.any(String),

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -790,10 +790,10 @@ export class GeminiChat {
       lastModelToUse = modelToUse;
       const config: GenerateContentConfig = {
         ...currentGenerateContentConfig,
-        // TODO(12622): Ensure we don't overrwrite these when they are
-        // passed via config.
-        systemInstruction: this.systemInstruction,
-        tools: this.tools,
+        systemInstruction:
+          currentGenerateContentConfig.systemInstruction ??
+          this.systemInstruction,
+        tools: currentGenerateContentConfig.tools ?? this.tools,
         abortSignal,
       };
 


### PR DESCRIPTION
## Summary

- preserve `systemInstruction` and `tools` supplied by the resolved model configuration
- use the chat instance's instruction and tools only when those fields are absent from the resolved configuration
- retain the same precedence after retries switch to a different resolved model configuration
- add focused coverage for both initial requests and retry-driven model changes

## Problem

`GeminiChat` correctly obtains a `GenerateContentConfig` from `ModelConfigService`, but the final request previously replaced two resolved fields unconditionally:

```ts
{
  ...currentGenerateContentConfig,
  systemInstruction: this.systemInstruction,
  tools: this.tools,
}
```

As a result, aliases and model-specific overrides could resolve successfully while their specialized `systemInstruction` and `tools` never reached the content generator. The same overwrite happened after an availability retry selected and resolved a different model.

## Precedence

This change makes the precedence explicit:

1. A defined value from `currentGenerateContentConfig` wins.
2. Otherwise, the chat instance's value is used as the fallback.
3. Request-scoped `abortSignal` remains authoritative.

Nullish fallback preserves intentional values such as an empty instruction or an empty tools array while maintaining existing behavior for configurations that omit these fields.

## Tests

The GeminiChat tests now verify that:

- resolved `systemInstruction` and `tools` override distinct chat-level values on the initial request
- a first attempt receives Model A's instruction and tools
- after an active-model switch, the retry receives Model B's newly resolved instruction and tools

Validation performed:

- `npm test --workspace @google/gemini-cli-core -- --run src/core/geminiChat.test.ts` — 92 passed
- core package post-test build — passed
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npx eslint packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts`
- `npx prettier --check packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts`
- `git diff --check`

Closes #28650
