### PR TITLE
[SSR Agent] Issue Fix (23313): Change steering eval test to always pass

### DIFF
--- a/evals/model_steering.eval.ts
+++ b/evals/model_steering.eval.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import { appEvalTest } from './app-test-helper.js';
 
 describe('Model Steering Behavioral Evals', () => {
-  appEvalTest('USUALLY_PASSES', {
+  appEvalTest('ALWAYS_PASSES', {
     suiteName: 'default',
     suiteType: 'behavioral',
     name: 'Corrective Hint: Model switches task based on hint during tool turn',
@@ -51,7 +51,7 @@ describe('Model Steering Behavioral Evals', () => {
     },
   });
 
-  appEvalTest('USUALLY_PASSES', {
+  appEvalTest('ALWAYS_PASSES', {
     suiteName: 'default',
     suiteType: 'behavioral',
     name: 'Suggestive Hint: Model incorporates user guidance mid-stream',


### PR DESCRIPTION
fixes #23313
https://github.com/google-gemini/gemini-cli/issues/23313

### Context & Problem

The model steering behavior eval tests were configured to use the `USUALLY_PASSES` policy. Because these tests perform essential model steering regression checks, they need to run under the `ALWAYS_PASSES` policy to act as mandatory regression checks in continuous integration.

### Detailed Changes

* Updated `evals/model_steering.eval.ts` to replace the `USUALLY_PASSES` policy with `ALWAYS_PASSES` for both steering eval tests:
  * "Corrective Hint: Model switches task based on hint during tool turn"
  * "Suggestive Hint: Model incorporates user guidance mid-stream"

### Verification

* Verified that the ESLint checks passed cleanly.
* Verified that the tests in `evals/model_steering.eval.ts` are set to run under the `ALWAYS_PASSES` policy.