### PR TITLE
[SSR Agent] Issue Fix (21331): Fix host network resolution for gVisor runsc sandbox

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -220,6 +220,24 @@ To set up runsc:
 2.  Configure the Docker daemon to use the runsc runtime.
 3.  Verify the installation.
 
+**Capabilities & Limitations:**
+
+- **Security Isolation**: Provides a virtualized kernel environment, completely
+  separating the container's execution and network namespaces from the host to
+  prevent malicious takeovers or unintended host access.
+- **IDE Companion Limitation**: The VSCode IDE companion extension relies on
+  HTTP over TCP communication to coordinate code actions between the host block
+  and the container environment. Because gVisor restricts raw TCP loopback/host
+  routing, the IDE companion extension cannot establish a direct connection
+  under default runsc settings.
+- **Connection Settings**: To allow the companion or other local processes to
+  resolve and communicate with host services under gVisor, Gemini CLI
+  automatically configures container TCP networking by dynamically resolving the
+  gateway IP of the active network (falling back to `172.17.0.1`) and pointing
+  `host.docker.internal` to it. If you experience connectivity issues, ensure
+  your host-side services are listening on `0.0.0.0` or the gateway IP and are
+  not blocked by the host firewall.
+
 ### 5. LXC/LXD (Linux only, experimental)
 
 Full-system container sandboxing using LXC/LXD. Unlike Docker/Podman, LXC

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -1173,11 +1173,16 @@ describe('sandbox', () => {
         expect.arrayContaining(['images', '-q', 'gemini-cli-sandbox']),
       );
 
-      // Verify docker run includes --runtime=runsc
+      // Verify docker run includes --runtime=runsc and maps host.docker.internal to bridge IP 172.17.0.1
       expect(spawn).toHaveBeenNthCalledWith(
         2,
         'docker',
-        expect.arrayContaining(['run', '--runtime=runsc']),
+        expect.arrayContaining([
+          'run',
+          '--runtime=runsc',
+          '--add-host',
+          'host.docker.internal:172.17.0.1',
+        ]),
         expect.objectContaining({ stdio: 'inherit' }),
       );
     });

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -406,7 +406,38 @@ export async function start_sandbox(
     }
 
     // allow access to host.docker.internal
-    args.push('--add-host', 'host.docker.internal:host-gateway');
+    if (config.command === 'runsc') {
+      let gatewayIp = '172.17.0.1';
+      try {
+        const useProxy = !!process.env['GEMINI_SANDBOX_PROXY_COMMAND'];
+        const hasNetworkAccess = config.networkAccess ?? false;
+        const networkName =
+          !hasNetworkAccess || useProxy ? SANDBOX_NETWORK_NAME : 'bridge';
+        if (networkName === SANDBOX_NETWORK_NAME) {
+          const isInternal = !hasNetworkAccess || useProxy;
+          const networkFlags = isInternal ? '--internal' : '';
+          execSync(
+            `${command} network inspect ${SANDBOX_NETWORK_NAME} || ${command} network create ${networkFlags} ${SANDBOX_NETWORK_NAME}`,
+            { stdio: 'ignore' },
+          );
+        }
+        const inspectOut = execSync(
+          `${command} network inspect ${networkName} --format "{{range .IPAM.Config}}{{.Gateway}}{{end}}"`,
+        )
+          ?.toString()
+          .trim();
+        if (inspectOut) {
+          gatewayIp = inspectOut;
+        }
+      } catch (err) {
+        debugLogger.warn(
+          `Failed to resolve gateway IP for host.docker.internal: ${err}`,
+        );
+      }
+      args.push('--add-host', `host.docker.internal:${gatewayIp}`);
+    } else {
+      args.push('--add-host', 'host.docker.internal:host-gateway');
+    }
 
     // mount current directory as working directory in sandbox (set via --workdir)
     args.push('--volume', `${workdir}:${containerWorkdir}`);


### PR DESCRIPTION
fixes #21331

### Context & Problem

The VSCode IDE companion extension failed to connect when using `GEMINI_SANDBOX=runsc` (gVisor) sandboxing, hindering IDE integration features. This issue occurred because gVisor severely limits host TCP network access, which prevents natural HTTP over TCP communication between the container and the host services.

Original issue: https://github.com/google-gemini/gemini-cli/issues/21331

### Detailed Changes

- **`packages/cli/src/utils/sandbox.ts`**: Updated the container startup argument generation for `runsc` (gVisor) configurations to parse and add a specific host routing entry (`host.docker.internal:172.17.0.1`), resolving to the standard Docker bridge network gateway.
- **`packages/cli/src/utils/sandbox.test.ts`**: Updated unit tests using Vitest to assert correct host resolution configuration under `runsc`.
- **`docs/cli/sandbox.md`**: Added a thorough explanation of gVisor network isolation capabilities, VSCode companion connectivity limitations under gVisor, and instruction on setting up services to listen on the Docker gateway.

### Verification

- Successfully ran Vitest unit tests in `packages/cli/src/utils/sandbox.test.ts` verifying sandbox startup parameter generation.
- Safe and clean static inspection of changes against requirements and successful execution of the codebase linter.