### PR TITLE
refactor(core): remove eslint-disable and type-asserts from shellExecutionService

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1247,6 +1247,84 @@ describe('ShellExecutionService', () => {
       // The catch block must call destroy() on spawnedPty to prevent fd leak
       expect(destroySpy).toHaveBeenCalled();
     });
+
+    it('should dispose of PTY event listeners on process exit', async () => {
+      const dataDisposeSpy = vi.fn();
+      const exitDisposeSpy = vi.fn();
+
+      mockPtyProcess.onData.mockReturnValue({ dispose: dataDisposeSpy });
+      mockPtyProcess.onExit.mockReturnValue({ dispose: exitDisposeSpy });
+
+      await simulateExecution('ls -l', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(dataDisposeSpy).toHaveBeenCalled();
+      expect(exitDisposeSpy).toHaveBeenCalled();
+    });
+
+    it('should dispose of PTY event listeners on abort', async () => {
+      const dataDisposeSpy = vi.fn();
+      const exitDisposeSpy = vi.fn();
+
+      mockPtyProcess.onData.mockReturnValue({ dispose: dataDisposeSpy });
+      mockPtyProcess.onExit.mockReturnValue({ dispose: exitDisposeSpy });
+
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'long-running',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        shellExecutionConfig,
+      );
+
+      await new Promise((resolve) => process.nextTick(resolve));
+      abortController.abort();
+      
+      // Simulate PTY process exit resulting from abort/SIGKILL
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 1, signal: 9 });
+      await handle.result;
+
+      expect(dataDisposeSpy).toHaveBeenCalled();
+      expect(exitDisposeSpy).toHaveBeenCalled();
+    });
+
+    it('should fall back to child_process when PTY creation fails with ENXIO', async () => {
+      const ptyError = new Error('posix_openpt failed: Device not configured');
+      // @ts-expect-error adding custom code property
+      ptyError.code = 'ENXIO';
+      mockPtySpawn.mockImplementationOnce(() => {
+        throw ptyError;
+      });
+
+      // Mock child process fallback
+      const mockFallbackChild = new EventEmitter() as any;
+      mockFallbackChild.stdout = new EventEmitter();
+      mockFallbackChild.stderr = new EventEmitter();
+      mockFallbackChild.kill = vi.fn();
+      mockFallbackChild.pid = 9999;
+      mockCpSpawn.mockReturnValueOnce(mockFallbackChild);
+
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'test-fallback',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        shellExecutionConfig,
+      );
+
+      // Simulate exit of standard child process fallback to allow handle to resolve
+      mockFallbackChild.emit('exit', 0, null);
+      mockFallbackChild.emit('close', 0, null);
+      
+      const result = await handle.result;
+      expect(result.executionMethod).toBe('child_process');
+      expect(mockCpSpawn).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1282,7 +1282,7 @@ describe('ShellExecutionService', () => {
 
       await new Promise((resolve) => process.nextTick(resolve));
       abortController.abort();
-      
+
       // Simulate PTY process exit resulting from abort/SIGKILL
       mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 1, signal: 9 });
       await handle.result;
@@ -1300,11 +1300,19 @@ describe('ShellExecutionService', () => {
       });
 
       // Mock child process fallback
-      const mockFallbackChild = new EventEmitter() as any;
-      mockFallbackChild.stdout = new EventEmitter();
-      mockFallbackChild.stderr = new EventEmitter();
-      mockFallbackChild.kill = vi.fn();
-      mockFallbackChild.pid = 9999;
+      const mockFallbackChild = new EventEmitter() as unknown as ChildProcess;
+      Object.defineProperty(mockFallbackChild, 'stdout', {
+        value: new EventEmitter(),
+      });
+      Object.defineProperty(mockFallbackChild, 'stderr', {
+        value: new EventEmitter(),
+      });
+      Object.defineProperty(mockFallbackChild, 'kill', {
+        value: vi.fn(),
+      });
+      Object.defineProperty(mockFallbackChild, 'pid', {
+        value: 9999,
+      });
       mockCpSpawn.mockReturnValueOnce(mockFallbackChild);
 
       const abortController = new AbortController();
@@ -1320,7 +1328,7 @@ describe('ShellExecutionService', () => {
       // Simulate exit of standard child process fallback to allow handle to resolve
       mockFallbackChild.emit('exit', 0, null);
       mockFallbackChild.emit('close', 0, null);
-      
+
       const result = await handle.result;
       expect(result.executionMethod).toBe('child_process');
       expect(mockCpSpawn).toHaveBeenCalled();

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -946,6 +946,8 @@ export class ShellExecutionService {
     }
     let spawnedPty: DestroyablePty | undefined;
     let cmdCleanup: (() => void) | undefined;
+    let headlessTerminal: pkg.Terminal | undefined;
+    const disposables: { dispose: () => void }[] = [];
 
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
@@ -991,13 +993,15 @@ export class ShellExecutionService {
       spawnedPty = ptyProcess as DestroyablePty;
       const ptyPid = Number(ptyProcess.pid);
 
-      const headlessTerminal = new Terminal({
+      headlessTerminal = new Terminal({
         allowProposedApi: true,
         cols,
         rows,
         scrollback: shellExecutionConfig.scrollback ?? SCROLLBACK_LIMIT,
       });
       headlessTerminal.scrollToTop();
+
+      const terminal = headlessTerminal!;
 
       this.activePtys.set(ptyPid, {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -1037,15 +1041,15 @@ export class ShellExecutionService {
             return false;
           }
         },
-        getBackgroundOutput: () => getFullBufferText(headlessTerminal),
+        getBackgroundOutput: () => getFullBufferText(terminal),
         getSubscriptionSnapshot: () => {
-          const endLine = headlessTerminal.buffer.active.length;
+          const endLine = terminal.buffer.active.length;
           const startLine = Math.max(
             0,
             endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
           );
           const bufferData = serializeTerminalToObject(
-            headlessTerminal,
+            terminal,
             startLine,
             endLine,
           );
@@ -1086,7 +1090,7 @@ export class ShellExecutionService {
 
         if (!shellExecutionConfig.disableDynamicLineTrimming) {
           if (!hasStartedOutput) {
-            const bufferText = getFullBufferText(headlessTerminal);
+            const bufferText = getFullBufferText(terminal);
             if (bufferText.trim().length === 0) {
               return;
             }
@@ -1094,7 +1098,7 @@ export class ShellExecutionService {
           }
         }
 
-        const buffer = headlessTerminal.buffer.active;
+        const buffer = terminal.buffer.active;
         const endLine = buffer.length;
         const startLine = Math.max(
           0,
@@ -1104,13 +1108,13 @@ export class ShellExecutionService {
         let newOutput: AnsiOutput;
         if (shellExecutionConfig.showColor) {
           newOutput = serializeTerminalToObject(
-            headlessTerminal,
+            terminal,
             startLine,
             endLine,
           );
         } else {
           newOutput = (
-            serializeTerminalToObject(headlessTerminal, startLine, endLine) ||
+            serializeTerminalToObject(terminal, startLine, endLine) ||
             []
           ).map((line) =>
             line.map((token) => {
@@ -1223,7 +1227,7 @@ export class ShellExecutionService {
                 }
 
                 isWriting = true;
-                headlessTerminal.write(decodedChunk, () => {
+                terminal.write(decodedChunk, () => {
                   render();
                   isWriting = false;
                   resolveChunk();
@@ -1242,12 +1246,13 @@ export class ShellExecutionService {
         );
       };
 
-      ptyProcess.onData((data: string) => {
+      const dataListener = ptyProcess.onData((data: string) => {
         const bufferData = Buffer.from(data, 'utf-8');
         handleOutput(bufferData);
       });
+      disposables.push(dataListener);
 
-      ptyProcess.onExit(
+      const exitListener = ptyProcess.onExit(
         ({ exitCode, signal }: { exitCode: number; signal?: number }) => {
           exited = true;
           abortSignal.removeEventListener('abort', abortHandler);
@@ -1260,6 +1265,15 @@ export class ShellExecutionService {
           const finalize = () => {
             render(true);
             cmdCleanup?.();
+
+            // Explicitly dispose of all node-pty event listeners to prevent closures from leaking
+            disposables.forEach((d) => {
+              try {
+                d.dispose();
+              } catch {
+                // Ignore
+              }
+            });
 
             const event: ShellOutputEvent = {
               type: 'exit',
@@ -1279,22 +1293,20 @@ export class ShellExecutionService {
             }
             onOutputEvent(event);
 
-            const endLine = headlessTerminal.buffer.active.length;
+            const endLine = headlessTerminal ? headlessTerminal.buffer.active.length : 0;
             const startLine = Math.max(
               0,
               endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
             );
-            const ansiOutputSnapshot = serializeTerminalToObject(
-              headlessTerminal,
-              startLine,
-              endLine,
-            );
-            const finalOutput = getFullBufferText(headlessTerminal);
+            const ansiOutputSnapshot = headlessTerminal
+              ? serializeTerminalToObject(headlessTerminal, startLine, endLine)
+              : [];
+            const finalOutput = headlessTerminal ? getFullBufferText(headlessTerminal) : '';
 
             // Dispose the headless terminal to free scrollback buffers.
             // This must happen after getFullBufferText() extracts the output.
             try {
-              headlessTerminal.dispose();
+              headlessTerminal?.dispose();
             } catch {
               // Ignore errors during terminal cleanup
             }
@@ -1339,6 +1351,7 @@ export class ShellExecutionService {
           });
         },
       );
+      disposables.push(exitListener);
 
       const abortHandler = async () => {
         if (ptyProcess.pid && !exited) {
@@ -1364,11 +1377,34 @@ export class ShellExecutionService {
         ShellExecutionService.destroyPtyProcess(spawnedPty);
       }
 
-      if (error?.message?.includes('posix_spawnp failed')) {
+      if (headlessTerminal) {
+        try {
+          headlessTerminal.dispose();
+        } catch {
+          // Ignore
+        }
+      }
+
+      // Dispose any registered event listeners to prevent leaks
+      disposables.forEach((d) => {
+        try {
+          d.dispose();
+        } catch {
+          // Ignore
+        }
+      });
+
+      const isPtyCreationFailure =
+        error?.message?.includes('posix_spawnp failed') ||
+        error?.message?.includes('ENXIO') ||
+        (error as any)?.code === 'ENXIO' ||
+        error?.message?.includes('Device not configured');
+
+      if (isPtyCreationFailure) {
         onOutputEvent({
           type: 'data',
           chunk:
-            '[GEMINI_CLI_WARNING] PTY execution failed, falling back to child_process. This may be due to sandbox restrictions.\n',
+            '[GEMINI_CLI_WARNING] PTY execution failed, falling back to child_process. This may be due to terminal exhaustion or sandbox restrictions.\n',
         });
         throw e;
       } else {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -991,7 +991,8 @@ export class ShellExecutionService {
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       spawnedPty = ptyProcess as DestroyablePty;
-      const ptyPid = Number(ptyProcess.pid);
+      const pty = spawnedPty;
+      const ptyPid = Number(pty.pid);
 
       headlessTerminal = new Terminal({
         allowProposedApi: true,
@@ -1004,8 +1005,7 @@ export class ShellExecutionService {
       const terminal = headlessTerminal;
 
       this.activePtys.set(ptyPid, {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ptyProcess,
+        ptyProcess: pty,
         headlessTerminal,
         maxSerializedLines: shellExecutionConfig.maxSerializedLines,
         command: shellExecutionConfig.originalCommand ?? commandToExecute,
@@ -1018,13 +1018,12 @@ export class ShellExecutionService {
           if (!ExecutionLifecycleService.isActive(ptyPid)) {
             return;
           }
-          ptyProcess.write(input);
+          pty.write(input);
         },
         kill: () => {
           killProcessGroup({
             pid: ptyPid,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            pty: ptyProcess,
+            pty,
           }).catch(() => {});
         },
         isActive: () => {
@@ -1241,20 +1240,20 @@ export class ShellExecutionService {
         );
       };
 
-      const dataListener = spawnedPty.onData((data) => {
+      const dataListener = pty.onData((data) => {
         const bufferData = Buffer.from(data, 'utf-8');
         handleOutput(bufferData);
       });
       disposables.push(dataListener);
 
-      const exitListener = spawnedPty.onExit(({ exitCode, signal }) => {
+      const exitListener = pty.onExit(({ exitCode, signal }) => {
         exited = true;
         abortSignal.removeEventListener('abort', abortHandler);
 
         // Immediately destroy the PTY to release its master FD.
         // The headless terminal is kept alive until finalize() extracts
         // its buffer contents, then disposed to free memory.
-        ShellExecutionService.destroyPtyProcess(spawnedPty!);
+        ShellExecutionService.destroyPtyProcess(pty);
 
         const finalize = () => {
           render(true);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -947,7 +947,7 @@ export class ShellExecutionService {
     let spawnedPty: DestroyablePty | undefined;
     let cmdCleanup: (() => void) | undefined;
     let headlessTerminal: pkg.Terminal | undefined;
-    const disposables: { dispose: () => void }[] = [];
+    const disposables: Array<{ dispose: () => void }> = [];
 
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
@@ -1001,7 +1001,7 @@ export class ShellExecutionService {
       });
       headlessTerminal.scrollToTop();
 
-      const terminal = headlessTerminal!;
+      const terminal = headlessTerminal;
 
       this.activePtys.set(ptyPid, {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -1107,15 +1107,10 @@ export class ShellExecutionService {
 
         let newOutput: AnsiOutput;
         if (shellExecutionConfig.showColor) {
-          newOutput = serializeTerminalToObject(
-            terminal,
-            startLine,
-            endLine,
-          );
+          newOutput = serializeTerminalToObject(terminal, startLine, endLine);
         } else {
           newOutput = (
-            serializeTerminalToObject(terminal, startLine, endLine) ||
-            []
+            serializeTerminalToObject(terminal, startLine, endLine) || []
           ).map((line) =>
             line.map((token) => {
               token.fg = '';
@@ -1246,111 +1241,113 @@ export class ShellExecutionService {
         );
       };
 
-      const dataListener = ptyProcess.onData((data: string) => {
+      const dataListener = spawnedPty.onData((data) => {
         const bufferData = Buffer.from(data, 'utf-8');
         handleOutput(bufferData);
       });
       disposables.push(dataListener);
 
-      const exitListener = ptyProcess.onExit(
-        ({ exitCode, signal }: { exitCode: number; signal?: number }) => {
-          exited = true;
-          abortSignal.removeEventListener('abort', abortHandler);
+      const exitListener = spawnedPty.onExit(({ exitCode, signal }) => {
+        exited = true;
+        abortSignal.removeEventListener('abort', abortHandler);
 
-          // Immediately destroy the PTY to release its master FD.
-          // The headless terminal is kept alive until finalize() extracts
-          // its buffer contents, then disposed to free memory.
-          ShellExecutionService.destroyPtyProcess(ptyProcess);
+        // Immediately destroy the PTY to release its master FD.
+        // The headless terminal is kept alive until finalize() extracts
+        // its buffer contents, then disposed to free memory.
+        ShellExecutionService.destroyPtyProcess(spawnedPty!);
 
-          const finalize = () => {
-            render(true);
-            cmdCleanup?.();
+        const finalize = () => {
+          render(true);
+          cmdCleanup?.();
 
-            // Explicitly dispose of all node-pty event listeners to prevent closures from leaking
-            disposables.forEach((d) => {
-              try {
-                d.dispose();
-              } catch {
-                // Ignore
-              }
-            });
-
-            const event: ShellOutputEvent = {
-              type: 'exit',
-              exitCode,
-              signal: signal ?? null,
-            };
-
-            const sessionId = shellExecutionConfig.sessionId ?? 'default';
-            const history =
-              ShellExecutionService.backgroundProcessHistory.get(sessionId);
-            const historyItem = history?.get(ptyPid);
-            if (historyItem) {
-              historyItem.status = 'exited';
-              historyItem.exitCode = exitCode;
-              historyItem.signal = signal ?? null;
-              historyItem.endTime = Date.now();
-            }
-            onOutputEvent(event);
-
-            const endLine = headlessTerminal ? headlessTerminal.buffer.active.length : 0;
-            const startLine = Math.max(
-              0,
-              endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
-            );
-            const ansiOutputSnapshot = headlessTerminal
-              ? serializeTerminalToObject(headlessTerminal, startLine, endLine)
-              : [];
-            const finalOutput = headlessTerminal ? getFullBufferText(headlessTerminal) : '';
-
-            // Dispose the headless terminal to free scrollback buffers.
-            // This must happen after getFullBufferText() extracts the output.
+          // Explicitly dispose of all node-pty event listeners to prevent closures from leaking
+          disposables.forEach((d) => {
             try {
-              headlessTerminal?.dispose();
+              d.dispose();
             } catch {
-              // Ignore errors during terminal cleanup
+              // Ignore
             }
+          });
 
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            ShellExecutionService.cleanupLogStream(ptyPid).then(() => {
-              ShellExecutionService.activePtys.delete(ptyPid);
-            });
-
-            ExecutionLifecycleService.completeWithResult(ptyPid, {
-              rawOutput: Buffer.from(''),
-              output: finalOutput,
-              ansiOutput: ansiOutputSnapshot,
-              exitCode,
-              signal: signal ?? null,
-              error,
-              aborted: abortSignal.aborted,
-              pid: ptyPid,
-              executionMethod: ptyInfo?.name ?? 'node-pty',
-            });
+          const event: ShellOutputEvent = {
+            type: 'exit',
+            exitCode,
+            signal: signal ?? null,
           };
 
-          if (abortSignal.aborted) {
-            finalize();
-            return;
+          const sessionId = shellExecutionConfig.sessionId ?? 'default';
+          const history =
+            ShellExecutionService.backgroundProcessHistory.get(sessionId);
+          const historyItem = history?.get(ptyPid);
+          if (historyItem) {
+            historyItem.status = 'exited';
+            historyItem.exitCode = exitCode;
+            historyItem.signal = signal ?? null;
+            historyItem.endTime = Date.now();
+          }
+          onOutputEvent(event);
+
+          const endLine = headlessTerminal
+            ? headlessTerminal.buffer.active.length
+            : 0;
+          const startLine = Math.max(
+            0,
+            endLine - (shellExecutionConfig.maxSerializedLines ?? 2000),
+          );
+          const ansiOutputSnapshot = headlessTerminal
+            ? serializeTerminalToObject(headlessTerminal, startLine, endLine)
+            : [];
+          const finalOutput = headlessTerminal
+            ? getFullBufferText(headlessTerminal)
+            : '';
+
+          // Dispose the headless terminal to free scrollback buffers.
+          // This must happen after getFullBufferText() extracts the output.
+          try {
+            headlessTerminal?.dispose();
+          } catch {
+            // Ignore errors during terminal cleanup
           }
 
-          const processingComplete = processingChain.then(() => 'processed');
-          const abortFired = new Promise<'aborted'>((res) => {
-            if (abortSignal.aborted) {
-              res('aborted');
-              return;
-            }
-            abortSignal.addEventListener('abort', () => res('aborted'), {
-              once: true,
-            });
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          ShellExecutionService.cleanupLogStream(ptyPid).then(() => {
+            ShellExecutionService.activePtys.delete(ptyPid);
           });
 
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          Promise.race([processingComplete, abortFired]).then(() => {
-            finalize();
+          ExecutionLifecycleService.completeWithResult(ptyPid, {
+            rawOutput: Buffer.from(''),
+            output: finalOutput,
+            ansiOutput: ansiOutputSnapshot,
+            exitCode,
+            signal: signal ?? null,
+            error,
+            aborted: abortSignal.aborted,
+            pid: ptyPid,
+            executionMethod: ptyInfo?.name ?? 'node-pty',
           });
-        },
-      );
+        };
+
+        if (abortSignal.aborted) {
+          finalize();
+          return;
+        }
+
+        const processingComplete = processingChain.then(() => 'processed');
+        const abortFired = new Promise<'aborted'>((res) => {
+          if (abortSignal.aborted) {
+            res('aborted');
+            return;
+          }
+          abortSignal.addEventListener('abort', () => res('aborted'), {
+            once: true,
+          });
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        Promise.race([processingComplete, abortFired]).then(() => {
+          finalize();
+        });
+      });
       disposables.push(exitListener);
 
       const abortHandler = async () => {
@@ -1397,7 +1394,7 @@ export class ShellExecutionService {
       const isPtyCreationFailure =
         error?.message?.includes('posix_spawnp failed') ||
         error?.message?.includes('ENXIO') ||
-        (error as any)?.code === 'ENXIO' ||
+        (isNodeError(error) && error.code === 'ENXIO') ||
         error?.message?.includes('Device not configured');
 
       if (isPtyCreationFailure) {


### PR DESCRIPTION
## Summary

This PR removes `eslint-disable` and unsafe type-assertions from `shellExecutionService.ts` on the branch `fix/mac-pty-resource-leak`. 

## Details

Previously, the `dataListener` and `exitListener` were registered by casting properties of `ptyProcess` (which was typed as `any` because `ptyInfo.module.spawn` returned `any`). By using the already type-asserted `spawnedPty` of type `DestroyablePty` instead, `.onData` and `.onExit` are fully typed from `@lydell/node-pty`. This removes any need for the `eslint-disable` block and custom assertions entirely. Additionally, unnecessary non-null assertions `spawnedPty!` on lines 1244 and 1250 have been removed, as the TypeScript compiler control flow correctly infers that they are defined in that scope.

## Related Issues

Related to cleanup of eslint-disable comments on fix/mac-pty-resource-leak branch.

## How to Validate

1. Run `npm run lint` to verify eslint rules pass.
2. Run `npm run typecheck` to verify TypeScript types compile.
3. Run `npm test -w @google/gemini-cli-core -- src/services/shellExecutionService.test.ts` to ensure PTY execution unit tests continue to pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
