### PR TITLE
fix(telemetry): wrap logChatCompression OTel calls in bufferTelemetryEvent

### DIFF
--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -199,6 +199,14 @@ describe('loggers', () => {
         { tokens_before: 9001, tokens_after: 9000 },
       );
     });
+
+    it('wraps OTel emit and metrics inside bufferTelemetryEvent', () => {
+      logChatCompression(
+        makeFakeConfig(),
+        makeChatCompressionEvent({ tokens_before: 100, tokens_after: 50 }),
+      );
+      expect(sdk.bufferTelemetryEvent).toHaveBeenCalled();
+    });
   });
 
   describe('logCliConfiguration', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -461,16 +461,18 @@ export function logChatCompression(
 ): void {
   ClearcutLogger.getInstance(config)?.logChatCompressionEvent(event);
 
-  const logger = logs.getLogger(SERVICE_NAME);
-  const logRecord: LogRecord = {
-    body: event.toLogBody(),
-    attributes: event.toOpenTelemetryAttributes(config),
-  };
-  logger.emit(logRecord);
+  bufferTelemetryEvent(() => {
+    const logger = logs.getLogger(SERVICE_NAME);
+    const logRecord: LogRecord = {
+      body: event.toLogBody(),
+      attributes: event.toOpenTelemetryAttributes(config),
+    };
+    logger.emit(logRecord);
 
-  recordChatCompressionMetrics(config, {
-    tokens_before: event.tokens_before,
-    tokens_after: event.tokens_after,
+    recordChatCompressionMetrics(config, {
+      tokens_before: event.tokens_before,
+      tokens_after: event.tokens_after,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- `logChatCompression` was the only function in `loggers.ts` calling `logger.emit()` and `recordChatCompressionMetrics()` outside of `bufferTelemetryEvent`. All ~48 other loggers use the wrapper.
- Without the wrapper, events fired before the OTel SDK finishes initializing are emitted against a no-op provider and silently dropped.

## Details

One-function change in `packages/core/src/telemetry/loggers.ts` — wraps the existing `logger.emit` + `recordChatCompressionMetrics` block in `bufferTelemetryEvent`, matching every other logger in the file. The `ClearcutLogger` call stays outside (it has its own buffering). Added one assertion to the existing test verifying `bufferTelemetryEvent` is called.

## Related Issues

Fixes #23445

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/telemetry/loggers.test.ts
```

## Pre-Merge Checklist

- [x] Added/updated tests
- [ ] Noted breaking changes — none
- [ ] Validated on platforms:
  - [ ] MacOS — npm run