### PR TITLE
fix(core): normalize git environment and resolve workspace state mismatch

### DIFF
--- a/packages/a2a-server/src/agent/executor.ts
+++ b/packages/a2a-server/src/agent/executor.ts
@@ -17,8 +17,6 @@ import {
   SimpleExtensionLoader,
   type ToolCallRequestInfo,
   type Config,
-  checkPathTrust,
-  isHeadlessMode,
   resolveToRealPath,
 } from '@google/gemini-cli-core';
 import { v4 as uuidv4 } from 'uuid';
@@ -37,6 +35,7 @@ import {
 import {
   loadConfig,
   setTargetDir,
+  setIsTrusted,
   envStorage,
   cwdSymbol,
   loadEnvironment,
@@ -134,23 +133,16 @@ export class CoderAgentExecutor implements AgentExecutor {
     fn: (isTrusted: boolean, workspaceRoot: string) => Promise<T>,
   ): Promise<T> {
     const workspaceRoot = await setTargetDir(agentSettings);
-    const initialSettings = loadSettings(workspaceRoot, false);
-    const { isTrusted } = checkPathTrust({
-      path: workspaceRoot,
-      isFolderTrustEnabled: initialSettings.folderTrust ?? true,
-      isHeadless: isHeadlessMode(),
-    });
+    const isTrusted = setIsTrusted(agentSettings, workspaceRoot);
 
     const envVars: TaskEnv = { ...process.env };
+    envVars['GEMINI_CLI_TRUST_WORKSPACE'] = isTrusted ? 'true' : 'false';
     envVars[cwdSymbol] = workspaceRoot;
 
     return envStorage.run(envVars, async () => {
-      const loadedEnv = await loadEnvironment(
-        isTrusted ?? false,
-        workspaceRoot,
-      );
+      const loadedEnv = await loadEnvironment(isTrusted, workspaceRoot);
       Object.assign(envVars, loadedEnv);
-      return fn(isTrusted ?? false, workspaceRoot);
+      return fn(isTrusted, workspaceRoot);
     });
   }
 

--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -546,30 +546,40 @@ describe('loadConfig', () => {
 describe('setIsTrusted', () => {
   beforeEach(() => {
     vi.resetModules();
+    // Ensure GEMINI_CLI_TRUST_WORKSPACE is not set by default in tests to prevent leakage
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', '');
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it('should return true when GEMINI_FOLDER_TRUST env var is true', async () => {
-    vi.stubEnv('GEMINI_FOLDER_TRUST', 'true');
-    const { setIsTrusted } = await import('./config.js');
-    expect(setIsTrusted(undefined)).toBe(true);
-    expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(true);
-  });
-
-  it('should return false when GEMINI_FOLDER_TRUST env var is false', async () => {
-    vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
-    const { setIsTrusted } = await import('./config.js');
-    expect(setIsTrusted(undefined)).toBe(false);
-    expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(false);
-  });
-
-  it('should fallback to agentSettings.isTrusted if env var is undefined', async () => {
+  it('should return agentSettings.isTrusted if defined, ignoring env vars', async () => {
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', 'false');
     const { setIsTrusted } = await import('./config.js');
     expect(setIsTrusted({ isTrusted: true } as AgentSettings)).toBe(true);
+
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', 'true');
     expect(setIsTrusted({ isTrusted: false } as AgentSettings)).toBe(false);
+  });
+
+  it('should return true when GEMINI_CLI_TRUST_WORKSPACE env var is true and agentSettings.isTrusted is undefined', async () => {
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', 'true');
+    const { setIsTrusted } = await import('./config.js');
+    expect(setIsTrusted(undefined)).toBe(true);
+    expect(setIsTrusted({} as AgentSettings)).toBe(true);
+  });
+
+  it('should return false when GEMINI_CLI_TRUST_WORKSPACE env var is false and agentSettings.isTrusted is undefined', async () => {
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', 'false');
+    const { setIsTrusted } = await import('./config.js');
     expect(setIsTrusted(undefined)).toBe(false);
+    expect(setIsTrusted({} as AgentSettings)).toBe(false);
+  });
+
+  it('should fallback to false if agentSettings.isTrusted and env var are undefined and no workspaceRoot is provided', async () => {
+    const { setIsTrusted } = await import('./config.js');
+    expect(setIsTrusted(undefined)).toBe(false);
+    expect(setIsTrusted({} as AgentSettings)).toBe(false);
   });
 });

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -31,10 +31,11 @@ import {
   type ConfigParameters,
   type ExtensionLoader,
   resolveToRealPath,
+  checkPathTrust,
 } from '@google/gemini-cli-core';
 
 import { logger } from '../utils/logger.js';
-import type { Settings } from './settings.js';
+import { type Settings, loadSettings } from './settings.js';
 import { type AgentSettings, CoderAgentEvent } from '../types.js';
 
 export const envStorage = new AsyncLocalStorage<TaskEnv>();
@@ -407,12 +408,25 @@ export async function loadConfig(
 
 export function setIsTrusted(
   agentSettings: AgentSettings | undefined,
+  workspaceRoot?: string,
 ): boolean {
-  const folderTrustEnv = getEnv('GEMINI_FOLDER_TRUST');
-  if (folderTrustEnv !== undefined) {
-    return folderTrustEnv === 'true';
+  if (agentSettings?.isTrusted !== undefined) {
+    return agentSettings.isTrusted;
   }
-  return !!agentSettings?.isTrusted;
+  const cliTrustEnv = getEnv('GEMINI_CLI_TRUST_WORKSPACE');
+  if (cliTrustEnv !== undefined) {
+    return cliTrustEnv === 'true';
+  }
+  if (workspaceRoot) {
+    const initialSettings = loadSettings(workspaceRoot, false);
+    const { isTrusted } = checkPathTrust({
+      path: workspaceRoot,
+      isFolderTrustEnabled: initialSettings.folderTrust ?? true,
+      isHeadless: isHeadlessMode(),
+    });
+    return isTrusted ?? false;
+  }
+  return false;
 }
 
 export async function setTargetDir(

--- a/packages/a2a-server/src/config/rce_vulnerability.test.ts
+++ b/packages/a2a-server/src/config/rce_vulnerability.test.ts
@@ -9,14 +9,14 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-let mockHomeDir = '';
+const mockHomeRef = vi.hoisted(() => ({ dir: '' }));
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...original,
-    homedir: () => mockHomeDir,
+    homedir: () => mockHomeRef.dir || os.tmpdir(),
   };
 });
 
@@ -27,7 +27,9 @@ describe('Vulnerability Mitigation: b-519269096', () => {
 
   beforeEach(() => {
     // Create a temporary home directory securely using mkdtempSync to ensure hermeticity
-    mockHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-mock-home-'));
+    mockHomeRef.dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-mock-home-'),
+    );
 
     // Create a temporary workspace directory representing an untrusted repo
     tempWorkspaceDir = fs.mkdtempSync(
@@ -44,7 +46,7 @@ describe('Vulnerability Mitigation: b-519269096', () => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
     fs.rmSync(tempWorkspaceDir, { recursive: true, force: true });
-    fs.rmSync(mockHomeDir, { recursive: true, force: true });
+    fs.rmSync(mockHomeRef.dir, { recursive: true, force: true });
   });
 
   it('should ignore GEMINI_CLI_TRUST_WORKSPACE and GEMINI_YOLO_MODE in untrusted workspaces', async () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -41,6 +41,7 @@ import {
   getAdminBlockedMcpServersMessage,
   getProjectRootForWorktree,
   isGeminiWorktree,
+  getSafeGitEnv,
   type WorktreeSettings,
   type HookDefinition,
   type HookEventName,
@@ -1142,6 +1143,7 @@ async function resolveWorktreeSettings(
   try {
     const { stdout } = await execa('git', ['rev-parse', '--show-toplevel'], {
       cwd,
+      env: getSafeGitEnv(),
     });
     const toplevel = stdout.trim();
     const projectRoot = await getProjectRootForWorktree(toplevel);
@@ -1161,6 +1163,7 @@ async function resolveWorktreeSettings(
   try {
     const { stdout } = await execa('git', ['rev-parse', 'HEAD'], {
       cwd: worktreePath,
+      env: getSafeGitEnv(),
     });
     worktreeBaseSha = stdout.trim();
   } catch (e: unknown) {

--- a/packages/cli/src/config/extension.test.ts
+++ b/packages/cli/src/config/extension.test.ts
@@ -58,6 +58,7 @@ const mockGit = {
   checkout: vi.fn(),
   listRemote: vi.fn(),
   revparse: vi.fn(),
+  env: vi.fn(() => mockGit),
   // Not a part of the actual API, but we need to use this to do the correct
   // file system interactions.
   path: vi.fn(),

--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -75,6 +75,7 @@ describe('github.ts', () => {
       checkout: ReturnType<typeof vi.fn>;
       listRemote: ReturnType<typeof vi.fn>;
       revparse: ReturnType<typeof vi.fn>;
+      env: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -85,6 +86,7 @@ describe('github.ts', () => {
         checkout: vi.fn(),
         listRemote: vi.fn(),
         revparse: vi.fn(),
+        env: vi.fn().mockReturnThis(),
       };
       vi.mocked(simpleGit).mockReturnValue(mockGit as unknown as SimpleGit);
     });
@@ -206,6 +208,7 @@ describe('github.ts', () => {
       getRemotes: ReturnType<typeof vi.fn>;
       listRemote: ReturnType<typeof vi.fn>;
       revparse: ReturnType<typeof vi.fn>;
+      env: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -216,6 +219,7 @@ describe('github.ts', () => {
         getRemotes: vi.fn(),
         listRemote: vi.fn(),
         revparse: vi.fn(),
+        env: vi.fn().mockReturnThis(),
       };
       vi.mocked(simpleGit).mockReturnValue(mockGit as unknown as SimpleGit);
     });

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -8,6 +8,7 @@ import { simpleGit } from 'simple-git';
 import {
   debugLogger,
   getErrorMessage,
+  getSafeGitEnv,
   type ExtensionInstallMetadata,
   type GeminiCLIExtension,
 } from '@google/gemini-cli-core';
@@ -33,7 +34,7 @@ export async function cloneFromGit(
   destination: string,
 ): Promise<void> {
   try {
-    const git = simpleGit(destination);
+    const git = simpleGit(destination).env(getSafeGitEnv());
     let sourceUrl = installMetadata.source;
     const token = getGitHubToken();
     if (token) {
@@ -223,7 +224,7 @@ export async function checkForExtensionUpdate(
 
   try {
     if (installMetadata.type === 'git') {
-      const git = simpleGit(extension.path);
+      const git = simpleGit(extension.path).env(getSafeGitEnv());
       const remotes = await git.getRemotes(true);
       if (remotes.length === 0) {
         debugLogger.error('No git remotes found.');

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1340,6 +1340,7 @@ export class Config implements McpContext, AgentLoopContext {
         approvalMode: engineApprovalMode,
         disableAlwaysAllow: this.disableAlwaysAllow,
         sandboxManager: this._sandboxManager,
+        isTrustedFolder: () => this.isTrustedFolder(),
       },
       checkerRunner,
     );
@@ -3159,13 +3160,16 @@ export class Config implements McpContext, AgentLoopContext {
    * 'false' for untrusted.
    */
   isTrustedFolder(): boolean {
+    if (this.trustedFolder !== undefined) {
+      return this.trustedFolder;
+    }
+
     const context = ideContextStore.get();
     if (context?.workspaceState?.isTrusted !== undefined) {
       return context.workspaceState.isTrusted;
     }
 
-    // Default to untrusted if folder trust is enabled and no explicit value is set.
-    return this.folderTrust ? (this.trustedFolder ?? false) : true;
+    return this.folderTrust ? false : true;
   }
 
   setIdeMode(value: boolean): void {

--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1531,6 +1531,77 @@ describe('PolicyEngine', () => {
       expect(result.decision).toBe(PolicyDecision.ALLOW);
     });
 
+    it('should NOT upgrade Git commands to ALLOW in untrusted workspace', async () => {
+      const isTrustedMock = vi.fn().mockReturnValue(false);
+      const engine = new PolicyEngine({
+        isTrustedFolder: isTrustedMock,
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'git status' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ASK_USER);
+      expect(isTrustedMock).toHaveBeenCalled();
+    });
+
+    it('should NOT treat commands with git in arguments or URLs as Git commands', async () => {
+      const isTrustedMock = vi.fn().mockReturnValue(false);
+      const engine = new PolicyEngine({
+        isTrustedFolder: isTrustedMock,
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'echo git' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should detect chained Git commands as Git commands and force ASK_USER in untrusted workspaces', async () => {
+      const isTrustedMock = vi.fn().mockReturnValue(false);
+      const engine = new PolicyEngine({
+        isTrustedFolder: isTrustedMock,
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'echo "hello" && git status' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ASK_USER);
+      expect(isTrustedMock).toHaveBeenCalled();
+    });
+
+    it('should upgrade Git commands to ALLOW in trusted workspace when heuristics apply', async () => {
+      const isTrustedMock = vi.fn().mockReturnValue(true);
+      const engine = new PolicyEngine({
+        isTrustedFolder: isTrustedMock,
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'git status' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+      expect(isTrustedMock).toHaveBeenCalled();
+    });
+
     it('should respect explicit DENY for compound commands even if parts are allowed', async () => {
       const rules: PolicyRule[] = [
         {

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import path from 'node:path';
 import { type FunctionCall } from '@google/genai';
 import {
   SHELL_TOOL_NAMES,
@@ -45,6 +46,34 @@ import {
   NoopSandboxManager,
   type SandboxPermissions,
 } from '../services/sandboxManager.js';
+
+function containsGitCommand(args: string[]): boolean {
+  if (!args || args.length === 0) return false;
+  const allowedPredecessors = new Set([
+    'sudo',
+    'env',
+    'time',
+    '&&',
+    '||',
+    ';',
+    '|',
+    '&',
+    '(',
+    '\\n',
+  ]);
+  return args.some((arg, index) => {
+    if (index > 0) {
+      const prev = args[index - 1].toLowerCase();
+      if (!allowedPredecessors.has(prev)) {
+        return false;
+      }
+    }
+    const trimmed = arg.trim();
+    if (!trimmed) return false;
+    const basename = path.basename(trimmed).toLowerCase();
+    return basename === 'git' || basename === 'git.exe';
+  });
+}
 
 function isWildcardPattern(name: string): boolean {
   return name === '*' || name.includes('*');
@@ -205,6 +234,7 @@ export class PolicyEngine {
   private readonly checkerRunner?: CheckerRunner;
   private approvalMode: ApprovalMode;
   private readonly sandboxManager: SandboxManager;
+  private readonly isTrustedFolderFn?: () => boolean;
 
   constructor(config: PolicyEngineConfig = {}, checkerRunner?: CheckerRunner) {
     this.rules = (config.rules ?? []).sort(
@@ -258,6 +288,14 @@ export class PolicyEngine {
     this.checkerRunner = checkerRunner;
     this.approvalMode = config.approvalMode ?? ApprovalMode.DEFAULT;
     this.sandboxManager = config.sandboxManager ?? new NoopSandboxManager();
+    this.isTrustedFolderFn = config.isTrustedFolder;
+  }
+
+  isTrustedFolder(): boolean {
+    if (this.isTrustedFolderFn) {
+      return this.isTrustedFolderFn();
+    }
+    return true;
   }
 
   /**
@@ -312,6 +350,13 @@ export class PolicyEngine {
       const parsedObjArgs = shellParse(command);
       const parsedArgs = parsedObjArgs.map(extractStringFromParseEntry);
 
+      if (containsGitCommand(parsedArgs) && !this.isTrustedFolder()) {
+        debugLogger.debug(
+          `[PolicyEngine.check] Git command evaluated in untrusted workspace. Forcing ASK_USER: ${command}`,
+        );
+        return PolicyDecision.ASK_USER;
+      }
+
       if (this.sandboxManager.isDangerousCommand(parsedArgs)) {
         if (this.approvalMode === ApprovalMode.YOLO) {
           debugLogger.debug(
@@ -330,6 +375,13 @@ export class PolicyEngine {
         this.sandboxManager.isKnownSafeCommand(parsedArgs) &&
         decision === PolicyDecision.ASK_USER
       ) {
+        if (containsGitCommand(parsedArgs) && !this.isTrustedFolder()) {
+          debugLogger.debug(
+            `[PolicyEngine.check] Known safe Git command evaluated in untrusted workspace. Preserving ASK_USER: ${command}`,
+          );
+          return PolicyDecision.ASK_USER;
+        }
+
         debugLogger.debug(
           `[PolicyEngine.check] Command evaluated as known safe, overriding ASK_USER to ALLOW: ${command}`,
         );

--- a/packages/core/src/policy/types.ts
+++ b/packages/core/src/policy/types.ts
@@ -327,6 +327,11 @@ export interface PolicyEngineConfig {
    * The sandbox manager instance.
    */
   sandboxManager?: SandboxManager;
+
+  /**
+   * Callback or boolean indicating whether the current workspace is trusted.
+   */
+  isTrustedFolder?: () => boolean;
 }
 
 export interface PolicySettings {

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -22,10 +22,8 @@ import { Storage } from '../config/storage.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
-import { GEMINI_DIR, homedir as pathsHomedir } from '../utils/paths.js';
+import { homedir as pathsHomedir } from '../utils/paths.js';
 import { spawnAsync } from '../utils/shell-utils.js';
-
-const PROJECT_SLUG = 'project-slug';
 
 vi.mock('../utils/shell-utils.js', () => ({
   spawnAsync: vi.fn(),
@@ -53,9 +51,13 @@ vi.mock('simple-git', () => ({
 }));
 
 const hoistedIsGitRepositoryMock = vi.hoisted(() => vi.fn());
-vi.mock('../utils/gitUtils.js', () => ({
-  isGitRepository: hoistedIsGitRepositoryMock,
-}));
+vi.mock('../utils/gitUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/gitUtils.js')>();
+  return {
+    ...actual,
+    isGitRepository: hoistedIsGitRepositoryMock,
+  };
+});
 
 const hoistedMockHomedir = vi.hoisted(() => vi.fn());
 vi.mock('node:os', async (importOriginal) => {
@@ -131,11 +133,13 @@ describe('GitService', () => {
       commit: 'initial',
     });
     storage = new Storage(projectRoot);
+    await storage.initialize();
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
-    await fs.rm(testRootDir, { recursive: true, force: true });
+    if (testRootDir) {
+      await fs.rm(testRootDir, { recursive: true, force: true });
+    }
   });
 
   describe('constructor', () => {
@@ -147,7 +151,9 @@ describe('GitService', () => {
   describe('verifyGitAvailability', () => {
     it('should resolve true if git --version command succeeds', async () => {
       await expect(GitService.verifyGitAvailability()).resolves.toBe(true);
-      expect(spawnAsync).toHaveBeenCalledWith('git', ['--version']);
+      expect(spawnAsync).toHaveBeenCalledWith('git', ['--version'], {
+        env: expect.anything(),
+      });
     });
 
     it('should resolve false if git --version command fails', async () => {
@@ -181,7 +187,7 @@ describe('GitService', () => {
     let gitConfigPath: string;
 
     beforeEach(async () => {
-      repoDir = path.join(homedir, GEMINI_DIR, 'history', PROJECT_SLUG);
+      repoDir = storage.getHistoryDir();
       gitConfigPath = path.join(repoDir, '.gitconfig');
     });
 

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -20,6 +20,7 @@ import {
   sanitizeEnvironment,
   getSecureSanitizationConfig,
 } from './environmentSanitization.js';
+import { getSafeGitEnv } from '../utils/gitUtils.js';
 
 export const SHADOW_REPO_AUTHOR_NAME = 'Gemini CLI';
 export const SHADOW_REPO_AUTHOR_EMAIL = 'gemini-cli@google.com';
@@ -91,7 +92,7 @@ export class GitService {
 
   static async verifyGitAvailability(): Promise<boolean> {
     try {
-      await spawnAsync('git', ['--version']);
+      await spawnAsync('git', ['--version'], { env: getSafeGitEnv() });
       return true;
     } catch {
       return false;
@@ -102,11 +103,13 @@ export class GitService {
     const gitConfigPath = path.join(repoDir, '.gitconfig');
     const systemConfigPath = path.join(repoDir, '.gitconfig_system_empty');
     return {
-      ...sanitizeEnvironment(
-        process.env,
-        getSecureSanitizationConfig({
-          enableEnvironmentVariableRedaction: true,
-        }),
+      ...getSafeGitEnv(
+        sanitizeEnvironment(
+          process.env,
+          getSecureSanitizationConfig({
+            enableEnvironmentVariableRedaction: true,
+          }),
+        ),
       ),
       // Prevent git from using the user's global git config.
       GIT_CONFIG_GLOBAL: gitConfigPath,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -14,6 +14,7 @@ import {
   type Mock,
 } from 'vitest';
 
+import os from 'node:os';
 import EventEmitter from 'node:events';
 import type { Readable } from 'node:stream';
 import { type ChildProcess } from 'node:child_process';
@@ -2140,16 +2141,36 @@ describe('ShellExecutionService environment variables', () => {
     expect(cpEnv).toHaveProperty('DISPLAY', '');
     expect(cpEnv).toHaveProperty('DBUS_SESSION_BUS_ADDRESS', '');
 
+    // Global / system config neutralization paths
+    const devNullPath = os.platform() === 'win32' ? 'NUL' : '/dev/null';
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_GLOBAL', devNullPath);
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_SYSTEM', devNullPath);
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_NOSYSTEM', '1');
+
     // Existing values should be preserved
     expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_0', 'core.editor');
     expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_0', 'vim');
     expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_1', 'pull.rebase');
     expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_1', 'true');
 
-    // The new credential.helper override should be appended at index 2
-    expect(cpEnv).toHaveProperty('GIT_CONFIG_COUNT', '3');
+    // The 8 security overrides should be appended at index 2..9
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_COUNT', '10');
     expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_2', 'credential.helper');
     expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_2', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_3', 'core.fsmonitor');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_3', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_4', 'core.hooksPath');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_4', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_5', 'core.sshCommand');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_5', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_6', 'core.pager');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_6', 'cat');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_7', 'core.editor');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_7', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_8', 'sequence.editor');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_8', '');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_KEY_9', 'diff.external');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_VALUE_9', '');
 
     // Ensure child_process exits
     mockChildProcess.emit('exit', 0, null);
@@ -2159,7 +2180,7 @@ describe('ShellExecutionService environment variables', () => {
     vi.unstubAllEnvs();
   });
 
-  it('should NOT include headless git and gh environment variables in interactive fallback mode', async () => {
+  it('should include headless git and gh environment variables in interactive fallback mode', async () => {
     vi.resetModules();
     vi.stubEnv('GIT_TERMINAL_PROMPT', undefined);
     vi.stubEnv('GIT_ASKPASS', undefined);
@@ -2184,12 +2205,12 @@ describe('ShellExecutionService environment variables', () => {
 
     expect(mockCpSpawn).toHaveBeenCalled();
     const cpEnv = mockCpSpawn.mock.calls[0][2].env;
-    expect(cpEnv).not.toHaveProperty('GIT_TERMINAL_PROMPT');
-    expect(cpEnv).not.toHaveProperty('GIT_ASKPASS');
-    expect(cpEnv).not.toHaveProperty('SSH_ASKPASS');
-    expect(cpEnv).not.toHaveProperty('GH_PROMPT_DISABLED');
-    expect(cpEnv).not.toHaveProperty('GCM_INTERACTIVE');
-    expect(cpEnv).not.toHaveProperty('GIT_CONFIG_COUNT');
+    expect(cpEnv).toHaveProperty('GIT_TERMINAL_PROMPT', '0');
+    expect(cpEnv).toHaveProperty('GIT_ASKPASS', '');
+    expect(cpEnv).toHaveProperty('SSH_ASKPASS', '');
+    expect(cpEnv).toHaveProperty('GH_PROMPT_DISABLED', '1');
+    expect(cpEnv).toHaveProperty('GCM_INTERACTIVE', 'never');
+    expect(cpEnv).toHaveProperty('GIT_CONFIG_COUNT');
 
     // Ensure child_process exits
     mockChildProcess.emit('exit', 0, null);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -139,7 +139,7 @@ export interface ShellExecutionConfig {
   backgroundCompletionBehavior?: 'inject' | 'notify' | 'silent';
   originalCommand?: string;
   sessionId?: string;
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
 }
 
 /**
@@ -464,11 +464,9 @@ export class ShellExecutionService {
     // 2. Prepare Environment
     const sourceEnv = shellExecutionConfig.env ?? process.env;
     const gitConfigKeys: string[] = [];
-    if (!isInteractive) {
-      for (const key in sourceEnv) {
-        if (key.startsWith('GIT_CONFIG_')) {
-          gitConfigKeys.push(key);
-        }
+    for (const key in sourceEnv) {
+      if (key.startsWith('GIT_CONFIG_')) {
+        gitConfigKeys.push(key);
       }
     }
 
@@ -492,36 +490,56 @@ export class ShellExecutionService {
       GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
     };
 
-    if (!isInteractive) {
-      // Ensure all GIT_CONFIG_* variables are preserved even if they were redacted
-      for (const key of gitConfigKeys) {
-        baseEnv[key] = sourceEnv[key];
-      }
-
-      const gitConfigCount = parseInt(baseEnv['GIT_CONFIG_COUNT'] || '0', 10);
-      const newKey = `GIT_CONFIG_KEY_${gitConfigCount}`;
-      const newValue = `GIT_CONFIG_VALUE_${gitConfigCount}`;
-
-      // Ensure these new keys are allowed through sanitization
-      sanitizationConfig.allowedEnvironmentVariables.push(
-        'GIT_CONFIG_COUNT',
-        newKey,
-        newValue,
-      );
-
-      Object.assign(baseEnv, {
-        GIT_TERMINAL_PROMPT: '0',
-        GIT_ASKPASS: '',
-        SSH_ASKPASS: '',
-        GH_PROMPT_DISABLED: '1',
-        GCM_INTERACTIVE: 'never',
-        DISPLAY: '',
-        DBUS_SESSION_BUS_ADDRESS: '',
-        GIT_CONFIG_COUNT: (gitConfigCount + 1).toString(),
-        [newKey]: 'credential.helper',
-        [newValue]: '',
-      });
+    // Ensure all GIT_CONFIG_* variables are preserved even if they were redacted
+    for (const key of gitConfigKeys) {
+      baseEnv[key] = sourceEnv[key];
     }
+
+    let gitConfigCount = parseInt(baseEnv['GIT_CONFIG_COUNT'] || '0', 10);
+    const devNullPath = os.platform() === 'win32' ? 'NUL' : '/dev/null';
+
+    baseEnv['GIT_CONFIG_GLOBAL'] = devNullPath;
+    baseEnv['GIT_CONFIG_SYSTEM'] = devNullPath;
+    baseEnv['GIT_CONFIG_NOSYSTEM'] = '1';
+
+    sanitizationConfig.allowedEnvironmentVariables.push(
+      'GIT_CONFIG_COUNT',
+      'GIT_CONFIG_GLOBAL',
+      'GIT_CONFIG_SYSTEM',
+      'GIT_CONFIG_NOSYSTEM',
+    );
+
+    const defaultGitOverrides: Array<[string, string]> = [
+      ['credential.helper', ''],
+      ['core.fsmonitor', ''],
+      ['core.hooksPath', ''],
+      ['core.sshCommand', ''],
+      ['core.pager', 'cat'],
+      ['core.editor', ''],
+      ['sequence.editor', ''],
+      ['diff.external', ''],
+    ];
+
+    for (const [overrideKey, overrideVal] of defaultGitOverrides) {
+      const keyVar = `GIT_CONFIG_KEY_${gitConfigCount}`;
+      const valVar = `GIT_CONFIG_VALUE_${gitConfigCount}`;
+      sanitizationConfig.allowedEnvironmentVariables.push(keyVar, valVar);
+      baseEnv[keyVar] = overrideKey;
+      baseEnv[valVar] = overrideVal;
+      gitConfigCount++;
+    }
+
+    baseEnv['GIT_CONFIG_COUNT'] = gitConfigCount.toString();
+
+    Object.assign(baseEnv, {
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ASKPASS: '',
+      SSH_ASKPASS: '',
+      GH_PROMPT_DISABLED: '1',
+      GCM_INTERACTIVE: 'never',
+      DISPLAY: '',
+      DBUS_SESSION_BUS_ADDRESS: '',
+    });
 
     // 3. Prepare Sandboxed Command
     const sandboxedCommand = await sandboxManager.prepareCommand({

--- a/packages/core/src/services/worktreeService.test.ts
+++ b/packages/core/src/services/worktreeService.test.ts
@@ -54,7 +54,7 @@ describe('worktree utilities', () => {
       expect(execa).toHaveBeenCalledWith(
         'git',
         ['rev-parse', '--git-common-dir'],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
     });
 
@@ -94,7 +94,7 @@ describe('worktree utilities', () => {
       expect(execa).toHaveBeenCalledWith(
         'git',
         ['worktree', 'add', expectedPath, '-b', `worktree-${worktreeName}`],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
     });
 
@@ -136,6 +136,7 @@ describe('worktree utilities', () => {
       expect(hasChanges).toBe(true);
       expect(execa).toHaveBeenCalledWith('git', ['status', '--porcelain'], {
         cwd: expectedPath,
+        env: expect.anything(),
       });
     });
 
@@ -195,19 +196,19 @@ describe('worktree utilities', () => {
         1,
         'git',
         ['-C', expectedPath, 'branch', '--show-current'],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
       expect(execa).toHaveBeenNthCalledWith(
         2,
         'git',
         ['worktree', 'remove', expectedPath, '--force'],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
       expect(execa).toHaveBeenNthCalledWith(
         3,
         'git',
         ['branch', '-D', `worktree-${worktreeName}`],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
     });
 
@@ -224,7 +225,7 @@ describe('worktree utilities', () => {
         2,
         'git',
         ['worktree', 'remove', expectedPath, '--force'],
-        { cwd: projectRoot },
+        { cwd: projectRoot, env: expect.anything() },
       );
     });
   });
@@ -248,6 +249,7 @@ describe('WorktreeService', () => {
 
       expect(execa).toHaveBeenCalledWith('git', ['rev-parse', 'HEAD'], {
         cwd: projectRoot,
+        env: expect.anything(),
       });
       expect(info.name).toBe('feature-x');
       expect(info.baseSha).toBe('current-sha');

--- a/packages/core/src/services/worktreeService.ts
+++ b/packages/core/src/services/worktreeService.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { execa } from 'execa';
 import { debugLogger } from '../utils/debugLogger.js';
+import { getSafeGitEnv } from '../utils/gitUtils.js';
 
 export interface WorktreeInfo {
   name: string;
@@ -43,6 +44,7 @@ export class WorktreeService {
     // Capture the base commit before creating the worktree
     const { stdout: baseSha } = await execa('git', ['rev-parse', 'HEAD'], {
       cwd: this.projectRoot,
+      env: getSafeGitEnv(),
     });
 
     const worktreePath = await createWorktree(this.projectRoot, worktreeName);
@@ -95,6 +97,7 @@ export async function getProjectRootForWorktree(cwd: string): Promise<string> {
   try {
     const { stdout } = await execa('git', ['rev-parse', '--git-common-dir'], {
       cwd,
+      env: getSafeGitEnv(),
     });
     const gitCommonDir = stdout.trim();
     const absoluteGitDir = path.isAbsolute(gitCommonDir)
@@ -124,6 +127,7 @@ export async function createWorktree(
 
   await execa('git', ['worktree', 'add', worktreePath, '-b', branchName], {
     cwd: projectRoot,
+    env: getSafeGitEnv(),
   });
 
   return worktreePath;
@@ -152,6 +156,7 @@ export async function hasWorktreeChanges(
     // 1. Check for uncommitted changes (index or working tree)
     const { stdout: status } = await execa('git', ['status', '--porcelain'], {
       cwd: dirPath,
+      env: getSafeGitEnv(),
     });
     if (status.trim() !== '') {
       return true;
@@ -161,6 +166,7 @@ export async function hasWorktreeChanges(
     if (baseSha) {
       const { stdout: currentSha } = await execa('git', ['rev-parse', 'HEAD'], {
         cwd: dirPath,
+        env: getSafeGitEnv(),
       });
       if (currentSha.trim() !== baseSha) {
         return true;
@@ -196,6 +202,7 @@ export async function cleanupWorktree(
       ['-C', dirPath, 'branch', '--show-current'],
       {
         cwd: projectRoot,
+        env: getSafeGitEnv(),
       },
     );
     branchName = stdout.trim() || undefined;
@@ -203,6 +210,7 @@ export async function cleanupWorktree(
     // 2. Remove the worktree
     await execa('git', ['worktree', 'remove', dirPath, '--force'], {
       cwd: projectRoot,
+      env: getSafeGitEnv(),
     });
   } catch (e: unknown) {
     debugLogger.debug(
@@ -214,6 +222,7 @@ export async function cleanupWorktree(
       try {
         await execa('git', ['branch', '-D', branchName], {
           cwd: projectRoot,
+          env: getSafeGitEnv(),
         });
       } catch (e: unknown) {
         debugLogger.debug(

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -31,7 +31,7 @@ import {
   resolveToRealPath,
 } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
-import { isGitRepository } from '../utils/gitUtils.js';
+import { isGitRepository, getSafeGitEnv } from '../utils/gitUtils.js';
 import type { Config } from '../config/config.js';
 import type { FileExclusions } from '../utils/ignorePatterns.js';
 import { ToolErrorType } from './tool-error.js';
@@ -462,6 +462,7 @@ class GrepToolInvocation extends BaseToolInvocation<
             signal: options.signal,
             allowedExitCodes: [0, 1],
             sandboxManager: this.config.sandboxManager,
+            env: getSafeGitEnv(),
           });
 
           const results: GrepMatch[] = [];

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -8,6 +8,44 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { spawnAsync } from './shell-utils.js';
 
+export function getSafeGitEnv(
+  baseEnv: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  const devNullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
+  // Strip pre-existing GIT_CONFIG_* and GIT_CONFIG_PARAMETERS variables to prevent environment pollution
+  const cleanedEnv: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (!key.startsWith('GIT_CONFIG_') && key !== 'GIT_CONFIG_PARAMETERS') {
+      cleanedEnv[key] = value;
+    }
+  }
+
+  return {
+    ...cleanedEnv,
+    GIT_CONFIG_GLOBAL: devNullPath,
+    GIT_CONFIG_SYSTEM: devNullPath,
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_COUNT: '8',
+    GIT_CONFIG_KEY_0: 'credential.helper',
+    GIT_CONFIG_VALUE_0: '',
+    GIT_CONFIG_KEY_1: 'core.fsmonitor',
+    GIT_CONFIG_VALUE_1: '',
+    GIT_CONFIG_KEY_2: 'core.hooksPath',
+    GIT_CONFIG_VALUE_2: '',
+    GIT_CONFIG_KEY_3: 'core.sshCommand',
+    GIT_CONFIG_VALUE_3: '',
+    GIT_CONFIG_KEY_4: 'core.pager',
+    GIT_CONFIG_VALUE_4: 'cat',
+    GIT_CONFIG_KEY_5: 'core.editor',
+    GIT_CONFIG_VALUE_5: '',
+    GIT_CONFIG_KEY_6: 'sequence.editor',
+    GIT_CONFIG_VALUE_6: '',
+    GIT_CONFIG_KEY_7: 'diff.external',
+    GIT_CONFIG_VALUE_7: '',
+  };
+}
+
 /**
  * Gets the absolute path to the git directory (.git) for the given working directory.
  * This handles standard git repositories, subdirectories, and worktrees.
@@ -15,6 +53,7 @@ import { spawnAsync } from './shell-utils.js';
 export async function getAbsoluteGitDir(cwd: string): Promise<string> {
   const result = await spawnAsync('git', ['rev-parse', '--absolute-git-dir'], {
     cwd,
+    env: getSafeGitEnv(),
   });
   return result.stdout.trim();
 }

--- a/packages/core/src/utils/trust.ts
+++ b/packages/core/src/utils/trust.ts
@@ -47,6 +47,9 @@ export function checkPathTrust(options: TrustOptions): TrustResult {
   if (process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'true') {
     return { isTrusted: true, source: 'env' };
   }
+  if (process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'false') {
+    return { isTrusted: false, source: 'env' };
+  }
 
   if (!options.isFolderTrustEnabled) {
     return { isTrusted: true, source: undefined };


### PR DESCRIPTION
## Summary

This PR standardizes environment configuration for Git subprocesses and resolves a state initialization issue in workspace trust evaluation. These changes ensure predictable, non-interactive execution of internal Git utilities across repositories and maintain consistent policy enforcement in restricted workspace mode.

## Details

- **Subprocess Environment Isolation:** Added the `getSafeGitEnv` utility to establish a clean, non-interactive Git subprocess environment (disabling custom pagers, external hooks, and background monitors) using `GIT_CONFIG_COUNT` overrides. This is applied across `ShellExecutionService`, `WorktreeService`, `GrepTool`, and `GitService`.
- **Workspace Trust Evaluation:** Corrected state initialization logic in `setIsTrusted` (`packages/a2a-server/src/config/config.ts`) to properly evaluate workspace trust status rather than checking an unrelated feature flag.
- **Policy Enforcement:** Ensured `PolicyEngine` consistently evaluates Git command invocations against workspace trust settings in restricted mode.
- **Testing:** Added Vitest unit tests covering environment variable construction and policy decision handling.

## How to Validate

1. **Unit Tests:** Run `npm run test:ci -w @google/gemini-cli-core` and `npm run test:ci -w @google/gemini-cli-a2a-server`.
2. **Subprocess Isolation Verification:**
   - In a test repository, set a custom pager: `git config core.pager "cat"`
   - Execute a git operation through Gemini CLI (e.g., viewing git logs).
   - Verify that standard programmatic output is returned without invoking custom pagers.
3. **Workspace Trust Verification:**
   - Open a repository in Restricted Mode (untrusted workspace).
   - Execute a git command.
   - Verify that the CLI requests user confirmation (`ASK_USER`) as expected in restricted mode.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [x] Docker
    - [x] Podman
    - [x] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [x] Docker
  - [x] Linux
    - [x] npm run
    - [x] npx
    - [x] Docker