### PR TITLE
fix(core): ensure formatTruncatedToolOutput returns unchanged content for non-positive maxChars

### DIFF
--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -663,7 +663,7 @@ export function formatTruncatedToolOutput(
   outputFile: string,
   maxChars: number,
 ): string {
-  if (contentStr.length <= maxChars) return contentStr;
+  if (maxChars <= 0 || contentStr.length <= maxChars) return contentStr;
 
   const headChars = Math.floor(maxChars * 0.2);
   const tailChars = maxChars - headChars;


### PR DESCRIPTION
Fixes #28620. Added a guard to prevent output inflation.