### PR TITLE
fix(core): implement context-aware silent retries and availability TTL for capacity errors (#28761)

### DIFF
--- a/packages/core/src/availability/modelAvailabilityService.test.ts
+++ b/packages/core/src/availability/modelAvailabilityService.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ModelAvailabilityService } from './modelAvailabilityService.js';
 
 describe('ModelAvailabilityService', () => {
@@ -207,6 +207,66 @@ describe('ModelAvailabilityService', () => {
 
       expect(service.snapshot('gemini-3-flash-preview')).toEqual({
         available: true,
+      });
+    });
+  });
+
+  describe('Capacity TTL expiration', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('recovers terminal status for capacity after the TTL expires', () => {
+      service.markTerminal(model, 'capacity');
+
+      // Before TTL expiration, model is unavailable
+      expect(service.snapshot(model)).toEqual({
+        available: false,
+        reason: 'capacity',
+      });
+
+      // Fast forward 29 seconds (default is 30s)
+      vi.advanceTimersByTime(29000);
+      expect(service.snapshot(model)).toEqual({
+        available: false,
+        reason: 'capacity',
+      });
+
+      // Fast forward past 30 seconds
+      vi.advanceTimersByTime(1001);
+      expect(service.snapshot(model)).toEqual({
+        available: true,
+      });
+    });
+
+    it('allows custom TTL parameter in snapshot', () => {
+      service.markTerminal(model, 'capacity');
+
+      // Check with a custom 5s TTL
+      expect(service.snapshot(model, 5000)).toEqual({
+        available: false,
+        reason: 'capacity',
+      });
+
+      // Advance 6 seconds
+      vi.advanceTimersByTime(6000);
+      expect(service.snapshot(model, 5000)).toEqual({
+        available: true,
+      });
+    });
+
+    it('does not expire terminal status for non-capacity reasons (e.g. quota)', () => {
+      service.markTerminal(model, 'quota');
+
+      // Even after advance, quota remains terminal
+      vi.advanceTimersByTime(60000);
+      expect(service.snapshot(model)).toEqual({
+        available: false,
+        reason: 'quota',
       });
     });
   });

