### PR TITLE
fix(core): normalize MCP tool schemas to ensure type:object at root

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -48,7 +48,7 @@ import {
 } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import { ServiceAccountImpersonationProvider } from '../mcp/sa-impersonation-provider.js';
-import { DiscoveredMCPTool } from './mcp-tool.js';
+import { DiscoveredMCPTool, normalizeToolSchema } from './mcp-tool.js';
 import { McpComplianceTransport } from './mcp-compliance-transport.js';
 
 import type { CallableTool, FunctionCall, Part, Tool } from '@google/genai';
@@ -1371,7 +1371,7 @@ export async function discoverTools(
           mcpServerName,
           toolDef.name,
           toolDef.description ?? '',
-          toolDef.inputSchema ?? { type: 'object', properties: {} },
+          normalizeToolSchema(toolDef.inputSchema),
           messageBus,
           mcpServerConfig.trust,
           isReadOnly,

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -19,6 +19,7 @@ import {
   DiscoveredMCPTool,
   generateValidName,
   formatMcpToolName,
+  normalizeToolSchema,
 } from './mcp-tool.js'; // Added getStringifiedResultForDisplay
 import { ToolConfirmationOutcome, type ToolResult } from './tools.js';
 import type { CallableTool, Part } from '@google/genai';
@@ -50,6 +51,42 @@ const createSdkResponse = (
     },
   },
 ];
+
+describe('normalizeToolSchema', () => {
+  it('passes through a valid {type:object} schema unchanged', () => {
+    const s = { type: 'object', properties: { x: { type: 'string' } } };
+    expect(normalizeToolSchema(s)).toBe(s);
+  });
+  it('injects type:object when type is missing', () => {
+    expect(normalizeToolSchema({ properties: {} })).toEqual({
+      properties: {},
+      type: 'object',
+    });
+  });
+  it('overrides a non-object type and ensures properties is present', () => {
+    expect(normalizeToolSchema({ type: 'string' })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+  it('normalizes malformed properties to empty object', () => {
+    expect(normalizeToolSchema({ type: 'object', properties: null })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+    expect(normalizeToolSchema({ type: 'object', properties: [] })).toEqual({
+      type: 'object',
+      properties: {},
+    });
+  });
+  it('returns default schema for null/undefined/array/primitive', () => {
+    const def = { type: 'object', properties: {} };
+    expect(normalizeToolSchema(null)).toEqual(def);
+    expect(normalizeToolSchema(undefined)).toEqual(def);
+    expect(normalizeToolSchema([])).toEqual(def);
+    expect(normalizeToolSchema('string')).toEqual(def);
+  });
+});
 
 describe('generateValidName', () => {
   it('should return a valid name for a simple function', () => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -153,6 +153,31 @@ type McpContentBlock =
   | McpResourceBlock
   | McpResourceLinkBlock;
 
+/**
+ * Ensures a tool parameter schema has `type: 'object'` at root, as required by
+ * strict JSON Schema validators (e.g. Vertex AI in strict mode). MCP servers
+ * sometimes omit `type` or use a non-object type at root.
+ */
+export function normalizeToolSchema(schema: unknown): Record<string, unknown> {
+  if (schema && typeof schema === 'object' && !Array.isArray(schema)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const s = schema as Record<string, unknown>;
+    const p = s['properties'];
+    const hasValidProperties =
+      p != null && typeof p === 'object' && !Array.isArray(p);
+    if (s['type'] === 'object' && hasValidProperties) {
+      return s;
+    }
+    return {
+      ...s,
+      type: 'object',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      properties: hasValidProperties ? (p as Record<string, unknown>) : {},
+    };
+  }
+  return { type: 'object', properties: {} };
+}
+
 export class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   ToolParams,
   ToolResult

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -18,7 +18,7 @@ import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../policy/types.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
-import { DiscoveredMCPTool } from './mcp-tool.js';
+import { DiscoveredMCPTool, normalizeToolSchema } from './mcp-tool.js';
 import { parse } from 'shell-quote';
 import { ToolErrorType } from './tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
@@ -497,20 +497,13 @@ export class ToolRegistry {
             debugLogger.warn('Discovered a tool with no name. Skipping.');
             continue;
           }
-          const parameters =
-            func.parametersJsonSchema &&
-            typeof func.parametersJsonSchema === 'object' &&
-            !Array.isArray(func.parametersJsonSchema)
-              ? func.parametersJsonSchema
-              : {};
           this.registerTool(
             new DiscoveredTool(
               this.config,
               func.name,
               DISCOVERED_TOOL_PREFIX + func.name,
               func.description ?? '',
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-              parameters as Record<string, unknown>,
+              normalizeToolSchema(func.parametersJsonSchema),
               this.messageBus,
             ),
           );


### PR DESCRIPTION
## Summary

- MCP servers sometimes advertise tool schemas with missing `type`, a non-object `type`, or a completely malformed structure. Strict JSON Schema validators (Vertex AI in strict mode, or any provider that validates schemas before forwarding) reject these with `tools.N.custom.input_schema.type: Input should be 'object'`.
- Added `normalizeToolSchema()` in `mcp-tool.ts` and applied it at both instantiation points.

## Details

`normalizeToolSchema(schema)`:
- Valid `{type: 'object', ...}` schema → returned as-is (no allocation)
- Object missing `type` or with wrong `type` → spreads existing fields, injects `type: 'object'`
- `null`/`undefined`/array/primitive → returns `{type: 'object', properties: {}}`

Applied at:
1. `mcp-client.ts` line 1374: `toolDef.inputSchema ?? {…}` → `normalizeToolSchema(toolDef.inputSchema)`
2. `tool-registry.ts` lines 500–505: replaced the existing object/array guard → `normalizeToolSchema(func.parametersJsonSchema)`

Both callers already import from `mcp-tool.ts` so no new dependency edge.

## Related Issues

Fixes #23382

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/tools/mcp-tool.test.ts
```

## Pre-Merge Checklist

- [x] Added/updated tests — 4 new cases for `normalizeToolSchema`
- [ ] Noted breaking changes — none; previously-malformed schemas now always get `type: 'object'` injected