### PR TITLE
Feat/evals tools expansion

### DIFF
--- a/evals/activate_skill.eval.ts
+++ b/evals/activate_skill.eval.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('activate_skill', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent activates behavioral-evals skill when asked about writing behavioral evaluations',
+    files: {
+      '.gemini/skills/behavioral-evals/SKILL.md': `---
+name: behavioral-evals
+description: Guidance for creating, running, fixing, and promoting behavioral evaluations. Use when verifying agent decision logic, debugging failures, debugging prompt steering, or adding workspace regression tests.
+---
+# Behavioral Evals
+Workflow decision tree for creating, fixing, and promoting behavioral evaluations.`,
+    },
+    prompt:
+      'I want to write a new behavioral evaluation test for verifying agent decision logic. What is the recommended workflow?',
+    setup: async (rig) => {
+      await rig.getConfig().reloadSkills();
+      rig.setBreakpoint(['activate_skill']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        'activate_skill',
+        30000,
+      );
+      expect(
+        confirmation,
+        'Expected activate_skill to be called',
+      ).toBeDefined();
+
+      const toolCalls = (rig as any).getToolCalls();
+      const activateSkillCall = toolCalls.find(
+        (call: any) => call.request?.name === 'activate_skill',
+      );
+      expect(
+        activateSkillCall,
+        'Expected activate_skill call in tool logs',
+      ).toBeDefined();
+      expect(activateSkillCall.request?.args?.name).toBe('behavioral-evals');
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/get_internal_docs.eval.ts
+++ b/evals/get_internal_docs.eval.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('get_internal_docs', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses get_internal_docs when asked about Gemini CLI internal documentation and features',
+    prompt:
+      'What internal CLI documentation is available regarding Gemini CLI authentication and setup?',
+    setup: async (rig) => {
+      rig.setBreakpoint([
+        'get_internal_docs',
+        'web_fetch',
+        'google_web_search',
+      ]);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['get_internal_docs', 'web_fetch', 'google_web_search'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use get_internal_docs to fetch built-in CLI docs instead of web tools',
+      ).toBe('get_internal_docs');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/mcp_resources.eval.ts
+++ b/evals/mcp_resources.eval.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+const MOCK_MCP_SERVER_CODE = `
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+rl.on('line', (line) => {
+  try {
+    const msg = JSON.parse(line);
+    
+    if (msg.method === 'initialize') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { resources: {} },
+          serverInfo: { name: 'mock-server', version: '1.0.0' }
+        } 
+      }));
+    } else if (msg.method === 'resources/list') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          resources: [
+            {
+              uri: 'mcp://mock-server/docs/api.md',
+              name: 'API Documentation',
+              mimeType: 'text/markdown'
+            }
+          ]
+        } 
+      }));
+    } else if (msg.method === 'resources/read') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          contents: [
+            {
+              uri: msg.params.uri,
+              mimeType: 'text/markdown',
+              text: '# API Reference\\nThis is the API documentation for mock-server.'
+            }
+          ]
+        } 
+      }));
+    }
+  } catch (e) {}
+});
+`;
+
+describe.sequential('mcp_resources', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent lists MCP resources when asked what resources are available from MCP servers',
+    files: {
+      'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
+    },
+    configOverrides: {
+      settings: {
+        mcpServers: {
+          'mock-server': {
+            command: 'node',
+            args: ['./mock_mcp_server.js'],
+          },
+        },
+      },
+    },
+    prompt: 'List all available MCP resources from the connected mock-server.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['list_mcp_resources']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['list_mcp_resources'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use list_mcp_resources to discover available MCP resources',
+      ).toBe('list_mcp_resources');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent reads specified MCP resource when asked to fetch resource content',
+    files: {
+      'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
+    },
+    configOverrides: {
+      settings: {
+        mcpServers: {
+          'mock-server': {
+            command: 'node',
+            args: ['./mock_mcp_server.js'],
+          },
+        },
+      },
+    },
+    prompt:
+      'Read the MCP resource at mcp://mock-server/docs/api.md and summarize it.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_mcp_resource']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_mcp_resource'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_mcp_resource to read the requested MCP resource URI',
+      ).toBe('read_mcp_resource');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/mcp_resources.eval.ts
+++ b/evals/mcp_resources.eval.ts
@@ -67,12 +67,10 @@ describe.sequential('mcp_resources', () => {
       'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
     },
     configOverrides: {
-      settings: {
-        mcpServers: {
-          'mock-server': {
-            command: 'node',
-            args: ['./mock_mcp_server.js'],
-          },
+      mcpServers: {
+        'mock-server': {
+          command: 'node',
+          args: ['./mock_mcp_server.js'],
         },
       },
     },
@@ -105,12 +103,10 @@ describe.sequential('mcp_resources', () => {
       'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
     },
     configOverrides: {
-      settings: {
-        mcpServers: {
-          'mock-server': {
-            command: 'node',
-            args: ['./mock_mcp_server.js'],
-          },
+      mcpServers: {
+        'mock-server': {
+          command: 'node',
+          args: ['./mock_mcp_server.js'],
         },
       },
     },

--- a/evals/read_many_files.eval.ts
+++ b/evals/read_many_files.eval.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('read_many_files', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses read_many_files when asked to inspect multiple configuration files in a directory',
+    files: {
+      'config/app.json': '{\n  "name": "my-app",\n  "version": "1.0.0"\n}',
+      'config/database.json': '{\n  "host": "localhost",\n  "port": 5432\n}',
+      'config/logging.json': '{\n  "level": "info"\n}',
+    },
+    prompt:
+      'Inspect and summarize all configuration JSON files in the config/ directory.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_many_files', 'read_file']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_many_files', 'read_file'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_many_files to inspect multiple files in batch',
+      ).toBe('read_many_files');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses read_file instead of read_many_files when asked to read a single file',
+    files: {
+      'src/index.ts': 'console.log("Hello World");',
+    },
+    prompt: 'Read the file src/index.ts and summarize what it does.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'read_many_files']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'read_many_files'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_file for a single file instead of read_many_files',
+      ).toBe('read_file');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -337,6 +337,10 @@ export async function prepareWorkspace(
     fs.writeFileSync(ackPath, JSON.stringify(acknowledgedAgents, null, 2));
   }
 
+  if (!fs.existsSync(path.join(projectRoot, '.gitignore'))) {
+    fs.writeFileSync(path.join(projectRoot, '.gitignore'), 'node_modules/\n');
+  }
+
   const execOptions = { cwd: testDir, stdio: 'ignore' as const };
   execSync('git init --initial-branch=main', execOptions);
   execSync('git config user.email "test@example.com"', execOptions);
@@ -407,7 +411,8 @@ export function symlinkNodeModules(testDir: string) {
     fs.existsSync(rootNodeModules) &&
     !fs.existsSync(testNodeModules)
   ) {
-    fs.symlinkSync(rootNodeModules, testNodeModules, 'dir');
+    const type = process.platform === 'win32' ? 'junction' : 'dir';
+    fs.symlinkSync(rootNodeModules, testNodeModules, type);
   }
 }
 

--- a/evals/web_fetch.eval.ts
+++ b/evals/web_fetch.eval.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('web_fetch', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent fetches URL when asked for summary of webpage and avoids shell curl or web search',
+    prompt:
+      'Please fetch the webpage at https://example.com/status and summarize its content for me.',
+    setup: async (rig) => {
+      rig.setBreakpoint([
+        'web_fetch',
+        'run_shell_command',
+        'google_web_search',
+      ]);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['web_fetch', 'run_shell_command', 'google_web_search'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use web_fetch instead of shell curl or google search',
+      ).toBe('web_fetch');
+
+      const toolCalls = (rig as any).getToolCalls();
+      const webFetchCall = toolCalls.find(
+        (call: any) => call.request?.name === 'web_fetch',
+      );
+      expect(
+        webFetchCall,
+        'Expected web_fetch call in tool logs',
+      ).toBeDefined();
+
+      const args = webFetchCall.request?.args;
+      const hasUrl =
+        args?.url?.includes('example.com/status') ||
+        args?.prompt?.includes('example.com/status');
+      expect(hasUrl, 'Expected target URL in web_fetch args').toBe(true);
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent does NOT fetch web content when asked for local repo details',
+    files: {
+      'README.md': '# My Cool Local Project\nThis is local repository content.',
+    },
+    prompt: 'Summarize the content of README.md in this project.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'web_fetch']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'web_fetch'],
+        30000,
+      );
+      expect(confirmation).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should read local file instead of fetching external URLs',
+      ).toBe('read_file');
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -481,6 +481,10 @@ export class AppRig {
     return Array.from(this.pendingConfirmations.values());
   }
 
+  getToolCalls() {
+    return this.toolCalls;
+  }
+
   private async waitUntil(
     predicate: () => boolean | Promise<boolean>,
     options: { timeout?: number; interval?: number; message?: string } = {},

--- a/scripts/tests/eval-report.test.ts
+++ b/scripts/tests/eval-report.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   findReportFiles,
   getModelFromPath,
+  getRelativePath,
   summarizeReports,
   formatReportSummary,
   formatReportSummaryJson,
@@ -94,6 +95,22 @@ describe('eval-report utility', () => {
     it('falls back to unknown-model if no env var or folder match exists', () => {
       const reportPath = path.join(tmpDir, 'some-other-folder', 'report.json');
       expect(getModelFromPath(reportPath)).toBe('unknown-model');
+    });
+  });
+
+  describe('getRelativePath', () => {
+    it('correctly handles Windows drive letter paths on any platform', () => {
+      const winPath = 'C:\\coding\\gemini-cli\\evals\\my_test.eval.ts';
+      expect(getRelativePath(winPath, '/home/runner/work/repo')).toBe(
+        'evals/my_test.eval.ts',
+      );
+    });
+
+    it('extracts relative path when starts with rootDir', () => {
+      const fullPath = '/home/runner/work/repo/evals/my_test.eval.ts';
+      expect(getRelativePath(fullPath, '/home/runner/work/repo')).toBe(
+        'evals/my_test.eval.ts',
+      );
     });
   });
 
@@ -294,6 +311,197 @@ describe('eval-report utility', () => {
       expect(c2.policy).toBe('USUALLY_PASSES');
       expect(c2.passed).toBe(0);
       expect(c2.total).toBe(1);
+    });
+
+    it('ignores skipped, pending, and todo assertions in pass rate calculation', async () => {
+      const modelDir = path.join(tmpDir, 'eval-logs-gemini-2.5-flash-999');
+      fs.mkdirSync(modelDir);
+
+      const dummyReport = {
+        testResults: [
+          {
+            name: '/repo/evals/test-one.eval.ts',
+            status: 'passed',
+            assertionResults: [
+              { title: 'passed case', status: 'passed' },
+              { title: 'failed case', status: 'failed' },
+              { title: 'skipped case', status: 'skipped' },
+              { title: 'pending case', status: 'pending' },
+              { title: 'todo case', status: 'todo' },
+            ],
+          },
+        ],
+      };
+
+      fs.writeFileSync(
+        path.join(modelDir, 'report.json'),
+        JSON.stringify(dummyReport),
+      );
+
+      const mockInventory: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 5,
+        repoRoot: '/repo',
+        files: [],
+        cases: [
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'passed case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 1, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'failed case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 2, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'skipped case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 3, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'pending case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 4, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'todo case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 5, column: 1 },
+          },
+        ],
+        diagnostics: [],
+      };
+
+      const result = await summarizeReports(tmpDir, mockInventory);
+
+      expect(result.models).toHaveLength(1);
+      const modelSummary = result.models[0];
+      // Only passed case and failed case should be processed.
+      // Skipped, pending, and todo assertions should be completely ignored.
+      expect(modelSummary.totalCases).toBe(2);
+      expect(modelSummary.totalRuns).toBe(2);
+      expect(modelSummary.passedRuns).toBe(1);
+      expect(modelSummary.overallPassRate).toBe(0.5);
+
+      const passedCase = modelSummary.cases.find(
+        (c) => c.name === 'passed case',
+      )!;
+      expect(passedCase.total).toBe(1);
+      expect(passedCase.passed).toBe(1);
+
+      const failedCase = modelSummary.cases.find(
+        (c) => c.name === 'failed case',
+      )!;
+      expect(failedCase.total).toBe(1);
+      expect(failedCase.passed).toBe(0);
+
+      const skippedCase = modelSummary.cases.find(
+        (c) => c.name === 'skipped case',
+      );
+      expect(skippedCase).toBeUndefined();
+    });
+
+    it('matches policy cases across different absolute checkouts and path prefixes', async () => {
+      const modelDir = path.join(tmpDir, 'eval-logs-gemini-2.5-flash-999');
+      fs.mkdirSync(modelDir);
+
+      // Report has an absolute path from a CI environment
+      const dummyReport = {
+        testResults: [
+          {
+            name: '/home/runner/work/gemini-cli/gemini-cli/evals/my-test.eval.ts',
+            status: 'passed',
+            assertionResults: [
+              { title: 'my evaluation case', status: 'passed' },
+            ],
+          },
+        ],
+      };
+
+      fs.writeFileSync(
+        path.join(modelDir, 'report.json'),
+        JSON.stringify(dummyReport),
+      );
+
+      // Inventory uses absolute paths from a local checkout
+      const mockInventory: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        repoRoot: '/Users/local/gemini-cli',
+        files: [],
+        cases: [
+          {
+            filePath: '/Users/local/gemini-cli/evals/my-test.eval.ts',
+            relativePath: 'evals/my-test.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'my evaluation case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 1, column: 1 },
+          },
+        ],
+        diagnostics: [],
+      };
+
+      const result = await summarizeReports(
+        tmpDir,
+        mockInventory,
+        '/Users/local/gemini-cli',
+      );
+
+      expect(result.models).toHaveLength(1);
+      const modelSummary = result.models[0];
+      expect(modelSummary.cases).toHaveLength(1);
+
+      const caseSummary = modelSummary.cases[0];
+      expect(caseSummary.name).toBe('my evaluation case');
+      // Verify that it correctly resolved the policy as ALWAYS_PASSES instead of 'unknown'
+      expect(caseSummary.policy).toBe('ALWAYS_PASSES');
     });
   });
 

