### PR TITLE
fix(vscode-ide-companion): comma operator in activate() leaked two Disposables

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -43,16 +43,24 @@ vi.mock('vscode', () => ({
   },
   workspace: {
     workspaceFolders: [],
-    onDidCloseTextDocument: vi.fn(),
-    registerTextDocumentContentProvider: vi.fn(),
-    onDidChangeWorkspaceFolders: vi.fn(),
-    onDidGrantWorkspaceTrust: vi.fn(),
+    onDidCloseTextDocument: vi.fn(() => ({
+      __disposableName: 'onDidCloseTextDocument',
+    })),
+    registerTextDocumentContentProvider: vi.fn(() => ({
+      __disposableName: 'registerTextDocumentContentProvider',
+    })),
+    onDidChangeWorkspaceFolders: vi.fn(() => ({
+      __disposableName: 'onDidChangeWorkspaceFolders',
+    })),
+    onDidGrantWorkspaceTrust: vi.fn(() => ({
+      __disposableName: 'onDidGrantWorkspaceTrust',
+    })),
     getConfiguration: vi.fn(() => ({
       get: vi.fn(),
     })),
   },
   commands: {
-    registerCommand: vi.fn(),
+    registerCommand: vi.fn((name: string) => ({ __disposableName: name })),
     executeCommand: vi.fn(),
   },
   Uri: {
@@ -129,6 +137,32 @@ describe('activate', () => {
   it('should register a handler for onDidGrantWorkspaceTrust', async () => {
     await activate(context);
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
+  });
+
+  it('should push every registered disposable into context.subscriptions', async () => {
+    await activate(context);
+
+    const subscriptionNames = context.subscriptions.map(
+      (disposable) =>
+        (disposable as unknown as { __disposableName: string })
+          .__disposableName,
+    );
+
+    // Regression test for a comma-operator bug where two pairs of
+    // registrations were wrapped in an extra set of parentheses, turning
+    // them into comma expressions. That caused only the last disposable of
+    // each pair (`gemini.diff.cancel`, `onDidGrantWorkspaceTrust`) to reach
+    // `context.subscriptions.push()`, silently leaking the others.
+    expect(subscriptionNames).toEqual([
+      'onDidCloseTextDocument',
+      'registerTextDocumentContentProvider',
+      'gemini.diff.accept',
+      'gemini.diff.cancel',
+      'onDidChangeWorkspaceFolders',
+      'onDidGrantWorkspaceTrust',
+      'gemini-cli.runGeminiCLI',
+      'gemini-cli.showNotices',
+    ]);
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { activate } from './extension.js';
+import { IDEServer } from './ide-server.js';
 import {
   IDE_DEFINITIONS,
   detectIdeFromEnv,
@@ -84,6 +85,10 @@ describe('activate', () => {
   let context: vscode.ExtensionContext;
 
   beforeEach(() => {
+    // activate() calls ideServer.start(), which normally binds a real HTTP
+    // server (app.listen in ide-server.ts). Stub it out so these unit tests
+    // don't leak live servers/ports.
+    vi.spyOn(IDEServer.prototype, 'start').mockResolvedValue(undefined);
     vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(
       undefined,
     );

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary
- Removes a stray extra pair of parentheses around two `context.subscriptions.push(...)` argument pairs in `packages/vscode-ide-companion/src/extension.ts`. Each pair had been (accidentally) turned into a JS comma expression, so only the *last* value of each pair (`gemini.diff.cancel`, `onDidGrantWorkspaceTrust`) was actually passed to `push()` — the `gemini.diff.accept` command Disposable and the `onDidChangeWorkspaceFolders` listener Disposable were created but never tracked in `context.subscriptions`, so they were never disposed on deactivation.
- Adds a regression test in `extension.test.ts` that asserts all 8 Disposables created in `activate()` land in `context.subscriptions`. The mocks for `registerCommand`/listener registration functions now return tagged objects (instead of `undefined`) so the test can distinguish which Disposable is which.

Fixes #27790

## Test plan
- [x] `npx vitest run packages/vscode-ide-companion/src/extension.test.ts` — 12/12 pass with the fix
- [x] Verified the new test fails against the original (unfixed) source, catching exactly the two missing disposables described in the issue
- [x] `npm run check-types --workspace=packages/vscode-ide-companion` — clean
- [x] `npx eslint packages/vscode-ide-companion/src/extension.ts packages/vscode-ide-companion/src/extension.test.ts` — clean