### PR TITLE
[SSR Agent] Issue Fix (23954): Add trailing space to autocomplete suggestions

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -481,7 +481,7 @@ describe('useCommandCompletion', () => {
   });
 
   describe('handleAutocomplete', () => {
-    it('should complete a partial command and NOT add a space if it has an action', async () => {
+    it('should complete a partial command and ADD a space even if it has an action', async () => {
       setupMocks({
         slashSuggestions: [{ label: 'memory', value: 'memory' }],
         slashCompletionRange: {
@@ -502,7 +502,7 @@ describe('useCommandCompletion', () => {
         result.current.handleAutocomplete(0);
       });
 
-      expect(result.current.textBuffer.text).toBe('/memory');
+      expect(result.current.textBuffer.text).toBe('/memory ');
     });
 
     it('should complete a partial command and ADD a space if it has NO action (e.g. just a parent)', async () => {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -438,16 +438,7 @@ export function useCommandCompletion({
       const lineCodePoints = toCodePoints(buffer.lines[cursorRow] || '');
       const charAfterCompletion = lineCodePoints[end];
 
-      let shouldAddSpace = true;
-      if (completionMode === CompletionMode.SLASH) {
-        const command =
-          slashCompletionRange.getCommandFromSuggestion(suggestion);
-        // Don't add a space if the command has an action (can be executed)
-        // and doesn't have a completion function (doesn't REQUIRE more arguments)
-        const isExecutableCommand = !!(command && command.action);
-        const requiresArguments = !!(command && command.completion);
-        shouldAddSpace = !isExecutableCommand || requiresArguments;
-      }
+      const shouldAddSpace = true;
 
       if (
         charAfterCompletion !== ' ' &&


### PR DESCRIPTION
fixes #23954
Original Issue URL: https://github.com/google-gemini/gemini-cli/issues/23954

### Context & Problem

Selecting a slash command suggestion via autocomplete using Tab or typing did not append a trailing space for executable commands, forcing users to manually add a space before hitting Enter. This was caused by the logic in `useCommandCompletion.tsx` preventing space padding for executable commands.

### Detailed Changes

- **packages/cli/src/ui/hooks/useCommandCompletion.tsx**: Always set `shouldAddSpace` to `true` to ensure space is appended on command completion.
- **packages/cli/src/ui/hooks/useCommandCompletion.test.tsx**: Updated the unit test to verify that command completion adds a trailing space even when the command has an associated action.

### Verification

- ESLint checks succeeded without errors.
- Unit tests under the `handleAutocomplete` suite in `useCommandCompletion.test.tsx` have been updated and verify that the trailing space is correctly added.