--- a/scripts/utils/eval-report.ts
+++ b/scripts/utils/eval-report.ts
@@ -81,12 +81,53 @@ export function getModelFromPath(reportPath: string): string {
 }
 
 /**
+ * Resolves an absolute path and turns it into a checkout-independent relative path.
+ * If the path contains standard repository subdirectories, it extracts starting from there
+ * to support cross-checkout/CI-produced absolute paths.
+ */
+export function getRelativePath(filePath: string, rootDir: string): string {
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  const root = path.resolve(rootDir).replace(/\\/g, '/');
+
+  // Handle Windows absolute paths with drive letters on POSIX systems
+  if (/^[a-zA-Z]:\//.test(normalizedPath)) {
+    if (normalizedPath.startsWith(root + '/')) {
+      return normalizedPath.slice(root.length + 1);
+    }
+    const match = normalizedPath.match(
+      /(?:^|\/)(evals|packages|scripts|integration-tests|memory-tests)\/(.+)$/,
+    );
+    if (match) {
+      return `${match[1]}/${match[2]}`;
+    }
+    return normalizedPath.split('/').pop() || '';
+  }
+
+  const absolute = path.resolve(rootDir, filePath).replace(/\\/g, '/');
+  if (absolute.startsWith(root + '/')) {
+    return absolute.slice(root.length + 1);
+  } else if (absolute === root) {
+    return '';
+  }
+  // Try matching standard subdirectories of the repository
+  const match = absolute.match(
+    /(?:^|\/)(evals|packages|scripts|integration-tests|memory-tests)\/(.+)$/,
+  );
+  if (match) {
+    return `${match[1]}/${match[2]}`;
+  }
+  return path.basename(filePath);
+}
+
+/**
  * Summarizes the pass rate stats by test case and model from report.json files.
  */
 export async function summarizeReports(
   reportsDir: string,
   inventory?: InventoryResult,
+  repoRoot?: string,
 ): Promise<ReportSummaryResult> {
+  const rootDir = repoRoot || process.cwd();
   const reportPaths = findReportFiles(reportsDir);
   const modelSummariesMap = new Map<
     string,
@@ -114,14 +155,20 @@ export async function summarizeReports(
           if (filePath.includes('\0')) {
             continue;
           }
-          const normalizedPath = path.resolve(filePath).replace(/\\/g, '/');
+          const relTestPath = getRelativePath(filePath, rootDir);
           if (Array.isArray(fileResult.assertionResults)) {
             for (const assertion of fileResult.assertionResults) {
               if (!assertion || typeof assertion.title !== 'string') {
                 continue;
               }
+              if (
+                assertion.status !== 'passed' &&
+                assertion.status !== 'failed'
+              ) {
+                continue;
+              }
               const testName = assertion.title;
-              const compoundKey = `${normalizedPath}::${testName}`;
+              const compoundKey = `${relTestPath}::${testName}`;
               if (!testCasesMap.has(compoundKey)) {
                 testCasesMap.set(compoundKey, {
                   name: testName,
@@ -148,10 +195,8 @@ export async function summarizeReports(
   const policyMap = new Map<string, string>();
   if (inventory) {
     for (const caseRec of inventory.cases) {
-      const normalizedCasePath = path
-        .resolve(caseRec.filePath)
-        .replace(/\\/g, '/');
-      const key = `${normalizedCasePath}::${caseRec.name}`;
+      const relCasePath = getRelativePath(caseRec.filePath, rootDir);
+      const key = `${relCasePath}::${caseRec.name}`;
       policyMap.set(key, caseRec.policy);
     }
   }
@@ -163,8 +208,8 @@ export async function summarizeReports(
     let passedRuns = 0;
 
     for (const stats of testCasesMap.values()) {
-      const normalizedPath = path.resolve(stats.filePath).replace(/\\/g, '/');
-      const key = `${normalizedPath}::${stats.name}`;
+      const relTestPath = getRelativePath(stats.filePath, rootDir);
+      const key = `${relTestPath}::${stats.name}`;
       const policy = policyMap.get(key) || 'unknown';
       const passRate = stats.total > 0 ? stats.passed / stats.total : 0;
       cases.push({
@@ -232,10 +277,9 @@ export function formatReportSummary(
     lines.push('');
     lines.push('  Test Cases:');
     for (const c of model.cases) {
-      const relPath =
-        repoRoot && path.isAbsolute(c.filePath)
-          ? path.relative(repoRoot, c.filePath).replace(/\\/g, '/')
-          : c.filePath;
+      const relPath = repoRoot
+        ? getRelativePath(c.filePath, repoRoot)
+        : c.filePath;
       const indicator =
         c.passRate === 1.0 ? '✓' : c.passRate === 0 ? '✗' : '⚠';
       lines.push(
@@ -279,10 +323,7 @@ export function formatReportSummaryJson(
         total: c.total,
         passRate: c.passRate,
         policy: c.policy,
-        filePath:
-          repoRoot && path.isAbsolute(c.filePath)
-            ? path.relative(repoRoot, c.filePath).replace(/\\/g, '/')
-            : c.filePath,
+        filePath: repoRoot ? getRelativePath(c.filePath, repoRoot) : c.filePath,
       })),
     })),
   };


### PR DESCRIPTION
## Summary

Adds behavioral evaluations for multi-file batch reading (`read_many_files`), internal CLI documentation lookup (`get_internal_docs`), and Model Context Protocol resource discovery and reading (`list_mcp_resources` and `read_mcp_resource`).

## Details

- `evals/read_many_files.eval.ts` — [NEW] Behavioral evaluations for batch file inspection versus single file reading:
  - *Positive case*: Asserts that `read_many_files` is used with glob patterns when asked to inspect multiple files in a directory.
  - *Negative case*: Asserts that `read_file` is preferred over `read_many_files` when requested to read a single file.
- `evals/get_internal_docs.eval.ts` — [NEW] Behavioral evaluation verifying that the agent invokes `get_internal_docs` to query built-in CLI features and authentication documentation rather than reaching out to external web search or fetch tools.
- `evals/mcp_resources.eval.ts` — [NEW] Behavioral evaluations for Model Context Protocol resources using an in-process mock MCP server fixture:
  - *Resource listing*: Asserts that `list_mcp_resources` is called to discover available resources.
  - *Resource reading*: Asserts that `read_mcp_resource` is called with the target resource URI to fetch markdown documentation content.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
