### PR TITLE
[SSR Agent] Issue Fix (21783): Emit pending tool call update before requesting permission

### DIFF
--- a/packages/cli/src/acp/acpSession.test.ts
+++ b/packages/cli/src/acp/acpSession.test.ts
@@ -455,6 +455,28 @@ describe('Session', () => {
       prompt: [{ type: 'text', text: 'Call tool' }],
     });
 
+    expect(mockConnection.sessionUpdate).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      update: expect.objectContaining({
+        sessionUpdate: 'tool_call',
+        status: 'pending',
+        toolCallId: 'call-1',
+      }),
+    });
+
+    const pendingCallIndex = mockConnection.sessionUpdate.mock.calls.findIndex(
+      (call) =>
+        call[0]?.update?.sessionUpdate === 'tool_call' &&
+        call[0]?.update?.status === 'pending',
+    );
+    expect(pendingCallIndex).toBeGreaterThanOrEqual(0);
+
+    const pendingCallInvocation =
+      mockConnection.sessionUpdate.mock.invocationCallOrder[pendingCallIndex];
+    const requestPermissionInvocation =
+      mockConnection.requestPermission.mock.invocationCallOrder[0];
+    expect(pendingCallInvocation).toBeLessThan(requestPermissionInvocation);
+
     expect(mockConnection.requestPermission).toHaveBeenCalled();
     expect(confirmationDetails.onConfirm).toHaveBeenCalled();
   });

--- a/packages/cli/src/acp/acpSession.ts
+++ b/packages/cli/src/acp/acpSession.ts
@@ -767,6 +767,16 @@ export class Session {
           },
         };
 
+        await this.sendUpdate({
+          sessionUpdate: 'tool_call',
+          toolCallId: callId,
+          status: 'pending',
+          title: displayTitle,
+          content,
+          locations: invocation.toolLocations(),
+          kind: toAcpToolKind(tool.kind),
+        });
+
         const output = RequestPermissionResponseSchema.parse(
           await this.connection.requestPermission(params),
         );


### PR DESCRIPTION
fixes #21783
https://github.com/google-gemini/gemini-cli/issues/21783

### Context & Problem

In ACP mode, when a tool requires user confirmation, the agent sends `session/request_permission` to the client without sending a preceding `tool_call` session update (with status `'pending'`). This violates the ACP tool calls specification and prevents clients from tracking the tool call lifecycle. The root cause is that `this.sendUpdate` with status `'pending'` was only called under the `else` branch of tool confirmation logic in packages/cli/src/acp/acpSession.ts, and was omitted when `confirmationDetails` existed.

### Detailed Changes

- [acpSession.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21783/tmp/eval/gemini-cli-clone/packages/cli/src/acp/acpSession.ts): Emits a `'pending'` status session update via `this.sendUpdate()` before `this.connection.requestPermission()` is invoked.
- [acpSession.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_21783/tmp/eval/gemini-cli-clone/packages/cli/src/acp/acpSession.test.ts): Added a new unit test assertion to guarantee sequence correctness, confirming that the `'pending'` update is dispatched prior to requesting permission.

### Verification

All ESLint checks and Vitest unit tests succeed successfully.