### PR TITLE
fix: resolve failing CI nightly release and perf tests

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -166,13 +166,14 @@ runs:
         INPUTS_CORE_PACKAGE_NAME: '${{ inputs.core-package-name }}'
       shell: 'bash'
       run: |
+        TMP_TAG="staging-${GITHUB_RUN_ID:-tmp}"
         npm publish \
           --ignore-scripts \
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_CORE_PACKAGE_NAME}" \
-          --tag staging-tmp
+          --tag "${TMP_TAG}"
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
+          npm dist-tag rm ${INPUTS_CORE_PACKAGE_NAME} "${TMP_TAG}" || echo "Warning: Failed to remove ${TMP_TAG} tag (this is normal on registries that forbid tag deletion, like Wombat)"
         fi
 
     - name: '🔗 Install latest core package'
@@ -245,13 +246,14 @@ runs:
           PUBLISH_TARGET="--workspace=${INPUTS_CLI_PACKAGE_NAME}"
         fi
 
+        TMP_TAG="staging-${GITHUB_RUN_ID:-tmp}"
         npm publish \
           --ignore-scripts \
           --dry-run="${INPUTS_DRY_RUN}" \
           ${PUBLISH_TARGET} \
-          --tag staging-tmp
+          --tag "${TMP_TAG}"
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
+          npm dist-tag rm ${INPUTS_CLI_PACKAGE_NAME} "${TMP_TAG}" || echo "Warning: Failed to remove ${TMP_TAG} tag (this is normal on registries that forbid tag deletion, like Wombat)"
         fi
 
     - name: 'Get a2a-server Token'
@@ -273,13 +275,14 @@ runs:
       shell: 'bash'
       # Tag staging for initial release
       run: |
+        TMP_TAG="staging-${GITHUB_RUN_ID:-tmp}"
         npm publish \
           --ignore-scripts \
           --dry-run="${INPUTS_DRY_RUN}" \
           --workspace="${INPUTS_A2A_PACKAGE_NAME}" \
-          --tag staging-tmp
+          --tag "${TMP_TAG}"
         if [[ "${INPUTS_DRY_RUN}" == "false" ]]; then
-          npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} staging-tmp || echo "Warning: Failed to remove staging-tmp tag (this is normal on registries that forbid tag deletion, like Wombat)"
+          npm dist-tag rm ${INPUTS_A2A_PACKAGE_NAME} "${TMP_TAG}" || echo "Warning: Failed to remove ${TMP_TAG} tag (this is normal on registries that forbid tag deletion, like Wombat)"
         fi
 
     - name: '🏷️ Tag release'

--- a/perf-tests/globalSetup.ts
+++ b/perf-tests/globalSetup.ts
@@ -7,7 +7,7 @@
 import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { canUseRipgrep } from '../packages/core/src/tools/ripGrep.js';
+import { resolveRipgrepPath } from '../packages/core/src/tools/ripGrep.js';
 import { isolateTestEnv } from '../packages/test-utils/src/env-setup.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -24,7 +24,7 @@ export async function setup() {
   isolateTestEnv(runDir);
 
   // Download ripgrep to avoid race conditions
-  const available = await canUseRipgrep();
+  const available = await resolveRipgrepPath();
   if (!available) {
     throw new Error('Failed to download ripgrep binary');
   }


### PR DESCRIPTION
Fixes a 403 DELETE error on Wombat due to static tags, and fixes ripgrep resolution for the perf test suite.