### PR TITLE
fix(core,cli): repair /compress session reload and quota-fallback tool response loss

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1046,6 +1046,101 @@ describe('useGeminiStream', () => {
     });
   });
 
+  it('should record tool responses in history when the model was switched due to a quota error', async () => {
+    // Regression test: returning early on a quota-triggered model switch
+    // without recording the responses leaves the already-recorded
+    // functionCall unpaired, which corrupts all subsequent requests.
+    const responseParts: Part[] = [
+      {
+        functionResponse: {
+          name: 'testTool',
+          id: 'call1',
+          response: { output: 'tool result' },
+        },
+      },
+    ];
+    const completedToolCalls: TrackedToolCall[] = [
+      {
+        request: {
+          callId: 'call1',
+          name: 'testTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-quota',
+        },
+        status: CoreToolCallStatus.Success,
+        responseSubmittedToGemini: false,
+        response: {
+          callId: 'call1',
+          responseParts,
+          errorType: undefined,
+        },
+        tool: { displayName: 'MockTool' },
+        invocation: {
+          getDescription: () => `Mock description`,
+        } as unknown as AnyToolInvocation,
+      } as TrackedCompletedToolCall,
+    ];
+
+    const client = new MockedGeminiClientClass(mockConfig);
+
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+
+    mockUseToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [
+        [],
+        mockScheduleToolCalls,
+        mockMarkToolsAsSubmitted,
+        vi.fn(),
+        mockCancelAllToolCalls,
+        0,
+      ];
+    });
+
+    await renderHookWithProviders(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        true, // modelSwitchedFromQuotaError
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    await act(async () => {
+      if (capturedOnComplete) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await capturedOnComplete(completedToolCalls);
+      }
+    });
+
+    await waitFor(() => {
+      expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['call1']);
+      // The tool response must be paired with its functionCall in history...
+      expect(client.addHistory).toHaveBeenCalledWith({
+        role: 'user',
+        parts: responseParts,
+      });
+      // ...but the turn must NOT auto-continue on the fallback model.
+      expect(mockSendMessageStream).not.toHaveBeenCalled();
+    });
+  });
+
   it('should NOT stop responding when only update_topic is called', async () => {
     const topicToolCalls: TrackedToolCall[] = [
       {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1083,6 +1083,7 @@ describe('useGeminiStream', () => {
     ];
 
     const client = new MockedGeminiClientClass(mockConfig);
+    const mockConsumeUserHint = vi.fn(() => 'switch to the nprd database');
 
     let capturedOnComplete:
       | ((completedTools: TrackedToolCall[]) => Promise<void>)
@@ -1119,6 +1120,8 @@ describe('useGeminiStream', () => {
         () => {},
         80,
         24,
+        false,
+        mockConsumeUserHint,
       ),
     );
 
@@ -1131,13 +1134,16 @@ describe('useGeminiStream', () => {
 
     await waitFor(() => {
       expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['call1']);
-      // The tool response must be paired with its functionCall in history...
+      // The tool response must be paired with its functionCall in history,
+      // with no steering-hint text ahead of it...
       expect(client.addHistory).toHaveBeenCalledWith({
         role: 'user',
         parts: responseParts,
       });
-      // ...but the turn must NOT auto-continue on the fallback model.
+      // ...the turn must NOT auto-continue on the fallback model...
       expect(mockSendMessageStream).not.toHaveBeenCalled();
+      // ...and the pending hint is left for the next real submit.
+      expect(mockConsumeUserHint).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2130,8 +2130,19 @@ export const useGeminiStream = (
 
       markToolsAsSubmitted(callIdsToMarkAsSubmitted);
 
-      // Don't continue if model was switched due to quota error
+      // Don't continue if model was switched due to quota error, but still
+      // record the responses: the matching functionCall is already in history,
+      // and leaving it unpaired corrupts every subsequent request.
       if (modelSwitchedFromQuotaError) {
+        const combinedParts = geminiTools.flatMap(
+          (toolCall) => toolCall.response.responseParts,
+        );
+        if (geminiClient && combinedParts.length > 0) {
+          await geminiClient.addHistory({
+            role: 'user',
+            parts: combinedParts,
+          });
+        }
         return;
       }
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2110,6 +2110,27 @@ export const useGeminiStream = (
         (toolCall) => toolCall.response.responseParts,
       );
 
+      const callIdsToMarkAsSubmitted = geminiTools.map(
+        (toolCall) => toolCall.request.callId,
+      );
+
+      markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+
+      // Don't continue if model was switched due to quota error, but still
+      // record the responses: the matching functionCall is already in history,
+      // and leaving it unpaired corrupts every subsequent request. Any pending
+      // steering hint is deliberately left unconsumed so it rides along with
+      // the next query the user actually submits.
+      if (modelSwitchedFromQuotaError) {
+        if (geminiClient && responsesToSend.length > 0) {
+          await geminiClient.addHistory({
+            role: 'user',
+            parts: responsesToSend,
+          });
+        }
+        return;
+      }
+
       if (consumeUserHint) {
         const userHint = consumeUserHint();
         if (userHint && userHint.trim().length > 0) {
@@ -2120,31 +2141,9 @@ export const useGeminiStream = (
         }
       }
 
-      const callIdsToMarkAsSubmitted = geminiTools.map(
-        (toolCall) => toolCall.request.callId,
-      );
-
       const prompt_ids = geminiTools.map(
         (toolCall) => toolCall.request.prompt_id,
       );
-
-      markToolsAsSubmitted(callIdsToMarkAsSubmitted);
-
-      // Don't continue if model was switched due to quota error, but still
-      // record the responses: the matching functionCall is already in history,
-      // and leaving it unpaired corrupts every subsequent request.
-      if (modelSwitchedFromQuotaError) {
-        const combinedParts = geminiTools.flatMap(
-          (toolCall) => toolCall.response.responseParts,
-        );
-        if (geminiClient && combinedParts.length > 0) {
-          await geminiClient.addHistory({
-            role: 'user',
-            parts: combinedParts,
-          });
-        }
-        return;
-      }
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       submitQuery(

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -356,6 +356,44 @@ describe('ChatRecordingService', () => {
       expect(reloaded.projectHash).toBe('resumed-project-hash');
       expect(reloaded.messages).toHaveLength(1);
     });
+
+    it('should preserve an unreadable session file instead of destroying it', async () => {
+      // The reload may have failed only transiently, so the original bytes
+      // must survive the recovery rewrite.
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'unreadable.jsonl');
+
+      // No usable metadata line => loadConversationRecord() returns null.
+      const originalBytes = '{"not":"a valid metadata line"}\n';
+      fs.writeFileSync(sessionFile, originalBytes);
+
+      await chatRecordingService.initialize({
+        filePath: sessionFile,
+        conversation: {
+          sessionId: 'recovered-session-id',
+          projectHash: 'recovered-project-hash',
+          startTime: new Date().toISOString(),
+          lastUpdated: new Date().toISOString(),
+          messages: [],
+        } as unknown as ConversationRecord,
+      });
+
+      // The rewritten file is loadable again...
+      const reloaded = (await loadConversationRecord(
+        sessionFile,
+      )) as ConversationRecord;
+      expect(reloaded.sessionId).toBe('recovered-session-id');
+
+      // ...and the original bytes were kept alongside it.
+      const preserved = fs
+        .readdirSync(chatsDir)
+        .filter((f) => f.startsWith('unreadable.jsonl.unreadable-'));
+      expect(preserved).toHaveLength(1);
+      expect(fs.readFileSync(path.join(chatsDir, preserved[0]), 'utf-8')).toBe(
+        originalBytes,
+      );
+    });
   });
 
   describe('recordMessage', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -308,6 +308,54 @@ describe('ChatRecordingService', () => {
       )) as ConversationRecord;
       expect(conversation.sessionId).toBe('old-session-id');
     });
+
+    it('should fall back to the in-memory conversation when the file cannot be reloaded', async () => {
+      // Regression test for the `/compress` "Failed to load resumed session
+      // data from file" bug: when resuming with a filePath that cannot be
+      // loaded from disk, initialize must NOT throw. It should adopt the
+      // in-memory conversation it was handed and rewrite a clean file.
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const missingFile = path.join(chatsDir, 'missing-session.jsonl');
+      expect(fs.existsSync(missingFile)).toBe(false);
+
+      const inMemoryConversation = {
+        sessionId: 'resumed-session-id',
+        projectHash: 'resumed-project-hash',
+        startTime: new Date().toISOString(),
+        lastUpdated: new Date().toISOString(),
+        messages: [
+          {
+            id: 'msg-1',
+            type: 'user',
+            timestamp: new Date().toISOString(),
+            content: 'hello from memory',
+          },
+        ],
+      } as unknown as ConversationRecord;
+
+      await expect(
+        chatRecordingService.initialize({
+          filePath: missingFile,
+          conversation: inMemoryConversation,
+        }),
+      ).resolves.not.toThrow();
+
+      // The in-memory conversation is adopted.
+      expect(chatRecordingService.getConversation()?.sessionId).toBe(
+        'resumed-session-id',
+      );
+
+      // A clean, loadable file is rewritten from the in-memory copy so future
+      // loads and appends succeed.
+      const reloaded = (await loadConversationRecord(
+        missingFile,
+      )) as ConversationRecord;
+      expect(reloaded).not.toBeNull();
+      expect(reloaded.sessionId).toBe('resumed-session-id');
+      expect(reloaded.projectHash).toBe('resumed-project-hash');
+      expect(reloaded.messages).toHaveLength(1);
+    });
   });
 
   describe('recordMessage', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -394,6 +394,39 @@ describe('ChatRecordingService', () => {
         originalBytes,
       );
     });
+
+    it('should not leave a temp file behind when the rewrite fails', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const sessionFile = path.join(chatsDir, 'rewrite-fails.jsonl');
+
+      // Fail the rename that publishes the temp file, leaving it orphaned.
+      const realRename = fs.renameSync;
+      vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+        if (String(from).includes('.tmp-')) {
+          throw new Error('simulated rename failure');
+        }
+        return realRename(from, to);
+      });
+
+      await expect(
+        chatRecordingService.initialize({
+          filePath: sessionFile,
+          conversation: {
+            sessionId: 'temp-cleanup-session',
+            projectHash: 'temp-cleanup-hash',
+            startTime: new Date().toISOString(),
+            lastUpdated: new Date().toISOString(),
+            messages: [],
+          } as unknown as ConversationRecord,
+        }),
+      ).rejects.toThrow('simulated rename failure');
+
+      const leftovers = fs
+        .readdirSync(chatsDir)
+        .filter((f) => f.includes('.tmp-'));
+      expect(leftovers).toEqual([]);
+    });
   });
 
   describe('recordMessage', () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -617,8 +617,18 @@ export class ChatRecordingService {
       }
 
       const tempFile = `${this.conversationFile}.tmp-${process.pid}`;
-      fs.writeFileSync(tempFile, content);
-      fs.renameSync(tempFile, this.conversationFile);
+      try {
+        fs.writeFileSync(tempFile, content);
+        fs.renameSync(tempFile, this.conversationFile);
+      } catch (error) {
+        // The rename did not complete, so the temp file would be left behind.
+        try {
+          fs.unlinkSync(tempFile);
+        } catch {
+          // Ignore cleanup errors so the original failure still surfaces.
+        }
+        throw error;
+      }
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOSPC') {
         this.conversationFile = null;

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -462,7 +462,16 @@ export class ChatRecordingService {
           // Update the session ID in the existing file
           this.updateMetadata({ sessionId: this.sessionId });
         } else {
-          throw new Error('Failed to load resumed session data from file');
+          // The file could not be reloaded (missing, corrupt metadata, or an
+          // I/O error). Fall back to the in-memory conversation we were handed
+          // rather than failing the caller, and rewrite a clean file from it.
+          debugLogger.warn(
+            'Failed to reload resumed session data from file; falling back ' +
+              'to the in-memory conversation.',
+          );
+          this.cachedConversation = resumedSessionData.conversation;
+          this.projectHash = this.cachedConversation.projectHash;
+          this.rewriteConversationFile(this.cachedConversation);
         }
       } else {
         // Create new session
@@ -553,6 +562,43 @@ export class ChatRecordingService {
       const line = JSON.stringify(record) + '\n';
       fs.mkdirSync(path.dirname(this.conversationFile), { recursive: true });
       fs.appendFileSync(this.conversationFile, line);
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOSPC') {
+        this.conversationFile = null;
+        debugLogger.warn(ENOSPC_WARNING_MESSAGE);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Rewrites the session file from an in-memory record, atomically (temp file
+   * + rename) so a partial write never clobbers the existing file.
+   */
+  private rewriteConversationFile(conversation: ConversationRecord): void {
+    if (!this.conversationFile) return;
+
+    // Normalize legacy `.json` paths to the `.jsonl` format we write.
+    if (this.conversationFile.endsWith('.json')) {
+      this.conversationFile = this.conversationFile + 'l';
+    }
+
+    const { messages, memoryScratchpad, ...metadata } = conversation;
+    const lines: string[] = [JSON.stringify(metadata)];
+    for (const msg of messages) {
+      lines.push(JSON.stringify(msg));
+    }
+    if (memoryScratchpad) {
+      lines.push(JSON.stringify({ $set: { memoryScratchpad } }));
+    }
+    const content = lines.join('\n') + '\n';
+
+    try {
+      fs.mkdirSync(path.dirname(this.conversationFile), { recursive: true });
+      const tempFile = `${this.conversationFile}.tmp-${process.pid}`;
+      fs.writeFileSync(tempFile, content);
+      fs.renameSync(tempFile, this.conversationFile);
     } catch (error) {
       if (isNodeError(error) && error.code === 'ENOSPC') {
         this.conversationFile = null;

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -573,8 +573,9 @@ export class ChatRecordingService {
   }
 
   /**
-   * Rewrites the session file from an in-memory record, atomically (temp file
-   * + rename) so a partial write never clobbers the existing file.
+   * Rewrites the session file from an in-memory record. Any existing
+   * (unreadable) file is preserved alongside rather than destroyed, and the
+   * new file is written atomically (temp file + rename).
    */
   private rewriteConversationFile(conversation: ConversationRecord): void {
     if (!this.conversationFile) return;
@@ -596,6 +597,25 @@ export class ChatRecordingService {
 
     try {
       fs.mkdirSync(path.dirname(this.conversationFile), { recursive: true });
+
+      // The existing file was unreadable, but it may have been only
+      // transiently so (a lock or I/O blip) rather than truly corrupt. Keep
+      // its bytes rather than destroying them.
+      if (fs.existsSync(this.conversationFile)) {
+        const backup = `${this.conversationFile}.unreadable-${Date.now()}`;
+        try {
+          fs.renameSync(this.conversationFile, backup);
+          debugLogger.warn(
+            `Preserved the unreadable session file at ${backup}.`,
+          );
+        } catch (backupError) {
+          debugLogger.error(
+            'Failed to preserve the unreadable session file.',
+            backupError,
+          );
+        }
+      }
+
       const tempFile = `${this.conversationFile}.tmp-${process.pid}`;
       fs.writeFileSync(tempFile, content);
       fs.renameSync(tempFile, this.conversationFile);


### PR DESCRIPTION
## Summary

Two independent bug fixes.

**1. `/compress` fails and stays broken.** Running `/compress` (or hitting automatic compression) could fail with `Failed to compress chat history: Failed to initialize chat: Failed to load resumed session data from file`.

**2. Hitting a quota limit corrupts the conversation.** After a quota/rate-limit fallback, the model starts _finishing your sentences_ instead of answering your next message.

Fix 2 is the higher-priority one: it silently poisons a conversation for the rest of its life.

## Details

Some background that makes both fixes easier to follow:

- Gemini CLI keeps a **session file** on disk (a log of your conversation), and also holds the same conversation **in memory**.
- When the model uses a tool, the conversation must contain a matching **pair**: the model's tool _call_, and the tool's _result_. The Gemini API requires every call to be followed by its result.

---

### Fix 1 — `/compress`: use the conversation we already have

**What happened.** Compression summarizes old messages to free up space, then re-initializes the chat. That re-initialization hands the recorder two things: the conversation **already loaded in memory**, and the path to the session file.

The recorder used the in-memory copy for two small fields, then ignored it and re-read the whole conversation **off disk anyway**. If that re-read came back empty — file missing, a corrupted first line, or a momentary disk/read error — it threw an error and gave up, even though a perfectly good copy was sitting right there in its own argument.

That error travelled up and became the `Failed to compress chat history` message the user sees.

**The fix.** Use the in-memory copy instead of giving up, and write a fresh, readable session file from it so future saves and loads work again.

**Safety.** The unreadable file is **moved aside** (to `<name>.unreadable-<timestamp>`), never overwritten. Of the three ways the read can come back empty, two are safe to replace (file missing; corrupt first line, which would fail forever anyway) — but the third, a momentary read error, may leave a perfectly intact file. So we keep its contents rather than destroy them. The new file is written to a temp path and renamed into place, so an interrupted write can't leave a half-written file.

**When this broke.** This is a regression. The older code handled an unreadable file gracefully (it fell back to an empty record and carried on). #23749 replaced that with a hard error, landing in a code path that had relied on the forgiving behaviour since #15714.

---

### Fix 2 — Quota fallback: don't throw away the tool result

**What happened.** When a quota error makes the CLI switch to a backup model, it deliberately stops the turn rather than silently continuing on a different model. That part is intentional.

The problem: it stopped **without saving the tool's result**. The model's tool _call_ was already in the conversation, so this left a call with no matching result — exactly the pairing the API requires. Nothing retried it, and the flag that caused it only resets on your next fresh (non-continuation) message, so every request after that carried the broken pair. The visible symptom is the model continuing/autocompleting your next message instead of replying to it.

**The fix.** Save the tool result before stopping. The turn still does **not** auto-continue on the backup model — this only repairs the record.

**One ordering detail.** The stop now happens _before_ the "steering hint" step (text you type while a tool is still running). That hint is built to be **sent** to the model, but this path never sends anything. Handling it here would both discard what you typed and write it into the conversation _ahead of_ the tool result. Leaving it alone keeps the saved turn to just the tool result, and your hint goes out with the next message you actually send.

**When this broke.** Long-standing, not new: the early stop was added in #3662 with no result-saving. It was simply rare to hit until quota fallbacks became common.

## Related Issues

None.

## How to Validate

Both fixes ship with regression tests. The Fix 2 test was confirmed to **fail without** the production change and pass with it.

```bash
npm test -w @google/gemini-cli-core -- src/services/chatRecordingService.test.ts
npm test -w @google/gemini-cli -- src/ui/hooks/useGeminiStream.test.tsx
npm run lint && npm run typecheck
```

Relevant test names:

- `should fall back to the in-memory conversation when the file cannot be reloaded`
- `should preserve an unreadable session file instead of destroying it`
- `should record tool responses in history when the model was switched due to a quota error`

Manual check of `/compress`:

1. `npm run build`
2. Start the CLI and run a couple of turns to build up some history.
3. Run `/compress`.
4. **Expected:** `Chat history compressed from N to M tokens.`, and the next message still works — no `Failed to load resumed session data from file`.

I ran this end-to-end in a real terminal against a local build: `/compress` reported `Chat history compressed from 14903 to 4615 tokens` and the following turn responded normally.

**Regression check.** No new failures. The `packages/core/src/{services,core}` suites are already red on `main` at this commit (pre-existing timeouts in `geminiChat.test.ts` and `logger.test.ts`); this branch does not add to them:

|                   | Result                  |
| ----------------- | ----------------------- |
| `main` (baseline) | 64 failed / 1001 passed |
| this branch       | 63 failed / 1004 passed |

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker

