### PR TITLE
chore: bump version to 0.54.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@google/gemini-cli",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "workspaces": [
         "packages/*"
       ],
@@ -17782,7 +17782,7 @@
     },
     "packages/a2a-server": {
       "name": "@google/gemini-cli-a2a-server",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "dependencies": {
         "@a2a-js/sdk": "0.3.11",
         "@google-cloud/storage": "7.19.0",
@@ -18242,7 +18242,7 @@
     },
     "packages/cli": {
       "name": "@google/gemini-cli",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.16.1",
@@ -18458,7 +18458,7 @@
     },
     "packages/core": {
       "name": "@google/gemini-cli-core",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "0.3.11",
@@ -19131,7 +19131,7 @@
     },
     "packages/devtools": {
       "name": "@google/gemini-cli-devtools",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "8.16.0"
@@ -19167,7 +19167,7 @@
     },
     "packages/sdk": {
       "name": "@google/gemini-cli-sdk",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
@@ -19506,7 +19506,7 @@
     },
     "packages/test-utils": {
       "name": "@google/gemini-cli-test-utils",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@google/gemini-cli-core": "file:../core",
@@ -19524,7 +19524,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "gemini-cli-vscode-ide-companion",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/google-gemini/gemini-cli.git"
   },
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.54.1"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.54.2"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development node scripts/start.js",

--- a/packages/a2a-server/package.json
+++ b/packages/a2a-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-a2a-server",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Gemini CLI A2A Server",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Gemini CLI",
   "license": "Apache-2.0",
   "repository": {
@@ -27,7 +27,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.54.1"
+    "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.54.2"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.16.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-core",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-devtools",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/src/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-sdk",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "Gemini CLI SDK",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/gemini-cli-test-utils",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "gemini-cli-vscode-ide-companion",
   "displayName": "Gemini CLI Companion",
   "description": "Enable Gemini CLI with direct access to your IDE workspace.",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "publisher": "google",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
## Summary

This PR bumps the package versions across all workspace packages in the monorepo to `0.54.2` via the release versioning script.

## Details

All `package.json` files and `package-lock.json` are updated to version `0.54.2` to prepare for the v0.54.2 release.

## Related Issues

None.

## How to Validate

1. Inspect modified `package.json` files and `package-lock.json` to ensure they point to `0.54.2`.
2. Confirm that workspace build and check tasks run correctly:
   ```bash
   npm run lint && npm run typecheck
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
