### PR TITLE
test(e2e): stabilize file-system-interactive test on slow runners

### DIFF
--- a/integration-tests/file-system-interactive.test.ts
+++ b/integration-tests/file-system-interactive.test.ts
@@ -42,6 +42,9 @@ describe('Interactive file system', () => {
     const readCall = await rig.waitForToolCall('read_file', 30000);
     expect(readCall, 'Expected to find a read_file tool call').toBe(true);
 
+    // Wait for the CLI to finish outputting the response and show the prompt again
+    await run.expectText('Type your message', 30000);
+
     // Step 2: Write the file
     const writePrompt = `now change the version to 1.0.1 in the file`;
     await run.type(writePrompt);
@@ -56,5 +59,5 @@ describe('Interactive file system', () => {
 
     // Wait for telemetry to flush and file system to sync, especially in sandboxed environments
     await rig.waitForTelemetryReady();
-  });
+  }, 60000);
 });


### PR DESCRIPTION
## Summary

This PR stabilizes the flaky interactive end-to-end test `file-system-interactive.test.ts` to ensure it passes reliably on slower virtualized systems and virtual machines (like the Slow E2E Windows runners).

## Details

1. **Prompt Synchronization:** Added `await run.expectText('Type your message', 30000);` after the first tool call is completed. This ensures that the test script does not start typing Step 2's prompt while the CLI is still busy streaming Step 1's model response, which previously caused keystrokes to be dropped or scrambled inside slow PTYs.
2. **Timeout Enlargement:** Set a standard `60000` ms (60 seconds) timeout on the test block. Interactive process spawning, mock APIs, and stream rendering often exceed Vitest's default 5-second timeout on loaded virtualized runners, which was a major contributor to the Windows E2E flakiness.

## How to Validate

Run the integration test from the workspace root:
```bash
npx vitest run integration-tests/file-system-interactive.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [ ] npm run
    - [x] npx
    - [ ] Docker
