### PR TITLE
fix(acp): don't start a fresh chat before resuming, it poisons the session file

### DIFF
--- a/packages/cli/src/acp/acpResume.test.ts
+++ b/packages/cli/src/acp/acpResume.test.ts
@@ -136,6 +136,48 @@ describe('GeminiAgent Session Resume', () => {
     agent = new GeminiAgent(mockConfig, mockSettings, mockArgv, mockConnection);
   });
 
+  it('resumes without first starting a fresh chat for the same session id', async () => {
+    // `GeminiClient.initialize()` starts a chat with no resumed session data, which
+    // initializes chat recording for a *fresh* conversation. The recording filename
+    // is keyed on the UTC minute plus the session id prefix, so a load in the same
+    // minute the session was created appends a metadata header and a `$set`
+    // checkpoint into the session's own file, burying its conversation and dropping
+    // it from the listing. `resumeChat` already does everything `initialize()` does,
+    // so calling both is redundant as well as destructive.
+    const sessionId = 'test-session-id';
+    const sessionData = {
+      sessionId,
+      projectHash: 'hash',
+      startTime: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      messages: [],
+    };
+
+    (SessionSelector as unknown as Mock).mockImplementation(() => ({
+      resolveSession: vi.fn().mockResolvedValue({
+        sessionData,
+        sessionPath: '/path/to/session.jsonl',
+      }),
+    }));
+    (convertSessionToHistoryFormats as unknown as Mock).mockReturnValue({
+      uiHistory: [],
+    });
+    (convertSessionToClientHistory as unknown as Mock).mockReturnValue([]);
+
+    const geminiClient = mockConfig.getGeminiClient();
+
+    await agent.loadSession({ sessionId, cwd: '/tmp', mcpServers: [] });
+
+    expect(geminiClient.initialize).not.toHaveBeenCalled();
+    expect(geminiClient.resumeChat).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        conversation: sessionData,
+        filePath: '/path/to/session.jsonl',
+      }),
+    );
+  });
+
   it('should advertise loadSession capability', async () => {
     const response = await agent.initialize({
       protocolVersion: acp.PROTOCOL_VERSION,

--- a/packages/cli/src/acp/acpSessionManager.ts
+++ b/packages/cli/src/acp/acpSessionManager.ts
@@ -180,7 +180,16 @@ export class AcpSessionManager {
     const clientHistory = convertSessionToClientHistory(sessionData.messages);
 
     const geminiClient = config.getGeminiClient();
-    await geminiClient.initialize();
+    // Resume directly. `initialize()` starts a chat with no resumed session data,
+    // which initializes chat recording for a *fresh* conversation and writes a
+    // metadata header plus a `$set` checkpoint. The recording filename is keyed on
+    // the UTC minute and the session id prefix, so when a load happens in the same
+    // minute the session was created, that append lands in the session's own file
+    // and buries its conversation in the fold: `hasResumableContent` flips false,
+    // the session drops out of the listing, and this and every later load fails
+    // with "No previous sessions found". `resumeChat` does everything
+    // `initialize()` does, including `updateTelemetryTokenCount()`, so the call
+    // was redundant as well as destructive.
     await geminiClient.resumeChat(clientHistory, {
       conversation: sessionData,
       filePath: sessionPath,


### PR DESCRIPTION
Partially addresses #28693 — see the correction below; this removes one of two fresh-chat starts on the load path, not both.

> **Correction (2026-08-10).** `loadSession` calls `initializeSessionConfig` first, and that ends with `await config.initialize()`, which itself calls `this._geminiClient.initialize()`. So there were **two** fresh-chat starts ahead of `resumeChat`, and this PR only removes the second. The test here could not catch that because `mockConfig.initialize` is a stub. #28767 fixes the underlying cause by handing the resumed session data to `config.initialize()`; the remaining ACP work after that is to resolve the session before `initializeSessionConfig` and pass it through. The removal in this PR is still correct on its own merits — `resumeChat` already does everything `initialize()` does — but it does not close #28693 by itself.

## Problem

`loadSession` called `geminiClient.initialize()` immediately before `resumeChat()`:

```ts
const geminiClient = config.getGeminiClient();
await geminiClient.initialize();          // starts a chat with NO resumed session data
await geminiClient.resumeChat(clientHistory, { conversation: sessionData, filePath: sessionPath });
```

`initialize()` is `this.chat = await this.startChat()` with no `resumedSessionData`, so `ChatRecordingService.initialize(undefined)` takes the fresh-conversation branch and writes a metadata header plus a `$set` checkpoint.

The recording filename is keyed on the UTC minute and the session id prefix — `session-<UTC-minute>-<id[0:8]>.jsonl` (`chatRecordingService.ts:495-519`). So when the load happens **in the same UTC minute the session was created**, that append lands in the session's own conversation file. The checkpoint buries the conversation in the fold, `hasResumableContent` flips false, the session is filtered out of the listing, and the load fails with `No previous sessions found for this project` — after durably destroying the session's resumability, so every later load for that id fails too.

No crash is required; it reproduces after a clean exit. Automated clients that reconnect immediately land in this window, while a human retrying minutes later lands in a different minute and sees loads succeed — which is why it read as intermittent or environment-dependent.

Credit to @realtonyyoung for the repro and for re-root-causing it; I'd earlier ruled out four candidate mechanisms on the issue and the load path was what was left.

## Approach

Remove the `initialize()` call. `resumeChat` already does everything it does — it sets `this.chat` via `startChat(history, resumedSessionData)` and calls `updateTelemetryTokenCount()` — so the call was redundant as well as destructive. One line out, plus a comment recording why it must not come back.

This deliberately does **not** change the filename scheme. Minute-precision plus an 8-char id prefix is a real collision surface, but widening it would change where existing sessions are looked up, and it isn't needed here: nothing should be writing a fresh-conversation header during a load in the first place.

## How tested

- `resumes without first starting a fresh chat for the same session id` asserts the client is resumed directly with the resolved session data and never initialized for a fresh chat. It fails on the parent commit with `expected "spy" to not be called at all, but actually been called 1 times`.
- Full ACP suite: **92 passed across 10 files**.
- `eslint --max-warnings 0` and `prettier --check` clean; `npm run typecheck` exit 0. The repo's `pre-commit` hook ran clean on the staged files.

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.

