### PR TITLE
[SSR Agent] Issue Fix (24587): Fix misleading admin error for personal accounts

### DIFF
--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts
@@ -598,7 +598,7 @@ describe('useQuotaAndFallback', () => {
         });
       }
 
-      it('should handle ModelNotFoundError correctly', async () => {
+      it('should handle ModelNotFoundError for personal accounts correctly', async () => {
         const { result } = await renderHook(() =>
           useQuotaAndFallback({
             config: mockConfig,
@@ -630,9 +630,60 @@ describe('useQuotaAndFallback', () => {
 
         const message = request!.message;
         expect(message).toBe(
-          `It seems like you don't have access to gemini-3-pro-preview.
-Your admin might have disabled the access. Contact them to enable the Preview Release Channel.`,
+          `It seems like you don't have access to gemini-3-pro-preview.\n` +
+            `This model is not available for personal accounts.`,
         );
+        expect(message).not.toContain('admin');
+        expect(message).not.toContain('Preview Release Channel');
+
+        // Simulate the user choosing to switch
+        act(() => {
+          result.current.handleProQuotaChoice('retry_always');
+        });
+
+        const intent = await promise!;
+        expect(intent).toBe('retry_always');
+
+        expect(result.current.proQuotaRequest).toBeNull();
+      });
+
+      it('should handle ModelNotFoundError for enterprise/workspace accounts correctly', async () => {
+        const { result } = await renderHook(() =>
+          useQuotaAndFallback({
+            config: mockConfig,
+            historyManager: mockHistoryManager,
+            userTier: UserTierId.STANDARD,
+            setModelSwitchedFromQuotaError: mockSetModelSwitchedFromQuotaError,
+            onShowAuthSelection: mockOnShowAuthSelection,
+            paidTier: null,
+            settings: mockSettings,
+          }),
+        );
+
+        const handler = setFallbackHandlerSpy.mock
+          .calls[0][0] as FallbackModelHandler;
+
+        let promise: Promise<FallbackIntent | null>;
+        const error = new ModelNotFoundError('model not found', 404);
+
+        act(() => {
+          promise = handler('gemini-3-pro-preview', 'gemini-2.5-pro', error);
+        });
+
+        // The hook should now have a pending request for the UI to handle
+        const request = result.current.proQuotaRequest;
+        expect(request).not.toBeNull();
+        expect(request?.failedModel).toBe('gemini-3-pro-preview');
+        expect(request?.isTerminalQuotaError).toBe(false);
+        expect(request?.isModelNotFoundError).toBe(true);
+
+        const message = request!.message;
+        expect(message).toBe(
+          `It seems like you don't have access to gemini-3-pro-preview.\n` +
+            `Your admin might have disabled the access. Contact them to enable the Preview Release Channel.`,
+        );
+        expect(message).toContain('admin');
+        expect(message).toContain('Preview Release Channel');
 
         // Simulate the user choosing to switch
         act(() => {

--- a/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
+++ b/packages/cli/src/ui/hooks/useQuotaAndFallback.ts
@@ -13,7 +13,7 @@ import {
   type ValidationIntent,
   TerminalQuotaError,
   ModelNotFoundError,
-  type UserTierId,
+  UserTierId,
   VALID_GEMINI_MODELS,
   isProModel,
   isOverageEligibleModel,
@@ -186,9 +186,13 @@ export function useQuotaAndFallback({
           ];
           message = messageLines.join('\n');
         } else if (VALID_GEMINI_MODELS.has(failedModel)) {
+          const detailMessage =
+            userTier === UserTierId.FREE
+              ? 'This model is not available for personal accounts.'
+              : 'Your admin might have disabled the access. Contact them to enable the Preview Release Channel.';
           const messageLines = [
             `It seems like you don't have access to ${getDisplayString(failedModel)}.`,
-            `Your admin might have disabled the access. Contact them to enable the Preview Release Channel.`,
+            detailMessage,
           ];
           message = messageLines.join('\n');
         } else {


### PR DESCRIPTION
fixes #24587

### Related Issue
Original Issue URL: https://github.com/google-gemini/gemini-cli/issues/24587

### Context & Problem
When an authenticated user on a personal account selects a Gemini model that is not available for personal accounts, the CLI displays a misleading enterprise-specific error message referencing admin settings and Preview Release Channels. This is because the `ModelNotFoundError` handler in `useQuotaAndFallback.ts` hardcoded this enterprise-specific error message for valid Gemini models without validating whether the user is on a personal or managed account tier.

### Detailed Changes
- **packages/cli/src/ui/hooks/useQuotaAndFallback.ts**: Updated the `ModelNotFoundError` handling logic for `VALID_GEMINI_MODELS` to conditionally inspect the `userTier`. If the tier is `UserTierId.FREE` (representing a personal user), the CLI now raises a clean, context-specific error indicating the model is unavailable for personal accounts without mentioning administrative permissions or Preview Release Channels. In other tiers, the original administrator warning is preserved.
- **packages/cli/src/ui/hooks/useQuotaAndFallback.test.ts**: Split the `ModelNotFoundError` unit test into two comprehensive tests: one verifying personal accounts (`UserTierId.FREE`) and ensuring they receive the simplified personal-account message (asserting no mention of 'admin' or 'Preview Release Channel'), and one verifying enterprise/workspace accounts (`UserTierId.STANDARD`) retaining the administrative instructions.

### Verification
- Executed unit tests in `useQuotaAndFallback.test.ts` via Vitest to assert correct behavior and expected text outputs for both personal and enterprise user tiers.
- Verified ESLint checks ran successfully without any warnings or errors.