### PR TITLE
fix(core): ignore .gemini folder by default in file search

### DIFF
--- a/packages/core/src/utils/filesearch/ignore.test.ts
+++ b/packages/core/src/utils/filesearch/ignore.test.ts
@@ -155,4 +155,15 @@ describe('loadIgnoreRules', () => {
     const dirFilter = ignore.getDirectoryFilter();
     expect(dirFilter('.git/')).toBe(true);
   });
+
+  it('should always add .gemini to the ignore list', async () => {
+    tmpDir = await createTmpDir({});
+    const service = new FileDiscoveryService(tmpDir, {
+      respectGitIgnore: false,
+      respectGeminiIgnore: false,
+    });
+    const ignore = loadIgnoreRules(service, []);
+    const dirFilter = ignore.getDirectoryFilter();
+    expect(dirFilter('.gemini/')).toBe(true);
+  });
 });

--- a/packages/core/src/utils/filesearch/ignore.ts
+++ b/packages/core/src/utils/filesearch/ignore.ts
@@ -29,7 +29,7 @@ export function loadIgnoreRules(
     }
   }
 
-  const allIgnoreDirs = ['.git', ...ignoreDirs];
+  const allIgnoreDirs = ['.git', '.gemini', ...ignoreDirs];
   ignorer.add(
     allIgnoreDirs.map((dir) => {
       if (dir.endsWith('/')) {


### PR DESCRIPTION
This PR adds `.gemini` to the list of default ignored directories in `loadIgnoreRules` (Issue #28826).

When running the tool within workspaces that contain the `.gemini` configuration directory (e.g. running in user's home directory), chokidar filesystem watchers and workspace crawlers attempt to index internal directories. This causes spurious file discovery events, indexing delays, and warnings when short-lived runtime lockfiles (like `projects.json.lock`) are created and deleted quickly.

Adding `.gemini` to default ignored directories resolves this. Added unit tests in `packages/core/src/utils/filesearch/ignore.test.ts` to ensure `.gemini` is always excluded.