### PR TITLE
fix(cli): --resume opens a second session file, and cleanup deletes the real one

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -805,7 +805,7 @@ export async function main() {
       return;
     }
 
-    await config.initialize();
+    await config.initialize(resumedSessionData);
     startupProfiler.flush(config);
 
     // If not a TTY, read from stdin

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1299,6 +1299,31 @@ describe('AppContainer State Management', () => {
       expect(mockResumeChat).not.toHaveBeenCalled();
       unmount();
     });
+
+    it('tells config a resume is in flight before it initializes', async () => {
+      const resumedData = {
+        conversation: {
+          sessionId: 'test-session',
+          projectHash: 'project-hash',
+          startTime: '2024-01-01T00:00:00Z',
+          lastUpdated: '2024-01-01T00:01:00Z',
+          messages: [],
+        },
+        filePath: '/tmp/chats/session-2024-01-01T00-00-test-ses.jsonl',
+      };
+
+      const { unmount } = await act(async () =>
+        renderAppContainer({
+          resumedSessionData: resumedData,
+        }),
+      );
+
+      // config.initialize() starts a chat. If it does not know a resume is
+      // coming, chat recording opens a second file for a session that already
+      // has one, under the same eight-character id suffix.
+      expect(mockConfig.initialize).toHaveBeenCalledWith(resumedData);
+      unmount();
+    });
   });
 
   describe('SessionStart Hook Rendering', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -480,7 +480,7 @@ export const AppContainer = (props: AppContainerProps) => {
       // Note: the program will not work if this fails so let errors be
       // handled by the global catch.
       if (!config.isInitialized()) {
-        await config.initialize();
+        await config.initialize(resumedSessionData);
       }
       setConfigInitialized(true);
       startupProfiler.flush(config);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -427,6 +427,26 @@ describe('Server Config (config.ts)', () => {
       await expect(config.initialize()).resolves.toBeUndefined();
     });
 
+    it('should hand resumed session data to the Gemini client', async () => {
+      const config = new Config({
+        ...baseParams,
+        checkpointing: false,
+      });
+      const resumedSessionData = {
+        conversation: { sessionId: 'resumed-session-id' },
+        filePath: '/tmp/chats/session-2024-01-01T10-00-resumed-.jsonl',
+      } as unknown as Parameters<typeof config.initialize>[0];
+
+      await config.initialize(resumedSessionData);
+
+      // The client has to know a resume is in flight before it starts a chat.
+      // Otherwise chat recording opens a second file for a session that already
+      // has one, under the same eight-character id suffix.
+      expect(config.getGeminiClient().initialize).toHaveBeenCalledWith(
+        resumedSessionData,
+      );
+    });
+
     it('should deduplicate multiple calls to initialize', async () => {
       const config = new Config({
         ...baseParams,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,6 +11,7 @@ import { inspect } from 'node:util';
 import process from 'node:process';
 import { z } from 'zod';
 import type { ConversationRecord } from '../services/chatRecordingService.js';
+import type { ResumedSessionData } from '../services/chatRecordingTypes.js';
 import type {
   AgentHistoryProviderConfig,
   ContextManagementConfig,
@@ -1435,17 +1436,19 @@ export class Config implements McpContext, AgentLoopContext {
    * Dedups initialization requests using a shared promise that is only resolved
    * once.
    */
-  async initialize(): Promise<void> {
+  async initialize(resumedSessionData?: ResumedSessionData): Promise<void> {
     if (this.initPromise) {
       return this.initPromise;
     }
 
-    this.initPromise = this._initialize();
+    this.initPromise = this._initialize(resumedSessionData);
 
     return this.initPromise;
   }
 
-  private async _initialize(): Promise<void> {
+  private async _initialize(
+    resumedSessionData?: ResumedSessionData,
+  ): Promise<void> {
     await this.storage.initialize();
     ragLogger.initialize(this.storage.getProjectTempLogsDir());
 
@@ -1557,7 +1560,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.memoryContextManager = new MemoryContextManager(this);
     await this.memoryContextManager.refresh();
 
-    await this._geminiClient.initialize();
+    await this._geminiClient.initialize(resumedSessionData);
     this.initialized = true;
   }
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -362,6 +362,48 @@ describe('Gemini Client (client.ts)', () => {
     });
   });
 
+  describe('initialize', () => {
+    it('passes resumed session data to startChat so recording reopens the existing file', async () => {
+      const resumedSessionData = {
+        conversation: {
+          sessionId: 'resumed-session-id',
+          projectHash: 'test-project-hash',
+          startTime: '2024-01-01T10:00:00.000Z',
+          lastUpdated: '2024-01-01T10:05:00.000Z',
+          messages: [],
+        },
+        filePath: '/test/temp/chats/session-2024-01-01T10-00-resumed-.jsonl',
+      } as unknown as Parameters<typeof client.initialize>[0];
+
+      client['startChat'] = vi.fn().mockResolvedValue({
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      } as unknown as GeminiChat);
+
+      await client.initialize(resumedSessionData);
+
+      // Without the resumed data the recording service treats this as a brand
+      // new conversation and opens a second file under the same eight-character
+      // id suffix, which startup retention cleanup later expands back over the
+      // real conversation.
+      expect(client['startChat']).toHaveBeenCalledWith(
+        undefined,
+        resumedSessionData,
+      );
+    });
+
+    it('starts a fresh chat when there is nothing to resume', async () => {
+      client['startChat'] = vi.fn().mockResolvedValue({
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      } as unknown as GeminiChat);
+
+      await client.initialize();
+
+      expect(client['startChat']).toHaveBeenCalledWith(undefined, undefined);
+    });
+  });
+
   describe('resetChat', () => {
     it('should create a new chat session, clearing the old history', async () => {
       // 1. Get the initial chat instance and add some history.

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -260,8 +260,18 @@ export class GeminiClient {
     }
   }
 
-  async initialize() {
-    this.chat = await this.startChat();
+  /**
+   * When the process was started to resume a session, `resumedSessionData` must
+   * be passed here even though the history is only replayed later by
+   * `resumeChat`. Without it the recording service treats this as a brand new
+   * conversation and opens a second file for a session that already has one:
+   * both files carry the same eight-character id suffix, because the resumed
+   * session id is reused for the process. Startup retention cleanup then
+   * expands that suffix back to every matching file and takes the real
+   * conversation down with the empty one.
+   */
+  async initialize(resumedSessionData?: ResumedSessionData) {
+    this.chat = await this.startChat(undefined, resumedSessionData);
     this.updateTelemetryTokenCount();
   }
 

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -309,6 +309,40 @@ describe('ChatRecordingService', () => {
       expect(conversation.sessionId).toBe('old-session-id');
     });
 
+    it('should not open a second file for a session that is being resumed', async () => {
+      const chatsDir = path.join(testTempDir, 'chats');
+      fs.mkdirSync(chatsDir, { recursive: true });
+      // Stored under the real naming scheme: prefix, UTC minute, and the first
+      // eight characters of the session id.
+      const sessionFile = path.join(
+        chatsDir,
+        'session-2024-01-01T10-00-test-ses.jsonl',
+      );
+      const initialData = {
+        sessionId: 'test-session-id',
+        projectHash: 'test-project-hash',
+      };
+      fs.writeFileSync(sessionFile, JSON.stringify(initialData) + '\n');
+
+      await chatRecordingService.initialize({
+        filePath: sessionFile,
+        conversation: initialData as ConversationRecord,
+      });
+      chatRecordingService.recordMessage({
+        type: 'user',
+        content: 'ping',
+        model: 'm',
+      });
+
+      // A second file here would share the `-test-ses` suffix with the real
+      // conversation, and startup retention cleanup expands that suffix to
+      // every matching file when it removes one of them.
+      expect(fs.readdirSync(chatsDir)).toEqual([
+        'session-2024-01-01T10-00-test-ses.jsonl',
+      ]);
+      expect(chatRecordingService.getConversationFilePath()).toBe(sessionFile);
+    });
+
     it('should fall back to the in-memory conversation when the file cannot be reloaded', async () => {
       // Regression test for the `/compress` "Failed to load resumed session
       // data from file" bug: when resuming with a filePath that cannot be


### PR DESCRIPTION
## The bug

`gemini --resume` reuses the resumed session's id for the process ([`resolveSessionId`](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/gemini.tsx#L306-L313) returns `sessionData.sessionId`), and then `config.initialize()` starts a chat with **no** resumed session data. `ChatRecordingService.initialize(undefined)` takes the "create new session" branch and opens a second file:

```
session-<UTC minute>-<session id[0:8]>.jsonl
```

The resumed conversation keeps going into its original file, so this new one never holds anything but a metadata header.

That empty file is the collision generator behind #27368 and #27877. Reporters described the intermediate state precisely before anyone had a root cause — one extra JSONL per resume, same eight-character suffix, new timestamp, only initial metadata, "effectively unused" ([#27368](https://github.com/google-gemini/gemini-cli/issues/27368#issuecomment-5081412297), and eight such files for one session id in [#27877](https://github.com/google-gemini/gemini-cli/issues/27877)).

The loss happens on the next launch:

1. `getAllSessionFiles` returns the orphan with `sessionInfo: null`, because `hasResumableContent` is false.
2. `identifySessionsToDelete` treats every `sessionInfo === null` entry as corrupted and schedules it for deletion.
3. [`cleanupExpiredSessions`](https://github.com/google-gemini/gemini-cli/blob/main/packages/cli/src/utils/sessionCleanup.ts#L152-L167) derives the short id from the doomed filename and expands it to *every* file ending in `-<shortId>.jsonl` — which includes the real conversation.
4. The only guard is `fullSessionId !== config.getSessionId()`, and on a normal launch the current session id is a fresh uuid, so it does not protect the previous session.

The session is gone from `/chat`, permanently, which is what @suiryc reported: the target session is wiped "the next time you use the CLI to start a new session or even simply list available sessions."

## The fix

`config.initialize()` takes the resumed session data and hands it to `GeminiClient.initialize()`, which forwards it to `startChat` so chat recording reopens the existing file instead of creating a second one.

History is deliberately untouched here — only the recording target changes. `startChat(undefined, resumedSessionData)` passes no `extraHistory`, so the model context is still built exclusively by `resumeChat` later in `useSessionResume`. There is no double-replay.

It also closes a smaller loss on the same path: quitting a `--resume` before the UI finishes resuming ran `deleteCurrentSessionIfNotResumableAsync` against the empty file, and that helper deletes artifacts by *full* session id — the resumed session's logs and tool-output directory. With recording pointed at the real file from the start, the resumable check sees the real conversation and leaves everything alone.

## What this does not touch

- **The cleanup expansion itself.** #28653 already narrows retention cleanup to the files it actually selected, and that is worth having independently: an eight-character suffix can collide on its own. This PR removes the thing that manufactures collisions on every resume; that one stops a collision from being fatal. They are complementary, and neither makes the other redundant.
- **The filename scheme.** Minute precision plus eight characters is a real collision surface, but widening it changes where existing sessions are found and it is not what breaks here.
- **ACP `session/load`.** Same class of defect, separate entry point — see the note below.

## A correction on #28744

While tracing this I found that my own PR #28744 is necessary but not sufficient. It removes the redundant `geminiClient.initialize()` in `AcpSessionManager.loadSession`, but `initializeSessionConfig` calls `config.initialize()` first, and that reaches `_geminiClient.initialize()` too. The test there mocks `config.initialize`, so it could not see the second source. I have said so on that PR. This change is what actually closes that path, once ACP resolves its session before initializing config; happy to do that as a follow-up.

## Verification

All three regression tests fail on the parent commit and pass here:

| test | failure on `eef19f2` |
| --- | --- |
| `config.test.ts` › hands resumed session data to the Gemini client | `expected "spy" to be called with arguments: [ { conversation: …, filePath: … } ]` |
| `client.test.ts` › passes resumed session data to startChat | `expected "spy" to be called with arguments: [ undefined, …(1) ]` |
| `AppContainer.test.tsx` › tells config a resume is in flight | `expected "initialize" to be called with arguments: [ { conversation: …, filePath: … } ]` |

A fourth test in `chatRecordingService.test.ts` locks the invariant the plumbing depends on: initializing with resumed data reopens the existing file and leaves the chats directory with exactly one entry.

```bash
npx vitest run --root packages/core src/core/client.test.ts src/config/config.test.ts src/services/chatRecordingService.test.ts src/core/geminiChat.test.ts
npx vitest run --root packages/cli src/ui/AppContainer.test.tsx src/utils/sessionCleanup.test.ts src/utils/sessionUtils.test.ts src/acp
npm run typecheck
```

- Targeted suites: **467 passed** (core), **310 passed across 14 files** (cli).
- Full suites: core **7784 passed**, cli **6949 passed**. The 6 core and 9 cli failures on my machine (`sandboxManager.integration`, `modelConfig.golden`, `topic-policy`, `gemini.test.tsx` trusted-folder) reproduce identically on pristine `main` — environment, not this change.
- `eslint --max-warnings 0` clean, `prettier --check` clean, `npm run typecheck` exit 0, pre-commit hook clean.

Fixes #27368.
Fixes #27877.
