### PR TITLE
fix(core): show Auto in /model when dynamicModelConfiguration is enabled and user lacks preview access

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -407,7 +407,7 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
     auto: {
       displayName: 'Auto',
       tier: 'auto',
-      isPreview: true,
+      isPreview: false,
       isVisible: true,
       features: { thinking: true, multimodalToolUse: false },
     },

--- a/packages/core/src/services/modelConfigService.test.ts
+++ b/packages/core/src/services/modelConfigService.test.ts
@@ -1118,6 +1118,19 @@ describe('ModelConfigService', () => {
   });
 
   describe('getAvailableModelOptions', () => {
+    it('should include auto when hasAccessToPreview is false', () => {
+      const config: ModelConfigServiceConfig = {
+        modelDefinitions: {
+          auto: { isVisible: true, tier: 'auto', isPreview: false },
+        },
+      };
+      const service = new ModelConfigService(config);
+      const options = service.getAvailableModelOptions({
+        hasAccessToPreview: false,
+      });
+      expect(options.map((o) => o.modelId)).toContain('auto');
+    });
+
     it('should filter out Pro models when hasAccessToProModel is false', () => {
       const config: ModelConfigServiceConfig = {
         modelDefinitions: {


### PR DESCRIPTION
## Summary

- `Auto` was missing from the `/model` picker when `dynamicModelConfiguration` is enabled and the user has no preview access.
- Root cause: `defaultModelConfigs.ts` marks the `auto` alias with `isPreview: true`. `ModelConfigService.getAvailableModelOptions` filters out any model where `isPreview && !hasAccessToPreview`. Since `auto` routes to stable models when preview is unavailable, it should never be hidden from non-preview users.
- Fix: one-field change — `isPreview: false` on the `auto` alias in `defaultModelConfigs.ts`.

## Details

Only `defaultModelConfigs.ts` changed (one field). The filtering logic in `modelConfigService.ts` is correct; the bug was the metadata. Added a regression test asserting `auto` appears in the available model list when `hasAccessToPreview` is false.

## Related Issues

Fixes #27715

## How to Validate

```bash
# With dynamicModelConfiguration enabled in settings.json, run:
gemini
/model
# Before fix: Auto not listed
# After fix: Auto listed

# Unit test
npm test -w @google/gemini-cli-core -- src/services/modelConfigService.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [x] npm run