### PR TITLE
docs(cli): add Homebrew deprecation notice and update existing-user message

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ npm install -g @google/gemini-cli
 
 #### Install globally with Homebrew (macOS/Linux)
 
+> **Note:** The `gemini-cli` formula is deprecated in `homebrew-core`. For the
+> most up-to-date version, use npm or another method above.
+
 ```bash
 brew install gemini-cli
 ```

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -39,6 +39,10 @@ installation methods. Note that Gemini CLI comes pre-installed on
   </TabItem>
   <TabItem label="Homebrew (macOS/Linux)">
 
+  :::caution
+  The `gemini-cli` formula is deprecated in `homebrew-core`. For the most up-to-date version, use npm or another installation method.
+  :::
+
   Install globally with Homebrew:
 
   ```bash

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -177,7 +177,8 @@ describe('getInstallationInfo', () => {
     expect(info.packageManager).toBe(PackageManager.HOMEBREW);
     expect(info.isGlobal).toBe(true);
     expect(info.updateMessage).toBe(
-      'Installed via Homebrew. Please update with "brew upgrade gemini-cli".',
+      'Installed via Homebrew (deprecated in homebrew-core). ' +
+        'For the latest version, migrate to npm: npm install -g @google/gemini-cli',
     );
   });
 

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -108,7 +108,8 @@ export function getInstallationInfo(
             packageManager: PackageManager.HOMEBREW,
             isGlobal: true,
             updateMessage:
-              'Installed via Homebrew. Please update with "brew upgrade gemini-cli".',
+              'Installed via Homebrew (deprecated in homebrew-core). ' +
+              'For the latest version, migrate to npm: npm install -g @google/gemini-cli',
           };
         }
       } catch {


### PR DESCRIPTION
## Summary

- `gemini-cli` is deprecated in `homebrew-core`. New users following the docs may install a version that won't receive updates.
- Added a caution note in `docs/get-started/installation.mdx` and `README.md` directing users to npm instead.
- Updated the update-available message in `installationInfo.ts` so existing Homebrew users see a migration prompt rather than `brew upgrade gemini-cli` (which would install the deprecated version).

## Details

3 files changed:
1. `packages/cli/src/utils/installationInfo.ts` — update message for HOMEBREW now says the formula is deprecated and suggests `npm install -g @google/gemini-cli`
2. `README.md` — added Note callout before the Homebrew code block
3. `docs/get-started/installation.mdx` — added Docusaurus `:::caution` block in the Homebrew tab

The Homebrew tab/section is kept (not removed) since some users may still have it working; the deprecation notice is the minimal correct fix.

## Related Issues

Fixes #28159

## How to Validate

```bash
npm test -w @google/gemini-cli -- src/utils/installationInfo.test.ts
```

## Pre-Merge Checklist

- [x] Updated relevant documentation
- [x] Added/updated tests
- [ ] Breaking changes — none