### PR TITLE
fix(cli): prevent fail-open and data loss on corrupt MCP enablement config (#28786)

### DIFF
--- a/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
@@ -42,7 +43,8 @@ function createMockEnablement(
 
 function setupFsMocks(): void {
   vi.spyOn(fs, 'readFile').mockImplementation(async (filePath) => {
-    const content = inMemoryFs[filePath.toString()];
+    const normPath = path.normalize(filePath.toString());
+    const content = inMemoryFs[normPath];
     if (content === undefined) {
       const error = new Error(`ENOENT: ${filePath}`);
       (error as NodeJS.ErrnoException).code = 'ENOENT';
@@ -51,7 +53,8 @@ function setupFsMocks(): void {
     return content;
   });
   vi.spyOn(fs, 'writeFile').mockImplementation(async (filePath, data) => {
-    inMemoryFs[filePath.toString()] = data.toString();
+    const normPath = path.normalize(filePath.toString());
+    inMemoryFs[normPath] = data.toString();
   });
   vi.spyOn(fs, 'mkdir').mockImplementation(async () => undefined);
 }
@@ -118,6 +121,24 @@ describe('McpServerEnablementManager', () => {
 
     expect(instance2.isSessionDisabled('test-server')).toBe(true);
     expect(instance1).toBe(instance2);
+  });
+
+  it('should fail closed and refuse to overwrite on corrupt JSON config', async () => {
+    const configPath = path.normalize(
+      '/virtual-home/.gemini/mcp-server-enablement.json',
+    );
+    inMemoryFs[configPath] = '{ invalid json syntax';
+
+    expect(await manager.isFileEnabled('some-server')).toBe(false);
+
+    const writeFileSpy = vi.spyOn(fs, 'writeFile');
+    await manager.disable('some-server');
+    expect(writeFileSpy).not.toHaveBeenCalled();
+
+    await manager.enable('some-server');
+    expect(writeFileSpy).not.toHaveBeenCalled();
+
+    expect(inMemoryFs[configPath]).toBe('{ invalid json syntax');
   });
 });
 

--- a/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
@@ -21,6 +21,7 @@ vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   };
 });
 
