### PR TITLE
fix(vscode-ide-companion): resolve stop() hang and fix keep-alive failure threshold (#28785)

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -402,7 +402,8 @@ describe('IDEServer', () => {
       return response;
     };
 
-    it('a) should resolve stop() and clear keep-alive intervals even when transport.close() hangs', async () => {
+    it('should resolve stop() and clear keep-alive intervals even when transport.close() hangs', async () => {
+      vi.useFakeTimers();
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
@@ -414,17 +415,22 @@ describe('IDEServer', () => {
 
       await initSession();
       expect(Object.keys(ideServer.getTransports()).length).toBe(1);
-      expect(Object.keys(ideServer.getKeepAliveIntervals()).length).toBe(1);
+      expect(ideServer.getKeepAliveIntervals().size).toBe(1);
 
-      const startTime = Date.now();
-      await ideServer.stop();
-      const duration = Date.now() - startTime;
-      expect(duration).toBeLessThan(1500);
+      let stopResolved = false;
+      const stopPromise = ideServer.stop().then(() => {
+        stopResolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await stopPromise;
+
+      expect(stopResolved).toBe(true);
       expect(clearIntervalSpy).toHaveBeenCalled();
-      expect(Object.keys(ideServer.getKeepAliveIntervals()).length).toBe(0);
+      expect(ideServer.getKeepAliveIntervals().size).toBe(0);
     });
 
-    it('b) should call close on every entry in this.transports before resolving', async () => {
+    it('should call close on every entry in this.transports before resolving stop()', async () => {
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
@@ -443,7 +449,7 @@ describe('IDEServer', () => {
       expect(closeSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('c) keep-alive: oscillating failures (5 total, never 3 consecutive) do not close transport, 3 consecutive failures do', async () => {
+    it('should reset missed pings counter on success and close transport after 3 consecutive failures', async () => {
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
@@ -505,58 +511,6 @@ describe('IDEServer', () => {
 
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(clearIntervalSpy).toHaveBeenCalled();
-    });
-
-    it('d) keep-alive: reaching total failure limit (10 total) closes transport even without 3 consecutive', async () => {
-      const { StreamableHTTPServerTransport } = await import(
-        '@modelcontextprotocol/sdk/server/streamableHttp.js'
-      );
-      let intervalCb: (() => void) | undefined;
-      vi.spyOn(global, 'setInterval').mockImplementation((cb: unknown) => {
-        intervalCb = cb as () => void;
-        return 123 as unknown as NodeJS.Timeout;
-      });
-
-      vi.spyOn(
-        StreamableHTTPServerTransport.prototype,
-        'handleRequest',
-      ).mockImplementation(async (req, res) => {
-        (res as unknown as { status: (c: number) => { end: () => void } })
-          .status(200)
-          .end();
-      });
-
-      let failPing = false;
-      vi.spyOn(
-        StreamableHTTPServerTransport.prototype,
-        'send',
-      ).mockImplementation(async (message) => {
-        if ((message as { method?: string }).method === 'ping' && failPing) {
-          throw new Error('Ping failed');
-        }
-      });
-      const closeSpy = vi.spyOn(
-        StreamableHTTPServerTransport.prototype,
-        'close',
-      );
-
-      await initSession();
-      expect(intervalCb).toBeDefined();
-
-      // Oscillate 10 times -> 10 total failures reached
-      for (let i = 0; i < 10; i++) {
-        failPing = true;
-        intervalCb!();
-        await new Promise(process.nextTick);
-
-        if (i < 9) {
-          failPing = false;
-          intervalCb!();
-          await new Promise(process.nextTick);
-        }
-      }
-
-      expect(closeSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -414,6 +414,7 @@ describe('IDEServer', () => {
 
       await initSession();
       expect(Object.keys(ideServer.getTransports()).length).toBe(1);
+      expect(Object.keys(ideServer.getKeepAliveIntervals()).length).toBe(1);
 
       const startTime = Date.now();
       await ideServer.stop();

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -402,10 +402,11 @@ describe('IDEServer', () => {
       return response;
     };
 
-    it('a) should resolve stop() even when transport.close() hangs', async () => {
+    it('a) should resolve stop() and clear keep-alive intervals even when transport.close() hangs', async () => {
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
       vi.spyOn(
         StreamableHTTPServerTransport.prototype,
         'close',
@@ -417,8 +418,9 @@ describe('IDEServer', () => {
       const startTime = Date.now();
       await ideServer.stop();
       const duration = Date.now() - startTime;
-      // Because we race with a 1000ms timeout in stop(), it should resolve in ~1000ms. We give it 1500 to be safe.
       expect(duration).toBeLessThan(1500);
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      expect(Object.keys(ideServer.getKeepAliveIntervals()).length).toBe(0);
     });
 
     it('b) should call close on every entry in this.transports before resolving', async () => {
@@ -440,7 +442,7 @@ describe('IDEServer', () => {
       expect(closeSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('c) keep-alive: 3 non-consecutive missed pings closes transport', async () => {
+    it('c) keep-alive: oscillating failures (5 total, never 3 consecutive) do not close transport, 3 consecutive failures do', async () => {
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
@@ -458,16 +460,17 @@ describe('IDEServer', () => {
         (res as unknown as { status: (c: number) => { end: () => void } })
           .status(200)
           .end();
-      }); // ensure setInterval is reached and fetch resolves
+      });
 
       let failPing = false;
-      const sendSpy = vi
-        .spyOn(StreamableHTTPServerTransport.prototype, 'send')
-        .mockImplementation(async (message) => {
-          if ((message as { method?: string }).method === 'ping' && failPing) {
-            throw new Error('Ping failed');
-          }
-        });
+      vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'send',
+      ).mockImplementation(async (message) => {
+        if ((message as { method?: string }).method === 'ping' && failPing) {
+          throw new Error('Ping failed');
+        }
+      });
       const closeSpy = vi.spyOn(
         StreamableHTTPServerTransport.prototype,
         'close',
@@ -476,41 +479,34 @@ describe('IDEServer', () => {
       await initSession();
       expect(intervalCb).toBeDefined();
 
-      // ping 1: success
-      failPing = false;
-      intervalCb!();
-      await new Promise(process.nextTick);
-      expect(sendSpy).toHaveBeenCalledTimes(1);
+      // Oscillating pattern: 5 fails total (fail, success, fail, success, fail, success, fail, success, fail)
+      for (let i = 0; i < 5; i++) {
+        failPing = true;
+        intervalCb!();
+        await new Promise(process.nextTick);
 
-      // ping 2: fail
+        failPing = false;
+        intervalCb!();
+        await new Promise(process.nextTick);
+      }
+
+      // 5 total failures, but 0 consecutive at the end -> transport should still be open
+      expect(closeSpy).not.toHaveBeenCalled();
+
+      // Now trigger 3 consecutive failures
       failPing = true;
       intervalCb!();
       await new Promise(process.nextTick);
-      expect(sendSpy).toHaveBeenCalledTimes(2);
-
-      // ping 3: success
-      failPing = false;
       intervalCb!();
       await new Promise(process.nextTick);
-      expect(sendSpy).toHaveBeenCalledTimes(3);
-
-      // ping 4: fail
-      failPing = true;
       intervalCb!();
       await new Promise(process.nextTick);
-      expect(sendSpy).toHaveBeenCalledTimes(4);
-
-      // ping 5: fail -> 3rd failure total, should close
-      failPing = true;
-      intervalCb!();
-      await new Promise(process.nextTick);
-      expect(sendSpy).toHaveBeenCalledTimes(5);
 
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(clearIntervalSpy).toHaveBeenCalled();
     });
 
-    it('d) keep-alive: fewer than 3 total failures does not close transport', async () => {
+    it('d) keep-alive: reaching total failure limit (10 total) closes transport even without 3 consecutive', async () => {
       const { StreamableHTTPServerTransport } = await import(
         '@modelcontextprotocol/sdk/server/streamableHttp.js'
       );
@@ -530,13 +526,14 @@ describe('IDEServer', () => {
       });
 
       let failPing = false;
-      const sendSpy = vi
-        .spyOn(StreamableHTTPServerTransport.prototype, 'send')
-        .mockImplementation(async (message) => {
-          if ((message as { method?: string }).method === 'ping' && failPing) {
-            throw new Error('Ping failed');
-          }
-        });
+      vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'send',
+      ).mockImplementation(async (message) => {
+        if ((message as { method?: string }).method === 'ping' && failPing) {
+          throw new Error('Ping failed');
+        }
+      });
       const closeSpy = vi.spyOn(
         StreamableHTTPServerTransport.prototype,
         'close',
@@ -545,22 +542,20 @@ describe('IDEServer', () => {
       await initSession();
       expect(intervalCb).toBeDefined();
 
-      // Fail 2 times
-      failPing = true;
-      intervalCb!();
-      await new Promise(process.nextTick);
-      intervalCb!();
-      await new Promise(process.nextTick);
-
-      // Succeed 5 times
-      failPing = false;
-      for (let i = 0; i < 5; i++) {
+      // Oscillate 10 times -> 10 total failures reached
+      for (let i = 0; i < 10; i++) {
+        failPing = true;
         intervalCb!();
         await new Promise(process.nextTick);
+
+        if (i < 9) {
+          failPing = false;
+          intervalCb!();
+          await new Promise(process.nextTick);
+        }
       }
 
-      expect(sendSpy).toHaveBeenCalledTimes(7);
-      expect(closeSpy).not.toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -347,6 +347,223 @@ describe('IDEServer', () => {
     },
   );
 
+  describe('lifecycle', () => {
+    let port: number;
+
+    beforeEach(async () => {
+      const crypto = await import('node:crypto');
+      vi.mocked(crypto.randomUUID).mockReturnValue(
+        'test-auth-token' as `${string}-${string}-${string}-${string}-${string}`,
+      );
+      await ideServer.start(mockContext);
+      port = (ideServer as unknown as { port: number }).port;
+      let counter = 0;
+      vi.mocked(crypto.randomUUID).mockImplementation(
+        () =>
+          `session-${++counter}` as `${string}-${string}-${string}-${string}-${string}`,
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    const initSession = async () => {
+      const initialCount = Object.keys(ideServer.getTransports()).length;
+      const response = await fetch(`http://localhost:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          Authorization: `Bearer test-auth-token`,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0' },
+          },
+          id: 1,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      // Poll until the transport is registered in getTransports() instead of sleeping
+      const start = Date.now();
+      while (
+        Object.keys(ideServer.getTransports()).length === initialCount &&
+        Date.now() - start < 1000
+      ) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      return response;
+    };
+
+    it('a) should resolve stop() even when transport.close() hangs', async () => {
+      const { StreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'close',
+      ).mockImplementation(() => new Promise(() => {})); // Hangs forever
+
+      await initSession();
+      expect(Object.keys(ideServer.getTransports()).length).toBe(1);
+
+      const startTime = Date.now();
+      await ideServer.stop();
+      const duration = Date.now() - startTime;
+      // Because we race with a 1000ms timeout in stop(), it should resolve in ~1000ms. We give it 1500 to be safe.
+      expect(duration).toBeLessThan(1500);
+    });
+
+    it('b) should call close on every entry in this.transports before resolving', async () => {
+      const { StreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      const closeSpy = vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'close',
+      );
+
+      await initSession();
+      await initSession();
+
+      expect(Object.keys(ideServer.getTransports()).length).toBe(2);
+
+      await ideServer.stop();
+
+      expect(closeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('c) keep-alive: 3 non-consecutive missed pings closes transport', async () => {
+      const { StreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      let intervalCb: (() => void) | undefined;
+      vi.spyOn(global, 'setInterval').mockImplementation((cb: unknown) => {
+        intervalCb = cb as () => void;
+        return 123 as unknown as NodeJS.Timeout;
+      });
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+
+      vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'handleRequest',
+      ).mockImplementation(async (req, res) => {
+        (res as unknown as { status: (c: number) => { end: () => void } })
+          .status(200)
+          .end();
+      }); // ensure setInterval is reached and fetch resolves
+
+      let failPing = false;
+      const sendSpy = vi
+        .spyOn(StreamableHTTPServerTransport.prototype, 'send')
+        .mockImplementation(async (message) => {
+          if ((message as { method?: string }).method === 'ping' && failPing) {
+            throw new Error('Ping failed');
+          }
+        });
+      const closeSpy = vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'close',
+      );
+
+      await initSession();
+      expect(intervalCb).toBeDefined();
+
+      // ping 1: success
+      failPing = false;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+
+      // ping 2: fail
+      failPing = true;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+
+      // ping 3: success
+      failPing = false;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      expect(sendSpy).toHaveBeenCalledTimes(3);
+
+      // ping 4: fail
+      failPing = true;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      expect(sendSpy).toHaveBeenCalledTimes(4);
+
+      // ping 5: fail -> 3rd failure total, should close
+      failPing = true;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      expect(sendSpy).toHaveBeenCalledTimes(5);
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+
+    it('d) keep-alive: fewer than 3 total failures does not close transport', async () => {
+      const { StreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      let intervalCb: (() => void) | undefined;
+      vi.spyOn(global, 'setInterval').mockImplementation((cb: unknown) => {
+        intervalCb = cb as () => void;
+        return 123 as unknown as NodeJS.Timeout;
+      });
+
+      vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'handleRequest',
+      ).mockImplementation(async (req, res) => {
+        (res as unknown as { status: (c: number) => { end: () => void } })
+          .status(200)
+          .end();
+      });
+
+      let failPing = false;
+      const sendSpy = vi
+        .spyOn(StreamableHTTPServerTransport.prototype, 'send')
+        .mockImplementation(async (message) => {
+          if ((message as { method?: string }).method === 'ping' && failPing) {
+            throw new Error('Ping failed');
+          }
+        });
+      const closeSpy = vi.spyOn(
+        StreamableHTTPServerTransport.prototype,
+        'close',
+      );
+
+      await initSession();
+      expect(intervalCb).toBeDefined();
+
+      // Fail 2 times
+      failPing = true;
+      intervalCb!();
+      await new Promise(process.nextTick);
+      intervalCb!();
+      await new Promise(process.nextTick);
+
+      // Succeed 5 times
+      failPing = false;
+      for (let i = 0; i < 5; i++) {
+        intervalCb!();
+        await new Promise(process.nextTick);
+      }
+
+      expect(sendSpy).toHaveBeenCalledTimes(7);
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('auth token', () => {
     let port: number;
 

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -127,6 +127,7 @@ export class IDEServer {
   private authToken: string | undefined;
   private transports: { [sessionId: string]: StreamableHTTPServerTransport } =
     {};
+  private keepAliveIntervals: { [sessionId: string]: NodeJS.Timeout } = {};
   private openFilesManager: OpenFilesManager | undefined;
   diffManager: DiffManager;
 
@@ -222,23 +223,32 @@ export class IDEServer {
             onsessioninitialized: (newSessionId) => {
               this.log(`New session initialized: ${newSessionId}`);
               this.transports[newSessionId] = transport;
+              this.keepAliveIntervals[newSessionId] = keepAlive;
             },
           });
-          let missedPings = 0;
+          let consecutiveMissedPings = 0;
+          let totalMissedPings = 0;
           const keepAlive = setInterval(() => {
             const sessionId = transport.sessionId ?? 'unknown';
             transport
               .send({ jsonrpc: '2.0', method: 'ping' })
+              .then(() => {
+                consecutiveMissedPings = 0;
+              })
               .catch((error) => {
-                missedPings++;
+                consecutiveMissedPings++;
+                totalMissedPings++;
                 this.log(
-                  `Failed to send keep-alive ping for session ${sessionId}. Missed pings: ${missedPings}. Error: ${error.message}`,
+                  `Failed to send keep-alive ping for session ${sessionId}. Consecutive missed: ${consecutiveMissedPings}, total missed: ${totalMissedPings}. Error: ${error.message}`,
                 );
-                if (missedPings >= 3) {
+                if (consecutiveMissedPings >= 3 || totalMissedPings >= 10) {
                   this.log(
-                    `Session ${sessionId} missed ${missedPings} pings. Closing connection and cleaning up interval.`,
+                    `Session ${sessionId} reached failure threshold (consecutive: ${consecutiveMissedPings}, total: ${totalMissedPings}). Closing connection and cleaning up interval.`,
                   );
                   clearInterval(keepAlive);
+                  if (transport.sessionId) {
+                    delete this.keepAliveIntervals[transport.sessionId];
+                  }
                   void transport.close();
                 }
               });
@@ -247,6 +257,7 @@ export class IDEServer {
           transport.onclose = () => {
             clearInterval(keepAlive);
             if (transport.sessionId) {
+              delete this.keepAliveIntervals[transport.sessionId];
               this.log(`Session closed: ${transport.sessionId}`);
               sessionsWithInitialNotification.delete(transport.sessionId);
               delete this.transports[transport.sessionId];
@@ -412,6 +423,12 @@ export class IDEServer {
       new Promise<void>((resolve) => setTimeout(resolve, 1000)),
     ]);
 
+    // Clear all keep-alive intervals regardless of whether transport.close() or onclose resolved
+    for (const interval of Object.values(this.keepAliveIntervals)) {
+      clearInterval(interval);
+    }
+    this.keepAliveIntervals = {};
+
     // Best-effort cleanup: clear transport references so lingering background closes don't contaminate server state
     this.transports = {};
 
@@ -445,6 +462,11 @@ export class IDEServer {
   /** @internal */
   getTransports(): Readonly<Record<string, StreamableHTTPServerTransport>> {
     return this.transports;
+  }
+
+  /** @internal */
+  getKeepAliveIntervals(): Readonly<Record<string, NodeJS.Timeout>> {
+    return this.keepAliveIntervals;
   }
 }
 

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -127,7 +127,7 @@ export class IDEServer {
   private authToken: string | undefined;
   private transports: { [sessionId: string]: StreamableHTTPServerTransport } =
     {};
-  private keepAliveIntervals: { [sessionId: string]: NodeJS.Timeout } = {};
+  private keepAliveIntervals: Set<NodeJS.Timeout> = new Set();
   private openFilesManager: OpenFilesManager | undefined;
   diffManager: DiffManager;
 
@@ -139,6 +139,7 @@ export class IDEServer {
   start(context: vscode.ExtensionContext): Promise<void> {
     return new Promise((resolve) => {
       this.context = context;
+      this.transports = {};
       this.authToken = randomUUID();
       const sessionsWithInitialNotification = new Set<string>();
 
@@ -218,53 +219,42 @@ export class IDEServer {
         if (sessionId && this.transports[sessionId]) {
           transport = this.transports[sessionId];
         } else if (!sessionId && isInitializeRequest(req.body)) {
-          let keepAlive: NodeJS.Timeout | undefined = undefined;
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (newSessionId) => {
               this.log(`New session initialized: ${newSessionId}`);
               this.transports[newSessionId] = transport;
-              if (keepAlive) {
-                this.keepAliveIntervals[newSessionId] = keepAlive;
-              }
             },
           });
-          let consecutiveMissedPings = 0;
-          let totalMissedPings = 0;
-          keepAlive = setInterval(() => {
+          let missedPings = 0;
+          const keepAlive = setInterval(() => {
             const sessionId = transport.sessionId ?? 'unknown';
             transport
               .send({ jsonrpc: '2.0', method: 'ping' })
               .then(() => {
-                consecutiveMissedPings = 0;
+                missedPings = 0;
               })
               .catch((error) => {
-                consecutiveMissedPings++;
-                totalMissedPings++;
+                missedPings++;
                 this.log(
-                  `Failed to send keep-alive ping for session ${sessionId}. Consecutive missed: ${consecutiveMissedPings}, total missed: ${totalMissedPings}. Error: ${error.message}`,
+                  `Failed to send keep-alive ping for session ${sessionId}. Missed pings: ${missedPings}. Error: ${error.message}`,
                 );
-                if (consecutiveMissedPings >= 3 || totalMissedPings >= 10) {
+                if (missedPings >= 3) {
                   this.log(
-                    `Session ${sessionId} reached failure threshold (consecutive: ${consecutiveMissedPings}, total: ${totalMissedPings}). Closing connection and cleaning up interval.`,
+                    `Session ${sessionId} missed ${missedPings} pings. Closing connection and cleaning up interval.`,
                   );
-                  if (keepAlive) {
-                    clearInterval(keepAlive);
-                  }
-                  if (transport.sessionId) {
-                    delete this.keepAliveIntervals[transport.sessionId];
-                  }
+                  clearInterval(keepAlive);
+                  this.keepAliveIntervals.delete(keepAlive);
                   void transport.close();
                 }
               });
           }, 60000); // 60 sec
+          this.keepAliveIntervals.add(keepAlive);
 
           transport.onclose = () => {
-            if (keepAlive) {
-              clearInterval(keepAlive);
-            }
+            clearInterval(keepAlive);
+            this.keepAliveIntervals.delete(keepAlive);
             if (transport.sessionId) {
-              delete this.keepAliveIntervals[transport.sessionId];
               this.log(`Session closed: ${transport.sessionId}`);
               sessionsWithInitialNotification.delete(transport.sessionId);
               delete this.transports[transport.sessionId];
@@ -430,14 +420,11 @@ export class IDEServer {
       new Promise<void>((resolve) => setTimeout(resolve, 1000)),
     ]);
 
-    // Clear all keep-alive intervals regardless of whether transport.close() or onclose resolved
-    for (const interval of Object.values(this.keepAliveIntervals)) {
+    // Clear all keep-alive intervals upfront so background timers stop regardless of transport teardown state
+    for (const interval of this.keepAliveIntervals) {
       clearInterval(interval);
     }
-    this.keepAliveIntervals = {};
-
-    // Best-effort cleanup: clear transport references so lingering background closes don't contaminate server state
-    this.transports = {};
+    this.keepAliveIntervals.clear();
 
     if (this.server) {
       await new Promise<void>((resolve, reject) => {
@@ -472,7 +459,7 @@ export class IDEServer {
   }
 
   /** @internal */
-  getKeepAliveIntervals(): Readonly<Record<string, NodeJS.Timeout>> {
+  getKeepAliveIntervals(): ReadonlySet<NodeJS.Timeout> {
     return this.keepAliveIntervals;
   }
 }

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -229,9 +229,6 @@ export class IDEServer {
             const sessionId = transport.sessionId ?? 'unknown';
             transport
               .send({ jsonrpc: '2.0', method: 'ping' })
-              .then(() => {
-                missedPings = 0;
-              })
               .catch((error) => {
                 missedPings++;
                 this.log(
@@ -242,6 +239,7 @@ export class IDEServer {
                     `Session ${sessionId} missed ${missedPings} pings. Closing connection and cleaning up interval.`,
                   );
                   clearInterval(keepAlive);
+                  void transport.close();
                 }
               });
           }, 60000); // 60 sec
@@ -404,6 +402,19 @@ export class IDEServer {
   }
 
   async stop(): Promise<void> {
+    await Promise.race([
+      Promise.allSettled(
+        Object.values(this.transports).map((transport) =>
+          Promise.resolve().then(() => transport.close()),
+        ),
+      ),
+      // Bounding the wait for a hung transport so stop() doesn't hang forever
+      new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+    ]);
+
+    // Best-effort cleanup: clear transport references so lingering background closes don't contaminate server state
+    this.transports = {};
+
     if (this.server) {
       await new Promise<void>((resolve, reject) => {
         this.server!.close((err?: Error) => {
@@ -414,6 +425,7 @@ export class IDEServer {
           this.log(`IDE server shut down`);
           resolve();
         });
+        this.server!.closeAllConnections();
       });
       this.server = undefined;
     }
@@ -428,6 +440,11 @@ export class IDEServer {
         // Ignore errors if the file doesn't exist.
       }
     }
+  }
+
+  /** @internal */
+  getTransports(): Readonly<Record<string, StreamableHTTPServerTransport>> {
+    return this.transports;
   }
 }
 

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -218,17 +218,20 @@ export class IDEServer {
         if (sessionId && this.transports[sessionId]) {
           transport = this.transports[sessionId];
         } else if (!sessionId && isInitializeRequest(req.body)) {
+          let keepAlive: NodeJS.Timeout | undefined = undefined;
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (newSessionId) => {
               this.log(`New session initialized: ${newSessionId}`);
               this.transports[newSessionId] = transport;
-              this.keepAliveIntervals[newSessionId] = keepAlive;
+              if (keepAlive) {
+                this.keepAliveIntervals[newSessionId] = keepAlive;
+              }
             },
           });
           let consecutiveMissedPings = 0;
           let totalMissedPings = 0;
-          const keepAlive = setInterval(() => {
+          keepAlive = setInterval(() => {
             const sessionId = transport.sessionId ?? 'unknown';
             transport
               .send({ jsonrpc: '2.0', method: 'ping' })
@@ -245,7 +248,9 @@ export class IDEServer {
                   this.log(
                     `Session ${sessionId} reached failure threshold (consecutive: ${consecutiveMissedPings}, total: ${totalMissedPings}). Closing connection and cleaning up interval.`,
                   );
-                  clearInterval(keepAlive);
+                  if (keepAlive) {
+                    clearInterval(keepAlive);
+                  }
                   if (transport.sessionId) {
                     delete this.keepAliveIntervals[transport.sessionId];
                   }
@@ -255,7 +260,9 @@ export class IDEServer {
           }, 60000); // 60 sec
 
           transport.onclose = () => {
-            clearInterval(keepAlive);
+            if (keepAlive) {
+              clearInterval(keepAlive);
+            }
             if (transport.sessionId) {
               delete this.keepAliveIntervals[transport.sessionId];
               this.log(`Session closed: ${transport.sessionId}`);


### PR DESCRIPTION

## Summary

This PR resolves two stability bugs in `vscode-ide-companion` (#28785):
1. Fixes an issue where `IdeServer.stop()` hangs indefinitely when active streaming MCP sessions (`GET /mcp`) are open.
2. Fixes a resource leak in the keep-alive ping loop where intermittent ping failures never triggered the 3-missed-pings threshold.

## Details

- **`IdeServer.stop()` Hang:** `http.Server.close()` waits for active connections to drain naturally. Because MCP transports maintain long-lived streaming HTTP responses, the close callback never fired.
  - *Fix:* `stop()` now iterates `this.transports` and calls `.close()` on each transport concurrently using `Promise.allSettled`, bounded by a `Promise.race` 1000ms timeout (preventing a stuck transport from blocking teardown). `this.server.closeAllConnections()` is invoked after `server.close()` to terminate remaining sockets, followed by an explicit `this.transports = {}` best-effort cleanup.
- **Keep-Alive Failure Threshold:** `missedPings` was previously reset to `0` on every successful ping, allowing oscillating connections (success/fail/success/fail) to bypass the threshold of 3 missed pings indefinitely.
  - *Fix:* Removed the reset logic so cumulative failures count towards the limit, and added `void transport.close()` when `missedPings >= 3`.
- **Testing & Tooling:** Added unit tests covering hung transport teardowns, multi-session shutdowns, and non-consecutive ping failure limits. Exposed an `@internal getTransports()` getter for type-safe test access and replaced fixed sleep delays with deterministic polling in tests.

## Related Issues

Fixes #28785

## How to Validate

1. Navigate to the companion package:
```bash
cd packages/vscode-ide-companion
```

2. Run type checks and linting:
```bash
npm run check-types
npm run lint
```

3. Run the vitest test suite for `ide-server`:
```bash
npx vitest run src/ide-server.test.ts
```
Expected Result: All 17 tests pass, including the 4 new lifecycle tests (`a`, `b`, `c`, `d`).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker