### PR TITLE
fix(security): upgrade sandbox Dockerfile to node:22-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Builder ----
-FROM docker.io/library/node:20-slim AS builder
+FROM docker.io/library/node:22-slim AS builder
 
 # Install git (needed by generate-git-commit-info.js script)
 RUN apt-get update && apt-get install -y --no-install-recommends git \
@@ -39,7 +39,7 @@ RUN HUSKY=0 npm run build && \
     npm pack -w packages/cli --pack-destination packages/cli/dist/
 
 # ---- Stage 2: Runtime ----
-FROM docker.io/library/node:20-slim
+FROM docker.io/library/node:22-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
 ARG CLI_VERSION_ARG

--- a/tools/caretaker-agent/cloudrun/egress-service/Dockerfile
+++ b/tools/caretaker-agent/cloudrun/egress-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/tools/caretaker-agent/cloudrun/ingestion-service/Dockerfile
+++ b/tools/caretaker-agent/cloudrun/ingestion-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/tools/caretaker-agent/cloudrun/pr-generator/Dockerfile
+++ b/tools/caretaker-agent/cloudrun/pr-generator/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Node.js 20 and npm directly from the official node:20-slim image
-COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:20-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Copy Node.js 22 and npm directly from the official node:22-slim image
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 


### PR DESCRIPTION
Fixes #28584

## Description

This PR updates the Sandbox `Dockerfile` and all other `tools/caretaker-agent/cloudrun/*/Dockerfile` instances from `node:20-slim` to `node:22-slim`. 

Node 20 is reaching EOL and is no longer receiving security fixes (e.g. recent CVEs are only patched in Node 22/24/26). Upgrading to Node 22 ensures the sandbox runtime boundary remains secure with supported Node.js versions.

This re-aligns the Dockerfiles with the intent introduced in PR #1038 (which originally moved to Node 22).

## Changes made
- Upgraded `Dockerfile` builder and runtime stages to `node:22-slim`
- Upgraded `tools/caretaker-agent/cloudrun/egress-service/Dockerfile` to `node:22-slim`
- Upgraded `tools/caretaker-agent/cloudrun/ingestion-service/Dockerfile` to `node:22-slim`
- Upgraded `tools/caretaker-agent/cloudrun/pr-generator/Dockerfile` references to `node:22-slim`
