### PR TITLE
[SSR Agent] Issue Fix (22323): Preserve original termination reason during subagent recovery

### DIFF
--- a/packages/core/src/agents/local-executor.test.ts
+++ b/packages/core/src/agents/local-executor.test.ts
@@ -2716,7 +2716,7 @@ describe('LocalAgentExecutor', () => {
 
       const output = await executor.run({ goal: 'Turns recovery' }, signal);
 
-      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+      expect(output.terminate_reason).toBe(AgentTerminateMode.MAX_TURNS);
       expect(output.result).toBe('Recovered!');
       expect(mockSendMessageStream).toHaveBeenCalledTimes(MAX + 1); // 1 regular + 1 recovery
 
@@ -2904,7 +2904,7 @@ describe('LocalAgentExecutor', () => {
       const output = await runPromise;
 
       expect(mockSendMessageStream).toHaveBeenCalledTimes(2); // 1 failed + 1 recovery
-      expect(output.terminate_reason).toBe(AgentTerminateMode.GOAL);
+      expect(output.terminate_reason).toBe(AgentTerminateMode.TIMEOUT);
       expect(output.result).toBe('Recovered from timeout!');
 
       expect(activities).toContainEqual(

--- a/packages/core/src/agents/local-executor.ts
+++ b/packages/core/src/agents/local-executor.ts
@@ -576,6 +576,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
     let turnCounter = 0;
     let terminateReason: AgentTerminateMode = AgentTerminateMode.ERROR;
     let finalResult: string | null = null;
+    let recoverySucceeded = false;
 
     const maxTimeMinutes =
       this.definition.runConfig.maxTimeMinutes ?? DEFAULT_MAX_TIME_MINUTES;
@@ -762,7 +763,13 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
         if (recoveryResult !== null) {
           // Recovery Succeeded
-          terminateReason = AgentTerminateMode.GOAL;
+          recoverySucceeded = true;
+          if (
+            terminateReason !== AgentTerminateMode.MAX_TURNS &&
+            terminateReason !== AgentTerminateMode.TIMEOUT
+          ) {
+            terminateReason = AgentTerminateMode.GOAL;
+          }
           finalResult = recoveryResult;
         } else {
           // Recovery Failed. Set the final error message based on the *original* reason.
@@ -796,7 +803,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
         }
       }
 
-      if (terminateReason === AgentTerminateMode.GOAL) {
+      if (terminateReason === AgentTerminateMode.GOAL || recoverySucceeded) {
         // Save the session summary upon completion
         if (finalResult && chat) {
           try {
@@ -844,7 +851,7 @@ export class LocalAgentExecutor<TOutput extends z.ZodTypeAny> {
 
           if (recoveryResult !== null) {
             // Recovery Succeeded
-            terminateReason = AgentTerminateMode.GOAL;
+            terminateReason = AgentTerminateMode.TIMEOUT;
             finalResult = recoveryResult;
 
             // Save the session summary upon successful recovery


### PR DESCRIPTION
fixes #22323
Original issue: https://github.com/google-gemini/gemini-cli/issues/22323

### Context & Problem

When a subagent reached its execution limits (such as `MAX_TURNS` or `TIMEOUT`) and successfully called `complete_task` during the final grace recovery turn, the [LocalAgentExecutor](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.ts) would unconditionally override the `terminateReason` to `GOAL`. This issue was caused by [LocalAgentExecutor.runInternal()](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.ts#L576) overwriting the termination mode, which masked the original limit condition and incorrectly reported a status of standard success.

### Detailed Changes

* Updated [LocalAgentExecutor.runInternal()](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.ts#L576) in [packages/core/src/agents/local-executor.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.ts) to track successful recovery using a boolean `recoverySucceeded` instead of immediately changing `terminateReason` to `GOAL`. This ensures that the returned `OutputObject` preserves the original execution limit termination reasons (`MAX_TURNS` or `TIMEOUT`) while still executing the successful recovery flow (saving the session summary, etc.).
* Adjusted the timeout catch block in [LocalAgentExecutor.runInternal()](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.ts#L844) to set `terminateReason` to `AgentTerminateMode.TIMEOUT` instead of `AgentTerminateMode.GOAL` when a subagent times out but successfully completes task during recovery.
* Updated the unit tests in [packages/core/src/agents/local-executor.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.test.ts) to assert that successful recovery preserves the original termination reason (`MAX_TURNS` or `TIMEOUT`).

### Verification

* Verified that the linter check in `linter_output.txt` succeeded without any errors or warnings.
* All relevant unit tests in [packages/core/src/agents/local-executor.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_22323/tmp/eval/gemini-cli-clone/packages/core/src/agents/local-executor.test.ts) have been successfully updated to assert the expected behavior and have passed.