### PR TITLE
fix(a2a-server): deep-merge nested settings to prevent user config loss

### DIFF
--- a/packages/a2a-server/src/config/settings.test.ts
+++ b/packages/a2a-server/src/config/settings.test.ts
@@ -128,7 +128,7 @@ describe('loadSettings', () => {
     expect(result.experimental?.enableAgents).toBe(true);
   });
 
-  it('should overwrite top-level settings from workspace (shallow merge)', () => {
+  it('should deep-merge nested settings from workspace, preserving unspecified user keys', () => {
     const userSettings = {
       showMemoryUsage: false,
       fileFiltering: {
@@ -154,9 +154,10 @@ describe('loadSettings', () => {
     // Primitive value overwritten
     expect(result.showMemoryUsage).toBe(true);
 
-    // Object value completely replaced (shallow merge behavior)
+    // Workspace partial override merged into user's nested object
     expect(result.fileFiltering?.respectGitIgnore).toBe(false);
-    expect(result.fileFiltering?.enableRecursiveFileSearch).toBeUndefined();
+    // Deep merge: user's enableRecursiveFileSearch preserved
+    expect(result.fileFiltering?.enableRecursiveFileSearch).toBe(true);
   });
 
   describe('security', () => {

--- a/packages/a2a-server/src/config/settings.ts
+++ b/packages/a2a-server/src/config/settings.ts
@@ -139,12 +139,33 @@ export function loadSettings(
     }
   }
 
-  // If there are overlapping keys, the values of workspaceSettings will
-  // override values from userSettings
-  const mergedSettings = {
-    ...userSettings,
-    ...workspaceSettings,
-  };
+  // Deep-merge so workspace overrides specific nested keys without erasing
+  // sibling keys from user settings (e.g. partial fileFiltering override).
+  const mergedSettings: Settings = { ...userSettings };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  for (const key of Object.keys(workspaceSettings) as Array<keyof Settings>) {
+    const wsVal = workspaceSettings[key];
+    const uVal = mergedSettings[key];
+    if (
+      wsVal !== null &&
+      wsVal !== undefined &&
+      uVal !== null &&
+      uVal !== undefined &&
+      typeof wsVal === 'object' &&
+      !Array.isArray(wsVal) &&
+      typeof uVal === 'object' &&
+      !Array.isArray(uVal)
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      (mergedSettings as Record<string, unknown>)[key] = {
+        ...(uVal as object),
+        ...(wsVal as object),
+      };
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      (mergedSettings as Record<string, unknown>)[key] = wsVal;
+    }
+  }
 
   // Security: ensure policyPaths and adminPolicyPaths are only loaded from trusted, user-level
   // configuration and cannot be overridden by workspace-level settings, even if the


### PR DESCRIPTION
## Summary

- A2A server combined user and workspace settings with a shallow spread, so a workspace `fileFiltering: { respectGitIgnore: false }` would erase the user's `enableRecursiveFileSearch: true` entirely.
- Replaced the spread with an inline one-level deep merge: for each key in workspace settings, if both sides are plain objects the key is merged; otherwise workspace value wins. Arrays and scalars are still replaced wholesale, matching expected override semantics.
- No new dependency: `customDeepMerge` from `packages/cli` is not accessible here; the one-level merge is all `Settings` needs.

## Related Issues

Fixes #25747

## How to Validate

```bash
npm test -w @google/gemini-cli-a2a-server -- src/config/settings.test.ts
```

The renamed test "should deep-merge nested settings from workspace, preserving unspecified user keys" now asserts that `enableRecursiveFileSearch` survives a partial workspace `fileFiltering` override.

## Pre-Merge Checklist

- [x] Added/updated tests
- [ ] Breaking changes — none (behavior change: nested user config no longer erased)