### PR TITLE
fix(core): preserve resolved model config systemInstruction and tools

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2327,6 +2327,128 @@ describe('GeminiChat', () => {
       expect(history[0]).toEqual(turn1);
       expect(history[1]).toEqual(turn2);
     });
+
+    describe('resolved model config precedence', () => {
+      const makeSimpleStream = () =>
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: { parts: [{ text: 'ok' }], role: 'model' },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })();
+
+      it('should use systemInstruction from resolved model config when present', async () => {
+        vi.mocked(
+          mockConfig.modelConfigService.getResolvedConfig,
+        ).mockReturnValue(
+          makeResolvedModelConfig('gemini-pro', {
+            systemInstruction: 'config-level instruction',
+          }),
+        );
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          makeSimpleStream(),
+        );
+
+        const chatWithInstruction = new GeminiChat(
+          mockConfig,
+          'chat-level instruction',
+        );
+        const stream = await chatWithInstruction.sendMessageStream(
+          { model: 'gemini-pro' },
+          'hello',
+          'test-prompt-id',
+          new AbortController().signal,
+          LlmRole.MAIN,
+        );
+        for await (const _ of stream) {
+          /* consume */
+        }
+
+        expect(mockContentGenerator.generateContentStream).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({
+              systemInstruction: 'config-level instruction',
+            }),
+          }),
+          expect.any(String),
+          expect.any(String),
+        );
+      });
+
+      it('should fall back to chat-level systemInstruction when resolved config has none', async () => {
+        vi.mocked(
+          mockConfig.modelConfigService.getResolvedConfig,
+        ).mockReturnValue(makeResolvedModelConfig('gemini-pro'));
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          makeSimpleStream(),
+        );
+
+        const chatWithInstruction = new GeminiChat(
+          mockConfig,
+          'chat-level instruction',
+        );
+        const stream = await chatWithInstruction.sendMessageStream(
+          { model: 'gemini-pro' },
+          'hello',
+          'test-prompt-id',
+          new AbortController().signal,
+          LlmRole.MAIN,
+        );
+        for await (const _ of stream) {
+          /* consume */
+        }
+
+        expect(mockContentGenerator.generateContentStream).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({
+              systemInstruction: 'chat-level instruction',
+            }),
+          }),
+          expect.any(String),
+          expect.any(String),
+        );
+      });
+
+      it('should use tools from resolved model config when present', async () => {
+        const configTools = [
+          { functionDeclarations: [{ name: 'config_tool' }] },
+        ];
+        vi.mocked(
+          mockConfig.modelConfigService.getResolvedConfig,
+        ).mockReturnValue(
+          makeResolvedModelConfig('gemini-pro', { tools: configTools }),
+        );
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          makeSimpleStream(),
+        );
+
+        const chatWithTools = new GeminiChat(mockConfig, '');
+        const stream = await chatWithTools.sendMessageStream(
+          { model: 'gemini-pro' },
+          'hello',
+          'test-prompt-id',
+          new AbortController().signal,
+          LlmRole.MAIN,
+        );
+        for await (const _ of stream) {
+          /* consume */
+        }
+
+        expect(mockContentGenerator.generateContentStream).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({
+              tools: configTools,
+            }),
+          }),
+          expect.any(String),
+          expect.any(String),
+        );
+      });
+    });
   });
 
   describe('sendMessageStream with retries', () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -829,10 +829,10 @@ export class GeminiChat {
       lastModelToUse = modelToUse;
       const config: GenerateContentConfig = {
         ...currentGenerateContentConfig,
-        // TODO(12622): Ensure we don't overrwrite these when they are
-        // passed via config.
-        systemInstruction: this.systemInstruction,
-        tools: this.tools,
+        systemInstruction:
+          currentGenerateContentConfig?.systemInstruction ??
+          this.systemInstruction,
+        tools: currentGenerateContentConfig?.tools ?? this.tools,
         abortSignal,
       };
 


### PR DESCRIPTION
## Summary

`GeminiChat.sendMessageStream()` calls `modelConfigService.getResolvedConfig()` to obtain a model-specific `GenerateContentConfig`. When that config includes `systemInstruction` or `tools`, those values were immediately overwritten by the chat-level `this.systemInstruction` and `this.tools`, silently discarding any model-specific configuration. A `TODO(12622)` comment in the code already acknowledged this bug.

## Old behavior

```typescript
const config: GenerateContentConfig = {
  ...currentGenerateContentConfig,
  // TODO(12622): Ensure we don't overrwrite these when they are
  // passed via config.
  systemInstruction: this.systemInstruction,  // always overwrites resolved config
  tools: this.tools,                          // always overwrites resolved config
  abortSignal,
};
```

Any `systemInstruction` or `tools` set via a resolved model config were silently dropped on every API call.

## New behavior

```typescript
const config: GenerateContentConfig = {
  ...currentGenerateContentConfig,
  systemInstruction:
    currentGenerateContentConfig?.systemInstruction ?? this.systemInstruction,
  tools: currentGenerateContentConfig?.tools ?? this.tools,
  abortSignal,
};
```

Values from the resolved model config take precedence when present; the chat-level fields are used as fallback only when the resolved config does not set them.

## Tests

Three new tests in `geminiChat.test.ts` verify:
1. Resolved config `systemInstruction` is used when present
2. Chat-level `systemInstruction` is used as fallback when resolved config has none
3. Resolved config `tools` are used when present

Closes #28650