### PR TITLE
fix(extensions): harden fetchJson against malformed JSON and stream failures

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -110,6 +110,7 @@ describe('fetchJson', () => {
     getMock.mockImplementationOnce((_url, _options, callback) => {
       const res = new EventEmitter() as IncomingMessage;
       res.statusCode = 404;
+      res.resume = vi.fn();
       (callback as (res: IncomingMessage) => void)(res);
       res.emit('end');
       return new EventEmitter() as ClientRequest;
@@ -130,6 +131,49 @@ describe('fetchJson', () => {
 
     await expect(fetchJson('https://example.com/error')).rejects.toThrow(
       'Network error',
+    );
+  });
+
+  it('should reject on malformed JSON', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{invalid'));
+      res.emit('end');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://example.com/data.json')).rejects.toThrow(
+      'Failed to parse JSON from https://example.com/data.json',
+    );
+  });
+
+  it('should reject on response stream error', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('error', new Error('Stream broken'));
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://example.com/data.json')).rejects.toThrow(
+      'Response stream error while fetching',
+    );
+  });
+
+  it('should reject on response aborted', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('aborted');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(fetchJson('https://example.com/data.json')).rejects.toThrow(
+      'Response aborted while fetching',
     );
   });
 

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -22,6 +22,13 @@ export async function fetchJson<T>(
     headers.Authorization = `token ${token}`;
   }
   return new Promise((resolve, reject) => {
+    const rejectStreamError = (err: Error): void => {
+      reject(
+        new Error(
+          `Response stream error while fetching ${url}: ${err.message}`,
+        ),
+      );
+    };
     https
       .get(url, { headers }, (res) => {
         if (res.statusCode === 302 || res.statusCode === 301) {
@@ -41,16 +48,29 @@ export async function fetchJson<T>(
           return;
         }
         if (res.statusCode !== 200) {
+          res.resume();
           return reject(
             new Error(`Request failed with status code ${res.statusCode}`),
           );
         }
         const chunks: Buffer[] = [];
         res.on('data', (chunk) => chunks.push(chunk));
+        res.on('error', rejectStreamError);
+        res.on('aborted', () => {
+          reject(new Error(`Response aborted while fetching ${url}`));
+        });
         res.on('end', () => {
           const data = Buffer.concat(chunks).toString();
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          resolve(JSON.parse(data) as T);
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            resolve(JSON.parse(data) as T);
+          } catch (err) {
+            reject(
+              new Error(
+                `Failed to parse JSON from ${url} (status ${res.statusCode}): ${err instanceof Error ? err.message : String(err)}`,
+              ),
+            );
+          }
         });
       })
       .on('error', reject);


### PR DESCRIPTION
## Fixes #28646

### What changed

`fetchJson` in `packages/cli/src/config/extensions/github_fetch.ts` now rejects the returned promise instead of leaking an uncaught exception when a GitHub API response is malformed, or the response stream fails.

- **Malformed JSON guard** - `JSON.parse` is now wrapped in a `try/catch`. A truncated/malformed 200 response rejects with `Failed to parse JSON from <url> (status 200): <message>` instead of throwing a `SyntaxError` out of the response `end` event callback.
- **Response stream `error` listener** - the response stream is now monitored for `error` events and rejects with `Response stream error while fetching <url>: <message>`.
- **`aborted` listener** - an aborted response rejects with `Response aborted while fetching <url>`.
- **Drain non-success responses** - non-200 responses call `res.resume()` so the socket/connection is freed, matching the behavior already used for redirects.

### Why it matters

Remote API/proxy failures can terminate an extension command (or the CLI process) instead of producing an actionable diagnostic. These paths are reachable from user-triggered GitHub extension operations, so failures should surface as controlled promise rejections that the existing extension error handling can report.

### Tests

Added regression tests in `github_fetch.test.ts` for:
- malformed JSON (rejects with contextual message),
- response stream error (rejects with contextual message),
- aborted response (rejects with contextual message),

and updated the existing non-200 test to mock `res.resume`.

- [x] `npx vitest run src/config/extensions/github_fetch.test.ts` - 11/11 passing
- [x] `npx vitest run src/config/extensions/` - 182/182 passing
- [x] `eslint` on changed files - clean (`--max-warnings 0`)
- [x] `tsc -p . --noEmit` - clean
