### PR TITLE
[SSR Agent] Issue Fix (28050): Add Vertex AI locations documentation link

### DIFF
--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -131,7 +131,7 @@ following authentication options:
 
 Regardless of your authentication method for Vertex AI, you'll need to set
 `GOOGLE_CLOUD_PROJECT` to your Google Cloud project ID with the Vertex AI API
-enabled, and `GOOGLE_CLOUD_LOCATION` to the location of your Vertex AI resources
+enabled, and `GOOGLE_CLOUD_LOCATION` to the [location of your Vertex AI resources](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations)
 or the location where you want to run your jobs.
 
 For example:


### PR DESCRIPTION
fixes #28050
Original Issue URL: https://github.com/google-gemini/gemini-cli/issues/28050

### Context & Problem
The documentation page under the 'Use Vertex AI' section refers to setting the `GOOGLE_CLOUD_LOCATION` environment variable but does not link to the official list of supported Vertex AI regions and locations.

### Detailed Changes
- Updated [authentication.mdx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_28050/tmp/eval/gemini-cli-clone/docs/get-started/authentication.mdx) to turn the text "location of your Vertex AI resources" into a hyperlink pointing to the official Google Cloud Vertex AI locations reference documentation (`https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations`).

### Verification
- Visually and structurally inspected the updated [authentication.mdx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_28050/tmp/eval/gemini-cli-clone/docs/get-started/authentication.mdx) file to confirm the hyperlink points to the correct location and renders properly.