### PR TITLE
fix(core): warn when a preview model is silently substituted

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4335,6 +4335,7 @@ describe('Model Persistence Bug Fix (#19864)', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining(PREVIEW_GEMINI_3_1_MODEL),
     );
+    warnSpy.mockRestore();
   });
 
   it('should persist model when user selects it with persistMode=true', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4291,6 +4291,52 @@ describe('Model Persistence Bug Fix (#19864)', () => {
     expect(config.getHasAccessToPreviewModel()).toBe(true);
   });
 
+  it('should warn when a requested preview model is silently substituted due to lack of entitlement', async () => {
+    const mockContentConfig = {
+      authType: AuthType.LOGIN_WITH_GOOGLE,
+    } as Partial<ContentGeneratorConfig> as ContentGeneratorConfig;
+
+    const mockContentGenerator = {
+      generateContent: vi.fn(),
+    } as Partial<ContentGenerator> as ContentGenerator;
+
+    vi.mocked(createContentGeneratorConfig).mockResolvedValue(
+      mockContentConfig,
+    );
+    vi.mocked(createContentGenerator).mockResolvedValue(mockContentGenerator);
+    vi.mocked(getCodeAssistServer).mockReturnValue({
+      projectId: 'test-project',
+      retrieveUserQuota: vi.fn().mockResolvedValue({
+        buckets: [
+          {
+            modelId: 'gemini-2.5-pro',
+            remainingAmount: '10',
+            remainingFraction: 0.1,
+          },
+        ],
+      }),
+    } as Partial<CodeAssistServer> as CodeAssistServer);
+    vi.mocked(getExperiments).mockResolvedValue({
+      experimentIds: [],
+      flags: {},
+    });
+
+    const config = new Config(baseParams);
+    const warnSpy = vi.spyOn(debugLogger, 'warn').mockImplementation(() => {});
+
+    expect(config.getModel()).toBe(PREVIEW_GEMINI_3_1_MODEL);
+
+    await config.refreshAuth(AuthType.LOGIN_WITH_GOOGLE);
+
+    // The account lacks preview entitlement, so the model is substituted.
+    expect(config.getHasAccessToPreviewModel()).toBe(false);
+    expect(config.getModel()).toBe(DEFAULT_GEMINI_MODEL_AUTO);
+    // The substitution must not happen silently.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(PREVIEW_GEMINI_3_1_MODEL),
+    );
+  });
+
   it('should persist model when user selects it with persistMode=true', () => {
     const onModelChange = vi.fn();
     const config = new Config({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1658,7 +1658,13 @@ export class Config implements McpContext, AgentLoopContext {
       isPreviewModel(this.model, this) &&
       this.hasAccessToPreviewModel === false
     ) {
+      const requestedModel = this.model;
       this.setModel(DEFAULT_GEMINI_MODEL_AUTO);
+      debugLogger.warn(
+        `[Config] Requested model "${requestedModel}" is not available to ` +
+          `the current account and will be substituted with an automatically ` +
+          `selected model instead.`,
+      );
     }
 
     const adminControlsEnabled =


### PR DESCRIPTION
## Summary

Fixes #28825.

When a user requests a preview model (e.g. `gemini-3.1-pro-preview`) but their
authenticated account has no preview-model entitlement, `Config` silently
rewrites the active model to the `auto-gemini-2.5` alias with zero
indication to the caller — no error, no warning, nothing in the CLI output.
The substitute model is then chosen by the auto-routing/classifier logic,
which is why different callers can observe different substitutes
(`gemini-2.5-pro` vs `gemini-2.5-flash`) for the same requested model,
as described in the issue.

This is a minimal fix for the smallest actionable ask in the issue ("Failing
that, warn on stderr whenever the served model differs from the requested
one."). The larger asks (hard error, `--strict-model` flag) require a
cross-component refactor across `packages/cli` argument parsing and multiple
`packages/core` fallback/routing components — the same scope called out as
`effort/medium` and requiring further design in the related, closed issue
#26938. This PR keeps things scoped to the specific code path this report
demonstrates: `Config`'s post-auth preview-access check
(`packages/core/src/config/config.ts`), which silently reset `this.model` via
`setModel(DEFAULT_GEMINI_MODEL_AUTO)` with no log of any kind.

## Change

In `packages/core/src/config/config.ts`, when this reset fires, log a
warning (via the existing `debugLogger.warn`, which surfaces to stderr in
non-interactive mode and to the console message log in interactive mode)
naming the originally-requested model:

```
[Config] Requested model "gemini-3.1-pro-preview" is not available to the
current account and will be substituted with an automatically selected
model instead.
```

## Test plan

Added a regression test in `packages/core/src/config/config.test.ts`
(`Model Persistence Bug Fix (#19864)` suite) that:
- Constructs a `Config` with the initial model set to the Gemini 3.1
  preview model.
- Mocks `getCodeAssistServer`/`retrieveUserQuota` so the account's quota
  buckets do not include a preview model (i.e. no entitlement).
- Calls `refreshAuth(AuthType.LOGIN_WITH_GOOGLE)` (the personal OAuth flow
  from the issue's repro).
- Asserts the model is substituted to `DEFAULT_GEMINI_MODEL_AUTO` (existing
  behavior, unchanged) **and** that `debugLogger.warn` was called with a
  message naming the originally-requested model (the new behavior).

Verified the test fails without the fix:
```
$ git stash push -- packages/core/src/config/config.ts   # revert only the fix
$ npx vitest run src/config/config.test.ts -t "silently substituted"
 × should warn when a requested preview model is silently substituted due to lack of entitlement
   → expected "warn" to be called with arguments: [ StringContaining{…} ]
   Number of calls: 0
$ git stash pop                                            # restore the fix
$ npx vitest run src/config/config.test.ts -t "silently substituted"
 ✓ should warn when a requested preview model is silently substituted due to lack of entitlement
```

Full suite run after the fix:
```
$ npx vitest run src/config/config.test.ts
 ✓ src/config/config.test.ts (237 tests) 730ms
 Test Files  1 passed (1)
      Tests  237 passed (237)

$ npx vitest run src/config/
 Test Files  14 passed (14)
      Tests  450 passed (450)
```

Also ran, with no new errors:
```
$ npx eslint packages/core/src/config/config.ts packages/core/src/config/config.test.ts --max-warnings 0
(clean)
$ npm run typecheck   # in packages/core
(clean)
```

## AI assistance disclosure

This change was implemented with the assistance of an AI coding agent
(Claude, Anthropic), which located the root cause, wrote the fix, and wrote
and verified the regression test described above.
