### PR TITLE
fix(sdk): don't abort sendStream on malformed tool arguments

### DIFF
--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -15,6 +15,7 @@ import {
   type ServerGeminiStreamEvent,
   type GeminiClient,
   type Content,
+  type Part,
   scheduleAgentTools,
   getAuthTypeFromEnv,
   type ToolRegistry,
@@ -25,6 +26,7 @@ import {
 } from '@google/gemini-cli-core';
 
 import { type Tool, SdkTool } from './tool.js';
+import { parseToolCallArguments } from './toolArguments.js';
 import { SdkAgentFilesystem } from './fs.js';
 import { SdkAgentShell } from './shell.js';
 import type {
@@ -246,15 +248,29 @@ export class GeminiCliSession {
       const stream = client.sendMessageStream(request, abortSignal, sessionId);
 
       const toolCallsToSchedule: ToolCallRequestInfo[] = [];
+      // Responses for calls we could not schedule because the model's arguments
+      // did not parse. These are sent back with the scheduled calls' responses
+      // so the model can correct itself, instead of the parse error escaping
+      // this generator and ending the session.
+      const malformedArgumentResponses: Part[] = [];
 
       for await (const event of stream) {
         yield event;
         if (event.type === GeminiEventType.ToolCallRequest) {
           const toolCall = event.value;
-          let args = toolCall.args;
-          if (typeof args === 'string') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            args = JSON.parse(args);
+          const { args, error } = parseToolCallArguments(
+            toolCall.name,
+            toolCall.args,
+          );
+          if (error) {
+            malformedArgumentResponses.push({
+              functionResponse: {
+                name: toolCall.name,
+                id: toolCall.callId,
+                response: { error },
+              },
+            });
+            continue;
           }
           toolCallsToSchedule.push({
             ...toolCall,
@@ -265,7 +281,10 @@ export class GeminiCliSession {
         }
       }
 
-      if (toolCallsToSchedule.length === 0) {
+      if (
+        toolCallsToSchedule.length === 0 &&
+        malformedArgumentResponses.length === 0
+      ) {
         break;
       }
 
@@ -293,19 +312,19 @@ export class GeminiCliSession {
         return tool;
       };
 
-      const completedCalls = await scheduleAgentTools(
-        this.config,
-        toolCallsToSchedule,
-        {
-          schedulerId: sessionId,
-          toolRegistry: scopedRegistry,
-          signal: abortSignal,
-        },
-      );
+      const completedCalls =
+        toolCallsToSchedule.length > 0
+          ? await scheduleAgentTools(this.config, toolCallsToSchedule, {
+              schedulerId: sessionId,
+              toolRegistry: scopedRegistry,
+              signal: abortSignal,
+            })
+          : [];
 
-      const functionResponses = completedCalls.flatMap(
-        (call) => call.response.responseParts,
-      );
+      const functionResponses = [
+        ...malformedArgumentResponses,
+        ...completedCalls.flatMap((call) => call.response.responseParts),
+      ];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       request = functionResponses as unknown as Parameters<

--- a/packages/sdk/src/toolArguments.test.ts
+++ b/packages/sdk/src/toolArguments.test.ts
@@ -42,10 +42,19 @@ describe('parseToolCallArguments', () => {
     });
   });
 
-  it('copies parsed arguments so callers cannot mutate shared state', () => {
+  it('gives the caller its own object when arguments were parsed from JSON', () => {
     const first = parseToolCallArguments('t', '{"a":1}');
     first.args['a'] = 2;
     expect(parseToolCallArguments('t', '{"a":1}').args).toEqual({ a: 1 });
+  });
+
+  it('returns already-structured arguments by reference', () => {
+    // Deliberate, and matching core's parseToolArguments: an object the model
+    // layer already built is not copied, so ownership stays with the caller.
+    const structured = { path: 'a.txt' };
+    expect(parseToolCallArguments('write_file', structured).args).toBe(
+      structured,
+    );
   });
 
   it.each([

--- a/packages/sdk/src/toolArguments.test.ts
+++ b/packages/sdk/src/toolArguments.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { parseToolCallArguments } from './toolArguments.js';
+
+describe('parseToolCallArguments', () => {
+  it('parses a JSON object string', () => {
+    expect(parseToolCallArguments('write_file', '{"path":"a.txt"}')).toEqual({
+      args: { path: 'a.txt' },
+    });
+  });
+
+  it('reports an error instead of throwing on malformed JSON', () => {
+    const { args, error } = parseToolCallArguments(
+      'write_file',
+      '{"unterminated":',
+    );
+
+    expect(args).toEqual({});
+    expect(error).toContain('Failed to parse JSON arguments');
+    expect(error).toContain('write_file');
+    // The offending text is echoed so the model can see what it produced.
+    expect(error).toContain('{"unterminated":');
+  });
+
+  it.each([
+    ['array', '[1,2]'],
+    ['string', '"hello"'],
+    ['number', '42'],
+    ['null', 'null'],
+  ])('treats a valid non-object JSON %s as no arguments', (_label, raw) => {
+    expect(parseToolCallArguments('some_tool', raw)).toEqual({ args: {} });
+  });
+
+  it('passes through arguments that are already an object', () => {
+    const structured = { path: 'a.txt' };
+    expect(parseToolCallArguments('write_file', structured)).toEqual({
+      args: structured,
+    });
+  });
+
+  it('copies parsed arguments so callers cannot mutate shared state', () => {
+    const first = parseToolCallArguments('t', '{"a":1}');
+    first.args['a'] = 2;
+    expect(parseToolCallArguments('t', '{"a":1}').args).toEqual({ a: 1 });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an array', [1, 2]],
+  ])('returns no arguments for %s', (_label, raw) => {
+    expect(parseToolCallArguments('some_tool', raw)).toEqual({ args: {} });
+  });
+});

--- a/packages/sdk/src/toolArguments.ts
+++ b/packages/sdk/src/toolArguments.ts
@@ -46,9 +46,14 @@ export function parseToolCallArguments(
     }
     // A valid JSON document that isn't an object (array, string, number, null)
     // carries no named arguments, so it degrades to "no arguments" rather than
-    // being spread into the call.
+    // being spread into the call. The spread also means the caller owns this
+    // object outright, since we just created it by parsing.
     return { args: isPlainObject(parsed) ? { ...parsed } : {} };
   }
 
+  // Already-structured arguments are returned by reference, matching what core's
+  // `parseToolArguments` does. Copying here would diverge from that path and
+  // would silently drop any non-enumerable or prototype state the caller relied
+  // on, so ownership deliberately stays with the caller.
   return { args: isPlainObject(rawArgs) ? rawArgs : {} };
 }

--- a/packages/sdk/src/toolArguments.ts
+++ b/packages/sdk/src/toolArguments.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Result of interpreting a model-provided tool-call `args` value.
+ *
+ * `error` is set when the value could not be interpreted at all. Callers are
+ * expected to surface it to the model as a tool failure rather than throwing,
+ * so one malformed function call cannot end the session.
+ */
+export interface ParsedToolArguments {
+  args: Record<string, unknown>;
+  error?: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Interpret a tool call's `args`, which is model output and therefore untrusted.
+ *
+ * Mirrors the behavior the core local executor already applies to subagent tool
+ * calls: a JSON string is parsed and used only when it decodes to a plain
+ * object, anything already structured is passed through, and a value that fails
+ * to parse yields an `error` for the model instead of an exception.
+ */
+export function parseToolCallArguments(
+  toolName: string,
+  rawArgs: unknown,
+): ParsedToolArguments {
+  if (typeof rawArgs === 'string') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawArgs);
+    } catch {
+      return {
+        args: {},
+        error:
+          `Failed to parse JSON arguments for tool "${toolName}": ${rawArgs}. ` +
+          `Ensure you provide a valid JSON object.`,
+      };
+    }
+    // A valid JSON document that isn't an object (array, string, number, null)
+    // carries no named arguments, so it degrades to "no arguments" rather than
+    // being spread into the call.
+    return { args: isPlainObject(parsed) ? { ...parsed } : {} };
+  }
+
+  return { args: isPlainObject(rawArgs) ? rawArgs : {} };
+}


### PR DESCRIPTION
Closes #28649.

## Problem

`GeminiCliSession.sendStream()` parsed string-valued tool arguments with an unguarded `JSON.parse()`:

```ts
let args = toolCall.args;
if (typeof args === 'string') {
  args = JSON.parse(args);   // throws out of the generator
}
```

Tool arguments are model output. One malformed function call threw `SyntaxError` out of the generator and ended an otherwise recoverable session — and it did so *after* the `ToolCallRequest` event had already been yielded to the caller, so consumers saw a request that then vanished into an exception.

## Approach

Malformed arguments now produce a `functionResponse` carrying the parse error, returned alongside the other tool responses so the model can correct itself and continue.

This is the behavior core already applies to subagent tool calls — `parseToolArguments` in `packages/core/src/agents/local-executor.ts` generates exactly this kind of error response. The SDK path simply hadn't adopted it, which is what @EvolveAegis pointed out.

Semantics deliberately match the core implementation rather than improving on it, so the two paths can't drift:

- A valid non-object JSON document (array, string, number, `null`) degrades to "no arguments" instead of being spread into the call.
- Anything already structured passes through.
- Parse failure yields an error, never an exception.

Two small additions beyond a straight port: arguments **parsed from a JSON string** are returned as a fresh object the caller owns outright, and scheduling is **skipped** when every call in a turn was malformed rather than invoking the scheduler with an empty list.

Arguments that arrive already structured are returned **by reference**, matching core. An earlier revision of this description overstated that as "parsed objects are copied" across both paths; the review bot caught it, and there is now a test pinning the by-reference behavior so the choice is explicit.

## Why a separate module

The parsing lives in `packages/sdk/src/toolArguments.ts` as an exported helper so it's directly unit-testable. The `sendStream()` describe block is currently `describe.skip` (tracked in #24999), so routing tests through it would have added zero real coverage.

## Deliberately not done

I did **not** extract a single shared implementation across core and the SDK, which the issue floats as an option. Core's version is a private method on `LocalAgentExecutor`, so hoisting it is a cross-package refactor with its own review surface. Happy to follow up with that if you'd prefer one implementation — the semantics are already aligned, so it would be a pure move.

## How tested

- 11 cases in `packages/sdk/src/toolArguments.test.ts`: the malformed-JSON path (asserting the offending text is echoed back so the model can see what it produced), each non-object JSON shape, structured pass-through, the defensive copy, and the null/undefined/array inputs.
- `packages/sdk`: **40 passed, 6 skipped** (the 6 are the pre-existing `describe.skip`).
- `npm run typecheck` exit 0. `npm run lint` (`--max-warnings 0`) exit 0. `prettier --check` clean. The repo's `pre-commit` hook ran clean on the staged files.
- On `packages/core` there are pre-existing environment-dependent failures in this checkout; the failing-test set on this branch is a **subset** of the same run against the base commit, so this change introduces no regressions.

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.


