### PR TITLE
fix(feat) : Allow agents to call agents

### DIFF
--- a/docs/core/subagents.md
+++ b/docs/core/subagents.md
@@ -430,6 +430,14 @@ Each subagent runs in its own isolated context loop. This means:
   with an explicit error. Each level is independently bounded by its own
   `max_turns` and `timeout_mins`.
 
+When one agent delegates to another, each agent's tools always come from its
+**own** `tools` list — a delegate is never handed its caller's tools, and is
+never narrowed to them either. This keeps an agent definition meaning the same
+thing however it was reached, so a thin coordinator that lists only other agents
+still works. Tool confirmations from a delegate are routed through its caller's
+message bus and attributed as `caller/delegate`, so nested tool calls stay
+sanitized and correctly labelled in the UI.
+
 ## Subagent tool isolation
 
 Subagent tool isolation moves Gemini CLI away from a single global tool

--- a/docs/core/subagents.md
+++ b/docs/core/subagents.md
@@ -359,17 +359,17 @@ it yourself; just report it.
 
 ### Configuration schema
 
-| Field          | Type   | Required | Description                                                                                                                                                                                                   |
-| :------------- | :----- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`         | string | Yes      | Unique identifier (slug) used as the tool name for the agent. Only lowercase letters, numbers, hyphens, and underscores.                                                                                      |
-| `description`  | string | Yes      | Short description of what the agent does. This is visible to the main agent to help it decide when to call this subagent.                                                                                     |
-| `kind`         | string | No       | `local` (default) or `remote`.                                                                                                                                                                                |
-| `tools`        | array  | No       | List of tool names this agent can use. Supports wildcards: `*` (all tools), `mcp_*` (all MCP tools), `mcp_server_*` (all tools from a server). **If omitted, it inherits all tools from the parent session.** |
-| `mcpServers`   | object | No       | Configuration for inline Model Context Protocol (MCP) servers isolated to this specific agent.                                                                                                                |
-| `model`        | string | No       | Specific model to use (for example, `gemini-3-preview`). Defaults to `inherit` (uses the main session model).                                                                                                 |
-| `temperature`  | number | No       | Model temperature (0.0 - 2.0). Defaults to `1`.                                                                                                                                                               |
-| `max_turns`    | number | No       | Maximum number of conversation turns allowed for this agent before it must return. Defaults to `30`.                                                                                                          |
-| `timeout_mins` | number | No       | Maximum execution time in minutes. Defaults to `10`.                                                                                                                                                          |
+| Field          | Type   | Required | Description                                                                                                                                                                                                                                                                                          |
+| :------------- | :----- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | string | Yes      | Unique identifier (slug) used as the tool name for the agent. Only lowercase letters, numbers, hyphens, and underscores.                                                                                                                                                                             |
+| `description`  | string | Yes      | Short description of what the agent does. This is visible to the main agent to help it decide when to call this subagent.                                                                                                                                                                            |
+| `kind`         | string | No       | `local` (default) or `remote`.                                                                                                                                                                                                                                                                       |
+| `tools`        | array  | No       | List of tool names this agent can use. Supports wildcards: `*` (all tools), `mcp_*` (all MCP tools), `mcp_server_*` (all tools from a server). May also list other agents by name (or `agent_*` for all of them) to allow delegation. **If omitted, it inherits all tools from the parent session.** |
+| `mcpServers`   | object | No       | Configuration for inline Model Context Protocol (MCP) servers isolated to this specific agent.                                                                                                                                                                                                       |
+| `model`        | string | No       | Specific model to use (for example, `gemini-3-preview`). Defaults to `inherit` (uses the main session model).                                                                                                                                                                                        |
+| `temperature`  | number | No       | Model temperature (0.0 - 2.0). Defaults to `1`.                                                                                                                                                                                                                                                      |
+| `max_turns`    | number | No       | Maximum number of conversation turns allowed for this agent before it must return. Defaults to `30`.                                                                                                                                                                                                 |
+| `timeout_mins` | number | No       | Maximum execution time in minutes. Defaults to `10`.                                                                                                                                                                                                                                                 |
 
 ### Tool wildcards
 
@@ -380,6 +380,41 @@ access to groups of tools:
 - `mcp_*`: Grant access to all tools from all connected MCP servers.
 - `mcp_my-server_*`: Grant access to all tools from a specific MCP server named
   `my-server`.
+- `agent_*`: Grant access to every registered agent (see
+  [Delegating to other agents](#delegating-to-other-agents)).
+
+### Delegating to other agents
+
+A subagent can delegate to other subagents — or to itself — for the same reason
+the main agent does: context isolation. Delegation is **opt-in**: list the
+agents you want to reach in `tools`.
+
+```markdown
+---
+name: release-manager
+description: Coordinates a release by delegating to specialized agents.
+tools:
+  - read_file
+  - security-auditor # delegate to this specific agent
+  - changelog-writer # ...and this one
+---
+
+Coordinate the release. Delegate the security review and the changelog to the
+appropriate agent instead of doing that work yourself.
+```
+
+Accepted entries:
+
+- **An agent name** (for example, `security-auditor`): grants access to that one
+  agent. Listing the agent's own name lets it recurse into itself.
+- **`agent_*`** or **`invoke_agent`**: grants access to every registered agent.
+
+When one or more agents are granted, the subagent receives an `invoke_agent`
+tool whose `agent_name` parameter is restricted to exactly those agents; calling
+anything else fails.
+
+The generic `*` wildcard does **not** grant agent access, and neither does
+omitting `tools` — delegation always has to be requested explicitly.
 
 ### Isolation and recursion protection
 
@@ -389,9 +424,11 @@ Each subagent runs in its own isolated context loop. This means:
   the main agent's context.
 - **Isolated tools:** The subagent only has access to the tools you explicitly
   grant it.
-- **Recursion protection:** To prevent infinite loops and excessive token usage,
-  subagents **cannot** call other subagents. If a subagent is granted the `*`
-  tool wildcard, it will still be unable to see or invoke other agents.
+- **Bounded recursion:** To prevent infinite loops and excessive token usage,
+  agent nesting is capped at 3 levels. An agent running at the maximum depth is
+  not given an `invoke_agent` tool at all, and any attempt to nest past it fails
+  with an explicit error. Each level is independently bounded by its own
+  `max_turns` and `timeout_mins`.
 
 ## Subagent tool isolation
 

--- a/packages/core/src/agents/agent-tool.test.ts
+++ b/packages/core/src/agents/agent-tool.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AgentTool } from './agent-tool.js';
+import { AgentTool, MAX_AGENT_DEPTH } from './agent-tool.js';
+import type { AgentLoopContext } from '../config/agent-loop-context.js';
 import { makeFakeConfig } from '../test-utils/config.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import type { Config } from '../config/config.js';
@@ -144,6 +145,102 @@ describe('AgentTool', () => {
       'invoke_agent',
       'Invoke Browser Agent',
     );
+  });
+
+  describe('allowedAgentNames', () => {
+    it('should advertise only the allowed agents in its schema', () => {
+      const scoped = new AgentTool(mockConfig, mockMessageBus, undefined, {
+        allowedAgentNames: ['TestLocalAgent'],
+      });
+
+      const schema = scoped.parameterSchema as {
+        properties: { agent_name: { enum?: string[]; description: string } };
+      };
+      expect(schema.properties.agent_name.enum).toEqual(['TestLocalAgent']);
+      expect(schema.properties.agent_name.description).toContain(
+        'TestLocalAgent',
+      );
+    });
+
+    it('should leave the schema unconstrained when unrestricted', () => {
+      const schema = tool.parameterSchema as {
+        properties: { agent_name: { enum?: string[] } };
+      };
+      expect(schema.properties.agent_name.enum).toBeUndefined();
+    });
+
+    it('should invoke an agent that is on the allowlist', async () => {
+      const scoped = new AgentTool(mockConfig, mockMessageBus, undefined, {
+        allowedAgentNames: ['TestLocalAgent'],
+      });
+
+      const invocation = scoped['createInvocation'](
+        { agent_name: 'TestLocalAgent', prompt: 'Do something' },
+        mockMessageBus,
+      );
+      await invocation.shouldConfirmExecute(new AbortController().signal);
+
+      expect(LocalSubagentInvocation).toHaveBeenCalled();
+    });
+
+    it('should reject an agent that exists but is not on the allowlist', () => {
+      const scoped = new AgentTool(mockConfig, mockMessageBus, undefined, {
+        allowedAgentNames: ['TestLocalAgent'],
+      });
+
+      expect(() =>
+        scoped['createInvocation'](
+          { agent_name: 'TestRemoteAgent', prompt: 'Hello' },
+          mockMessageBus,
+        ),
+      ).toThrow(
+        "Subagent 'TestRemoteAgent' is not available to this agent. Available subagents: TestLocalAgent.",
+      );
+    });
+  });
+
+  describe('recursion depth', () => {
+    const contextAtDepth = (agentDepth: number): AgentLoopContext =>
+      ({ config: mockConfig, agentDepth }) as unknown as AgentLoopContext;
+
+    it('should allow invocation below the maximum depth', async () => {
+      const nested = new AgentTool(
+        contextAtDepth(MAX_AGENT_DEPTH - 1),
+        mockMessageBus,
+      );
+
+      const invocation = nested['createInvocation'](
+        { agent_name: 'TestLocalAgent', prompt: 'Do something' },
+        mockMessageBus,
+      );
+      await invocation.shouldConfirmExecute(new AbortController().signal);
+
+      expect(LocalSubagentInvocation).toHaveBeenCalled();
+    });
+
+    it('should refuse to nest past the maximum depth', () => {
+      const nested = new AgentTool(
+        contextAtDepth(MAX_AGENT_DEPTH),
+        mockMessageBus,
+      );
+
+      expect(() =>
+        nested['createInvocation'](
+          { agent_name: 'TestLocalAgent', prompt: 'Do something' },
+          mockMessageBus,
+        ),
+      ).toThrow(`Maximum agent nesting depth (${MAX_AGENT_DEPTH}) reached`);
+    });
+
+    it('should treat a missing depth as the top level', async () => {
+      const invocation = tool['createInvocation'](
+        { agent_name: 'TestLocalAgent', prompt: 'Do something' },
+        mockMessageBus,
+      );
+      await invocation.shouldConfirmExecute(new AbortController().signal);
+
+      expect(LocalSubagentInvocation).toHaveBeenCalled();
+    });
   });
 
   describe('agentSessionSubagentEnabled feature flag', () => {

--- a/packages/core/src/agents/agent-tool.ts
+++ b/packages/core/src/agents/agent-tool.ts
@@ -34,6 +34,36 @@ import {
 import { AGENT_TOOL_NAME } from '../tools/tool-names.js';
 
 /**
+ * Maximum number of nested agent levels. A top-level (user-facing) turn is at
+ * depth 0, the agent it invokes runs at depth 1, and so on. Once an agent is
+ * running at this depth it can no longer invoke further agents.
+ */
+export const MAX_AGENT_DEPTH = 3;
+
+/** Optional restrictions applied to an {@link AgentTool} instance. */
+export interface AgentToolOptions {
+  /**
+   * The only agents this tool may invoke. Omit to allow every registered
+   * agent (the behaviour of the top-level tool).
+   */
+  readonly allowedAgentNames?: readonly string[];
+}
+
+function buildAgentNameSchema(allowedAgentNames?: readonly string[]): object {
+  if (!allowedAgentNames) {
+    return {
+      type: 'string',
+      description: 'Name of the subagent to invoke',
+    };
+  }
+  return {
+    type: 'string',
+    description: `Name of the subagent to invoke. Must be one of: ${allowedAgentNames.join(', ')}.`,
+    enum: [...allowedAgentNames],
+  };
+}
+
+/**
  * A unified tool for invoking subagents.
  *
  * Handles looking up the subagent, validating its eligibility,
@@ -46,10 +76,13 @@ export class AgentTool extends BaseDeclarativeTool<
 > {
   static readonly Name = AGENT_TOOL_NAME;
 
+  private readonly allowedAgentNames?: readonly string[];
+
   constructor(
     private readonly context: AgentLoopContext,
     messageBus: MessageBus,
     private readonly onAgentEvent?: (event: AgentEvent) => void,
+    options?: AgentToolOptions,
   ) {
     super(
       AGENT_TOOL_NAME,
@@ -59,10 +92,7 @@ export class AgentTool extends BaseDeclarativeTool<
       {
         type: 'object',
         properties: {
-          agent_name: {
-            type: 'string',
-            description: 'Name of the subagent to invoke',
-          },
+          agent_name: buildAgentNameSchema(options?.allowedAgentNames),
           prompt: {
             type: 'string',
             description:
@@ -75,6 +105,7 @@ export class AgentTool extends BaseDeclarativeTool<
       /* isOutputMarkdown */ true,
       /* canUpdateOutput */ true,
     );
+    this.allowedAgentNames = options?.allowedAgentNames;
   }
 
   protected createInvocation(
@@ -83,6 +114,26 @@ export class AgentTool extends BaseDeclarativeTool<
     _toolName?: string,
     _toolDisplayName?: string,
   ): ToolInvocation<{ agent_name: string; prompt: string }, ToolResult> {
+    const depth = this.context.agentDepth ?? 0;
+    if (depth >= MAX_AGENT_DEPTH) {
+      throw new Error(
+        `Maximum agent nesting depth (${MAX_AGENT_DEPTH}) reached; ` +
+          `'${params.agent_name}' cannot be invoked from here. ` +
+          `Complete the task directly instead of delegating further.`,
+      );
+    }
+
+    if (
+      this.allowedAgentNames &&
+      !this.allowedAgentNames.includes(params.agent_name)
+    ) {
+      const available = this.allowedAgentNames.join(', ') || '(none)';
+      throw new Error(
+        `Subagent '${params.agent_name}' is not available to this agent. ` +
+          `Available subagents: ${available}.`,
+      );
+    }
+
     const registry = this.context.config.getAgentRegistry();
     const definition = registry.getDefinition(params.agent_name);
 

--- a/packages/core/src/agents/agent-tool.ts
+++ b/packages/core/src/agents/agent-tool.ts
@@ -34,18 +34,14 @@ import {
 import { AGENT_TOOL_NAME } from '../tools/tool-names.js';
 
 /**
- * Maximum number of nested agent levels. A top-level (user-facing) turn is at
- * depth 0, the agent it invokes runs at depth 1, and so on. Once an agent is
- * running at this depth it can no longer invoke further agents.
+ * Maximum number of nested agent levels. A user-facing turn is at depth 0, the
+ * agent it invokes at depth 1, and so on; an agent at this depth cannot
+ * invoke further agents.
  */
 export const MAX_AGENT_DEPTH = 3;
 
-/** Optional restrictions applied to an {@link AgentTool} instance. */
 export interface AgentToolOptions {
-  /**
-   * The only agents this tool may invoke. Omit to allow every registered
-   * agent (the behaviour of the top-level tool).
-   */
+  /** The only agents this tool may invoke. Omit to allow every agent. */
   readonly allowedAgentNames?: readonly string[];
 }
 

--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -84,6 +84,63 @@ System prompt content.`);
       });
     });
 
