### PR TITLE
fix(perf-tests): update ripgrep import from canUseRipgrep to resolveRipgrepPath

### DIFF
--- a/perf-tests/globalSetup.ts
+++ b/perf-tests/globalSetup.ts
@@ -7,7 +7,7 @@
 import { mkdir, readdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { canUseRipgrep } from '../packages/core/src/tools/ripGrep.js';
+import { resolveRipgrepPath } from '../packages/core/src/tools/ripGrep.js';
 import { isolateTestEnv } from '../packages/test-utils/src/env-setup.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -24,8 +24,8 @@ export async function setup() {
   isolateTestEnv(runDir);
 
   // Download ripgrep to avoid race conditions
-  const available = await canUseRipgrep();
-  if (!available) {
+  const ripgrepPath = await resolveRipgrepPath();
+  if (!ripgrepPath) {
     throw new Error('Failed to download ripgrep binary');
   }
 


### PR DESCRIPTION
## Summary

- Nightly performance tests abort in global setup because `perf-tests/globalSetup.ts` still imports `canUseRipgrep`, which was removed in `0750b01f` when it was replaced by `resolveRipgrepPath`.
- One-file fix: update the import name and update the availability check to use the `string | null` return value.

## Related Issues

Fixes #28417

## How to Validate

The nightly perf workflow ([perf-nightly.yml](https://github.com/google-gemini/gemini-cli/actions/workflows/perf-nightly.yml)) should no longer abort at global setup with `canUseRipgrep is not exported`.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed) — perf tests are CI-only; no unit test for this global setup entry point
- [ ] Noted breaking changes — none