### PR TITLE
fix(core): rollback entire multi-turn request on cancellation or abort

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1628,6 +1628,89 @@ describe('GeminiChat', () => {
       expect(chat.agentHistory.length).toBe(initialHistoryLength);
     });
 
+    it('should roll back the entire multi-turn request including function responses when a continuation stream is aborted/cancelled', async () => {
+      const initialHistoryLength = chat.agentHistory.length;
+      const abortController = new AbortController();
+
+      // 1. Send the first message of the prompt. This will succeed and register prompt-id-multi-turn-abort.
+      const streamFirst = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'model first response' }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamFirst,
+      );
+
+      const s1 = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        'user original prompt',
+        'prompt-id-multi-turn-abort',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+      for await (const _ of s1) {
+        // consume the stream
+      }
+
+      // Expect history to contain: user, model
+      expect(chat.agentHistory.length).toBe(initialHistoryLength + 2);
+
+      // 2. Send a continuation (functionResponse), which is cancelled mid-stream.
+      const streamSecond = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'partial model response before abort' }],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+        abortController.abort();
+        throw new Error('User aborted a continuation stream.');
+      })();
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamSecond,
+      );
+
+      const s2 = await chat.sendMessageStream(
+        { model: 'gemini-2.0-flash' },
+        [
+          {
+            functionResponse: {
+              id: 'call_id_1',
+              name: 'my_tool',
+              response: { result: 'success' },
+            },
+          },
+        ],
+        'prompt-id-multi-turn-abort',
+        abortController.signal,
+        LlmRole.MAIN,
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of s2) {
+            // consume the stream to trigger abort
+          }
+        })(),
+      ).rejects.toThrow();
+
+      // Verify history has been rolled back entirely to initialHistoryLength (before the original prompt started)!
+      expect(chat.agentHistory.length).toBe(initialHistoryLength);
+    });
+
     it('should roll back the un-responded user turn from history when an ApiError is thrown', async () => {
       const initialHistoryLength = chat.agentHistory.length;
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -38,6 +38,7 @@ import {
 import { hasCycleInSchema } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
 import type { CompletedToolCall } from '../scheduler/types.js';
+import { isAbortError } from '../utils/errors.js';
 import {
   logContentRetry,
   logContentRetryFailure,
@@ -296,6 +297,9 @@ export class GeminiChat {
   private lastPromptTokenCount: number;
   private callCounter = 0;
   agentHistory: AgentChatHistory;
+  private lastPromptId?: string;
+  private promptOriginalHistoryLength?: number;
+  private promptOriginalTokenCount?: number;
 
   constructor(
     readonly context: AgentLoopContext,
@@ -406,6 +410,17 @@ export class GeminiChat {
 
     const historyLengthBefore = this.agentHistory.length;
     const baselinePromptTokenCount = this.lastPromptTokenCount;
+
+    if (this.lastPromptId && this.lastPromptId !== prompt_id) {
+      this.promptOriginalHistoryLength = undefined;
+      this.promptOriginalTokenCount = undefined;
+    }
+    this.lastPromptId = prompt_id;
+
+    if (this.promptOriginalHistoryLength === undefined) {
+      this.promptOriginalHistoryLength = historyLengthBefore;
+      this.promptOriginalTokenCount = baselinePromptTokenCount;
+    }
 
     let streamDoneResolver: () => void;
     const streamDonePromise = new Promise<void>((resolve) => {
@@ -684,7 +699,26 @@ export class GeminiChat {
           }
         }
       } catch (error) {
-        if (!isOriginalFunctionResponse) {
+        const isAborted =
+          signal?.aborted ||
+          isAbortError(error) ||
+          (error instanceof Error &&
+            (error.name === 'CanceledError' ||
+              error.name === 'FatalCancellationError'));
+        const originalLength = this.promptOriginalHistoryLength;
+        const originalTokenCount = this.promptOriginalTokenCount;
+        if (isAborted && originalLength !== undefined) {
+          this.agentHistory.rollback(originalLength);
+          this.chatRecordingService.updateMessagesFromHistory(
+            this.agentHistory.get(),
+          );
+          if (originalTokenCount !== undefined) {
+            this.lastPromptTokenCount = originalTokenCount;
+          }
+          this.promptOriginalHistoryLength = undefined;
+          this.promptOriginalTokenCount = undefined;
+          this.lastPromptId = undefined;
+        } else if (!isOriginalFunctionResponse) {
           this.agentHistory.rollback(historyLengthBefore);
           this.chatRecordingService.updateMessagesFromHistory(
             this.agentHistory.get(),


### PR DESCRIPTION
## Summary

This PR resolves a recurring issue where aborting/cancelling a multi-turn prompt containing tool calls left the session's chat history in an incomplete, un-responded state (ending with pending tool response turns). Consequently, when the user sent a new unrelated request (such as `Hello`), the model would continue the unfinished task from the previous cancelled prompt instead of answering the new request.

### ⚠️ Note on why PR #28316 didn't cover this issue
The previous fix in **PR #28316** was limited strictly to `packages/a2a-server` (the experimental Agent-to-Agent server project), where it ensured that the background execution loop in the a2a executor terminated upon task cancellation. However, it did not address or modify the core `GeminiChat` session history or token tracking layer (`packages/core/src/core/geminiChat.ts`) which manages history and session turns for the main Gemini CLI Agent itself. As a result, the history corruption and subsequent task resumption bug persisted in the standard CLI agent.

---

## Details

- **Initial State Tracking:** Added mapping fields `promptOriginalHistoryLengths` and `promptOriginalTokenCounts` in `GeminiChat` to record the conversation history length and baseline token counts whenever a new prompt starts.
- **Rollback on Abort/Cancellation:** Refactored the catch block of `GeminiChat.sendMessageStream`. If the prompt execution is aborted or cancelled at any point (even deep during subsequent tool continuation streams under the same `prompt_id`), the conversational history and token baseline are fully rolled back to the pristine state before that prompt started.
- **Added Tests:** Added a new unit test in `packages/core/src/core/geminiChat.test.ts` (`should roll back the entire multi-turn request including function responses when a continuation stream is aborted/cancelled`) to ensure correct multi-turn cancellation and rollback behavior.

## Related Issues

Resolves the issue described in `issue.md`.

## How to Validate

### **Automated Verification**
You can run the new unit test programmatically:
```bash
npm test -w @google/gemini-cli-core -- src/core/geminiChat.test.ts
```

### **Manual Verification**
1. Build and start the CLI in development:
   ```bash
   npm run build && npm run start
   ```
2. Run a query that uses tools, e.g.:
   ```
   Add a description at the top of @package.json
   ```
3. Press `Ctrl + C` while it is executing/streaming.
4. Send a simple `Hello` greeting.
5. **Expected Behavior:** The model greets you nicely rather than attempting to continue the cancelled package.json edit.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
