### PR TITLE
fix(vscode-ide-companion): track all activate() Disposables in context.subscriptions

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -131,6 +131,38 @@ describe('activate', () => {
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
   });
 
+  it('should track every created Disposable in context.subscriptions', async () => {
+    const tag = (name: string) =>
+      ({ name, dispose: vi.fn() }) as unknown as vscode.Disposable;
+    vi.mocked(vscode.commands.registerCommand).mockImplementation(
+      (command: string) => tag(`command:${command}`),
+    );
+    vi.mocked(vscode.workspace.onDidChangeWorkspaceFolders).mockReturnValue(
+      tag('onDidChangeWorkspaceFolders'),
+    );
+    vi.mocked(vscode.workspace.onDidGrantWorkspaceTrust).mockReturnValue(
+      tag('onDidGrantWorkspaceTrust'),
+    );
+    vi.mocked(vscode.workspace.onDidCloseTextDocument).mockReturnValue(
+      tag('onDidCloseTextDocument'),
+    );
+    vi.mocked(
+      vscode.workspace.registerTextDocumentContentProvider,
+    ).mockReturnValue(tag('contentProvider'));
+
+    await activate(context);
+
+    const names = context.subscriptions.map(
+      (subscription) => (subscription as { name?: string }).name,
+    );
+    expect(names).toContain('command:gemini.diff.accept');
+    expect(names).toContain('command:gemini.diff.cancel');
+    expect(names).toContain('onDidChangeWorkspaceFolders');
+    expect(names).toContain('onDidGrantWorkspaceTrust');
+    expect(names).toContain('onDidCloseTextDocument');
+    expect(names).toContain('contentProvider');
+  });
+
   it('should launch the Gemini CLI when the user clicks the button', async () => {
     const showInformationMessageMock = vi
       .mocked(vscode.window.showInformationMessage)

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -161,6 +161,8 @@ describe('activate', () => {
     expect(names).toContain('onDidGrantWorkspaceTrust');
     expect(names).toContain('onDidCloseTextDocument');
     expect(names).toContain('contentProvider');
+    expect(names).toContain('command:gemini-cli.runGeminiCLI');
+    expect(names).toContain('command:gemini-cli.showNotices');
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary

In `activate()`, two `context.subscriptions.push(...)` calls wrapped pairs of registrations in an extra pair of parentheses, turning them into comma expressions: both registrations ran, but only the last Disposable of each pair was tracked. As a result:

- the `gemini.diff.accept` command Disposable was never disposed — on deactivation/reload within the same extension host (e.g. an extension update) the command stays registered and re-activation throws `command 'gemini.diff.accept' already exists`;
- the `onDidChangeWorkspaceFolders` listener was never torn down and keeps firing `ideServer.syncEnvVars()` against a stopped IDEServer.

The fix unwraps both pairs so every registration becomes its own `push()` argument, and adds a regression test that tags every created Disposable and asserts all of them land in `context.subscriptions` (verified mutation-sensitive: with the fix reverted it fails 1/12).

## Testing

- `npx vitest run packages/vscode-ide-companion/src/extension.test.ts` — 12/12
- `npm run check-types` and `npm run lint` in `packages/vscode-ide-companion` — clean

Fixes #27790
