### PR TITLE
fix(core): skip user agents dir when workspace is home to avoid duplicate warnings

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -285,7 +285,7 @@ describe('AgentRegistry', () => {
 
       await registry.initialize();
 
-      // loadAgentsFromDirectory called only once (project dir == user dir, so skip user dir)
+      // loadAgentsFromDirectory called only once (project pass skipped, user pass runs)
       expect(
         vi.mocked(tomlLoader.loadAgentsFromDirectory),
       ).toHaveBeenCalledTimes(1);

--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -268,6 +268,34 @@ describe('AgentRegistry', () => {
       ).toHaveBeenCalledTimes(2);
     });
 
+    it('should load user agents only once when workspace is the home directory', async () => {
+      mockConfig = makeMockedConfig({ enableAgents: true });
+      registry = new TestableAgentRegistry(mockConfig);
+      vi.spyOn(mockConfig.storage, 'isWorkspaceHomeDir').mockReturnValue(true);
+
+      const agent = { ...MOCK_AGENT_V1, name: 'home-agent' };
+      vi.mocked(tomlLoader.loadAgentsFromDirectory).mockResolvedValueOnce({
+        agents: [agent],
+        errors: [],
+      });
+
+      const feedbackSpy = vi
+        .spyOn(coreEvents, 'emitFeedback')
+        .mockImplementation(() => {});
+
+      await registry.initialize();
+
+      // loadAgentsFromDirectory called only once (project dir == user dir, so skip user dir)
+      expect(
+        vi.mocked(tomlLoader.loadAgentsFromDirectory),
+      ).toHaveBeenCalledTimes(1);
+      expect(feedbackSpy).not.toHaveBeenCalledWith(
+        'warning',
+        expect.stringContaining('Duplicate agent name'),
+      );
+      expect(registry.getDefinition('home-agent')).toBeDefined();
+    });
+
     it('should NOT load TOML agents when enableAgents is false', async () => {
       const disabledConfig = makeMockedConfig({
         enableAgents: false,

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -170,100 +170,95 @@ export class AgentRegistry {
     }
 
     // Load project-level agents: .gemini/agents/ (relative to Project Root)
+    // Skip when workspace IS the home directory — those agents will be loaded as
+    // user agents below, which is the correct trust level (no acknowledgment required).
     const folderTrustEnabled = this.config.getFolderTrust();
     const isTrustedFolder = this.config.isTrustedFolder();
 
-    if (!folderTrustEnabled || isTrustedFolder) {
-      const projectAgentsDir = this.config.storage.getProjectAgentsDir();
-      const projectAgents = await loadAgentsFromDirectory(projectAgentsDir);
-      for (const error of projectAgents.errors) {
-        const msg = `Agent loading error: ${error.message}`;
-        errors?.push(msg);
-        coreEvents.emitFeedback('error', msg);
-      }
-
-      const ackService = this.config.getAcknowledgedAgentsService();
-      const projectRoot = this.config.getProjectRoot();
-      const unacknowledgedAgents: AgentDefinition[] = [];
-      const agentsToRegister: AgentDefinition[] = [];
-
-      for (const agent of projectAgents.agents) {
-        this.ensureRemoteAgentHash(agent);
-
-        if (!agent.metadata?.hash) {
-          agentsToRegister.push(agent);
-          continue;
+    if (!this.config.storage.isWorkspaceHomeDir()) {
+      if (!folderTrustEnabled || isTrustedFolder) {
+        const projectAgentsDir = this.config.storage.getProjectAgentsDir();
+        const projectAgents = await loadAgentsFromDirectory(projectAgentsDir);
+        for (const error of projectAgents.errors) {
+          const msg = `Agent loading error: ${error.message}`;
+          errors?.push(msg);
+          coreEvents.emitFeedback('error', msg);
         }
 
-        const isAcknowledged = await ackService.isAcknowledged(
-          projectRoot,
-          agent.name,
-          agent.metadata.hash,
-        );
+        const ackService = this.config.getAcknowledgedAgentsService();
+        const projectRoot = this.config.getProjectRoot();
+        const unacknowledgedAgents: AgentDefinition[] = [];
+        const agentsToRegister: AgentDefinition[] = [];
 
-        if (isAcknowledged) {
-          agentsToRegister.push(agent);
-        } else {
-          unacknowledgedAgents.push(agent);
-        }
-      }
+        for (const agent of projectAgents.agents) {
+          this.ensureRemoteAgentHash(agent);
 
-      if (unacknowledgedAgents.length > 0) {
-        coreEvents.emitAgentsDiscovered(unacknowledgedAgents);
-      }
-
-      await Promise.allSettled(
-        agentsToRegister.map(async (agent) => {
-          try {
-            await this.registerAgent(agent, errors);
-          } catch (e) {
-            const msg = `Error registering project agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
-            debugLogger.warn(`[AgentRegistry] ${msg}`, e);
-            errors?.push(msg);
-            coreEvents.emitFeedback('error', msg);
+          if (!agent.metadata?.hash) {
+            agentsToRegister.push(agent);
+            continue;
           }
-        }),
-      );
-    } else {
-      coreEvents.emitFeedback(
-        'info',
-        'Skipping project agents due to untrusted folder. To enable, ensure that the project root is trusted.',
-      );
+
+          const isAcknowledged = await ackService.isAcknowledged(
+            projectRoot,
+            agent.name,
+            agent.metadata.hash,
+          );
+
+          if (isAcknowledged) {
+            agentsToRegister.push(agent);
+          } else {
+            unacknowledgedAgents.push(agent);
+          }
+        }
+
+        if (unacknowledgedAgents.length > 0) {
+          coreEvents.emitAgentsDiscovered(unacknowledgedAgents);
+        }
+
+        await Promise.allSettled(
+          agentsToRegister.map(async (agent) => {
+            try {
+              await this.registerAgent(agent, errors);
+            } catch (e) {
+              const msg = `Error registering project agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
+              debugLogger.warn(`[AgentRegistry] ${msg}`, e);
+              errors?.push(msg);
+              coreEvents.emitFeedback('error', msg);
+            }
+          }),
+        );
+      } else {
+        coreEvents.emitFeedback(
+          'info',
+          'Skipping project agents due to untrusted folder. To enable, ensure that the project root is trusted.',
+        );
+      }
     }
 
     // Load user-level agents: ~/.gemini/agents/
-    // Skip when the workspace IS the home directory — the project agents dir already
-    // resolves to the same path, so agents were loaded above and a second pass
-    // would cause duplicate-agent warnings for every file in that directory.
     const userAgentsDir = Storage.getUserAgentsDir();
-    const projectAgentsAlreadyCoveredUserDir =
-      (!folderTrustEnabled || isTrustedFolder) &&
-      this.config.storage.isWorkspaceHomeDir();
-
-    if (!projectAgentsAlreadyCoveredUserDir) {
-      const userAgents = await loadAgentsFromDirectory(userAgentsDir);
-      for (const error of userAgents.errors) {
-        debugLogger.warn(
-          `[AgentRegistry] Error loading user agent: ${error.message}`,
-        );
-        const msg = `Agent loading error: ${error.message}`;
-        errors?.push(msg);
-        coreEvents.emitFeedback('error', msg);
-      }
-      await Promise.allSettled(
-        userAgents.agents.map(async (agent) => {
-          try {
-            this.ensureRemoteAgentHash(agent);
-            await this.registerAgent(agent, errors);
-          } catch (e) {
-            const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
-            debugLogger.warn(`[AgentRegistry] ${msg}`, e);
-            errors?.push(msg);
-            coreEvents.emitFeedback('error', msg);
-          }
-        }),
+    const userAgents = await loadAgentsFromDirectory(userAgentsDir);
+    for (const error of userAgents.errors) {
+      debugLogger.warn(
+        `[AgentRegistry] Error loading user agent: ${error.message}`,
       );
+      const msg = `Agent loading error: ${error.message}`;
+      errors?.push(msg);
+      coreEvents.emitFeedback('error', msg);
     }
+    await Promise.allSettled(
+      userAgents.agents.map(async (agent) => {
+        try {
+          this.ensureRemoteAgentHash(agent);
+          await this.registerAgent(agent, errors);
+        } catch (e) {
+          const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
+          debugLogger.warn(`[AgentRegistry] ${msg}`, e);
+          errors?.push(msg);
+          coreEvents.emitFeedback('error', msg);
+        }
+      }),
+    );
 
     // Load agents from extensions
     for (const extension of this.config.getExtensions()) {

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -232,29 +232,38 @@ export class AgentRegistry {
     }
 
     // Load user-level agents: ~/.gemini/agents/
+    // Skip when the workspace IS the home directory — the project agents dir already
+    // resolves to the same path, so agents were loaded above and a second pass
+    // would cause duplicate-agent warnings for every file in that directory.
     const userAgentsDir = Storage.getUserAgentsDir();
-    const userAgents = await loadAgentsFromDirectory(userAgentsDir);
-    for (const error of userAgents.errors) {
-      debugLogger.warn(
-        `[AgentRegistry] Error loading user agent: ${error.message}`,
+    const projectAgentsAlreadyCoveredUserDir =
+      (!folderTrustEnabled || isTrustedFolder) &&
+      this.config.storage.isWorkspaceHomeDir();
+
+    if (!projectAgentsAlreadyCoveredUserDir) {
+      const userAgents = await loadAgentsFromDirectory(userAgentsDir);
+      for (const error of userAgents.errors) {
+        debugLogger.warn(
+          `[AgentRegistry] Error loading user agent: ${error.message}`,
+        );
+        const msg = `Agent loading error: ${error.message}`;
+        errors?.push(msg);
+        coreEvents.emitFeedback('error', msg);
+      }
+      await Promise.allSettled(
+        userAgents.agents.map(async (agent) => {
+          try {
+            this.ensureRemoteAgentHash(agent);
+            await this.registerAgent(agent, errors);
+          } catch (e) {
+            const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
+            debugLogger.warn(`[AgentRegistry] ${msg}`, e);
+            errors?.push(msg);
+            coreEvents.emitFeedback('error', msg);
+          }
+        }),
       );
-      const msg = `Agent loading error: ${error.message}`;
-      errors?.push(msg);
-      coreEvents.emitFeedback('error', msg);
     }
-    await Promise.allSettled(
-      userAgents.agents.map(async (agent) => {
-        try {
-          this.ensureRemoteAgentHash(agent);
-          await this.registerAgent(agent, errors);
-        } catch (e) {
-          const msg = `Error registering user agent "${agent.name}": ${e instanceof Error ? e.message : String(e)}`;
-          debugLogger.warn(`[AgentRegistry] ${msg}`, e);
-          errors?.push(msg);
-          coreEvents.emitFeedback('error', msg);
-        }
-      }),
-    );
 
     // Load agents from extensions
     for (const extension of this.config.getExtensions()) {


### PR DESCRIPTION
## Summary

- Eliminates the spurious `Duplicate agent name '<name>' detected` warning that appears whenever the user runs Gemini CLI from their home directory.
- Root cause: `getProjectAgentsDir()` and `getUserAgentsDir()` both resolve to `~/.gemini/agents` when the workspace is `~`. The registry loaded that directory twice, hitting the duplicate-detection guard on every agent file.
- Fix: gate the user-agents load on `storage.isWorkspaceHomeDir()`. If the workspace is the home directory AND project agents were loaded (folder trust not blocking), the user agents dir is already covered — skip the second pass.

## Details

Change is in `packages/core/src/agents/AgentRegistry.loadAgents()`. The existing `Storage.isWorkspaceHomeDir()` helper already performs the symlink-aware path comparison, so no new utilities are needed. The condition also accounts for the folder-trust case: if project agents were skipped due to an untrusted folder, user agents are still loaded normally even when CWD is `~`.

## Related Issues

Fixes #27692

## How to Validate

```bash
# Create an agent in ~/.gemini/agents/
mkdir -p ~/.gemini/agents
cat > ~/.gemini/agents/test-agent.md <<'MD'
---
name: test-agent
description: Test agent for dedup validation
---
A test agent.
MD

# Run Gemini CLI from home directory
cd ~
gemini -p "hi" --yolo
# Before fix: "Duplicate agent name 'test-agent' detected. The later definition will be ignored."
# After fix:  no duplicate warning

# Run the targeted unit test
npm test -w @google/gemini-cli-core -- src/agents/registry.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run