### PR TITLE
[SSR Agent] Issue Fix (21919): Fix TypeScript strict-null errors in integration tests

### DIFF
--- a/integration-tests/concurrency-limit.test.ts
+++ b/integration-tests/concurrency-limit.test.ts
@@ -36,15 +36,13 @@ describe('web-fetch rate limiting', () => {
 
     // We expect to find at least one tool call that failed with a rate limit error.
     const toolLogs = rig.readToolLogs();
-    const rateLimitedCalls = toolLogs.filter(
-      (log) =>
-        log.toolRequest.name === 'web_fetch' &&
-        (
-          ('error' in log.toolRequest
-            ? (log.toolRequest as unknown as Record<string, string>)['error']
-            : '') as string
-        )?.includes('Rate limit exceeded'),
-    );
+    const rateLimitedCalls = toolLogs.filter((log) => {
+      const toolRequest = log.toolRequest as { name: string; error?: string };
+      return (
+        toolRequest.name === 'web_fetch' &&
+        toolRequest.error?.includes('Rate limit exceeded')
+      );
+    });
 
     expect(rateLimitedCalls.length).toBeGreaterThan(0);
     expect(result).toContain('Rate limit exceeded');

--- a/integration-tests/concurrency-limit.test.ts
+++ b/integration-tests/concurrency-limit.test.ts
@@ -40,7 +40,7 @@ describe('web-fetch rate limiting', () => {
       const toolRequest = log.toolRequest as { name: string; error?: string };
       return (
         toolRequest.name === 'web_fetch' &&
-        toolRequest.error?.includes('Rate limit exceeded')
+        (toolRequest.error?.includes('Rate limit exceeded') ?? false)
       );
     });
 

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -159,8 +159,8 @@ describe.skipIf(skipFlaky)(
         const blockHook = hookLogs.find(
           (log) =>
             log.hookCall.hook_event_name === 'BeforeTool' &&
-            (log.hookCall.stdout?.includes('"decision":"deny"') ||
-              log.hookCall.stderr?.includes('"decision":"deny"')),
+            ((log.hookCall.stdout?.includes('"decision":"deny"') ?? false) ||
+              (log.hookCall.stderr?.includes('"decision":"deny"') ?? false)),
         );
         expect(blockHook).toBeDefined();
         expect(

--- a/integration-tests/hooks-system.test.ts
+++ b/integration-tests/hooks-system.test.ts
@@ -159,8 +159,8 @@ describe.skipIf(skipFlaky)(
         const blockHook = hookLogs.find(
           (log) =>
             log.hookCall.hook_event_name === 'BeforeTool' &&
-            (log.hookCall.stdout.includes('"decision":"deny"') ||
-              log.hookCall.stderr.includes('"decision":"deny"')),
+            (log.hookCall.stdout?.includes('"decision":"deny"') ||
+              log.hookCall.stderr?.includes('"decision":"deny"')),
         );
         expect(blockHook).toBeDefined();
         expect(


### PR DESCRIPTION
fixes #21919
Original Issue: https://github.com/google-gemini/gemini-cli/issues/21919

### Context & Problem
TypeScript strict-null property and union type checking errors occur during builds on integration test files [hooks-system.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21919/tmp/eval/gemini-cli-clone/integration-tests/hooks-system.test.ts) and [concurrency-limit.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21919/tmp/eval/gemini-cli-clone/integration-tests/concurrency-limit.test.ts). Property `error` was being accessed on the `toolRequest` union type without proper narrowing, and `stdout`/`stderr` fields on hook actions were accessed without checking if they were undefined.

### Detailed Changes
- In [concurrency-limit.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21919/tmp/eval/gemini-cli-clone/integration-tests/concurrency-limit.test.ts), narrowed `log.toolRequest` by casting it inline and using optional chaining to check `toolRequest.error?.includes('Rate limit exceeded')` safely.
- In [hooks-system.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21919/tmp/eval/gemini-cli-clone/integration-tests/hooks-system.test.ts), updated stdout and stderr accesses to use optional chaining: `log.hookCall.stdout?.includes('"decision":"deny"') || log.hookCall.stderr?.includes('"decision":"deny"')`.

### Verification
- Verified that static checks pass successfully. The ESLint check has succeeded.