### PR TITLE
fix(core): record usage already received when a stream is aborted

### DIFF
--- a/packages/core/src/core/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator.test.ts
@@ -634,6 +634,58 @@ describe('LoggingContentGenerator', () => {
       expect(responseEvent.usage.total_token_count).toBe(18);
     });
 
+    it('also carries the aborted usage onto the dev trace span', async () => {
+      // The logged response and the trace must agree about the same turn; the
+      // success path sets these attributes, so the abort path has to as well.
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+
+      async function* createAsyncGenerator() {
+        yield {
+          candidates: [
+            { content: { role: 'model', parts: [{ text: 'partial' }] } },
+          ],
+          usageMetadata: {
+            promptTokenCount: 11,
+            candidatesTokenCount: 7,
+            totalTokenCount: 18,
+          },
+        } as unknown as GenerateContentResponse;
+        throw abortError;
+      }
+
+      vi.mocked(wrapped.generateContentStream).mockResolvedValue(
+        createAsyncGenerator(),
+      );
+      await loggingContentGenerator.generateContentStream(
+        req,
+        'prompt-abort-span',
+        LlmRole.MAIN,
+      );
+
+      const spanArgs = vi.mocked(runInDevTraceSpan).mock.calls[0];
+      const fn = spanArgs[1];
+      const metadata: SpanMetadata = { name: '', attributes: {} };
+
+      vi.mocked(wrapped.generateContentStream).mockResolvedValue(
+        createAsyncGenerator(),
+      );
+      const spanStream = await fn({ metadata });
+
+      await expect(async () => {
+        for await (const _ of spanStream) {
+          // drain until the abort
+        }
+      }).rejects.toThrow(abortError);
+
+      expect(metadata.attributes[GEN_AI_USAGE_INPUT_TOKENS]).toBe(11);
+      expect(metadata.attributes[GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(7);
+    });
+
     it('does not record a usage event when the stream aborts before any usage arrives', async () => {
       const req = {
         contents: [{ role: 'user', parts: [{ text: 'hello' }] }],

--- a/packages/core/src/core/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator.test.ts
@@ -579,6 +579,99 @@ describe('LoggingContentGenerator', () => {
       expect(errorEvent.duration_ms).toBe(1000);
     });
 
+    it('records usage already received when the stream is aborted mid-flight', async () => {
+      // The provider bills for tokens it streamed before the abort. `_logApiError`
+      // deliberately ignores AbortError, so without an explicit flush the usage
+      // captured per-chunk is discarded and the cancelled turn accounts for
+      // nothing.
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const userPromptId = 'prompt-abort-usage';
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+
+      async function* createAsyncGenerator() {
+        yield {
+          candidates: [
+            { content: { role: 'model', parts: [{ text: 'partial' }] } },
+          ],
+          usageMetadata: {
+            promptTokenCount: 11,
+            candidatesTokenCount: 7,
+            totalTokenCount: 18,
+          },
+          responseId: 'resp-abort',
+          modelVersion: 'gemini-pro',
+        } as unknown as GenerateContentResponse;
+        throw abortError;
+      }
+
+      vi.mocked(wrapped.generateContentStream).mockResolvedValue(
+        createAsyncGenerator(),
+      );
+
+      const stream = await loggingContentGenerator.generateContentStream(
+        req,
+        userPromptId,
+        LlmRole.MAIN,
+      );
+
+      await expect(async () => {
+        for await (const _ of stream) {
+          // drain until the abort
+        }
+      }).rejects.toThrow(abortError);
+
+      // Still not an API error.
+      expect(logApiError).not.toHaveBeenCalled();
+
+      expect(logApiResponse).toHaveBeenCalled();
+      const responseEvent = vi.mocked(logApiResponse).mock.calls[0][1];
+      expect(responseEvent.usage.input_token_count).toBe(11);
+      expect(responseEvent.usage.output_token_count).toBe(7);
+      expect(responseEvent.usage.total_token_count).toBe(18);
+    });
+
+    it('does not record a usage event when the stream aborts before any usage arrives', async () => {
+      const req = {
+        contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        model: 'gemini-pro',
+      };
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+
+      async function* createAsyncGenerator() {
+        yield {
+          candidates: [
+            { content: { role: 'model', parts: [{ text: 'partial' }] } },
+          ],
+        } as unknown as GenerateContentResponse;
+        throw abortError;
+      }
+
+      vi.mocked(wrapped.generateContentStream).mockResolvedValue(
+        createAsyncGenerator(),
+      );
+
+      const stream = await loggingContentGenerator.generateContentStream(
+        req,
+        'prompt-abort-no-usage',
+        LlmRole.MAIN,
+      );
+
+      await expect(async () => {
+        for await (const _ of stream) {
+          // drain until the abort
+        }
+      }).rejects.toThrow(abortError);
+
+      // Nothing was reported, so nothing is invented.
+      expect(logApiResponse).not.toHaveBeenCalled();
+      expect(logApiError).not.toHaveBeenCalled();
+    });
+
     it('should NOT log error on AbortError during connection phase', async () => {
       const req = {
         contents: [{ role: 'user', parts: [{ text: 'hello' }] }],

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -591,6 +591,12 @@ export class LoggingContentGenerator implements ContentGenerator {
       // Record it here instead, so a cancelled turn still accounts for the
       // tokens it actually consumed.
       if (isAbortError(error) && lastUsageMetadata) {
+        // Mirror the success path's span attributes too, so the trace and the
+        // logged response agree about the same aborted turn.
+        spanMetadata.attributes[GEN_AI_USAGE_INPUT_TOKENS] =
+          lastUsageMetadata.promptTokenCount ?? 0;
+        spanMetadata.attributes[GEN_AI_USAGE_OUTPUT_TOKENS] =
+          lastUsageMetadata.candidatesTokenCount ?? 0;
         this._logApiResponse(
           requestContents,
           durationMs,

--- a/packages/core/src/core/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator.ts
@@ -584,6 +584,27 @@ export class LoggingContentGenerator implements ContentGenerator {
     } catch (error) {
       spanMetadata.error = error;
       const durationMs = Date.now() - startTime;
+      // An aborted stream is not an API error, so `_logApiError` deliberately
+      // ignores it. That left usage the provider had already reported — and
+      // already billed — discarded along with the cancellation, because the
+      // success flush below is the only place `lastUsageMetadata` was recorded.
+      // Record it here instead, so a cancelled turn still accounts for the
+      // tokens it actually consumed.
+      if (isAbortError(error) && lastUsageMetadata) {
+        this._logApiResponse(
+          requestContents,
+          durationMs,
+          responses[0]?.modelVersion || req.model,
+          userPromptId,
+          role,
+          responses[0]?.responseId,
+          responses.flatMap((response) => response.candidates || []),
+          lastUsageMetadata,
+          undefined,
+          req.config,
+          serverDetails,
+        );
+      }
       this._logApiError(
         durationMs,
         error,


### PR DESCRIPTION
Closes #28682.

## Problem

`generateContentStream` captures `usageMetadata` from every chunk into `lastUsageMetadata` (`loggingContentGenerator.ts:544-546`), but the only place that value is ever flushed is the success path at `:551`. The catch block calls `_logApiError`, which **deliberately early-returns** for `AbortError`:

```ts
if (isAbortError(error)) {
  // Don't log aborted requests (e.g., user cancellation, internal timeouts) as API errors.
  return;
}
```

That guard is right — a cancellation isn't an API error. But it means the abort path records **nothing at all**, so the usage the provider had already reported went out with the cancellation. The provider still billed for what it streamed, and the cancelled turn accounted for zero tokens it actually consumed.

@EvolveAegis's report has the mechanism exactly right; I verified each step against `main` before changing anything.

## Approach

The abort path now flushes the captured usage through `_logApiResponse` before rethrowing. That function already takes a `usageMetadata` argument, so nothing new was needed to carry it.

`_logApiError` is untouched and still ignores aborts, so a cancellation never appears as an error — this adds the missing usage record without reclassifying the cancellation.

**Nothing is invented when there's nothing to report.** If the stream aborts before any chunk carried `usageMetadata`, no event is emitted at all. That's the second test, and it's the case that would otherwise turn this fix into the very problem #28683 describes: a fabricated all-zero usage record indistinguishable from a real zero-token response.

## How tested

- `records usage already received when the stream is aborted mid-flight` — yields one chunk carrying usage, then throws `AbortError`. Asserts the usage lands (`input 11 / output 7 / total 18`) **and** that `logApiError` is still not called. Fails on the parent commit with `expected "spy" to be called at least once`.
- `does not record a usage event when the stream aborts before any usage arrives` — pins the negative, so a future change can't start emitting zeros.

Full file suite: **35 passed**. `eslint --max-warnings 0` and `prettier --check` clean on both files. `npm run typecheck` exit 0. The repo's `pre-commit` hook ran clean on the staged files.

## Not included

#28683 (missing `usageMetadata` recorded as all-zero) is the adjacent issue in the same subsystem and I've deliberately left it alone — it's a change to `ApiResponseEvent`'s constructor semantics in `telemetry/types.ts` with a wider blast radius than this one, and it deserves its own review rather than riding along. Happy to take it separately.

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.
