### PR TITLE
fix(core): ensure oauth callback timeout is cleared when flow completes

### DIFF
--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -232,8 +232,13 @@ export function startCallbackServer(
       );
       timeoutId.unref();
 
-      const onAbort = () => {
+      const cleanup = () => {
+        clearTimeout(timeoutId);
         server.close();
+      };
+
+      const onAbort = () => {
+        cleanup();
         reject(abortController.signal.reason);
       };
       abortController.signal.addEventListener('abort', onAbort, { once: true });
@@ -241,6 +246,23 @@ export function startCallbackServer(
       server.on('close', () => {
         abortController.signal.removeEventListener('abort', onAbort);
       });
+
+      // Wrap resolve and reject to ensure cleanup is always called
+      const originalResolve = resolve;
+      resolve = (
+        value:
+          | OAuthAuthorizationResponse
+          | PromiseLike<OAuthAuthorizationResponse>,
+      ) => {
+        cleanup();
+        originalResolve(value);
+      };
+
+      const originalReject = reject;
+      reject = (reason?: unknown) => {
+        cleanup();
+        originalReject(reason);
+      };
     },
   );
 


### PR DESCRIPTION
Fixes #28652. Wrapped resolve and reject in startCallbackServer to clear the timeout and close the server gracefully, preventing dangling timeouts after authentication completes.