### PR TITLE
test(core): skip environment-dependent tests with a reason instead of failing (#28830)

### DIFF
--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { AllowedPathChecker } from './built-in.js';
 import { SafetyCheckDecision, type SafetyCheckInput } from './protocol.js';
 import type { FunctionCall } from '@google/genai';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 describe('AllowedPathChecker', () => {
   let checker: AllowedPathChecker;
@@ -116,35 +117,41 @@ describe('AllowedPathChecker', () => {
     expect(result.decision).toBe(SafetyCheckDecision.ALLOW);
   });
 
-  it('should deny access if path contains a symlink pointing outside allowed directories', async () => {
-    const symlinkPath = path.join(mockCwd, 'symlink');
-    const targetPath = path.join(testRootDir, 'etc', 'passwd');
-    await fs.mkdir(path.dirname(targetPath), { recursive: true });
-    await fs.writeFile(targetPath, 'secret');
+  it.skipIf(!canCreateSymlinks())(
+    'should deny access if path contains a symlink pointing outside allowed directories',
+    async () => {
+      const symlinkPath = path.join(mockCwd, 'symlink');
+      const targetPath = path.join(testRootDir, 'etc', 'passwd');
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, 'secret');
 
-    // Create symlink: mockCwd/symlink -> targetPath
-    await fs.symlink(targetPath, symlinkPath);
+      // Create symlink: mockCwd/symlink -> targetPath
+      await fs.symlink(targetPath, symlinkPath);
 
-    const input = createInput({ path: symlinkPath });
-    const result = await checker.check(input);
-    expect(result.decision).toBe(SafetyCheckDecision.DENY);
-    expect(result.reason).toContain(
-      'outside of the allowed workspace directories',
-    );
-  });
+      const input = createInput({ path: symlinkPath });
+      const result = await checker.check(input);
+      expect(result.decision).toBe(SafetyCheckDecision.DENY);
+      expect(result.reason).toContain(
+        'outside of the allowed workspace directories',
+      );
+    },
+  );
 
-  it('should allow access if path contains a symlink pointing INSIDE allowed directories', async () => {
-    const symlinkPath = path.join(mockCwd, 'symlink-inside');
-    const realFilePath = path.join(mockCwd, 'real-file');
-    await fs.writeFile(realFilePath, 'real content');
+  it.skipIf(!canCreateSymlinks())(
+    'should allow access if path contains a symlink pointing INSIDE allowed directories',
+    async () => {
+      const symlinkPath = path.join(mockCwd, 'symlink-inside');
+      const realFilePath = path.join(mockCwd, 'real-file');
+      await fs.writeFile(realFilePath, 'real content');
 
-    // Create symlink: mockCwd/symlink-inside -> mockCwd/real-file
-    await fs.symlink(realFilePath, symlinkPath);
+      // Create symlink: mockCwd/symlink-inside -> mockCwd/real-file
+      await fs.symlink(realFilePath, symlinkPath);
 
-    const input = createInput({ path: symlinkPath });
-    const result = await checker.check(input);
-    expect(result.decision).toBe(SafetyCheckDecision.ALLOW);
-  });
+      const input = createInput({ path: symlinkPath });
+      const result = await checker.check(input);
+      expect(result.decision).toBe(SafetyCheckDecision.ALLOW);
+    },
+  );
 
   it('should check explicitly included arguments', async () => {
     const outsidePath = path.join(testRootDir, 'etc', 'passwd');

--- a/packages/core/src/services/sandboxManager.integration.test.ts
+++ b/packages/core/src/services/sandboxManager.integration.test.ts
@@ -26,6 +26,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
 import http from 'node:http';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 /**
  * Cross-platform command wrappers using Node.js inline scripts.
@@ -691,48 +692,51 @@ describe('SandboxManager Integration', () => {
         expect(fs.existsSync(nonExistentFile)).toBe(false);
       });
 
-      it('restricts symlinks to forbidden targets', async () => {
-        const tempWorkspace = createTempDir('workspace-');
-        const targetFile = path.join(tempWorkspace, 'target.txt');
-        const symlinkFile = path.join(tempWorkspace, 'link.txt');
+      it.skipIf(!canCreateSymlinks())(
+        'restricts symlinks to forbidden targets',
+        async () => {
+          const tempWorkspace = createTempDir('workspace-');
+          const targetFile = path.join(tempWorkspace, 'target.txt');
+          const symlinkFile = path.join(tempWorkspace, 'link.txt');
 
-        fs.writeFileSync(targetFile, 'secret data');
-        fs.symlinkSync(targetFile, symlinkFile);
+          fs.writeFileSync(targetFile, 'secret data');
+          fs.symlinkSync(targetFile, symlinkFile);
 
-        const osManager = createSandboxManager(
-          { enabled: true },
-          {
-            workspace: tempWorkspace,
-            forbiddenPaths: async () => [symlinkFile],
-          },
-        );
+          const osManager = createSandboxManager(
+            { enabled: true },
+            {
+              workspace: tempWorkspace,
+              forbiddenPaths: async () => [symlinkFile],
+            },
+          );
 
-        // Attempt to write to the target file directly
-        const { command: cmdTarget, args: argsTarget } =
-          Platform.touch(targetFile);
-        const commandTarget = await osManager.prepareCommand({
-          command: cmdTarget,
-          args: argsTarget,
-          cwd: tempWorkspace,
-          env: process.env,
-        });
+          // Attempt to write to the target file directly
+          const { command: cmdTarget, args: argsTarget } =
+            Platform.touch(targetFile);
+          const commandTarget = await osManager.prepareCommand({
+            command: cmdTarget,
+            args: argsTarget,
+            cwd: tempWorkspace,
+            env: process.env,
+          });
 
-        const resultTarget = await runCommand(commandTarget);
-        assertResult(resultTarget, commandTarget, 'failure');
+          const resultTarget = await runCommand(commandTarget);
+          assertResult(resultTarget, commandTarget, 'failure');
 
-        // Attempt to write via the symlink
-        const { command: cmdLink, args: argsLink } =
-          Platform.touch(symlinkFile);
-        const commandLink = await osManager.prepareCommand({
-          command: cmdLink,
-          args: argsLink,
-          cwd: tempWorkspace,
-          env: process.env,
-        });
+          // Attempt to write via the symlink
+          const { command: cmdLink, args: argsLink } =
+            Platform.touch(symlinkFile);
+          const commandLink = await osManager.prepareCommand({
+            command: cmdLink,
+            args: argsLink,
+            cwd: tempWorkspace,
+            env: process.env,
+          });
 
-        const resultLink = await runCommand(commandLink);
-        assertResult(resultLink, commandLink, 'failure');
-      });
+          const resultLink = await runCommand(commandLink);
+          assertResult(resultLink, commandLink, 'failure');
+        },
+      );
     });
 
     describe('Governance Files', () => {

--- a/packages/core/src/services/shellExecutionService.windows.integration.test.ts
+++ b/packages/core/src/services/shellExecutionService.windows.integration.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import os from 'node:os';
 import { ShellExecutionService } from './shellExecutionService.js';
 import { NoopSandboxManager } from './sandboxManager.js';
+import { hasPowerShell7 } from '../test-utils/environment-capabilities.js';
 
 const isWindows = os.platform() === 'win32';
 
@@ -21,8 +22,12 @@ const isWindows = os.platform() === 'win32';
  * These tests exercise the full pipeline end-to-end. They pass when
  * gemini-cli selects pwsh.exe from PATH; they fail when the pipeline
  * routes through Windows PowerShell 5.1.
+ *
+ * That condition is the guard below rather than only a note here: on a
+ * default Windows install pwsh.exe is absent, so these would otherwise
+ * fail for a reason unrelated to the change under test.
  */
-describe.skipIf(!isWindows)(
+describe.skipIf(!isWindows || !hasPowerShell7())(
   'ShellExecutionService Windows quoting (real shell)',
   () => {
     const baseConfig = {

--- a/packages/core/src/test-utils/environment-capabilities.ts
+++ b/packages/core/src/test-utils/environment-capabilities.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Capability probes for tests whose outcome depends on the host rather than on
+ * the code under test.
+ *
+ * These exist so such a test can be skipped with a reason instead of failing.
+ * A suite that is red for environmental reasons teaches contributors to ignore
+ * it, which costs more than the coverage the test provides.
+ *
+ * Prefer a capability probe to a `process.platform` check. Skipping every
+ * Windows host would also skip the contributors most likely to be changing
+ * Windows-specific behavior, whose machines can usually run these tests.
+ */
+
+let cachedCanCreateSymlinks: boolean | undefined;
+
+/**
+ * Whether this host can create symbolic links.
+ *
+ * On Windows `fs.symlinkSync` needs Developer Mode or an elevated shell and
+ * otherwise throws `EPERM`, so a default developer machine cannot build a
+ * symlink fixture. This creates one real link rather than inferring from the
+ * platform, and caches the answer because it cannot change within a run.
+ */
+export function canCreateSymlinks(): boolean {
+  if (cachedCanCreateSymlinks !== undefined) {
+    return cachedCanCreateSymlinks;
+  }
+
+  let dir: string | undefined;
+  try {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-probe-'));
+    const target = path.join(dir, 'target');
+    fs.writeFileSync(target, '');
+    fs.symlinkSync(target, path.join(dir, 'link'));
+    cachedCanCreateSymlinks = true;
+  } catch {
+    cachedCanCreateSymlinks = false;
+  } finally {
+    if (dir !== undefined) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // The probe must never fail a suite it is only there to describe.
+      }
+    }
+  }
+
+  return cachedCanCreateSymlinks;
+}
+
+/**
+ * Whether PowerShell 7+ (`pwsh`) is resolvable on PATH.
+ *
+ * The Windows shell-quoting pipeline behaves differently when it falls back to
+ * Windows PowerShell 5.1, which is what a default Windows install provides.
+ */
+export function hasPowerShell7(): boolean {
+  if (os.platform() !== 'win32') {
+    return false;
+  }
+
+  return (process.env['PATH'] ?? '').split(path.delimiter).some((entry) => {
+    if (entry === '') {
+      return false;
+    }
+    try {
+      return fs.existsSync(path.join(entry, 'pwsh.exe'));
+    } catch {
+      return false;
+    }
+  });
+}

--- a/packages/core/src/test-utils/environment-capabilities.ts
+++ b/packages/core/src/test-utils/environment-capabilities.ts
@@ -70,11 +70,16 @@ export function hasPowerShell7(): boolean {
   }
 
   return (process.env['PATH'] ?? '').split(path.delimiter).some((entry) => {
-    if (entry === '') {
+    // Windows PATH entries containing spaces are sometimes stored quoted.
+    // `path.join` would keep the quote inside the path, so the lookup would
+    // miss a pwsh that is actually installed — and a false negative here
+    // skips the tests on precisely the hosts that can run them.
+    const unquoted = entry.replace(/^"|"$/g, '');
+    if (unquoted === '') {
       return false;
     }
     try {
-      return fs.existsSync(path.join(entry, 'pwsh.exe'));
+      return fs.existsSync(path.join(unquoted, 'pwsh.exe'));
     } catch {
       return false;
     }

--- a/packages/core/src/test-utils/index.ts
+++ b/packages/core/src/test-utils/index.ts
@@ -4,4 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from './environment-capabilities.js';
 export * from './mock-tool.js';

--- a/packages/core/src/tools/at-reference-resolution.test.ts
+++ b/packages/core/src/tools/at-reference-resolution.test.ts
@@ -19,6 +19,7 @@ import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
 import { isSubpath } from '../utils/paths.js';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 vi.mock('../telemetry/loggers.js', () => ({
   logFileOperation: vi.fn(),
@@ -401,53 +402,59 @@ describe('Consolidated At-Reference Path Resolution Tests (b-495551283)', () => 
     ).rejects.toThrow('Path not in workspace');
   });
 
-  it('getCorrectedFileContent handles symlink loops gracefully', async () => {
-    const symlinkPath1 = path.join(tempRootDir, 'symlink1');
-    const symlinkPath2 = path.join(tempRootDir, 'symlink2');
-    await fsp.symlink(symlinkPath2, symlinkPath1);
-    await fsp.symlink(symlinkPath1, symlinkPath2);
+  it.skipIf(!canCreateSymlinks())(
+    'getCorrectedFileContent handles symlink loops gracefully',
+    async () => {
+      const symlinkPath1 = path.join(tempRootDir, 'symlink1');
+      const symlinkPath2 = path.join(tempRootDir, 'symlink2');
+      await fsp.symlink(symlinkPath2, symlinkPath1);
+      await fsp.symlink(symlinkPath1, symlinkPath2);
 
-    const result = await getCorrectedFileContent(
-      mockConfigInstance,
-      'symlink1',
-      'content',
-      abortSignal,
-    );
+      const result = await getCorrectedFileContent(
+        mockConfigInstance,
+        'symlink1',
+        'content',
+        abortSignal,
+      );
 
-    // The utility should fail gracefully with a resolution error
-    expect(result.error).toBeDefined();
-    expect(result.error?.message).toContain('Failed to resolve path');
-  });
+      // The utility should fail gracefully with a resolution error
+      expect(result.error).toBeDefined();
+      expect(result.error?.message).toContain('Failed to resolve path');
+    },
+  );
 
-  it('EditTool.getModifyContext handles symlink loops gracefully by throwing a descriptive error', async () => {
-    const symlinkPath1 = path.join(tempRootDir, 'symlink1');
-    const symlinkPath2 = path.join(tempRootDir, 'symlink2');
-    await fsp.symlink(symlinkPath2, symlinkPath1);
-    await fsp.symlink(symlinkPath1, symlinkPath2);
+  it.skipIf(!canCreateSymlinks())(
+    'EditTool.getModifyContext handles symlink loops gracefully by throwing a descriptive error',
+    async () => {
+      const symlinkPath1 = path.join(tempRootDir, 'symlink1');
+      const symlinkPath2 = path.join(tempRootDir, 'symlink2');
+      await fsp.symlink(symlinkPath2, symlinkPath1);
+      await fsp.symlink(symlinkPath1, symlinkPath2);
 
-    const editTool = new EditTool(mockConfigInstance, createMockMessageBus());
-    const modifyContext = editTool.getModifyContext(abortSignal);
+      const editTool = new EditTool(mockConfigInstance, createMockMessageBus());
+      const modifyContext = editTool.getModifyContext(abortSignal);
 
-    // The getCurrentContent method should throw a path resolution error
-    await expect(
-      modifyContext.getCurrentContent({
-        file_path: 'symlink1',
-        instruction: 'read file',
-        old_string: '',
-        new_string: '',
-      }),
-    ).rejects.toThrow('Failed to resolve path');
+      // The getCurrentContent method should throw a path resolution error
+      await expect(
+        modifyContext.getCurrentContent({
+          file_path: 'symlink1',
+          instruction: 'read file',
+          old_string: '',
+          new_string: '',
+        }),
+      ).rejects.toThrow('Failed to resolve path');
 
-    // The getProposedContent method should throw a path resolution error
-    await expect(
-      modifyContext.getProposedContent({
-        file_path: 'symlink1',
-        instruction: 'read file',
-        old_string: '',
-        new_string: '',
-      }),
-    ).rejects.toThrow('Failed to resolve path');
-  });
+      // The getProposedContent method should throw a path resolution error
+      await expect(
+        modifyContext.getProposedContent({
+          file_path: 'symlink1',
+          instruction: 'read file',
+          old_string: '',
+          new_string: '',
+        }),
+      ).rejects.toThrow('Failed to resolve path');
+    },
+  );
 
   it('getCorrectedFileContent successfully resolves paths in Plan Mode', async () => {
     const plansDir = path.join(tempRootDir, '.plans');

--- a/packages/core/src/tools/exit-plan-mode.test.ts
+++ b/packages/core/src/tools/exit-plan-mode.test.ts
@@ -16,6 +16,7 @@ import * as fs from 'node:fs';
 import os from 'node:os';
 import { validatePlanPath } from '../utils/planUtils.js';
 import * as loggers from '../telemetry/loggers.js';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 vi.mock('../telemetry/loggers.js', () => ({
   logPlanExecution: vi.fn(),
@@ -493,20 +494,23 @@ Ask the user for specific feedback on how to improve the plan.`,
       expect(result).toContain('Plan file does not exist');
     });
 
-    it('should reject symbolic links pointing outside the plans directory', () => {
-      const outsideFile = path.join(tempRootDir, 'outside.txt');
-      fs.writeFileSync(outsideFile, 'secret');
-      const maliciousPath = path.join(mockPlansDir, 'malicious.md');
-      fs.symlinkSync(outsideFile, maliciousPath);
+    it.skipIf(!canCreateSymlinks())(
+      'should reject symbolic links pointing outside the plans directory',
+      () => {
+        const outsideFile = path.join(tempRootDir, 'outside.txt');
+        fs.writeFileSync(outsideFile, 'secret');
+        const maliciousPath = path.join(mockPlansDir, 'malicious.md');
+        fs.symlinkSync(outsideFile, maliciousPath);
 
-      const result = tool.validateToolParams({
-        plan_filename: 'malicious.md',
-      });
+        const result = tool.validateToolParams({
+          plan_filename: 'malicious.md',
+        });
 
-      expect(result).toBe(
-        `Access denied: plan path (malicious.md) must be within the designated plans directory (${mockPlansDir}).`,
-      );
-    });
+        expect(result).toBe(
+          `Access denied: plan path (malicious.md) must be within the designated plans directory (${mockPlansDir}).`,
+        );
+      },
+    );
 
     it('should accept valid path within plans directory', () => {
       createPlanFile('valid.md', '# Content');

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -39,6 +39,7 @@ import {
 } from './fileUtils.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 vi.mock('mime/lite', () => ({
   default: { getType: vi.fn() },
@@ -189,7 +190,7 @@ describe('fileUtils', () => {
       expect(getRealPath(ghostFile)).toBe(path.resolve(ghostFile));
     });
 
-    it('should resolve symbolic links', () => {
+    it.skipIf(!canCreateSymlinks())('should resolve symbolic links', () => {
       const targetFile = path.join(tempRootDir, 'target.txt');
       const linkFile = path.join(tempRootDir, 'link.txt');
       actualNodeFs.writeFileSync(targetFile, 'content');

--- a/packages/core/src/utils/planUtils.test.ts
+++ b/packages/core/src/utils/planUtils.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import * as fs from 'node:fs';
 import os from 'node:os';
 import { validatePlanPath, validatePlanContent } from './planUtils.js';
+import { canCreateSymlinks } from '../test-utils/environment-capabilities.js';
 
 describe('planUtils', () => {
   let tempRootDir: string;
@@ -45,24 +46,27 @@ describe('planUtils', () => {
       expect(result).toContain('Plan file does not exist');
     });
 
-    it('should detect path traversal via symbolic links', async () => {
-      const maliciousPath = 'malicious.md';
-      const fullMaliciousPath = path.join(plansDir, maliciousPath);
+    it.skipIf(!canCreateSymlinks())(
+      'should detect path traversal via symbolic links',
+      async () => {
+        const maliciousPath = 'malicious.md';
+        const fullMaliciousPath = path.join(plansDir, maliciousPath);
 
-      // Create a file outside the plans directory
-      const outsideFile = path.join(tempRootDir, 'outside.md');
-      fs.writeFileSync(outsideFile, 'secret content');
+        // Create a file outside the plans directory
+        const outsideFile = path.join(tempRootDir, 'outside.md');
+        fs.writeFileSync(outsideFile, 'secret content');
 
-      // Create a symbolic link pointing outside the plans directory
-      fs.symlinkSync(outsideFile, fullMaliciousPath);
+        // Create a symbolic link pointing outside the plans directory
+        fs.symlinkSync(outsideFile, fullMaliciousPath);
 
-      const result = await validatePlanPath(
-        maliciousPath,
-        plansDir,
-        tempRootDir,
-      );
-      expect(result).toContain('Access denied');
-    });
+        const result = await validatePlanPath(
+          maliciousPath,
+          plansDir,
+          tempRootDir,
+        );
+        expect(result).toContain('Access denied');
+      },
+    );
   });
 
   describe('validatePlanContent', () => {


### PR DESCRIPTION
Closes #28830.

On a clean Windows checkout, `npx vitest run` in `packages/core` reports **13 failures before any change is made**. None of them indicate a product defect — 8 need a privilege Windows does not grant by default, 4 need PowerShell 7. This makes them skip with a reason instead.

The problem was never that they fail. It is that a contributor cannot tell them from a regression they just caused, and `test_windows` is gated on `github.repository == 'google-gemini/gemini-cli'`, so it does not run on forks — there is no reference result to diff against.

## Capability probes, not platform checks

Both guards ask the host what it can do rather than what it is:

```ts
it.skipIf(!canCreateSymlinks())('should resolve symbolic links', ...)
describe.skipIf(!isWindows || !hasPowerShell7())('ShellExecutionService Windows quoting (real shell)', ...)
```

`skipIf(process.platform === 'win32')` would have been one line shorter and worse: it would also skip Windows contributors who *do* have Developer Mode or `pwsh` installed, and those are exactly the people most likely to be changing this code. `canCreateSymlinks()` creates one real link in a temp dir and caches the result; its cleanup is wrapped so the probe can never fail a suite it exists only to describe.

For the quoting suite, the precondition was already written down — in prose, in the file's own header:

> These tests exercise the full pipeline end-to-end. They pass when gemini-cli selects pwsh.exe from PATH; they fail when the pipeline routes through Windows PowerShell 5.1.

This turns that sentence into the guard.

## Verification

Targeted run over the six affected files, before and after:

```
before:  11 failed
after:    5 passed | 1 skipped (files)
          150 passed | 12 skipped (tests), 0 failed
```

Full `packages/core` suite before the change: `14 failed | 392 passed` files, `13 failed | 7396 passed` tests. After, the count drops to the one item below. `prettier` and `eslint --max-warnings 0` are clean on all changed files (the repo's pre-commit hook re-ran both on the staged set).

## One failure I did not fix, and am not claiming

`SandboxManager Integration > automatically allows write access to .git when running git command` still fails here:

```
Stderr: 0 [main] sh (21420) C:\Program Files\Git\usr\bin\sh.exe: *** fatal error -
NtCreateDirectoryObject(\BaseNamedObjects\msys-2.0S5-...): 0xC0000022
```

The sandbox binary shells out to msys `sh`, which cannot create its shared object — almost certainly because I invoked the suite from Git Bash, so a second msys runtime was already holding it. That is an environment interaction, not a capability a probe can honestly test, and I would rather leave it visible than paper over it with a guard that hides a real failure later. Worth a separate look by someone running from PowerShell or cmd.

I also would not trust a repeat full-suite run I did while another suite was still running — it produced per-test durations of 664,000ms and above, which is machine contention rather than signal. The numbers quoted above come from clean runs.

## Placement note

The probes live in `packages/core/src/test-utils/` rather than the shared `packages/test-utils`. I tried the shared package first; importing that barrel from a `core` test fails with `Failed to resolve entry for package "@google/gemini-cli-core"`, because the barrel re-exports modules that import core. If you would rather they were shared, that resolution issue needs solving first and is bigger than this change.

## Third Windows finding, not in this PR

While setting this up: `git clone` of this repo on Windows **without** `core.longpaths=true` leaves the working tree broken. Several snapshot filenames exceed the 260-character limit:

```
error: cannot stat 'packages/cli/src/ui/components/__snapshots__/
InputPrompt-InputPrompt-Highlighting-and-Cursor-Display-multi-line-scenarios-should-display-
cursor-correctly-at-the-beginning-of-a-line-in-a-multiline-block.snap.svg': Filename too long
```

git then records them as staged deletions — 3037 dirty entries in a repo that looks cloned. `git clone -c core.longpaths=true` gives 0 dirty files, which confirms the cause. Nothing in CONTRIBUTING mentions it, and it is a worse first-contact failure than the test noise this PR addresses. Happy to send a docs PR for that separately if useful.