### PR TITLE
fix(core): handle EACCES in resolveToRealPath to prevent sandbox crash

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -564,6 +564,25 @@ describe('resolveToRealPath', () => {
     expect(resolveToRealPath(input)).toBe(expected);
   });
 
+  it('should return decoded path even if fs.realpathSync fails with EACCES', () => {
+    vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
+      const err = new Error('Permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+    vi.spyOn(fs, 'lstatSync').mockImplementationOnce(() => {
+      const err = new Error('Permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+
+    const p = path.resolve('path', 'to', 'New Project');
+    const input = pathToFileURL(p).toString();
+    const expected = p;
+
+    expect(resolveToRealPath(input)).toBe(expected);
+  });
+
   it('should recursively resolve symlinks for non-existent child paths', () => {
     const parentPath = path.resolve('/some/parent/path');
     const resolvedParentPath = path.resolve('/resolved/parent/path');

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -564,24 +564,27 @@ describe('resolveToRealPath', () => {
     expect(resolveToRealPath(input)).toBe(expected);
   });
 
-  it('should return decoded path even if fs.realpathSync fails with EACCES', () => {
-    vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
-      const err = new Error('Permission denied') as NodeJS.ErrnoException;
-      err.code = 'EACCES';
-      throw err;
-    });
-    vi.spyOn(fs, 'lstatSync').mockImplementationOnce(() => {
-      const err = new Error('Permission denied') as NodeJS.ErrnoException;
-      err.code = 'EACCES';
-      throw err;
-    });
+  it.each(['EACCES', 'EPERM'])(
+    'should return decoded path even if fs.realpathSync fails with %s',
+    (code) => {
+      vi.spyOn(fs, 'realpathSync').mockImplementationOnce(() => {
+        const err = new Error('Permission denied') as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      });
+      vi.spyOn(fs, 'lstatSync').mockImplementationOnce(() => {
+        const err = new Error('Permission denied') as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      });
 
-    const p = path.resolve('path', 'to', 'New Project');
-    const input = pathToFileURL(p).toString();
-    const expected = p;
+      const p = path.resolve('path', 'to', 'New Project');
+      const input = pathToFileURL(p).toString();
+      const expected = p;
 
-    expect(resolveToRealPath(input)).toBe(expected);
-  });
+      expect(resolveToRealPath(input)).toBe(expected);
+    },
+  );
 
   it('should recursively resolve symlinks for non-existent child paths', () => {
     const parentPath = path.resolve('/some/parent/path');

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -444,7 +444,8 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         e.code === 'EISDIR' ||
         e.code === 'ENAMETOOLONG' ||
         e.code === 'ENOTDIR' ||
-        e.code === 'EACCES')
+        e.code === 'EACCES' ||
+        e.code === 'EPERM')
     ) {
       try {
         const stat = fs.lstatSync(p);
@@ -455,7 +456,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         }
       } catch (lstatError: unknown) {
         // Not a symlink, or lstat failed. Re-throw if it's not an expected
-        // ENOENT/EACCES (e.g., a permissions error), otherwise resolve parent.
+        // ENOENT/EACCES/EPERM (e.g., a permissions error), otherwise resolve parent.
         if (
           !(
             lstatError &&
@@ -465,7 +466,8 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
               lstatError.code === 'EISDIR' ||
               lstatError.code === 'ENAMETOOLONG' ||
               lstatError.code === 'ENOTDIR' ||
-              lstatError.code === 'EACCES')
+              lstatError.code === 'EACCES' ||
+              lstatError.code === 'EPERM')
           )
         ) {
           throw lstatError;

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -443,7 +443,8 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       (e.code === 'ENOENT' ||
         e.code === 'EISDIR' ||
         e.code === 'ENAMETOOLONG' ||
-        e.code === 'ENOTDIR')
+        e.code === 'ENOTDIR' ||
+        e.code === 'EACCES')
     ) {
       try {
         const stat = fs.lstatSync(p);
@@ -454,7 +455,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         }
       } catch (lstatError: unknown) {
         // Not a symlink, or lstat failed. Re-throw if it's not an expected
-        // ENOENT (e.g., a permissions error), otherwise resolve parent.
+        // ENOENT/EACCES (e.g., a permissions error), otherwise resolve parent.
         if (
           !(
             lstatError &&
@@ -463,7 +464,8 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
             (lstatError.code === 'ENOENT' ||
               lstatError.code === 'EISDIR' ||
               lstatError.code === 'ENAMETOOLONG' ||
-              lstatError.code === 'ENOTDIR')
+              lstatError.code === 'ENOTDIR' ||
+              lstatError.code === 'EACCES')
           )
         ) {
           throw lstatError;


### PR DESCRIPTION
## Summary

- Fixes a CLI crash on startup when macOS Seatbelt sandboxing is enabled and the CWD is inside a Git repository.
- `resolveToRealPath` (in `packages/core/src/utils/paths.ts`) only recovered from `fs.realpathSync` failures with codes `ENOENT`, `EISDIR`, `ENAMETOOLONG`, or `ENOTDIR`. Any other error — notably `EACCES` (permission denied) — propagated as an uncaught exception.
- During Seatbelt profile generation (`buildSeatbeltProfile` in `packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts`), `denyUnlessExplicitlyAllowed` calls `resolveToRealPath` on governance paths such as `.git` with no surrounding try/catch, and this is invoked synchronously from `MacOsSandboxManager.prepareCommand`, which also has no error handling around it. In restricted macOS sandbox environments, `fs.realpathSync` can throw `EACCES` while resolving `.git`, which crashed the CLI immediately on startup — but only when run inside a Git repository (outside of one, the `.git` resolution is never attempted).

## Details

`robustRealpath` already has a documented fallback path for "expected" filesystem errors: fall back to resolving the parent directory and re-joining the basename, so the function degrades to a best-effort lexical path instead of throwing. This PR adds `EACCES` to the list of codes that trigger this fallback (both when `fs.realpathSync` itself fails, and when the subsequent `fs.lstatSync` check also fails), matching the existing pattern for `ENOENT`/`EISDIR`/`ENAMETOOLONG`/`ENOTDIR`.

This is a minimal, targeted fix to `resolveToRealPath`/`robustRealpath` — no changes to the Seatbelt profile rules or sandbox permission logic themselves.

## Related Issues

Fixes #28598

## How to Validate

1. `cd packages/core && npx vitest run src/utils/paths.test.ts` — includes a new test, "should return decoded path even if fs.realpathSync fails with EACCES", proving the previous behavior threw and the fix resolves gracefully.
2. On macOS with `"tools": { "sandbox": true }` set, run `gemini` inside a directory containing a Git repository — the CLI should start normally instead of crashing.

### Test output (after fix)

```
✓ src/utils/paths.test.ts (154 tests | 37 skipped)
✓ src/sandbox/macos/seatbeltArgsBuilder.test.ts (9 tests)
✓ src/sandbox/macos/MacOsSandboxManager.test.ts (11 tests)

Test Files  3 passed (3)
     Tests  137 passed | 37 skipped (174)
```

Full `packages/core` test suite: 399 files / 7380 tests pass. The only failures (19 tests, all in `sandboxManager.integration.test.ts`) are pre-existing and unrelated — they require the `bwrap` binary (Linux bubblewrap sandboxing) which isn't installed in this environment; they fail identically against unmodified `main`.

Confirmed the added test fails without the fix: checked out the pre-fix version of `packages/core/src/utils/paths.ts` with the new test in place, and the EACCES test failed with an uncaught "Permission denied" error, matching the reported crash.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — not needed, internal error-handling fix
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
  - [ ] Windows
  - [ ] Linux

---

_Disclosure: this PR was prepared with AI assistance (Claude)._
