### PR TITLE
fix(core): suppress spurious ENOENT warning for transient subdirs in workspace scan

### DIFF
--- a/docs/superpowers/plans/2026-08-16-workspace-scan-enoent-warning.md
+++ b/docs/superpowers/plans/2026-08-16-workspace-scan-enoent-warning.md
@@ -1,0 +1,43 @@
+# Plan: Fix spurious ENOENT warning during workspace scan (#28826)
+
+## Problem
+
+`getFolderStructure` BFS walker warns on ENOENT when a subdirectory (e.g.
+`projects.json.lock`) disappears between `readdir` and recursive descent. This
+is a normal race — lock dirs are transient — but `debugLogger.warn` calls
+`console.warn` unconditionally, producing visible noise.
+
+## Fix
+
+**File:** `packages/core/src/utils/getFolderStructure.ts`, lines 113–129 (catch
+block in `readFullStructure`)
+
+Separate ENOENT from EACCES/EPERM:
+
+- ENOENT on root path → `return null` (unchanged)
+- ENOENT on non-root path → silent `continue` (race condition, no warning)
+- EACCES / EPERM → `debugLogger.warn` + `continue` (real access problem, keep
+  warning)
+
+## Test
+
+**File:** `packages/core/src/utils/getFolderStructure.test.ts`
+
+Add:
+`'should silently skip a subdirectory that disappears between readdir and descent'`
+
+- Spy on `fsPromises.readdir` to throw ENOENT for one specific subdir path
+- Assert structure still returns successfully
+- Assert `console.warn` was NOT called
+
+## Verify
+
+```bash
+npm test -w @google/gemini-cli-core -- src/utils/getFolderStructure.test.ts
+npm run preflight
+```
+
+## Rollback
+
+Revert the two-line logic change in getFolderStructure.ts; the test file change
+can stay.

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import { getFolderStructure } from './getFolderStructure.js';
@@ -204,6 +204,41 @@ ${testRootDir}${path.sep}
     expect(structure).toContain(
       `Error: Could not read directory "${nonExistentPath}". Check path and permissions.`,
     );
+  });
+
+  it('should silently skip a subdirectory that disappears between readdir and descent', async () => {
+    await createTestFile('stable.txt');
+    await createEmptyDir('stable-folder');
+    await createEmptyDir('vanishing-folder');
+
+    const vanishingPath = path.join(testRootDir, 'vanishing-folder');
+    const originalReaddir = fsPromises.readdir;
+    const readdirSpy = vi
+      .spyOn(fsPromises, 'readdir')
+      .mockImplementation(async (p, opts) => {
+        if (String(p) === vanishingPath) {
+          const err = Object.assign(
+            new Error('ENOENT: no such file or directory'),
+            {
+              code: 'ENOENT',
+            },
+          );
+          throw err;
+        }
+        return originalReaddir(p, opts);
+      });
+
+    const warnSpy = vi.spyOn(console, 'warn');
+
+    try {
+      const structure = await getFolderStructure(testRootDir);
+      expect(structure).toContain('stable.txt');
+      expect(structure).toContain('stable-folder');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      readdirSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('should handle deep folder structure within limits', async () => {

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -111,20 +111,21 @@ async function readFullStructure(
       // Sort entries alphabetically by name for consistent processing order
       entries = rawEntries.sort((a, b) => a.name.localeCompare(b.name));
     } catch (error: unknown) {
-      if (
-        isNodeError(error) &&
-        (error.code === 'EACCES' ||
-          error.code === 'ENOENT' ||
-          error.code === 'EPERM')
-      ) {
-        debugLogger.warn(
-          `Warning: Could not read directory ${currentPath}: ${error.message}`,
-        );
-        if (currentPath === rootPath && error.code === 'ENOENT') {
-          return null; // Root directory itself not found
+      if (isNodeError(error)) {
+        if (error.code === 'ENOENT') {
+          if (currentPath === rootPath) {
+            return null; // Root directory itself not found
+          }
+          // Directory disappeared between readdir and descent (e.g. transient lock
+          // dirs released by proper-lockfile). This is a normal race — skip silently.
+          continue;
         }
-        // For other EACCES/ENOENT/EPERM on subdirectories, just skip them.
-        continue;
+        if (error.code === 'EACCES' || error.code === 'EPERM') {
+          debugLogger.warn(
+            `Warning: Could not read directory ${currentPath}: ${error.message}`,
+          );
+          continue;
+        }
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Eliminates the spurious `Warning: Could not read directory ... projects.json.lock: ENOENT` message that appears when the BFS workspace tree walker encounters a transient lock directory that disappears between `readdir` and recursive descent.
- `ENOENT` on a non-root subdirectory is a normal race condition (e.g. `proper-lockfile` releases `.gemini/projects.json.lock` mid-scan). It is now skipped silently instead of calling `debugLogger.warn` (which calls `console.warn` unconditionally).
- `EACCES` and `EPERM` still produce the warning, since those indicate genuine access problems.

## Details

Root cause is in `packages/core/src/utils/getFolderStructure.ts` `readFullStructure()`. The original catch block grouped `ENOENT`, `EACCES`, and `EPERM` together and always called `debugLogger.warn` before deciding what to do. The fix separates the three cases:

- `ENOENT` on root → `return null` (unchanged)
- `ENOENT` on non-root → silent `continue` (race, expected)
- `EACCES` / `EPERM` → warn + `continue` (real problem, keep warning)

## Related Issues

Fixes #28826

## How to Validate

```bash
# Reproduce the original warning
workdir="$(mktemp -d)"
mkdir -p "$workdir/.gemini"
HOME="$workdir" GEMINI_CLI_HOME="$workdir" gemini -p "write hello.txt" --yolo
# After this fix: no "Warning: Could not read directory ... ENOENT" line in output

# Run the targeted unit test
npm test -w @google/gemini-cli-core -- src/utils/getFolderStructure.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run