### PR TITLE
fix(core): reject A2A openIdConnect auth during validation

### DIFF
--- a/packages/core/src/agents/auth-provider/factory.test.ts
+++ b/packages/core/src/agents/auth-provider/factory.test.ts
@@ -256,7 +256,10 @@ describe('A2AAuthProviderFactory', () => {
     });
 
     describe('openIdConnect scheme matching', () => {
-      it('should match openIdConnect config with openIdConnect scheme', () => {
+      it('should reject openIdConnect config because no provider exists yet', () => {
+        // create() has no openIdConnect branch, so validation must not report
+        // this config as usable; otherwise the failure lands later, when the
+        // agent is connected.
         const authConfig: A2AAuthConfig = {
           type: 'openIdConnect',
           issuer_url: 'https://auth.example.com',
@@ -275,7 +278,36 @@ describe('A2AAuthProviderFactory', () => {
           securitySchemes,
         );
 
-        expect(result).toEqual({ valid: true });
+        expect(result.valid).toBe(false);
+        expect(result.diff?.missingConfig).toContain(
+          "Scheme 'oidcAuth' requires OpenID Connect authentication (not yet supported)",
+        );
+      });
+
+      it('should not report a config as valid that create() cannot construct', async () => {
+        const authConfig: A2AAuthConfig = {
+          type: 'openIdConnect',
+          issuer_url: 'https://auth.example.com',
+          client_id: 'client-id',
+        };
+        const securitySchemes: Record<string, SecurityScheme> = {
+          oidcAuth: {
+            type: 'openIdConnect',
+            openIdConnectUrl:
+              'https://auth.example.com/.well-known/openid-configuration',
+          },
+        };
+
+        const validation = A2AAuthProviderFactory.validateAuthConfig(
+          authConfig,
+          securitySchemes,
+        );
+        const create = A2AAuthProviderFactory.createFromConfig(authConfig);
+
+        await expect(create).rejects.toThrow(
+          'openIdConnect auth provider not yet implemented',
+        );
+        expect(validation.valid).toBe(false);
       });
 
       it('should not match google-credentials for openIdConnect scheme', () => {
@@ -297,7 +329,7 @@ describe('A2AAuthProviderFactory', () => {
 
         expect(result.valid).toBe(false);
         expect(result.diff?.missingConfig).toContain(
-          "Scheme 'oidcAuth' requires OpenID Connect authentication",
+          "Scheme 'oidcAuth' requires OpenID Connect authentication (not yet supported)",
         );
       });
     });

--- a/packages/core/src/agents/auth-provider/factory.ts
+++ b/packages/core/src/agents/auth-provider/factory.ts
@@ -201,12 +201,12 @@ export class A2AAuthProviderFactory {
           );
           break;
 
+        // Reported as unsupported rather than matched: create() has no
+        // openIdConnect branch, so matching here would let configuration pass
+        // validation and then fail when the agent is actually connected.
         case 'openIdConnect':
-          if (authConfig.type === 'openIdConnect') {
-            return { matched: true, missingConfig: [] };
-          }
           missingConfig.push(
-            `Scheme '${schemeName}' requires OpenID Connect authentication`,
+            `Scheme '${schemeName}' requires OpenID Connect authentication (not yet supported)`,
           );
           break;
 

--- a/packages/core/src/agents/auth-provider/types.ts
+++ b/packages/core/src/agents/auth-provider/types.ts
@@ -84,7 +84,12 @@ export interface OAuth2AuthConfig extends BaseAuthConfig {
   registration_url?: string;
 }
 
-/** Client config corresponding to OpenIdConnectSecurityScheme. */
+/**
+ * Client config corresponding to OpenIdConnectSecurityScheme.
+ *
+ * Reserved for future use: no provider is implemented yet, so configuring this
+ * type is rejected during auth validation. See `A2AAuthProviderFactory.create`.
+ */
 export interface OpenIdConnectAuthConfig extends BaseAuthConfig {
   type: 'openIdConnect';
   issuer_url: string;


### PR DESCRIPTION
Fixes #28651

## The problem in plain terms

Gemini CLI can connect to remote "A2A" agents that sit behind a login. One of the login methods it appears to support is OpenID Connect (the "Sign in with..." standard).

If you set that up, the CLI tells you your configuration is valid. Then, the moment it actually tries to connect to the agent, it crashes with:

```
openIdConnect auth provider not yet implemented
```

So the code that checks your settings said "looks good", but the code that uses your settings was never written. You only find out at the worst possible moment, and because the check passed, there's nothing pointing you at the real cause.

## What this changes

The settings check now says no up front, with a reason:

```
Scheme 'oidcAuth' requires OpenID Connect authentication (not yet supported)
```

You get told immediately that this login method isn't available yet, instead of getting a confusing crash later.

That's it. It doesn't add OpenID Connect support; it just stops the CLI from promising something it can't do.

## Why this approach

The issue offered two options: build OpenID Connect support, or make the CLI reject it clearly until someone does. I did the second one, because it's small, it can't break anything that currently works, and it turns a confusing failure into a clear message today.

There's already a precedent right next to it in the same function: `mutualTLS` is another login method that isn't implemented, and it's reported as "not yet supported" at exactly this point. OpenID Connect was the odd one out.

Building actual OpenID Connect support is still worth doing, and it would likely reuse the existing OAuth2 flow and token storage. Happy to take that on separately if you'd like it, but it seemed wrong to bundle a new feature into a bug fix.

## Notes for reviewers

- The `OpenIdConnectAuthConfig` type is left in place, since removing it from the public `A2AAuthConfig` union would be a breaking change for anyone importing it. I added a comment marking it as reserved for future use, so it no longer reads like a working option.
- One existing test asserted the old behaviour ("openIdConnect config matches an openIdConnect scheme, valid: true"). That test was encoding the bug, so it now asserts the rejection instead.
- I added a test that runs the whole path in one go: validate the config, then try to build the provider. It checks that validation says invalid *and* that building still throws. That pairing is what was missing, and it's what stops this from regressing.

## How I checked it

`npx vitest run packages/core/src/agents/auth-provider/factory.test.ts` passes (30 tests). With my change to `factory.ts` reverted but the new tests kept, 3 of them fail, so they're really testing the fix.

I also ran the full `packages/core/src/agents/` suite (735 passed, 1 skipped), plus prettier, eslint with `--max-warnings 0`, and `tsc --noEmit` on the core package. The repo's pre-commit hook ran clean on the commit.

I couldn't run the whole `npm run preflight` end to end here, so CI may surface something outside these packages.

*An AI coding agent helped me write this. I reviewed the change, confirmed the new tests fail without it, and ran the checks above myself.*
