### PR TITLE
fix(a2a-server): enforce authentication and stop checkpoint path traversal

### DIFF
--- a/packages/a2a-server/src/commands/restore.test.ts
+++ b/packages/a2a-server/src/commands/restore.test.ts
@@ -105,6 +105,33 @@ describe('RestoreCommand', () => {
       'An unexpected error occurred during restore.',
     );
   });
+
+  it('should reject a checkpoint name containing directory traversal', async () => {
+    const command = new RestoreCommand();
+    const result = await command.execute(mockConfig, [
+      '../../../../etc/some-secret.json',
+    ]);
+    expect(result.data).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Invalid checkpoint name: ../../../../etc/some-secret.json',
+    });
+    // The traversal must be rejected before ever touching the filesystem.
+    expect(mockFs.readFile).not.toHaveBeenCalled();
+  });
+
+  it('should reject a checkpoint name with a path separator even without ".json"', async () => {
+    const command = new RestoreCommand();
+    const result = await command.execute(mockConfig, [
+      '../sibling-project/checkpoints/leaked',
+    ]);
+    expect(result.data).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Invalid checkpoint name: ../sibling-project/checkpoints/leaked',
+    });
+    expect(mockFs.readFile).not.toHaveBeenCalled();
+  });
 });
 
 describe('ListCheckpointsCommand', () => {

--- a/packages/a2a-server/src/commands/restore.ts
+++ b/packages/a2a-server/src/commands/restore.ts
@@ -45,9 +45,24 @@ export class RestoreCommand implements Command {
         };
       }
 
-      const selectedFile = argsStr.endsWith('.json')
+      const requestedName = argsStr.endsWith('.json')
         ? argsStr
         : `${argsStr}.json`;
+
+      // Checkpoint filenames are always flat (see generateCheckpointFileName),
+      // so reject anything containing directory components to prevent
+      // reading files outside checkpointDir via a "../" traversal.
+      const selectedFile = path.basename(requestedName);
+      if (selectedFile !== requestedName) {
+        return {
+          name: this.name,
+          data: {
+            type: 'message',
+            messageType: 'error',
+            content: `Invalid checkpoint name: ${argsStr}`,
+          },
+        };
+      }
 
       const checkpointDir = config.storage.getProjectTempCheckpointsDir();
       const filePath = path.join(checkpointDir, selectedFile);

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -107,11 +107,31 @@ vi.mock('@google/gemini-cli-core', async () => {
   };
 });
 
