### PR TITLE
[SSR Agent] Issue Fix (21477): Prevent indefinite TUI hang by adding execution timeouts

### DIFF
--- a/packages/core/src/ide/process-utils.test.ts
+++ b/packages/core/src/ide/process-utils.test.ts
@@ -48,6 +48,7 @@ describe('getIdeProcessInfo', () => {
       expect(result).toEqual({ pid: 12345, command: 'my-ide-command' });
       expect(mockedExec).toHaveBeenCalledWith(
         expect.stringContaining('ps -o ppid=,command= -p 12345'),
+        { timeout: 3000 },
       );
     });
 
@@ -102,6 +103,21 @@ describe('getIdeProcessInfo', () => {
 
       const result = await getIdeProcessInfo();
       expect(result).toEqual({ pid: 800, command: '/bin/bash' });
+    });
+
+    it('should handle timeout when ps command hangs or rejects during getProcessInfo', async () => {
+      (os.platform as Mock).mockReturnValue('linux');
+      const timeoutError = new Error('exec timeout');
+      Object.assign(timeoutError, {
+        killed: true,
+        code: undefined,
+        signal: 'SIGTERM',
+      });
+      mockedExec.mockRejectedValue(timeoutError);
+
+      const result = await getIdeProcessInfo();
+
+      expect(result).toEqual({ pid: 1000, command: '' });
     });
   });
 

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -37,9 +37,15 @@ async function getProcessTableWindows(): Promise<Map<number, ProcessInfo>> {
     const powershellCommand =
       'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress';
     // Increase maxBuffer to handle large process lists (default is 1MB)
-    const { stdout } = await execAsync(`powershell "${powershellCommand}"`, {
-      maxBuffer: 10 * 1024 * 1024,
-    });
+    const { stdout } = await execAsync(
+      'powershell -NoProfile -NonInteractive -Command "' +
+        powershellCommand +
+        '"',
+      {
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 5000,
+      },
+    );
 
     if (!stdout.trim()) {
       return processMap;
@@ -86,7 +92,7 @@ async function getProcessInfo(pid: number): Promise<{
 }> {
   try {
     const command = `ps -o ppid=,command= -p ${pid}`;
-    const { stdout } = await execAsync(command);
+    const { stdout } = await execAsync(command, { timeout: 3000 });
     const trimmedStdout = stdout.trim();
     if (!trimmedStdout) {
       return { parentPid: 0, name: '', command: '' };


### PR DESCRIPTION
fixes #21477
Original Issue: https://github.com/google-gemini/gemini-cli/issues/21477

### Context & Problem
When launched from a bare Linux terminal, the interactive TUI can hang indefinitely at "Initializing...". This occurs because `getProcessInfo()` relies on `execAsync` to execute Unix `ps` (and Windows `PowerShell` in `getProcessTableWindows()`) without any execution timeout, which can hang forever on certain environment configurations and halt the CLI startup sequence.

### Detailed Changes
- **packages/core/src/ide/process-utils.ts**:
  - Added a `timeout` option of `3000`ms to `execAsync` when invoking the Unix `ps` command within `getProcessInfo()`.
  - Added a `timeout` option of `5000`ms to `execAsync` when invoking the Windows `PowerShell` command within `getProcessTableWindows()`.
  - Ensured that `getProcessInfo()` catches errors and gracefully falls back to empty default process options, allowing parent traversal to cleanly terminate instead of blocking startup.
- **packages/core/src/ide/process-utils.test.ts**:
  - Updated current mock expectations for `execAsync` to match the new `timeout` parameter options.
  - Added a new unit test validating that `getIdeProcessInfo` resolves cleanly with fallback PID and command when `execAsync` times out or fails during process extraction.

### Verification
- Verified process utility functionality with a set of robust Vitest tests covering process tree traversal and timeout error handling scenarios.
- All ESLint checks have successfully run and passed.