### PR TITLE
[SSR Agent] Issue Fix (22093): Prevent subagents from running when agents mode is disabled

### DIFF
--- a/packages/core/src/agents/registry.test.ts
+++ b/packages/core/src/agents/registry.test.ts
@@ -289,6 +289,17 @@ describe('AgentRegistry', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('should NOT load built-in agents when enableAgents is false (without per-agent overrides)', async () => {
+      const disabledConfig = makeMockedConfig({
+        enableAgents: false,
+      });
+      const disabledRegistry = new TestableAgentRegistry(disabledConfig);
+
+      await disabledRegistry.initialize();
+
+      expect(disabledRegistry.getAllDefinitions()).toHaveLength(0);
+    });
+
     it('should register CLI help agent by default', async () => {
       const config = makeMockedConfig();
       const registry = new TestableAgentRegistry(config);

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -160,7 +160,6 @@ export class AgentRegistry {
   private async loadAgents(errors?: string[]): Promise<void> {
     this.agents.clear();
     this.allDefinitions.clear();
-    this.loadBuiltInAgents();
 
     // Clear old dynamic rules before reloading
     this.config.getPolicyEngine()?.removeRulesBySource(DYNAMIC_RULE_SOURCE);
@@ -168,6 +167,8 @@ export class AgentRegistry {
     if (!this.config.isAgentsEnabled()) {
       return;
     }
+
+    this.loadBuiltInAgents();
 
     // Load project-level agents: .gemini/agents/ (relative to Project Root)
     const folderTrustEnabled = this.config.getFolderTrust();
@@ -317,6 +318,9 @@ export class AgentRegistry {
   private async refreshAgents(
     scope: AgentDefinition['kind'] | 'all' = 'all',
   ): Promise<void> {
+    if (!this.config.isAgentsEnabled()) {
+      return;
+    }
     this.loadBuiltInAgents();
     await Promise.allSettled(
       Array.from(this.agents.values()).map(async (agent) => {


### PR DESCRIPTION
fixes #22093

### Context & Problem

Subagents (such as the generalist agent) were initialized and run even when the agents mode was set to disabled in the configuration. This regression was introduced in v0.33.0 because `loadBuiltInAgents()` was called inside `AgentRegistry.loadAgents` prior to checking whether agent mode is actually enabled via `isAgentsEnabled()`.

Original Issue: https://github.com/google-gemini/gemini-cli/issues/22093

### Detailed Changes

- **packages/core/src/agents/registry.ts**:
  - Moved the `this.loadBuiltInAgents()` invocation in `loadAgents()` to after the `isAgentsEnabled()` early return check.
  - Added an early return check `if (!this.config.isAgentsEnabled())` in `refreshAgents()` to prevent built-in agents from being reloaded during refreshes.

- **packages/core/src/agents/registry.test.ts**:
  - Added a Vitest unit test suite to ensure that when `enableAgents` is configured to `false`, `AgentRegistry` has zero registered agent definitions.

### Verification

- Leveraged Vitest unit testing framework to execute automated test suites asserting `AgentRegistry` remains clean and free of registered agents when disabled.