+const TEST_BEARER_TOKEN = 'test-bearer-token-for-a2a-server-tests';
+
+function authedAgent(app: express.Express) {
+  return request.agent(app).set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`);
+}
+
+function authedRequest(app: express.Express) {
+  return {
+    get: (path: string) =>
+      request(app)
+        .get(path)
+        .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`),
+    post: (path: string) =>
+      request(app)
+        .post(path)
+        .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`),
+  };
+}
+
 describe('E2E Tests', () => {
   let app: express.Express;
   let server: Server;
 
   beforeAll(async () => {
+    process.env['CODER_AGENT_BEARER_TOKEN'] = TEST_BEARER_TOKEN;
     app = await createApp();
     server = app.listen(0); // Listen on a random available port
   });
@@ -123,6 +143,7 @@ describe('E2E Tests', () => {
   afterAll(
     () =>
       new Promise<void>((resolve) => {
+        delete process.env['CODER_AGENT_BEARER_TOKEN'];
         server.close(() => {
           resolve();
         });
@@ -138,7 +159,7 @@ describe('E2E Tests', () => {
       yield* [{ type: 'content', value: 'Hello how are you?' }];
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(createStreamMessageRequest('hello', 'a2a-test-message'))
@@ -200,7 +221,7 @@ describe('E2E Tests', () => {
       getTool: vi.fn().mockReturnValue(mockTool),
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(createStreamMessageRequest('run a tool', 'a2a-tool-test-message'))
@@ -302,7 +323,7 @@ describe('E2E Tests', () => {
       }),
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(
@@ -475,7 +496,7 @@ describe('E2E Tests', () => {
       }),
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(
@@ -597,7 +618,7 @@ describe('E2E Tests', () => {
       getTool: vi.fn().mockReturnValue(mockTool),
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(
@@ -742,7 +763,7 @@ describe('E2E Tests', () => {
       getTool: vi.fn().mockReturnValue(mockTool),
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(
@@ -859,7 +880,7 @@ describe('E2E Tests', () => {
       ];
     });
 
-    const agent = request.agent(app);
+    const agent = authedAgent(app);
     const res = await agent
       .post('/')
       .send(createStreamMessageRequest('hello', 'a2a-trace-id-test'))
@@ -914,7 +935,7 @@ describe('E2E Tests', () => {
         .spyOn(commandRegistry, 'getAllCommands')
         .mockReturnValue(mockCommands);
 
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent.get('/listCommands').expect(200);
 
       expect(res.body).toEqual({
@@ -961,7 +982,7 @@ describe('E2E Tests', () => {
         .spyOn(commandRegistry, 'getAllCommands')
         .mockReturnValue([cyclicCommand]);
 
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent.get('/listCommands').expect(200);
 
       expect(res.body.commands[0].name).toBe('cyclic-command');
@@ -999,7 +1020,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockExtensionsCommand);
 
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent
         .post('/executeCommand')
         .send({ command: 'extensions list', args: [] })
@@ -1016,7 +1037,7 @@ describe('E2E Tests', () => {
     it('should return 404 for invalid command', async () => {
       vi.spyOn(commandRegistry, 'get').mockReturnValue(undefined);
 
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent
         .post('/executeCommand')
         .send({ command: 'invalid command' })
@@ -1028,7 +1049,7 @@ describe('E2E Tests', () => {
     });
 
     it('should return 400 for missing command', async () => {
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       await agent
         .post('/executeCommand')
         .send({ args: [] })
@@ -1038,7 +1059,7 @@ describe('E2E Tests', () => {
     });
 
     it('should return 400 if args is not an array', async () => {
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent
         .post('/executeCommand')
         .send({ command: 'extensions.list', args: 'not-an-array' })
@@ -1060,7 +1081,7 @@ describe('E2E Tests', () => {
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockCommand);
 
       delete process.env['CODER_AGENT_WORKSPACE_PATH'];
-      const response = await request(app)
+      const response = await authedRequest(app)
         .post('/executeCommand')
         .send({ command: 'test-command', args: [] });
 
@@ -1080,7 +1101,7 @@ describe('E2E Tests', () => {
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
       delete process.env['CODER_AGENT_WORKSPACE_PATH'];
-      const response = await request(app)
+      const response = await authedRequest(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });
 
@@ -1102,7 +1123,7 @@ describe('E2E Tests', () => {
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockWorkspaceCommand);
 
       process.env['CODER_AGENT_WORKSPACE_PATH'] = '/tmp/test-workspace';
-      const response = await request(app)
+      const response = await authedRequest(app)
         .post('/executeCommand')
         .send({ command: 'workspace-command', args: [] });
 
@@ -1123,7 +1144,7 @@ describe('E2E Tests', () => {
       };
       vi.spyOn(commandRegistry, 'get').mockReturnValue(mockCommand);
 
-      const agent = request.agent(app);
+      const agent = authedAgent(app);
       const res = await agent
         .post('/executeCommand')
         .send({ command: 'context-check-command', args: [] })
@@ -1163,7 +1184,7 @@ describe('E2E Tests', () => {
         };
         vi.spyOn(commandRegistry, 'get').mockReturnValue(mockStreamCommand);
 
-        const agent = request.agent(app);
+        const agent = authedAgent(app);
         agent
           .post('/executeCommand')
           .send({ command: 'stream-test', args: [] })
@@ -1212,7 +1233,7 @@ describe('E2E Tests', () => {
         };
         vi.spyOn(commandRegistry, 'get').mockReturnValue(mockNonStreamCommand);
 
-        const agent = request.agent(app);
+        const agent = authedAgent(app);
         const res = await agent
           .post('/executeCommand')
           .send({ command: 'non-stream-test', args: [] })
@@ -1221,6 +1242,58 @@ describe('E2E Tests', () => {
 
         expect(res.body).toEqual({ name: 'non-stream-test', data: 'done' });
       });
+    });
+  });
+
+  describe('authentication', () => {
+    it('serves the public agent card with no credentials', async () => {
+      await request(app).get('/.well-known/agent-card.json').expect(200);
+    });
+
+    it('rejects /tasks with no credentials', async () => {
+      await request(app)
+        .post('/tasks')
+        .send({})
+        .set('Content-Type', 'application/json')
+        .expect(401);
+    });
+
+    it('rejects /executeCommand with no credentials', async () => {
+      await request(app)
+        .post('/executeCommand')
+        .send({ command: 'restore', args: [] })
+        .set('Content-Type', 'application/json')
+        .expect(401);
+    });
+
+    it('rejects /listCommands with no credentials', async () => {
+      await request(app).get('/listCommands').expect(401);
+    });
+
+    it('rejects the JSON-RPC endpoint with no credentials', async () => {
+      await request(app)
+        .post('/')
+        .send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tasks/get',
+          params: { id: 'nonexistent' },
+        })
+        .set('Content-Type', 'application/json')
+        .expect(401);
+    });
+
+    it('rejects a stale/guessed hardcoded-style credential', async () => {
+      await request(app)
+        .post('/tasks')
+        .set('Authorization', 'Bearer valid-token')
+        .send({})
+        .set('Content-Type', 'application/json')
+        .expect(401);
+    });
+
+    it('accepts requests with the configured bearer token', async () => {
+      await authedRequest(app).get('/listCommands').expect(200);
     });
   });
 

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import express, { type Request } from 'express';
 
-import type { AgentCard, Message } from '@a2a-js/sdk';
+import { AGENT_CARD_PATH, type AgentCard, type Message } from '@a2a-js/sdk';
 import {
   type TaskStore,
   DefaultRequestHandler,
   InMemoryTaskStore,
   DefaultExecutionEventBus,
   type AgentExecutionEvent,
+  type User,
   UnauthenticatedUser,
 } from '@a2a-js/sdk/server';
 import { A2AExpressApp, type UserBuilder } from '@a2a-js/sdk/server/express'; // Import server components
@@ -93,34 +95,83 @@ export function updateCoderAgentCardUrl(port: number) {
   coderAgentCard.url = `http://localhost:${port}/`;
 }
 
+// Constant-time comparison to avoid leaking credential length/content via timing.
+function safeCompare(actual: string, expected: string): boolean {
+  const actualBuf = Buffer.from(actual);
+  const expectedBuf = Buffer.from(expected);
+  if (actualBuf.length !== expectedBuf.length) {
+    // Still run a same-length comparison so failure timing doesn't reveal length.
+    timingSafeEqual(actualBuf, actualBuf);
+    return false;
+  }
+  return timingSafeEqual(actualBuf, expectedBuf);
+}
+
 const customUserBuilder: UserBuilder = async (req: Request) => {
   const auth = req.headers['authorization'];
-  if (auth) {
-    const scheme = auth.split(' ')[0];
-    logger.info(
-      `[customUserBuilder] Received Authorization header with scheme: ${scheme}`,
-    );
-  }
   if (!auth) return new UnauthenticatedUser();
 
+  const expectedToken = process.env['CODER_AGENT_BEARER_TOKEN'];
+  const expectedUser = process.env['CODER_AGENT_BASIC_USERNAME'];
+  const expectedPassword = process.env['CODER_AGENT_BASIC_PASSWORD'];
+
   // 1. Bearer Auth
-  if (auth.startsWith('Bearer ')) {
+  if (auth.startsWith('Bearer ') && expectedToken) {
     const token = auth.substring(7);
-    if (token === 'valid-token') {
+    if (safeCompare(token, expectedToken)) {
       return { userName: 'bearer-user', isAuthenticated: true };
     }
   }
 
   // 2. Basic Auth
-  if (auth.startsWith('Basic ')) {
-    const credentials = Buffer.from(auth.substring(6), 'base64').toString();
-    if (credentials === 'admin:password') {
-      return { userName: 'basic-user', isAuthenticated: true };
+  if (auth.startsWith('Basic ') && expectedUser && expectedPassword) {
+    const decoded = Buffer.from(auth.substring(6), 'base64').toString();
+    const separatorIndex = decoded.indexOf(':');
+    if (separatorIndex !== -1) {
+      const user = decoded.slice(0, separatorIndex);
+      const password = decoded.slice(separatorIndex + 1);
+      if (
+        safeCompare(user, expectedUser) &&
+        safeCompare(password, expectedPassword)
+      ) {
+        return { userName: 'basic-user', isAuthenticated: true };
+      }
     }
   }
 
   return new UnauthenticatedUser();
 };
+
+const wellKnownAgentCardPath = `/${AGENT_CARD_PATH}`;
+
+/**
+ * Enforces authentication on every request except the public agent card
+ * (metadata only, meant to be fetched without credentials per the A2A
+ * client convention). The SDK's own request handler only checks
+ * `user.isAuthenticated` for the authenticated-extended-card method, not for
+ * task-driving RPCs like message/send, so this must be enforced here for
+ * every route -- including the custom /tasks, /executeCommand, /listCommands,
+ * and /tasks/:taskId/metadata routes below, which are plain Express routes
+ * the SDK never sees at all.
+ */
+function requireAuthentication(userBuilder: UserBuilder) {
+  return async (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    if (req.path === wellKnownAgentCardPath) {
+      next();
+      return;
+    }
+    const user: User = await userBuilder(req);
+    if (!user.isAuthenticated) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    next();
+  };
+}
 
 async function handleExecuteCommand(
   req: express.Request,
@@ -222,6 +273,9 @@ export async function createApp() {
       'GOOGLE_APPLICATION_CREDENTIALS',
       'GOOGLE_CLOUD_PROJECT',
       'GEMINI_CLI_USE_COMPUTE_ADC',
+      'CODER_AGENT_BEARER_TOKEN',
+      'CODER_AGENT_BASIC_USERNAME',
+      'CODER_AGENT_BASIC_PASSWORD',
     ];
     for (const key of allowedServerKeys) {
       if (globalEnv[key] !== undefined) {
@@ -276,6 +330,7 @@ export async function createApp() {
     expressApp.use((req, res, next) => {
       requestStorage.run({ req }, next);
     });
+    expressApp.use(requireAuthentication(customUserBuilder));
 
     const appBuilder = new A2AExpressApp(requestHandler, customUserBuilder);
     expressApp = appBuilder.setupRoutes(expressApp, '');

--- a/packages/a2a-server/src/http/endpoints.test.ts
+++ b/packages/a2a-server/src/http/endpoints.test.ts
@@ -69,6 +69,8 @@ vi.mock('../config/config.js', async () => {
   };
 });
 
+const TEST_BEARER_TOKEN = 'test-bearer-token-for-a2a-server-endpoints-tests';
+
 describe('Agent Server Endpoints', () => {
   let app: express.Express;
   let server: Server;
@@ -77,6 +79,7 @@ describe('Agent Server Endpoints', () => {
   const createTask = (contextId: string) =>
     request(app)
       .post('/tasks')
+      .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`)
       .send({
         contextId,
         agentSettings: {
@@ -87,6 +90,7 @@ describe('Agent Server Endpoints', () => {
       .set('Content-Type', 'application/json');
 
   beforeAll(async () => {
+    process.env['CODER_AGENT_BEARER_TOKEN'] = TEST_BEARER_TOKEN;
     // Create a unique temporary directory for the workspace to avoid conflicts
     testWorkspace = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-agent-test-'),
@@ -102,6 +106,7 @@ describe('Agent Server Endpoints', () => {
   });
 
   afterAll(async () => {
+    delete process.env['CODER_AGENT_BEARER_TOKEN'];
     if (server) {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => {
@@ -129,7 +134,9 @@ describe('Agent Server Endpoints', () => {
   it('should get metadata for a specific task via GET /tasks/:taskId/metadata', async () => {
     const createResponse = await createTask('test-context-2');
     const taskId = createResponse.body;
-    const response = await request(app).get(`/tasks/${taskId}/metadata`);
+    const response = await request(app)
+      .get(`/tasks/${taskId}/metadata`)
+      .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`);
     expect(response.status).toBe(200);
     expect(response.body.metadata.id).toBe(taskId);
   }, 6000);
@@ -137,7 +144,9 @@ describe('Agent Server Endpoints', () => {
   it('should get metadata for all tasks via GET /tasks/metadata', async () => {
     const createResponse = await createTask('test-context-3');
     const taskId = createResponse.body;
-    const response = await request(app).get('/tasks/metadata');
+    const response = await request(app)
+      .get('/tasks/metadata')
+      .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`);
     expect(response.status).toBe(200);
     expect(Array.isArray(response.body)).toBe(true);
     expect(response.body.length).toBeGreaterThan(0);
@@ -148,7 +157,9 @@ describe('Agent Server Endpoints', () => {
   });
 
   it('should return 404 for a non-existent task', async () => {
-    const response = await request(app).get('/tasks/fake-task/metadata');
+    const response = await request(app)
+      .get('/tasks/fake-task/metadata')
+      .set('Authorization', `Bearer ${TEST_BEARER_TOKEN}`);
     expect(response.status).toBe(404);
   });
 


### PR DESCRIPTION
## Summary

The A2A server's custom REST routes (`/tasks`, `/executeCommand`, `/listCommands`, `/tasks/:taskId/metadata`) are registered directly on the Express app in `createApp()` and never go through the configured `UserBuilder` at all, so they accept requests with no credentials whatsoever. Separately, `@a2a-js/sdk`'s own `DefaultRequestHandler` only checks `user.isAuthenticated` for the authenticated-extended-card method, not for `message/send` and other task-driving JSON-RPC methods, so `customUserBuilder` was never actually enforced there either. On top of that, the two example credentials it checked against (`'valid-token'`, `'admin:password'`) are hardcoded literals in public source. Net effect: the agent card's declared `bearerAuth`/`basicAuth` `securitySchemes` were not enforced anywhere, on a service the docs (`docs/core/remote-agents.md`) describe deploying as a public Cloud Run endpoint.

Verified locally: a built `a2a-server` accepted `POST /tasks`, `POST /executeCommand`, `POST /` (`message/send`), and `GET /listCommands` with zero `Authorization` header at all.

Separately, `RestoreCommand` builds the checkpoint file path from the `executeCommand` request body's `args` via `path.join(checkpointDir, selectedFile)` without validating `selectedFile`, so a name such as `../../other-project/checkpoints/some-real-checkpoint.json` escapes `checkpointDir`. Since matching checkpoint content is echoed back in the response, this discloses the contents of any other project's checkpoint file on the host (which routinely contains full conversation/tool-call history). Verified with a crafted sibling checkpoint file: the traversal read its content back through `/executeCommand` with no authentication.

## Fix

- Add an authentication middleware applied ahead of every route (public agent card excepted) that checks credentials against `CODER_AGENT_BEARER_TOKEN` / `CODER_AGENT_BASIC_USERNAME` / `CODER_AGENT_BASIC_PASSWORD` using a constant-time comparison, and fails closed (rejects everything) when unconfigured rather than falling back to a hardcoded default.
- `RestoreCommand`: reject any requested checkpoint name that isn't equal to its own `path.basename` (checkpoint filenames are always flat, see `generateCheckpointFileName`), before it ever reaches the filesystem.
- Updated `app.test.ts` / `endpoints.test.ts` to authenticate via the new env-configured bearer token, and added regression tests for: no-credentials rejection on every custom route and the JSON-RPC endpoint, rejection of the old hardcoded-style credential, and traversal rejection in `restore.test.ts`.

## Test plan

- [x] `npx vitest run --root packages/a2a-server` — 154/154 passing
- [x] `npm run typecheck --workspace=@google/gemini-cli-a2a-server`
- [x] `npx eslint` on all changed files — clean
- [x] Manual PoC against a locally built+running server: confirmed `/tasks`, `/executeCommand`, `/listCommands`, and `POST /` (`message/send`) all return `401` with no credentials post-fix (previously all succeeded); confirmed a valid configured bearer token still authenticates correctly; confirmed the checkpoint traversal PoC is rejected with "Invalid checkpoint name" both with and without valid credentials.