+    it('should accept agent names and the agent wildcard in tools', async () => {
+      const filePath = await writeAgentMarkdown(`---
+name: orchestrator
+description: An agent that delegates to other agents
+tools:
+  - run_shell_command
+  - code-reviewer
+  - codebase_investigator
+  - invoke_agent
+  - agent_*
+---
+System prompt content.`);
+
+      const result = await parseAgentMarkdown(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        name: 'orchestrator',
+        tools: [
+          'run_shell_command',
+          'code-reviewer',
+          'codebase_investigator',
+          'invoke_agent',
+          'agent_*',
+        ],
+      });
+    });
+
+    it('should still reject tool entries that are not valid tool or agent names', async () => {
+      const filePath = await writeAgentMarkdown(`---
+name: bad-tools-agent
+description: An agent with a bogus tool entry
+tools:
+  - Not A Valid Name
+---
+System prompt content.`);
+
+      const error = await parseAgentMarkdown(filePath).catch((e) => e);
+      expect(error).toBeInstanceOf(AgentLoadError);
+      expect(error.message).toContain('Invalid tool or agent name');
+    });
+
+    it('should convert agent references in tools into the agent definition', async () => {
+      const filePath = await writeAgentMarkdown(`---
+name: orchestrator-2
+description: An agent that delegates to other agents
+tools:
+  - code-reviewer
+---
+System prompt content.`);
+
+      const [markdown] = await parseAgentMarkdown(filePath);
+      const definition = markdownToAgentDefinition(
+        markdown,
+      ) as LocalAgentDefinition;
+      expect(definition.toolConfig?.tools).toEqual(['code-reviewer']);
+    });
+
     it('should parse frontmatter with mcp_servers', async () => {
       const filePath = await writeAgentMarkdown(`---
 name: mcp-agent

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -97,14 +97,17 @@ const localAgentSchema = z
     display_name: z.string().optional(),
     tools: z
       .array(
-        z
-          .string()
-          .refine(
-            (val: string) => isValidToolName(val, { allowWildcards: true }),
-            {
-              message: 'Invalid tool name',
-            },
-          ),
+        z.string().refine(
+          (val: string) =>
+            isValidToolName(val, {
+              allowWildcards: true,
+              // Agents may also list other agents (or themselves) here.
+              allowAgentNames: true,
+            }),
+          {
+            message: 'Invalid tool or agent name',
+          },
+        ),
       )
       .optional(),
     mcp_servers: z.record(mcpServerSchema).optional(),

--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -58,10 +58,13 @@ import { ResourceRegistry } from '../resources/resource-registry.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import { LSTool } from '../tools/ls.js';
 import {
+  AGENT_TOOL_NAME,
+  ALL_AGENTS_WILDCARD,
   COMPLETE_TASK_TOOL_NAME,
   LS_TOOL_NAME,
   READ_FILE_TOOL_NAME,
 } from '../tools/tool-names.js';
+import { AgentTool, MAX_AGENT_DEPTH } from './agent-tool.js';
 import {
   GeminiChat,
   StreamEventType,
@@ -487,6 +490,7 @@ describe('LocalAgentExecutor', () => {
     );
     vi.spyOn(mockConfig, 'getAgentRegistry').mockReturnValue({
       getAllAgentNames: () => [],
+      getDefinition: () => undefined,
     } as unknown as AgentRegistry);
 
     mockedGetDirectoryContextString.mockResolvedValue(
@@ -834,6 +838,204 @@ describe('LocalAgentExecutor', () => {
 
       // Should exclude subagent
       expect(agentRegistry.getTool(subAgentName)).toBeUndefined();
+    });
+
+    describe('agents calling agents', () => {
+      const stubAgentRegistry = (names: string[]) => {
+        vi.spyOn(mockConfig, 'getAgentRegistry').mockReturnValue({
+          getAllAgentNames: () => names,
+          getDefinition: (name: string) =>
+            names.includes(name)
+              ? ({ kind: 'local', name } as unknown as LocalAgentDefinition)
+              : undefined,
+        } as unknown as AgentRegistry);
+      };
+
+      const getAllowedAgentNames = (
+        registry: ToolRegistry,
+      ): string[] | undefined => {
+        const tool = registry.getTool(AGENT_TOOL_NAME);
+        if (!tool) return undefined;
+        const schema = tool.parameterSchema as {
+          properties: { agent_name: { enum?: string[] } };
+        };
+        return schema.properties.agent_name.enum;
+      };
+
+      it('should grant a scoped invoke_agent tool for a listed agent name', async () => {
+        stubAgentRegistry(['code-reviewer', 'doc-writer']);
+
+        const definition = createTestDefinition([
+          LS_TOOL_NAME,
+          'code-reviewer',
+        ]);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+        const registry = executor['toolRegistry'];
+
+        expect(registry.getTool(LS_TOOL_NAME)).toBeDefined();
+        const agentTool = registry.getTool(AGENT_TOOL_NAME);
+        expect(agentTool).toBeDefined();
+        expect(agentTool!.kind).toBe(Kind.Agent);
+        // Only the listed agent is offered, not every registered agent.
+        expect(getAllowedAgentNames(registry)).toEqual(['code-reviewer']);
+      });
+
+      it('should allow an agent to list itself for recursion', async () => {
+        stubAgentRegistry(['TestAgent']);
+
+        const definition = createTestDefinition([LS_TOOL_NAME, 'TestAgent']);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(getAllowedAgentNames(executor['toolRegistry'])).toEqual([
+          'TestAgent',
+        ]);
+      });
+
+      it.each([ALL_AGENTS_WILDCARD, AGENT_TOOL_NAME])(
+        'should grant access to all agents via %s',
+        async (entry) => {
+          stubAgentRegistry(['code-reviewer', 'doc-writer']);
+
+          const definition = createTestDefinition([LS_TOOL_NAME, entry]);
+          const executor = await LocalAgentExecutor.create(
+            definition,
+            mockConfig,
+            onActivity,
+          );
+
+          expect(getAllowedAgentNames(executor['toolRegistry'])).toEqual([
+            'code-reviewer',
+            'doc-writer',
+          ]);
+        },
+      );
+
+      it('should not register invoke_agent when no agents are listed', async () => {
+        stubAgentRegistry(['code-reviewer']);
+
+        const definition = createTestDefinition([LS_TOOL_NAME]);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(
+          executor['toolRegistry'].getTool(AGENT_TOOL_NAME),
+        ).toBeUndefined();
+      });
+
+      it('should not grant agent access via the "*" wildcard', async () => {
+        stubAgentRegistry(['code-reviewer']);
+        const { messageBus } = mockConfig as unknown as {
+          messageBus: MessageBus;
+        };
+        parentToolRegistry.registerTool(new AgentTool(mockConfig, messageBus));
+
+        const definition = createTestDefinition(['*']);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(
+          executor['toolRegistry'].getTool(AGENT_TOOL_NAME),
+        ).toBeUndefined();
+      });
+
+      it('should not grant agent access when toolConfig is undefined', async () => {
+        stubAgentRegistry(['code-reviewer']);
+        const { messageBus } = mockConfig as unknown as {
+          messageBus: MessageBus;
+        };
+        parentToolRegistry.registerTool(new AgentTool(mockConfig, messageBus));
+
+        const definition = createTestDefinition();
+        definition.toolConfig = undefined;
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+        const registry = executor['toolRegistry'];
+
+        expect(registry.getTool(LS_TOOL_NAME)).toBeDefined();
+        expect(registry.getTool(AGENT_TOOL_NAME)).toBeUndefined();
+      });
+
+      it('should warn and ignore names matching neither a tool nor an agent', async () => {
+        stubAgentRegistry(['code-reviewer']);
+        const warnSpy = vi
+          .spyOn(debugLogger, 'warn')
+          .mockImplementation(() => {});
+
+        const definition = createTestDefinition([LS_TOOL_NAME, 'no-such-name']);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(
+          executor['toolRegistry'].getTool(AGENT_TOOL_NAME),
+        ).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('no-such-name'),
+        );
+      });
+
+      it('should hand the nested agent tool an incremented depth', async () => {
+        stubAgentRegistry(['code-reviewer']);
+
+        const definition = createTestDefinition([
+          LS_TOOL_NAME,
+          'code-reviewer',
+        ]);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        const agentTool = executor['toolRegistry'].getTool(
+          AGENT_TOOL_NAME,
+        ) as AgentTool;
+        const nestedContext = agentTool['context'];
+        expect(nestedContext.agentDepth).toBe(1);
+        expect(nestedContext.config).toBe(mockConfig);
+        expect(nestedContext.toolRegistry).toBe(parentToolRegistry);
+      });
+
+      it('should stop granting agent access at the maximum nesting depth', async () => {
+        stubAgentRegistry(['code-reviewer']);
+        Object.defineProperty(mockConfig, 'agentDepth', {
+          value: MAX_AGENT_DEPTH - 1,
+          configurable: true,
+        });
+
+        const definition = createTestDefinition([
+          LS_TOOL_NAME,
+          'code-reviewer',
+        ]);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(
+          executor['toolRegistry'].getTool(AGENT_TOOL_NAME),
+        ).toBeUndefined();
+      });
     });
 
     it('should automatically qualify MCP tools in agent definitions', async () => {

--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -1012,7 +1012,66 @@ describe('LocalAgentExecutor', () => {
         const nestedContext = agentTool['context'];
         expect(nestedContext.agentDepth).toBe(1);
         expect(nestedContext.config).toBe(mockConfig);
-        expect(nestedContext.toolRegistry).toBe(parentToolRegistry);
+      });
+
+      it('should nest the message bus and isolated registries for the child', async () => {
+        stubAgentRegistry(['code-reviewer']);
+
+        const definition = createTestDefinition([
+          LS_TOOL_NAME,
+          'code-reviewer',
+        ]);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        const agentTool = executor['toolRegistry'].getTool(
+          AGENT_TOOL_NAME,
+        ) as AgentTool;
+        const nestedContext = agentTool['context'];
+
+        // Publishing through this agent's derived bus is what attributes the
+        // child's confirmations as `parent/child` rather than `child`.
+        expect(nestedContext.messageBus).toBe(
+          executor['toolRegistry'].getMessageBus(),
+        );
+        expect(nestedContext.messageBus).not.toBe(
+          parentToolRegistry.getMessageBus(),
+        );
+        expect(nestedContext.promptRegistry).toBe(executor['promptRegistry']);
+        expect(nestedContext.resourceRegistry).toBe(
+          executor['resourceRegistry'],
+        );
+      });
+
+      it('should let a delegated agent resolve tools its caller does not have', async () => {
+        // A coordinator listing only another agent has no file tools of its
+        // own, but its delegates must still resolve theirs.
+        stubAgentRegistry(['code-reviewer']);
+
+        const definition = createTestDefinition(['code-reviewer']);
+        const executor = await LocalAgentExecutor.create(
+          definition,
+          mockConfig,
+          onActivity,
+        );
+
+        expect(executor['toolRegistry'].getTool(LS_TOOL_NAME)).toBeUndefined();
+        expect(
+          executor['toolRegistry'].getTool(READ_FILE_TOOL_NAME),
+        ).toBeUndefined();
+
+        const agentTool = executor['toolRegistry'].getTool(
+          AGENT_TOOL_NAME,
+        ) as AgentTool;
+        const nestedContext = agentTool['context'];
+
+        expect(nestedContext.toolRegistry.getTool(LS_TOOL_NAME)).toBeDefined();
+        expect(
+          nestedContext.toolRegistry.getTool(READ_FILE_TOOL_NAME),
+        ).toBeDefined();
       });
 
       it('should stop granting agent access at the maximum nesting depth', async () => {

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -192,14 +192,11 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     const parentToolRegistry = context.toolRegistry;
     const agentRegistry = context.config.getAgentRegistry();
 
-    // Agents this agent is explicitly allowed to invoke. Populated from the
-    // agent references in `toolConfig.tools`; an empty set means this agent
-    // gets no `invoke_agent` tool at all.
+    // Agents named in `toolConfig.tools`. Empty means no `invoke_agent` tool.
     const allowedAgentNames = new Set<string>();
 
     const registerToolInstance = (tool: AnyDeclarativeTool) => {
-      // Agent tools are never inherited wholesale: an agent only gets an
-      // `invoke_agent` tool scoped to the agents it explicitly lists.
+      // Agent tools are never inherited; delegation is granted explicitly below.
       if (tool.kind === Kind.Agent) {
         return;
       }
@@ -260,8 +257,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
         return;
       }
 
-      // Not a tool: it may name another agent (or this agent itself), in which
-      // case the agent gets an `invoke_agent` tool scoped to it.
+      // Not a tool, so it may name another agent (or this agent itself).
       if (agentRegistry?.getDefinition(toolName)) {
         allowedAgentNames.add(toolName);
         return;
@@ -288,8 +284,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       }
     } else {
       // If no tools are explicitly configured, default to all available tools.
-      // Agent delegation stays opt-in: it has to be requested explicitly via an
-      // agent name, `agent_*` or `invoke_agent` in `toolConfig.tools`.
+      // Delegation stays opt-in, so agent tools are not inherited here.
       for (const toolName of parentToolRegistry.getAllToolNames()) {
         if (toolName === AGENT_TOOL_NAME) {
           continue;
@@ -298,9 +293,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       }
     }
 
-    // Give the agent an `invoke_agent` tool scoped to the agents it listed, so
-    // it can delegate to (or recurse into) them. Nesting is bounded by
-    // MAX_AGENT_DEPTH to keep agent-calls-agent from running away.
+    // Grant an `invoke_agent` tool scoped to the agents this one listed.
     const nestedDepth = (context.agentDepth ?? 0) + 1;
     if (allowedAgentNames.size > 0) {
       if (nestedDepth >= MAX_AGENT_DEPTH) {
@@ -313,10 +306,15 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
           config: context.config,
           promptId: context.promptId,
           parentSessionId: context.parentSessionId,
+          // Resolution source for the child's own declared tools. Narrowing it
+          // to this agent's registry would intersect the child's toolset with
+          // its caller's, leaving a coordinator's delegates nothing to resolve.
           toolRegistry: context.toolRegistry,
-          promptRegistry: context.promptRegistry,
-          resourceRegistry: context.resourceRegistry,
-          messageBus: context.messageBus,
+          // The rest nests, keeping the child inside this agent's isolation
+          // boundary and its confirmations attributed `parent/child`.
+          promptRegistry: agentPromptRegistry,
+          resourceRegistry: agentResourceRegistry,
+          messageBus: subagentMessageBus,
           geminiClient: context.geminiClient,
           sandboxManager: context.sandboxManager,
           agentDepth: nestedDepth,

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -89,6 +89,8 @@ import {
   ACTIVATE_SKILL_TOOL_NAME,
   UPDATE_TOPIC_TOOL_NAME,
 } from '../tools/definitions/base-declarations.js';
+import { AGENT_TOOL_NAME, ALL_AGENTS_WILDCARD } from '../tools/tool-names.js';
+import { AgentTool, MAX_AGENT_DEPTH } from './agent-tool.js';
 
 /** A callback function to report on agent activity. */
 export type ActivityCallback = (activity: SubagentActivityEvent) => void;
@@ -188,10 +190,16 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     }
 
     const parentToolRegistry = context.toolRegistry;
+    const agentRegistry = context.config.getAgentRegistry();
+
+    // Agents this agent is explicitly allowed to invoke. Populated from the
+    // agent references in `toolConfig.tools`; an empty set means this agent
+    // gets no `invoke_agent` tool at all.
+    const allowedAgentNames = new Set<string>();
 
     const registerToolInstance = (tool: AnyDeclarativeTool) => {
-      // Check if the tool is an agent tool to prevent recursion.
-      // We do not allow agents to call other agents.
+      // Agent tools are never inherited wholesale: an agent only gets an
+      // `invoke_agent` tool scoped to the agents it explicitly lists.
       if (tool.kind === Kind.Agent) {
         return;
       }
@@ -206,6 +214,14 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     };
 
     const registerToolByName = (toolName: string) => {
+      // `invoke_agent` / `agent_*` grant access to every registered agent.
+      if (toolName === AGENT_TOOL_NAME || toolName === ALL_AGENTS_WILDCARD) {
+        for (const agentName of agentRegistry?.getAllAgentNames() ?? []) {
+          allowedAgentNames.add(agentName);
+        }
+        return;
+      }
+
       // Handle global wildcard
       if (toolName === '*') {
         for (const tool of parentToolRegistry.getAllTools()) {
@@ -241,7 +257,19 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       const tool = parentToolRegistry.getTool(toolName);
       if (tool) {
         registerToolInstance(tool);
+        return;
       }
+
+      // Not a tool: it may name another agent (or this agent itself), in which
+      // case the agent gets an `invoke_agent` tool scoped to it.
+      if (agentRegistry?.getDefinition(toolName)) {
+        allowedAgentNames.add(toolName);
+        return;
+      }
+
+      debugLogger.warn(
+        `Agent '${definition.name}' lists '${toolName}' in its tools, which matches no known tool or agent. Ignoring it.`,
+      );
     };
 
     if (definition.toolConfig) {
@@ -260,8 +288,44 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
       }
     } else {
       // If no tools are explicitly configured, default to all available tools.
+      // Agent delegation stays opt-in: it has to be requested explicitly via an
+      // agent name, `agent_*` or `invoke_agent` in `toolConfig.tools`.
       for (const toolName of parentToolRegistry.getAllToolNames()) {
+        if (toolName === AGENT_TOOL_NAME) {
+          continue;
+        }
         registerToolByName(toolName);
+      }
+    }
+
+    // Give the agent an `invoke_agent` tool scoped to the agents it listed, so
+    // it can delegate to (or recurse into) them. Nesting is bounded by
+    // MAX_AGENT_DEPTH to keep agent-calls-agent from running away.
+    const nestedDepth = (context.agentDepth ?? 0) + 1;
+    if (allowedAgentNames.size > 0) {
+      if (nestedDepth >= MAX_AGENT_DEPTH) {
+        debugLogger.warn(
+          `Agent '${definition.name}' is running at depth ${nestedDepth}; ` +
+            `not granting it agent delegation (max depth ${MAX_AGENT_DEPTH}).`,
+        );
+      } else {
+        const nestedContext: AgentLoopContext = {
+          config: context.config,
+          promptId: context.promptId,
+          parentSessionId: context.parentSessionId,
+          toolRegistry: context.toolRegistry,
+          promptRegistry: context.promptRegistry,
+          resourceRegistry: context.resourceRegistry,
+          messageBus: context.messageBus,
+          geminiClient: context.geminiClient,
+          sandboxManager: context.sandboxManager,
+          agentDepth: nestedDepth,
+        };
+        agentToolRegistry.registerTool(
+          new AgentTool(nestedContext, subagentMessageBus, undefined, {
+            allowedAgentNames: [...allowedAgentNames].sort(),
+          }),
+        );
       }
     }
 

--- a/packages/core/src/config/agent-loop-context.ts
+++ b/packages/core/src/config/agent-loop-context.ts
@@ -43,4 +43,11 @@ export interface AgentLoopContext {
 
   /** The service used to prepare commands for sandboxed execution. */
   readonly sandboxManager: SandboxManager;
+
+  /**
+   * How many agents deep this context is. Absent (or 0) at the top level; each
+   * nested agent invocation increments it. Used to bound agent-calls-agent
+   * recursion.
+   */
+  readonly agentDepth?: number;
 }

--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -7,7 +7,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   isValidToolName,
+  isAgentReferenceName,
   getToolAliases,
+  ALL_AGENTS_WILDCARD,
   ALL_BUILTIN_TOOL_NAMES,
   DISCOVERED_TOOL_PREFIX,
   LS_TOOL_NAME,
@@ -95,6 +97,73 @@ describe('tool-names', () => {
       expect(
         isValidToolName('mcp_server_tool*', { allowWildcards: true }),
       ).toBe(false);
+    });
+
+    describe('agent references', () => {
+      it('should reject agent names unless explicitly allowed', () => {
+        expect(isValidToolName('code-reviewer')).toBe(false);
+        expect(isValidToolName('code_reviewer')).toBe(false);
+        expect(isValidToolName(ALL_AGENTS_WILDCARD)).toBe(false);
+        expect(isValidToolName('code-reviewer', { allowWildcards: true })).toBe(
+          false,
+        );
+      });
+
+      it('should accept agent names when allowAgentNames is set', () => {
+        expect(
+          isValidToolName('code-reviewer', { allowAgentNames: true }),
+        ).toBe(true);
+        expect(
+          isValidToolName('code_reviewer', { allowAgentNames: true }),
+        ).toBe(true);
+        expect(
+          isValidToolName('codebase_investigator', { allowAgentNames: true }),
+        ).toBe(true);
+        expect(
+          isValidToolName(ALL_AGENTS_WILDCARD, { allowAgentNames: true }),
+        ).toBe(true);
+      });
+
+      it('should still reject non-slug names when allowAgentNames is set', () => {
+        expect(
+          isValidToolName('Code Reviewer', { allowAgentNames: true }),
+        ).toBe(false);
+        expect(isValidToolName('CodeReviewer', { allowAgentNames: true })).toBe(
+          false,
+        );
+        expect(
+          isValidToolName('agent_*_extra', { allowAgentNames: true }),
+        ).toBe(false);
+        expect(isValidToolName('', { allowAgentNames: true })).toBe(false);
+      });
+
+      it('should not let agent names smuggle in malformed MCP names', () => {
+        // Malformed MCP names are slug-shaped, but must stay rejected.
+        expect(isValidToolName('mcp__tool', { allowAgentNames: true })).toBe(
+          false,
+        );
+        expect(isValidToolName('mcp_server', { allowAgentNames: true })).toBe(
+          false,
+        );
+        expect(isValidToolName('mcp_server_', { allowAgentNames: true })).toBe(
+          false,
+        );
+      });
+    });
+  });
+
+  describe('isAgentReferenceName', () => {
+    it('should recognize agent-name-shaped slugs and the wildcard', () => {
+      expect(isAgentReferenceName('code-reviewer')).toBe(true);
+      expect(isAgentReferenceName('cli_help')).toBe(true);
+      expect(isAgentReferenceName(ALL_AGENTS_WILDCARD)).toBe(true);
+    });
+
+    it('should reject anything that is not a slug', () => {
+      expect(isAgentReferenceName('Code-Reviewer')).toBe(false);
+      expect(isAgentReferenceName('agent name')).toBe(false);
+      expect(isAgentReferenceName('*')).toBe(false);
+      expect(isAgentReferenceName('')).toBe(false);
     });
   });
 

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -190,6 +190,30 @@ export const TRACKER_VISUALIZE_TOOL_NAME = 'tracker_visualize';
 
 export const AGENT_TOOL_NAME = 'invoke_agent';
 
+/**
+ * Wildcard entry usable in an agent's `tools` list to grant it access to every
+ * registered agent. `invoke_agent` is accepted as an equivalent spelling.
+ */
+export const ALL_AGENTS_WILDCARD = 'agent_*';
+
+/**
+ * Shape of an agent name. Kept in sync with the `nameSchema` slug rule used by
+ * the agent frontmatter loader.
+ */
+const AGENT_NAME_PATTERN = /^[a-z0-9-_]+$/;
+
+/**
+ * Returns true if `name` could refer to a subagent when it appears in an
+ * agent's `tools` list, i.e. either the "all agents" wildcard or an
+ * agent-name-shaped slug.
+ *
+ * This is a purely syntactic check; callers resolve the name against the agent
+ * registry to find out whether such an agent actually exists.
+ */
+export function isAgentReferenceName(name: string): boolean {
+  return name === ALL_AGENTS_WILDCARD || AGENT_NAME_PATTERN.test(name);
+}
+
 // Tool Display Names
 export const WRITE_FILE_DISPLAY_NAME = 'WriteFile';
 export const EDIT_DISPLAY_NAME = 'Edit';
@@ -299,10 +323,15 @@ export const PLAN_MODE_TOOLS = [
 /**
  * Validates if a tool name is syntactically valid.
  * Checks against built-in tools, discovered tools, and MCP naming conventions.
+ *
+ * @param options.allowWildcards Accept policy wildcards such as `*` and `mcp_*`.
+ * @param options.allowAgentNames Accept subagent references (a bare agent name
+ *   or {@link ALL_AGENTS_WILDCARD}). Only meaningful where the name is later
+ *   resolved against the agent registry, e.g. an agent's own `tools` list.
  */
 export function isValidToolName(
   name: string,
-  options: { allowWildcards?: boolean } = {},
+  options: { allowWildcards?: boolean; allowAgentNames?: boolean } = {},
 ): boolean {
   // Built-in tools
   if ((ALL_BUILTIN_TOOL_NAMES as readonly string[]).includes(name)) {
@@ -362,6 +391,13 @@ export function isValidToolName(
     }
 
     return false;
+  }
+
+  // Subagent references. Checked after the MCP branch so that malformed MCP
+  // names (e.g. `mcp__tool`) are still rejected rather than being mistaken for
+  // an agent name.
+  if (options.allowAgentNames && isAgentReferenceName(name)) {
+    return true;
   }
 
   return false;

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -191,24 +191,17 @@ export const TRACKER_VISUALIZE_TOOL_NAME = 'tracker_visualize';
 export const AGENT_TOOL_NAME = 'invoke_agent';
 
 /**
- * Wildcard entry usable in an agent's `tools` list to grant it access to every
- * registered agent. `invoke_agent` is accepted as an equivalent spelling.
+ * Wildcard entry in an agent's `tools` list granting access to every registered
+ * agent. `invoke_agent` is accepted as an equivalent spelling.
  */
 export const ALL_AGENTS_WILDCARD = 'agent_*';
 
-/**
- * Shape of an agent name. Kept in sync with the `nameSchema` slug rule used by
- * the agent frontmatter loader.
- */
+/** Kept in sync with the `nameSchema` slug rule in the agent loader. */
 const AGENT_NAME_PATTERN = /^[a-z0-9-_]+$/;
 
 /**
- * Returns true if `name` could refer to a subagent when it appears in an
- * agent's `tools` list, i.e. either the "all agents" wildcard or an
- * agent-name-shaped slug.
- *
- * This is a purely syntactic check; callers resolve the name against the agent
- * registry to find out whether such an agent actually exists.
+ * Whether `name` could refer to a subagent in an agent's `tools` list. Purely
+ * syntactic; callers resolve it against the agent registry.
  */
 export function isAgentReferenceName(name: string): boolean {
   return name === ALL_AGENTS_WILDCARD || AGENT_NAME_PATTERN.test(name);
@@ -325,9 +318,8 @@ export const PLAN_MODE_TOOLS = [
  * Checks against built-in tools, discovered tools, and MCP naming conventions.
  *
  * @param options.allowWildcards Accept policy wildcards such as `*` and `mcp_*`.
- * @param options.allowAgentNames Accept subagent references (a bare agent name
- *   or {@link ALL_AGENTS_WILDCARD}). Only meaningful where the name is later
- *   resolved against the agent registry, e.g. an agent's own `tools` list.
+ * @param options.allowAgentNames Accept subagent references, for callers that
+ *   resolve them against the agent registry (e.g. an agent's `tools` list).
  */
 export function isValidToolName(
   name: string,
@@ -393,9 +385,8 @@ export function isValidToolName(
     return false;
   }
 
-  // Subagent references. Checked after the MCP branch so that malformed MCP
-  // names (e.g. `mcp__tool`) are still rejected rather than being mistaken for
-  // an agent name.
+  // Must stay after the MCP branch, so malformed MCP names (e.g. `mcp__tool`)
+  // are rejected rather than mistaken for slug-shaped agent names.
   if (options.allowAgentNames && isAgentReferenceName(name)) {
     return true;
   }

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -390,7 +390,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ============================================================
-which@5.0.0
+which@2.0.2
 (git+https://github.com/npm/node-which.git)
 
 The ISC License
@@ -411,7 +411,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ============================================================
-isexe@3.1.5
+isexe@2.0.0
 (No repository found)
 
 # Blue Oak Model License

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -390,7 +390,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ============================================================
-which@2.0.2
+which@5.0.0
 (git+https://github.com/npm/node-which.git)
 
 The ISC License
@@ -411,7 +411,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ============================================================
-isexe@2.0.0
+isexe@3.1.5
 (No repository found)
 
 # Blue Oak Model License


### PR DESCRIPTION
## Summary
Allow agents to call agents

Fixes #22092 
<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details
Fixes #22092 by letting subagents delegate to other subagents — or recurse into themselves — via their `tools:` frontmatter. This was blocked twice over: the agent loader rejected agent names as `Invalid tool name`, and the executor stripped every `Kind.Agent` tool from subagent registries, so even a name that passed validation would have had no effect. i`sValidToolName()` now takes an `allowAgentNames` option (checked after the MCP branch, so malformed names like `mcp__tool` stay rejected), and the executor resolves each `tools:` entry through the tool registry, then the agent registry, then warns instead of silently dropping it. Resolved agents get an `invoke_agent` tool whose `agent_name` is constrained to a JSON-schema `enum` of exactly those agents. A bare agent name grants that one agent, `agent_*` or `invoke_agent` grants all of them, and a self-reference enables recursion;` *` and an omitted `tools:` deliberately grant no agent access, so no existing definition changes behaviour — notably `generalist-agent`, whose list is built from `getAllToolNames()`. Recursion is bounded three ways: an agent at max depth is never handed the tool, `AgentTool.createInvocation` rejects nesting past `MAX_AGENT_DEPTH = 3`, and each level keeps its own `max_turns/timeout_mins`. Docs updated; 26 tests added across `tool-names`, `agentLoader`, `agent-tool` and `local-executor`, with the two pre-existing recursion tests still passing unmodified. Note that this introduces a deferred import cycle (`local-executor` → `agent-tool` → `local-invocation)`, which ESM resolves correctly and the tests exercise in both load orders — happy to switch to a dynamic import if preferred.
<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
