### PR TITLE
[SSR Agent] Issue Fix (19239): Update /clear command docs to include context reset

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -101,11 +101,12 @@ Slash commands provide meta-level control over the CLI itself.
 
 ### `/clear`
 
-- **Description:** Clear the terminal screen, including the visible session
-  history and scrollback within the CLI. The underlying session data (for
-  history recall) might be preserved depending on the exact implementation, but
-  the visual display is cleared.
-- **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a clear action.
+- **Description:** Clear the agent conversation context (active conversation history)
+  and start a new session, in addition to clearing the visible terminal screen,
+  history, and scrollback within the CLI.
+- **Keyboard shortcut:** Press **Ctrl+L** at any time to perform a visual clear
+  action (note that **Ctrl+L** only clears the terminal display and redraws the UI,
+  preserving the active conversation context; use `/clear` to start a new session).
 
 ### `/commands`
 


### PR DESCRIPTION
fixes #19239
https://github.com/google-gemini/gemini-cli/issues/19239

### Context & Problem

The documentation for the `/clear` command in `docs/reference/commands.md` incorrectly stated that it only clears the visual terminal screen and scrollback, failing to mention that it also clears the active conversation context and starts a new session.

### Detailed Changes

- Updated the `/clear` command description in [commands.md](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_19239/tmp/eval/gemini-cli-clone/docs/reference/commands.md) to clarify that running `/clear` resets the agent's conversation context and starts a new session in addition to clearing the visible terminal screen.
- Clarified the keyboard shortcut behavior, explicitly explaining that **Ctrl+L** only performs a visual clear of the screen while preserving the active conversation context, and that `/clear` must be used to start a new session.

### Verification

- Reviewed the documentation changes to ensure they are clear, accurate, and completely satisfy the expected behavior in the specification.