### PR TITLE
[SSR Agent] Issue Fix (19463): Format cli_help subagent output as markdown

### DIFF
--- a/packages/core/src/agents/cli-help-agent.test.ts
+++ b/packages/core/src/agents/cli-help-agent.test.ts
@@ -55,12 +55,14 @@ describe('CliHelpAgent', () => {
     expect(query).toContain('${question}');
   });
 
-  it('should process output to a formatted JSON string', () => {
+  it('should process output to a formatted markdown string', () => {
     const mockOutput = {
-      answer: 'This is the answer.',
-      sources: ['file1.md', 'file2.md'],
+      answer: '  This is the answer.  ',
+      sources: ['file1.md', 'file2.md', 'file1.md', '   ', ''],
     };
     const processed = localAgent.processOutput?.(mockOutput);
-    expect(processed).toBe(JSON.stringify(mockOutput, null, 2));
+    expect(processed).toBe(
+      'This is the answer.\n\n**Sources:**\n- file1.md\n- file2.md',
+    );
   });
 });

--- a/packages/core/src/agents/cli-help-agent.ts
+++ b/packages/core/src/agents/cli-help-agent.ts
@@ -49,7 +49,24 @@ export const CliHelpAgent = (
     schema: CliHelpReportSchema,
   },
 
-  processOutput: (output) => JSON.stringify(output, null, 2),
+  processOutput: (output) => {
+    if (!output) {
+      return '';
+    }
+    const answer = output.answer?.trim() ?? '';
+    const uniqueSources = Array.from(
+      new Set(
+        (output.sources ?? [])
+          .map((s) => s?.trim())
+          .filter((s) => s && s.length > 0),
+      ),
+    );
+
+    if (uniqueSources.length > 0) {
+      return `${answer}\n\n**Sources:**\n${uniqueSources.map((s) => `- ${s}`).join('\n')}`;
+    }
+    return answer;
+  },
 
   modelConfig: {
     model: GEMINI_MODEL_ALIAS_FLASH,


### PR DESCRIPTION
fixes #19463
Original Issue: https://github.com/google-gemini/gemini-cli/issues/19463

### Context & Problem
The Gemini CLI fails to cleanly present the answer from the `cli_help` subagent to the user, resulting in leaking internal thoughts and model monologue in the output. This occurs because the `cli_help` subagent's `processOutput` handler returns a raw stringified JSON object which the primary agent fails to parse as user-facing output.

### Detailed Changes
- Updated the `processOutput` function in [cli-help-agent.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_19463/tmp/eval/gemini-cli-clone/packages/core/src/agents/cli-help-agent.ts) to cleanly format the answer and sources using Markdown instead of JSON.
- Updated the unit tests in [cli-help-agent.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_19463/tmp/eval/gemini-cli-clone/packages/core/src/agents/cli-help-agent.test.ts) to assert the formatted markdown output has the expected structural details.

### Verification
- ESLint checks succeeded silently without errors.
- Vitest unit tests have been updated with correct assertions to verify formatting.