--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -48,6 +48,26 @@ import { normalizeModelId } from '../utils/modelUtils.js';
 export class ModelAvailabilityService {
   private readonly health = new Map<ModelId, HealthState>();
 
+  private getHealth(
+    model: ModelId,
+    ttlMs: number = 30000,
+  ): HealthState | undefined {
+    const state = this.health.get(model);
+    if (
+      state &&
+      state.status === 'terminal' &&
+      state.reason === 'capacity' &&
+      state.markedAt !== undefined
+    ) {
+      const elapsed = Date.now() - state.markedAt;
+      if (elapsed >= ttlMs) {
+        this.clearState(model);
+        return undefined;
+      }
+    }
+    return state;
+  }
+
   markTerminal(modelId: ModelId, reason: TerminalUnavailabilityReason) {
     const model = normalizeModelId(modelId);
     this.setState(model, {
@@ -64,7 +84,7 @@ export class ModelAvailabilityService {
 
   markRetryOncePerTurn(modelId: ModelId, attempts: number = 1) {
     const model = normalizeModelId(modelId);
-    const currentState = this.health.get(model);
+    const currentState = this.getHealth(model);
     // Do not override a terminal failure with a transient one.
     if (currentState?.status === 'terminal') {
       return;
@@ -87,7 +107,7 @@ export class ModelAvailabilityService {
 
   consumeStickyAttempt(modelId: ModelId) {
     const model = normalizeModelId(modelId);
-    const state = this.health.get(model);
+    const state = this.getHealth(model);
     if (state?.status === 'sticky_retry') {
       this.setState(model, { ...state, consumed: true });
     }
@@ -95,21 +115,13 @@ export class ModelAvailabilityService {
 
   snapshot(modelId: ModelId, ttlMs: number = 30000): ModelAvailabilitySnapshot {
     const model = normalizeModelId(modelId);
-    const state = this.health.get(model);
+    const state = this.getHealth(model, ttlMs);
 
     if (!state) {
       return { available: true };
     }
 
     if (state.status === 'terminal') {
-      if (state.reason === 'capacity' && state.markedAt !== undefined) {
-        const elapsed = Date.now() - state.markedAt;
-        if (elapsed >= ttlMs) {
-          // TTL expired! Automatically clear state and return available
-          this.clearState(model);
-          return { available: true };
-        }
-      }
       return { available: false, reason: state.reason };
     }
 
@@ -127,7 +139,7 @@ export class ModelAvailabilityService {
       const model = normalizeModelId(modelId);
       const snapshot = this.snapshot(model);
       if (snapshot.available) {
-        const state = this.health.get(model);
+        const state = this.getHealth(model);
         // A sticky model is being attempted, so note that.
         const attempts =
           state?.status === 'sticky_retry' ? state.attempts : undefined;

--- a/packages/core/src/availability/modelAvailabilityService.ts
+++ b/packages/core/src/availability/modelAvailabilityService.ts
@@ -17,7 +17,11 @@ export type UnavailabilityReason =
 export type ModelHealthStatus = 'terminal' | 'sticky_retry';
 
 type HealthState =
-  | { status: 'terminal'; reason: TerminalUnavailabilityReason }
+  | {
+      status: 'terminal';
+      reason: TerminalUnavailabilityReason;
+      markedAt?: number;
+    }
   | {
       status: 'sticky_retry';
       reason: TurnUnavailabilityReason;
@@ -49,6 +53,7 @@ export class ModelAvailabilityService {
     this.setState(model, {
       status: 'terminal',
       reason,
+      markedAt: Date.now(),
     });
   }
 
@@ -88,7 +93,7 @@ export class ModelAvailabilityService {
     }
   }
 
-  snapshot(modelId: ModelId): ModelAvailabilitySnapshot {
+  snapshot(modelId: ModelId, ttlMs: number = 30000): ModelAvailabilitySnapshot {
     const model = normalizeModelId(modelId);
     const state = this.health.get(model);
 
@@ -97,6 +102,14 @@ export class ModelAvailabilityService {
     }
 
     if (state.status === 'terminal') {
+      if (state.reason === 'capacity' && state.markedAt !== undefined) {
+        const elapsed = Date.now() - state.markedAt;
+        if (elapsed >= ttlMs) {
+          // TTL expired! Automatically clear state and return available
+          this.clearState(model);
+          return { available: true };
+        }
+      }
       return { available: false, reason: state.reason };
     }
 

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -938,4 +938,121 @@ describe('retryWithBackoff', () => {
       expect(mockService.markTerminal).not.toHaveBeenCalled();
     });
   });
+
+  describe('Capacity Exhaustion Context-Aware Retries (Option 2)', () => {
+    it('should retry automatically when onPersistent429 is undefined (unattended runs)', async () => {
+      const capacityError = new TerminalQuotaError(
+        'Resource has been exhausted (e.g. MODEL_CAPACITY_EXHAUSTED).',
+        {
+          code: 429,
+          message: 'MODEL_CAPACITY_EXHAUSTED',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              reason: 'MODEL_CAPACITY_EXHAUSTED',
+            },
+          ],
+        },
+        undefined,
+        'MODEL_CAPACITY_EXHAUSTED',
+      );
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(capacityError)
+        .mockResolvedValue('success');
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 3,
+        initialDelayMs: 1,
+        maxDelayMs: 2,
+        onPersistent429: undefined, // unattended mode
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result).toBe('success');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should silently retry up to 2 times and succeed on the 3rd attempt in interactive mode without calling onPersistent429', async () => {
+      const capacityError = new TerminalQuotaError(
+        'Resource has been exhausted (e.g. MODEL_CAPACITY_EXHAUSTED).',
+        {
+          code: 429,
+          message: 'MODEL_CAPACITY_EXHAUSTED',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              reason: 'MODEL_CAPACITY_EXHAUSTED',
+            },
+          ],
+        },
+        undefined,
+        'MODEL_CAPACITY_EXHAUSTED',
+      );
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(capacityError)
+        .mockRejectedValueOnce(capacityError)
+        .mockResolvedValue('success');
+
+      const onPersistent429 = vi.fn().mockResolvedValue(null);
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 1,
+        maxDelayMs: 2,
+        onPersistent429, // interactive mode
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result).toBe('success');
+      expect(fn).toHaveBeenCalledTimes(3);
+      expect(onPersistent429).not.toHaveBeenCalled();
+    });
+
+    it('should silently retry up to 2 times and invoke onPersistent429 on the 3rd failure in interactive mode', async () => {
+      const capacityError = new TerminalQuotaError(
+        'Resource has been exhausted (e.g. MODEL_CAPACITY_EXHAUSTED).',
+        {
+          code: 429,
+          message: 'MODEL_CAPACITY_EXHAUSTED',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              reason: 'MODEL_CAPACITY_EXHAUSTED',
+            },
+          ],
+        },
+        undefined,
+        'MODEL_CAPACITY_EXHAUSTED',
+      );
+
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(capacityError)
+        .mockRejectedValueOnce(capacityError)
+        .mockRejectedValueOnce(capacityError)
+        .mockResolvedValue('success');
+
+      const onPersistent429 = vi.fn().mockResolvedValue(null);
+
+      const promise = retryWithBackoff(fn, {
+        maxAttempts: 5,
+        initialDelayMs: 1,
+        maxDelayMs: 2,
+        onPersistent429, // interactive mode
+      });
+
+      await Promise.all([
+        expect(promise).rejects.toThrow(TerminalQuotaError),
+        vi.runAllTimersAsync(),
+      ]);
+      expect(fn).toHaveBeenCalledTimes(3);
+      expect(onPersistent429).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -390,6 +390,7 @@ export async function retryWithBackoff<T>(
           );
           if (silentDelayMs !== undefined) {
             retryable.retryDelayMs = silentDelayMs;
+            currentDelay = silentDelayMs;
           }
           classifiedError = retryable;
         } else {

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -294,6 +294,8 @@ export async function retryWithBackoff<T>(
     getAvailabilityContext?.()?.policy.maxAttempts ?? maxAttempts;
 
   let attempt = 0;
+  let capacityAttempts = 0;
+  const MAX_SILENT_CAPACITY_ATTEMPTS = 3;
   let currentDelay = initialDelayMs;
   const throwIfAborted = () => {
     if (signal?.aborted) {
@@ -337,7 +339,7 @@ export async function retryWithBackoff<T>(
       }
       throwIfAborted();
 
-      const classifiedError = classifyGoogleError(error);
+      let classifiedError = classifyGoogleError(error);
 
       const errorCode = getErrorStatus(error);
 
@@ -345,25 +347,75 @@ export async function retryWithBackoff<T>(
         classifiedError instanceof TerminalQuotaError ||
         classifiedError instanceof ModelNotFoundError
       ) {
-        if (onPersistent429) {
-          try {
-            const fallbackModel = await onPersistent429(
-              authType,
-              classifiedError,
-            );
-            if (fallbackModel) {
-              attempt = 0; // Reset attempts and retry with the new model.
-              currentDelay = initialDelayMs;
-              continue;
+        // Fall back to automatic retry for capacity exhaustion in unattended/non-interactive mode,
+        // or allow up to 3 silent retries in interactive mode before prompting the fallback dialog.
+        const isCapacityExceeded =
+          classifiedError instanceof TerminalQuotaError &&
+          (classifiedError.reason === 'MODEL_CAPACITY_EXHAUSTED' ||
+            classifiedError.reason === 'MODEL_CAPACITY_EXCEEDED' ||
+            /exhausted your capacity|capacity exceeded|MODEL_CAPACITY_EXHAUSTED/i.test(
+              classifiedError.message,
+            ));
+
+        let useSilentRetry = false;
+        let silentDelayMs: number | undefined;
+
+        if (
+          classifiedError instanceof TerminalQuotaError &&
+          isCapacityExceeded
+        ) {
+          if (!onPersistent429) {
+            // Unattended mode: always retry up to standard maxAttempts
+            useSilentRetry = true;
+            silentDelayMs = classifiedError.retryDelayMs;
+          } else {
+            // Interactive mode: allow up to 3 silent retries with progressive backoff before calling fallback handler
+            capacityAttempts++;
+            if (capacityAttempts < MAX_SILENT_CAPACITY_ATTEMPTS) {
+              useSilentRetry = true;
+              silentDelayMs =
+                classifiedError.retryDelayMs !== undefined
+                  ? classifiedError.retryDelayMs
+                  : capacityAttempts === 1
+                    ? 1000
+                    : 3000; // 1s on attempt 1, 3s on attempt 2
             }
-          } catch (fallbackError) {
-            debugLogger.warn('Fallback to Flash model failed:', fallbackError);
           }
         }
-        // Terminal/not_found already recorded; nothing else to mark here.
-        throw classifiedError instanceof Error
-          ? enrichQuotaError(classifiedError, authType)
-          : classifiedError; // Throw if no fallback or fallback failed.
+
+        if (useSilentRetry && classifiedError instanceof TerminalQuotaError) {
+          const retryable = new RetryableQuotaError(
+            classifiedError.message,
+            classifiedError.cause,
+          );
+          if (silentDelayMs !== undefined) {
+            retryable.retryDelayMs = silentDelayMs;
+          }
+          classifiedError = retryable;
+        } else {
+          if (onPersistent429) {
+            try {
+              const fallbackModel = await onPersistent429(
+                authType,
+                classifiedError,
+              );
+              if (fallbackModel) {
+                attempt = 0; // Reset attempts and retry with the new model.
+                currentDelay = initialDelayMs;
+                continue;
+              }
+            } catch (fallbackError) {
+              debugLogger.warn(
+                'Fallback to Flash model failed:',
+                fallbackError,
+              );
+            }
+          }
+          // Terminal/not_found already recorded; nothing else to mark here.
+          throw classifiedError instanceof Error
+            ? enrichQuotaError(classifiedError, authType)
+            : classifiedError; // Throw if no fallback or fallback failed.
+        }
       }
 
       // Handle ValidationRequiredError - user needs to verify before proceeding


### PR DESCRIPTION
## Summary

This PR addresses and fully closes the critical capacity exhaustion retry regression reported in #28761. It introduces context-aware retry policies for capacity exhaustion errors, allowing unattended/non-interactive CLI runs to automatically back off and retry, while adding up to 2 silent backoffs in interactive mode to absorb transient capacity blips without immediately interrupting the user with a fallback dialog. Additionally, it implements a 30-second sliding expiration TTL in `ModelAvailabilityService` for models marked terminal due to capacity exhaustion, ensuring users aren't permanently locked out of their preferred models for their entire session.

## Details

1. **Context-Aware Silent Retries in `retryWithBackoff` (`packages/core/src/utils/retry.ts`)**:
   - Introduced a `capacityAttempts` counter tracking capacity exhaustion errors.
   - **Interactive Mode:** Allows up to 2 silent, progressive backoff retries with jitter (1s delay on failure 1, 3s delay on failure 2) to absorb highly transient server-side capacity blips. The low-level client only triggers the interactive fallback model selection/dialog (`onPersistent429`) if capacity limits fail 3 consecutive times.
   - **Unattended Mode:** Bypasses fallback prompting completely, translating capacity errors to standard retryable errors so they retry silently up to the standard limit (defaulting to 10 attempts) with exponential backoff.
2. **Model Availability TTL in `ModelAvailabilityService` (`packages/core/src/availability/modelAvailabilityService.ts`)**:
   - Stamped a `markedAt` timestamp on terminal health states.
   - Implemented a sliding 30-second TTL in `snapshot()`. When a model is marked terminal with reason `'capacity'`, it is treated as unavailable during the TTL window, but automatically clears and recovers to `'available'` state once 30 seconds have elapsed. Harder errors (like `'quota'`) remain terminal permanently.

## Related Issues

Closes #28761
Related to #28599, #28716

## How to Validate

1. Run the retry unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/retry.test.ts --run
   ```
2. Run the availability service unit tests:
   ```bash
   npm test -w @google/gemini-cli-core -- src/availability/modelAvailabilityService.test.ts --run
   ```
3. Run linting and typechecking project-wide:
   ```bash
   npm run lint && npm run typecheck
   ```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
