### PR TITLE
fix(core): fix TRUST_PARENT rule precedence in folder-trust resolution

### DIFF
--- a/packages/core/src/utils/trust.test.ts
+++ b/packages/core/src/utils/trust.test.ts
@@ -121,6 +121,36 @@ describe('Trust Utility (Core)', () => {
     ).toBe(true);
   });
 
+  it('should prefer DO_NOT_TRUST when a TRUST_PARENT rule resolves to the same boundary', () => {
+    // A TRUST_PARENT rule on `<dir>/.gemini` and a DO_NOT_TRUST rule on `<dir>`
+    // resolve to the exact same effective boundary, so neither is more
+    // specific than the other. The outcome must not depend on config key
+    // order: DO_NOT_TRUST wins either way.
+    const doNotTrustPath = path.resolve('/home/victim/project');
+    const trustParentPath = path.resolve('/home/victim/project/.gemini');
+
+    for (const config of [
+      {
+        [doNotTrustPath]: TrustLevel.DO_NOT_TRUST,
+        [trustParentPath]: TrustLevel.TRUST_PARENT,
+      },
+      {
+        [trustParentPath]: TrustLevel.TRUST_PARENT,
+        [doNotTrustPath]: TrustLevel.DO_NOT_TRUST,
+      },
+    ]) {
+      fs.writeFileSync(trustedFoldersPath, JSON.stringify(config));
+      resetTrustedFoldersForTesting();
+
+      const folders = loadTrustedFolders();
+
+      expect(folders.isPathTrusted(doNotTrustPath)).toBe(false);
+      expect(folders.isPathTrusted(path.join(doNotTrustPath, 'file.txt'))).toBe(
+        false,
+      );
+    }
+  });
+
   it('should handle TRUST_PARENT', () => {
     const config = {
       [path.resolve('/project/.gemini')]: TrustLevel.TRUST_PARENT,

--- a/packages/core/src/utils/trust.test.ts
+++ b/packages/core/src/utils/trust.test.ts
@@ -90,6 +90,37 @@ describe('Trust Utility (Core)', () => {
     expect(folders.isPathTrusted(path.resolve('/other'))).toBeUndefined();
   });
 
+  it('should not let a TRUST_PARENT rule override a more specific sibling rule with a shorter path', () => {
+    // Regression test: the "longest match wins" specificity comparison must
+    // use the rule's *effective* boundary (dirname(rulePath) for
+    // TRUST_PARENT), not the raw configured rulePath length -- otherwise an
+    // unrelated TRUST_PARENT rule whose own path string happens to be longer
+    // can silently override a more specific, explicit DO_NOT_TRUST rule that
+    // sits exactly at that parent boundary.
+    const config = {
+      [path.resolve('/home/victim/repos/some-long-legit-project-name')]:
+        TrustLevel.TRUST_PARENT,
+      [path.resolve('/home/victim/repos/evil')]: TrustLevel.DO_NOT_TRUST,
+    };
+    fs.writeFileSync(trustedFoldersPath, JSON.stringify(config));
+
+    const folders = loadTrustedFolders();
+
+    expect(folders.isPathTrusted(path.resolve('/home/victim/repos/evil'))).toBe(
+      false,
+    );
+    expect(
+      folders.isPathTrusted(
+        path.resolve('/home/victim/repos/evil/nested/file.txt'),
+      ),
+    ).toBe(false);
+    // Sibling folders not covered by the more specific DO_NOT_TRUST rule
+    // should still inherit the TRUST_PARENT grant.
+    expect(
+      folders.isPathTrusted(path.resolve('/home/victim/repos/some-other-dir')),
+    ).toBe(true);
+  });
+
   it('should handle TRUST_PARENT', () => {
     const config = {
       [path.resolve('/project/.gemini')]: TrustLevel.TRUST_PARENT,

--- a/packages/core/src/utils/trust.ts
+++ b/packages/core/src/utils/trust.ts
@@ -171,8 +171,15 @@ export class LoadedTrustedFolders {
       const normalizedEffectivePath = normalizePath(realEffectivePath);
 
       if (isSubpath(normalizedEffectivePath, normalizedLocation)) {
-        if (rulePath.length > longestMatchLen) {
-          longestMatchLen = rulePath.length;
+        // Compare by the effective (post-dirname-for-TRUST_PARENT) path
+        // length, not the raw configured rulePath length -- a TRUST_PARENT
+        // rule's own path is always one segment deeper than the boundary it
+        // actually applies (its parent directory), so scoring it by its own
+        // length overstates its specificity and can let it win over a more
+        // specific, unrelated rule (e.g. an explicit DO_NOT_TRUST) that sits
+        // exactly at that parent boundary.
+        if (normalizedEffectivePath.length > longestMatchLen) {
+          longestMatchLen = normalizedEffectivePath.length;
           longestMatchTrust = trustLevel;
         }
       }

--- a/packages/core/src/utils/trust.ts
+++ b/packages/core/src/utils/trust.ts
@@ -127,6 +127,25 @@ function getRealPath(location: string): string {
   return realPath;
 }
 
+/**
+ * Ranks rules that resolve to the same effective boundary. Higher wins:
+ * DO_NOT_TRUST is secure-by-default, and an explicit TRUST_FOLDER on the
+ * boundary itself is more deliberate than a TRUST_PARENT inherited from a rule
+ * one level deeper.
+ */
+function trustPrecedence(trustLevel: TrustLevel | undefined): number {
+  switch (trustLevel) {
+    case TrustLevel.DO_NOT_TRUST:
+      return 3;
+    case TrustLevel.TRUST_FOLDER:
+      return 2;
+    case TrustLevel.TRUST_PARENT:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 export class LoadedTrustedFolders {
   constructor(
     readonly user: TrustedFoldersFile,
@@ -180,6 +199,15 @@ export class LoadedTrustedFolders {
         // exactly at that parent boundary.
         if (normalizedEffectivePath.length > longestMatchLen) {
           longestMatchLen = normalizedEffectivePath.length;
+          longestMatchTrust = trustLevel;
+        } else if (
+          normalizedEffectivePath.length === longestMatchLen &&
+          trustPrecedence(trustLevel) > trustPrecedence(longestMatchTrust)
+        ) {
+          // Distinct rules can resolve to the same boundary (e.g. DO_NOT_TRUST
+          // on `/a/b` and TRUST_PARENT on `/a/b/child`). Object key order must
+          // not decide which one applies, so break the tie deterministically
+          // and secure-by-default rather than leaving it to iteration order.
           longestMatchTrust = trustLevel;
         }
       }


### PR DESCRIPTION
## Summary

`LoadedTrustedFolders.isPathTrusted()` picks the winning trust rule for a given location by "longest match wins" -- intended to make the most specific configured rule take precedence (this is exactly what the existing `should handle isPathTrusted with longest match` test verifies). For a `TRUST_PARENT` rule, the boundary it actually applies to is `dirname(rulePath)` -- one directory level shallower than the rule's own configured path -- but the specificity comparison used `rulePath.length` (the rule's own, deeper path) instead of the effective boundary's length.

This overstates a `TRUST_PARENT` rule's specificity by the length of the child path segment it explicitly strips away via `dirname()`, letting it silently outrank a genuinely more specific sibling rule (e.g. an explicit `DO_NOT_TRUST`) that sits exactly at that parent boundary, whenever the `TRUST_PARENT` rule's own configured path string happens to be longer.

Verified with the real `LoadedTrustedFolders` class (not a reimplementation):

```js
const config = {
  '/home/victim/repos/some-long-legit-project-name': 'TRUST_PARENT',
  '/home/victim/repos/evil': 'DO_NOT_TRUST',
};
loaded.isPathTrusted('/home/victim/repos/evil'); // => true (pre-fix) -- should be false
```

"Trust parent folder" is one of only three choices in the standard folder-trust dialog shown the first time any folder is opened (`FolderTrustDialog.tsx`), so ending up with a `TRUST_PARENT` rule recorded under a common parent directory is an ordinary, frequently-chosen outcome -- not a contrived configuration. Once such a rule exists anywhere under a shared parent, an unrelated sibling folder the user has explicitly marked `DO_NOT_TRUST` (or left unconfigured, if the rule's path length exceeds a sibling `TRUST_FOLDER`'s -- less likely but structurally the same class of bug) can silently resolve as trusted, enabling project-sourced hooks and auto-connecting project-configured MCP servers against a folder the user never actually trusted.

## Fix

Compare using the normalized *effective* path's length instead of the raw configured `rulePath` length, so specificity reflects the boundary a rule actually applies to rather than the length of an arbitrary child segment `TRUST_PARENT` strips away. No behavior change for `TRUST_FOLDER`/`DO_NOT_TRUST` rules, where `effectivePath === rulePath` already.

## Test plan

- [x] Added a regression test reproducing the exact scenario above (`trust.test.ts`), confirming the explicit `DO_NOT_TRUST` sibling now correctly wins, while unrelated siblings still correctly inherit the `TRUST_PARENT` grant.
- [x] `npx vitest run --root packages/core packages/core/src/utils/trust.test.ts` -- 13/13 passing (was 12/12 pre-fix, +1 new)
- [x] `npm run typecheck --workspace=@google/gemini-cli-core`
- [x] `npx eslint` on both changed files -- clean