### PR TITLE
fix(cli): handle refreshAuth failures gracefully in non-interactive mode

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1510,15 +1510,13 @@ describe('gemini.tsx main function exit codes', () => {
       networkAccess: false,
     } as unknown as CliArgs);
 
-    process.env['GEMINI_API_KEY'] = 'test-key';
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
     try {
       await main();
       expect.fail('Should have thrown MockProcessExitError');
     } catch (e) {
       expect(e).toBeInstanceOf(MockProcessExitError);
       expect((e as MockProcessExitError).code).toBe(41);
-    } finally {
-      delete process.env['GEMINI_API_KEY'];
     }
   });
 });

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1474,6 +1474,53 @@ describe('gemini.tsx main function exit codes', () => {
 
     expect(refreshAuthSpy).toHaveBeenCalledWith(AuthType.USE_GEMINI);
   });
+
+  it('should exit with 41 instead of crashing when refreshAuth fails in non-interactive mode', async () => {
+    // Force the "hop into sandbox" branch to be skipped so execution reaches
+    // the non-interactive refreshAuth call further down in main().
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      createMockConfig({
+        isInteractive: () => false,
+        getQuestion: () => 'test prompt',
+        getSandbox: () => undefined,
+        refreshAuth: vi
+          .fn()
+          .mockRejectedValue(new Error('This client is no longer supported')),
+      }),
+    );
+    vi.mocked(validateNonInteractiveAuth).mockResolvedValue(
+      AuthType.USE_GEMINI,
+    );
+
+    vi.mocked(loadSettings).mockReturnValue(
+      createMockSettings({
+        merged: {
+          security: {
+            auth: { selectedType: undefined },
+            folderTrust: { enabled: false },
+          },
+          ui: {},
+        },
+      }),
+    );
+    vi.mocked(parseArguments).mockResolvedValue({
+      enabled: true,
+      allowedPaths: [],
+      networkAccess: false,
+    } as unknown as CliArgs);
+
+    process.env['GEMINI_API_KEY'] = 'test-key';
+    try {
+      await main();
+      expect.fail('Should have thrown MockProcessExitError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(MockProcessExitError);
+      expect((e as MockProcessExitError).code).toBe(41);
+    } finally {
+      delete process.env['GEMINI_API_KEY'];
+    }
+  });
 });
 
 describe('validateDnsResolutionOrder', () => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -38,6 +38,8 @@ import {
   getProjectHash,
   loadConversationRecord,
   type MessageRecord,
+  OutputFormat,
+  getErrorMessage,
 } from '@google/gemini-cli-core';
 
 import { loadCliConfig, parseArguments } from './config/config.js';
@@ -84,6 +86,7 @@ import {
 import { validateAuthMethod } from './config/auth.js';
 import { runAcpClient } from './acp/acpStdioTransport.js';
 import { validateNonInteractiveAuth } from './validateNonInterActiveAuth.js';
+import { handleError } from './utils/errors.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import {
   RESUME_LATEST,
@@ -866,7 +869,21 @@ export async function main() {
       config,
       settings,
     );
-    await config.refreshAuth(authType);
+    try {
+      await config.refreshAuth(authType);
+    } catch (error) {
+      if (config.getOutputFormat() === OutputFormat.JSON) {
+        handleError(
+          error instanceof Error ? error : new Error(String(error)),
+          config,
+          ExitCodes.FATAL_AUTHENTICATION_ERROR,
+        );
+      } else {
+        debugLogger.error(`Failed to authenticate: ${getErrorMessage(error)}`);
+        await runExitCleanup();
+        process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR);
+      }
+    }
 
     if (config.getDebugMode()) {
       debugLogger.log('Session ID: %s', sessionId);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -872,7 +872,10 @@ export async function main() {
     try {
       await config.refreshAuth(authType);
     } catch (error) {
-      if (config.getOutputFormat() === OutputFormat.JSON) {
+      if (
+        config.getOutputFormat() === OutputFormat.JSON ||
+        config.getOutputFormat() === OutputFormat.STREAM_JSON
+      ) {
         handleError(
           error instanceof Error ? error : new Error(String(error)),
           config,


### PR DESCRIPTION
## Summary

When `refreshAuth()` fails during non-interactive (`--prompt`) startup, the
CLI can crash with an uncaught raw stack trace and exit code 1 instead of a
clean, actionable error and the dedicated auth error exit code.

## Details

`main()` in `packages/cli/src/gemini.tsx` calls `config.refreshAuth(authType)`
twice on the non-interactive path:

1. Once early (before the sandbox-launch decision), wrapped in a `try/catch`
   that records `initialAuthFailed` — but that flag is only ever checked
   inside the `if (sandboxConfig)` branch, right before relaunching into a
   sandboxed child process.
2. Once again later, unconditionally, after the full `Config` has been
   loaded — with **no error handling at all**.

For most CLI users sandboxing is not enabled, so `sandboxConfig` is
`undefined`, the `initialAuthFailed` check is never reached, and the second,
unprotected `refreshAuth()` call runs the same auth flow again. When it
throws — e.g. because Google's Code Assist backend rejects a legacy
`oauth-personal` client with `UNSUPPORTED_CLIENT` (as reported in #28846) —
the rejection is not caught anywhere in `main()`, so it propagates to the
top-level `main().catch(...)` handler in `packages/cli/index.ts`, which
treats it as "An unexpected critical error occurred" and dumps a raw stack
trace, exiting with code 1 instead of `ExitCodes.FATAL_AUTHENTICATION_ERROR`.

This PR wraps that second `refreshAuth()` call in a `try/catch`, mirroring
the existing error-handling pattern already used in
`validateNonInteractiveAuth` (JSON output → `handleError`, text output →
log + `process.exit(ExitCodes.FATAL_AUTHENTICATION_ERROR)`). Users now get a
readable "Failed to authenticate: <message>" error (which, for the
`UNSUPPORTED_CLIENT` case, already includes the server-provided migration
guidance) and exit code 41 instead of an unhandled crash.

This does not change the underlying auth/network behavior — the account
still needs to migrate or re-authenticate — it only ensures the failure is
reported cleanly instead of crashing with an uncaught exception.

## Related Issues

Related to #28846

## How to Validate

- `npx vitest run src/gemini.test.tsx -t "should exit with 41 instead of crashing"` (new test)
- `npx eslint packages/cli/src/gemini.tsx packages/cli/src/gemini.test.tsx`
- `npx tsc -p packages/cli/tsconfig.json --noEmit`

### Test output

```
✓ src/gemini.test.tsx (45 tests | 44 skipped) 540ms
  ✓ gemini.tsx main function exit codes > should exit with 41 instead of crashing when refreshAuth fails in non-interactive mode 538ms

 Test Files  1 passed (1)
      Tests  1 passed | 44 skipped (45)
```

The new test was verified to fail against the pre-fix code (uncaught
`Error: This client is no longer supported` instead of the expected
`MockProcessExitError` with code 41), and to pass after the fix.

Note: this repo checkout's sandbox environment is not a "trusted" folder
per `GEMINI_CLI_TRUST_WORKSPACE`, which causes several *pre-existing*,
unrelated `gemini.test.tsx` tests (e.g. "should read from stdin in
non-interactive mode", "project hooks loading based on trust > ...") to
fail with `FatalUntrustedWorkspaceError` when the whole file is run
together. This reproduces identically on unmodified `main` and is not
caused by this change.

## Pre-Merge Checklist

- [x] Added/updated tests
- [ ] Updated relevant documentation and README (not needed — internal error-handling fix)
- [ ] Noted breaking changes (none)
- [ ] Validated on required platforms/methods (validated via unit tests only; no access to a live deprecated `oauth-personal` account to reproduce manually)

## AI assistance disclosure

This change (analysis, implementation, and tests) was prepared with AI
assistance (Claude Code / Anthropic).
