### PR TITLE
fix(release): handle npm dist-tag deletion failures on registries that forbid it

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -172,7 +172,7 @@ runs:
           --workspace="${INPUTS_CORE_PACKAGE_NAME}" \
           --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} staging-tmp
+          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
         fi
 
     - name: '🔗 Install latest core package'
@@ -251,7 +251,7 @@ runs:
           ${PUBLISH_TARGET} \
           --tag staging-tmp
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} staging-tmp
+          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
         fi
 
     - name: 'Get a2a-server Token'
@@ -278,9 +278,9 @@ runs:
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
           --tag staging-tmp
-          if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-            npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} staging-tmp
-          fi
+        if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
+          npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
+        fi
 
     - name: '🏷️ Tag release'
       uses: './.github/actions/tag-npm-release'


### PR DESCRIPTION
## Summary

This PR handles npm `dist-tag` deletion failures on npm registries that forbid tag deletion (like Wombat Dressing Room, which returns `403 Forbidden`).

## Details

During nightly release runs, the target registry fallback is configured to Wombat Dressing Room (`https://wombat-dressing-room.appspot.com`). Since Wombat blocks HTTP `DELETE` operations on tags for security reasons, the `npm dist-tag rm` step failed and halted the nightly builds.

By appending `|| echo "Warning: ..."` to each of the three `npm dist-tag rm ... staging-tmp` steps in `.github/actions/publish-release/action.yml`, we gracefully handle these failures. The staging/release flow remains fully functional because:
1. `staging-tmp` is only a temporary staging marker to prevent `npm` from automatically applying the `latest` tag prematurely.
2. The final release channel tags are successfully applied via `npm dist-tag add` during the subsequent `tag-npm-release` step.

This is a robust and registry-agnostic solution that logs a warning and allows the release pipeline to proceed on registries where tag deletion is disabled.

## Related Issues

Resolves the nightly release pipeline failures that began after Commit `d3ef6aca40c5` (PR #28104) changed the default registry fallback.

## How to Validate

- Validated yaml syntax correctness.
- Ran `npm run lint` and `npm run typecheck` locally to confirm no regressions.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Linux
    - [x] npm run