+import { coreEvents } from '@google/gemini-cli-core';
 import {
   McpServerEnablementManager,
   canLoadServer,
@@ -123,22 +124,86 @@ describe('McpServerEnablementManager', () => {
     expect(instance1).toBe(instance2);
   });
 
-  it('should fail closed and refuse to overwrite on corrupt JSON config', async () => {
+  it('returns false for isFileEnabled when JSON content is corrupted', async () => {
     const configPath = path.normalize(
       '/virtual-home/.gemini/mcp-server-enablement.json',
     );
     inMemoryFs[configPath] = '{ invalid json syntax';
 
     expect(await manager.isFileEnabled('some-server')).toBe(false);
+  });
 
+  it.each(['null', '[1, 2, 3]', '"a string"', '123'])(
+    'returns false for isFileEnabled when JSON is valid but not an object (%s)',
+    async (content) => {
+      const configPath = path.normalize(
+        '/virtual-home/.gemini/mcp-server-enablement.json',
+      );
+      inMemoryFs[configPath] = content;
+
+      expect(await manager.isFileEnabled('some-server')).toBe(false);
+    },
+  );
+
+  it('throws and preserves file when calling disable() or enable() on corrupt config', async () => {
+    const configPath = path.normalize(
+      '/virtual-home/.gemini/mcp-server-enablement.json',
+    );
+    inMemoryFs[configPath] = '{ corrupt json';
     const writeFileSpy = vi.spyOn(fs, 'writeFile');
-    await manager.disable('some-server');
+
+    await expect(manager.disable('some-server')).rejects.toThrow(/corrupted/i);
     expect(writeFileSpy).not.toHaveBeenCalled();
 
-    await manager.enable('some-server');
+    await expect(manager.enable('some-server')).rejects.toThrow(/corrupted/i);
     expect(writeFileSpy).not.toHaveBeenCalled();
 
-    expect(inMemoryFs[configPath]).toBe('{ invalid json syntax');
+    expect(inMemoryFs[configPath]).toBe('{ corrupt json');
+  });
+
+  it('handles autoEnableServers with corrupt config without throwing or reporting re-enabled servers', async () => {
+    const configPath = path.normalize(
+      '/virtual-home/.gemini/mcp-server-enablement.json',
+    );
+    inMemoryFs[configPath] = '{ corrupt json';
+    const writeFileSpy = vi.spyOn(fs, 'writeFile');
+
+    const result = await manager.autoEnableServers(['server1', 'server2']);
+    expect(result).toEqual([]);
+    expect(writeFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns isPersistentDisabled: true for getDisplayState and getAllDisplayStates on corrupt config', async () => {
+    const configPath = path.normalize(
+      '/virtual-home/.gemini/mcp-server-enablement.json',
+    );
+    inMemoryFs[configPath] = '{ corrupt json';
+
+    const state = await manager.getDisplayState('server1');
+    expect(state).toEqual({
+      enabled: false,
+      isSessionDisabled: false,
+      isPersistentDisabled: true,
+    });
+
+    const allStates = await manager.getAllDisplayStates(['server1', 'server2']);
+    expect(allStates['server1']?.isPersistentDisabled).toBe(true);
+    expect(allStates['server2']?.isPersistentDisabled).toBe(true);
+  });
+
+  it('emits coreEvents error feedback when corruption is detected', async () => {
+    const feedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
+    const configPath = path.normalize(
+      '/virtual-home/.gemini/mcp-server-enablement.json',
+    );
+    inMemoryFs[configPath] = '{ corrupt json';
+
+    await manager.isFileEnabled('some-server');
+    expect(feedbackSpy).toHaveBeenCalledWith(
+      'error',
+      'Failed to read MCP server enablement config.',
+      expect.any(Error),
+    );
   });
 });
 

--- a/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.test.ts
@@ -191,14 +191,15 @@ describe('McpServerEnablementManager', () => {
     expect(allStates['server2']?.isPersistentDisabled).toBe(true);
   });
 
-  it('emits coreEvents error feedback when corruption is detected', async () => {
+  it('emits coreEvents error feedback exactly once on getAllDisplayStates with corrupt config', async () => {
     const feedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
     const configPath = path.normalize(
       '/virtual-home/.gemini/mcp-server-enablement.json',
     );
     inMemoryFs[configPath] = '{ corrupt json';
 
-    await manager.isFileEnabled('some-server');
+    await manager.getAllDisplayStates(['server1', 'server2', 'server3']);
+    expect(feedbackSpy).toHaveBeenCalledTimes(1);
     expect(feedbackSpy).toHaveBeenCalledWith(
       'error',
       'Failed to read MCP server enablement config.',

--- a/packages/cli/src/config/mcp/mcpServerEnablement.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.ts
@@ -299,11 +299,16 @@ export class McpServerEnablementManager {
   }
 
   /**
-   * Get display state for a specific server (for UI).
+   * Helper to compute display state for a server given a loaded config.
    */
-  async getDisplayState(serverName: string): Promise<McpServerDisplayState> {
-    const isSessionDisabled = this.isSessionDisabled(serverName);
-    const isPersistentDisabled = !(await this.isFileEnabled(serverName));
+  private computeDisplayState(
+    serverId: string,
+    config: McpServerEnablementConfig | null,
+  ): McpServerDisplayState {
+    const normalizedId = normalizeServerId(serverId);
+    const isSessionDisabled = this.isSessionDisabled(normalizedId);
+    const isPersistentDisabled =
+      config === null ? true : !(config[normalizedId]?.enabled ?? true);
 
     return {
       enabled: !isSessionDisabled && !isPersistentDisabled,
@@ -313,15 +318,26 @@ export class McpServerEnablementManager {
   }
 
   /**
+   * Get display state for a specific server (for UI).
+   */
+  async getDisplayState(serverName: string): Promise<McpServerDisplayState> {
+    const config = await this.readConfig();
+    return this.computeDisplayState(serverName, config);
+  }
+
+  /**
    * Get all display states (for UI listing).
    */
   async getAllDisplayStates(
     serverIds: string[],
   ): Promise<Record<string, McpServerDisplayState>> {
+    const config = await this.readConfig();
     const result: Record<string, McpServerDisplayState> = {};
     for (const serverId of serverIds) {
-      result[normalizeServerId(serverId)] =
-        await this.getDisplayState(serverId);
+      result[normalizeServerId(serverId)] = this.computeDisplayState(
+        serverId,
+        config,
+      );
     }
     return result;
   }
@@ -358,8 +374,12 @@ export class McpServerEnablementManager {
         try {
           await this.enable(normalizedName);
           wasDisabled = true;
-        } catch {
-          // If enabling fails, do not report as enabled
+        } catch (error) {
+          coreEvents.emitFeedback(
+            'error',
+            `Failed to auto-enable server '${serverName}'.`,
+            error,
+          );
         }
       }
       if (isSessionDisabled) {

--- a/packages/cli/src/config/mcp/mcpServerEnablement.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.ts
@@ -225,6 +225,9 @@ export class McpServerEnablementManager {
    */
   async isFileEnabled(serverName: string): Promise<boolean> {
     const config = await this.readConfig();
+    if (config === null) {
+      return false;
+    }
     const state = config[normalizeServerId(serverName)];
     return state?.enabled ?? true;
   }
@@ -254,6 +257,9 @@ export class McpServerEnablementManager {
   async enable(serverName: string): Promise<void> {
     const normalizedName = normalizeServerId(serverName);
     const config = await this.readConfig();
+    if (config === null) {
+      return;
+    }
 
     if (normalizedName in config) {
       delete config[normalizedName];
@@ -267,6 +273,9 @@ export class McpServerEnablementManager {
    */
   async disable(serverName: string): Promise<void> {
     const config = await this.readConfig();
+    if (config === null) {
+      return;
+    }
     config[normalizeServerId(serverName)] = { enabled: false };
     await this.writeConfig(config);
   }
@@ -355,7 +364,7 @@ export class McpServerEnablementManager {
   /**
    * Read config from file asynchronously.
    */
-  private async readConfig(): Promise<McpServerEnablementConfig> {
+  private async readConfig(): Promise<McpServerEnablementConfig | null> {
     try {
       const content = await fs.readFile(this.configFilePath, 'utf-8');
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -373,7 +382,7 @@ export class McpServerEnablementManager {
         'Failed to read MCP server enablement config.',
         error,
       );
-      return {};
+      return null;
     }
   }
 

--- a/packages/cli/src/config/mcp/mcpServerEnablement.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.ts
@@ -258,7 +258,9 @@ export class McpServerEnablementManager {
     const normalizedName = normalizeServerId(serverName);
     const config = await this.readConfig();
     if (config === null) {
-      return;
+      throw new Error(
+        `Cannot modify MCP server enablement: config file at ${this.configFilePath} is corrupted. Fix or delete the file and try again.`,
+      );
     }
 
     if (normalizedName in config) {
@@ -274,7 +276,9 @@ export class McpServerEnablementManager {
   async disable(serverName: string): Promise<void> {
     const config = await this.readConfig();
     if (config === null) {
-      return;
+      throw new Error(
+        `Cannot modify MCP server enablement: config file at ${this.configFilePath} is corrupted. Fix or delete the file and try again.`,
+      );
     }
     config[normalizeServerId(serverName)] = { enabled: false };
     await this.writeConfig(config);
@@ -337,18 +341,28 @@ export class McpServerEnablementManager {
    * Returns server names that were actually re-enabled.
    */
   async autoEnableServers(serverNames: string[]): Promise<string[]> {
+    const config = await this.readConfig();
+    if (config === null) {
+      return [];
+    }
+
     const enabledServers: string[] = [];
 
     for (const serverName of serverNames) {
       const normalizedName = normalizeServerId(serverName);
-      const state = await this.getDisplayState(normalizedName);
+      const isSessionDisabled = this.isSessionDisabled(normalizedName);
+      const isPersistentDisabled = !(config[normalizedName]?.enabled ?? true);
 
       let wasDisabled = false;
-      if (state.isPersistentDisabled) {
-        await this.enable(normalizedName);
-        wasDisabled = true;
+      if (isPersistentDisabled) {
+        try {
+          await this.enable(normalizedName);
+          wasDisabled = true;
+        } catch {
+          // If enabling fails, do not report as enabled
+        }
       }
-      if (state.isSessionDisabled) {
+      if (isSessionDisabled) {
         this.clearSessionDisable(normalizedName);
         wasDisabled = true;
       }
@@ -367,8 +381,21 @@ export class McpServerEnablementManager {
   private async readConfig(): Promise<McpServerEnablementConfig | null> {
     try {
       const content = await fs.readFile(this.configFilePath, 'utf-8');
+      const parsed: unknown = JSON.parse(content);
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed)
+      ) {
+        coreEvents.emitFeedback(
+          'error',
+          'Failed to read MCP server enablement config.',
+          new Error('Config is not a valid JSON object'),
+        );
+        return null;
+      }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      return JSON.parse(content) as McpServerEnablementConfig;
+      return parsed as McpServerEnablementConfig;
     } catch (error) {
       if (
         error instanceof Error &&


### PR DESCRIPTION
## Summary

Fixes #28786

This PR resolves a vulnerability and data-loss bug in `McpServerEnablementManager` when `mcp-server-enablement.json` is corrupted or contains invalid JSON syntax:

1. **Prevents Fail-Open Re-enablement:** `readConfig()` previously returned `{}` on JSON parse failure, causing `isFileEnabled()` to default to `true` (`state?.enabled ?? true`). This silently re-enabled all MCP servers that the user had explicitly disabled.
   - *Fix:* `readConfig()` now returns `null` on JSON parse errors or non-object JSON shapes (`null`, array, string, number). When `config === null`, `isFileEnabled()` fails closed (`return false`), keeping disabled servers disabled.

2. **Prevents Config Data Loss:** When `disable()` or `enable()` ran after a failed `readConfig()`, it mutated `{}` and wrote it back to disk, destroying all other stored enablement entries.
   - *Fix:* `enable()` and `disable()` check for `config === null` and throw an explicit `Error`, preserving the user's corrupt file for manual resolution rather than overwriting it.

3. **Prevents Duplicate Error Toasts:** `getAllDisplayStates()` now loads `readConfig()` once up-front and delegates to a shared `computeDisplayState()` private helper, ensuring `coreEvents.emitFeedback` fires **exactly once** for the entire call instead of $N$ times for $N$ servers.

## Details

- **`packages/cli/src/config/mcp/mcpServerEnablement.ts`**:
  - `readConfig()` returns `null` on JSON parse errors, non-object JSON shapes, and non-`ENOENT` errors.
  - `isFileEnabled()` fails closed (`return false`) when `readConfig()` returns `null`.
  - `enable()` and `disable()` throw an error when `readConfig()` returns `null` without calling `writeConfig()`.
  - Extracted shared `computeDisplayState()` helper used by both `getDisplayState()` and `getAllDisplayStates()`.
  - `autoEnableServers()` returns `[]` immediately if the config is unreadable, and additionally catches and logs any per-server `enable()` failure that occurs mid-loop without marking that server as re-enabled.

- **`packages/cli/src/config/mcp/mcpServerEnablement.test.ts`**:
  - Added unit tests verifying fail-closed behavior for corrupted JSON syntax and non-object JSON shapes (`null`, `[1, 2, 3]`, `"a string"`, `123`).
  - Added unit tests for `enable()` and `disable()` throwing on corrupt config while leaving disk content untouched.
  - Added unit tests for `autoEnableServers()`, `getAllDisplayStates()`, and single `emitFeedback` emission.

## Related Issues

Fixes #28786

## How to Validate

1. Run unit tests for `mcpServerEnablement`:
```bash
cd packages/cli
npx vitest run src/config/mcp/mcpServerEnablement.test.ts
```

2. Run type check and linter:
```bash
cd packages/cli
npx tsc --noEmit
npm run lint
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
  - [x] Windows
    - [x] npm run
    - [x] npx
  - [ ] Linux
