### PR TITLE
[SSR Agent] Issue Fix (14724): Translate compact matchers to compress and update enum

### DIFF
--- a/packages/cli/src/commands/hooks/migrate.test.ts
+++ b/packages/cli/src/commands/hooks/migrate.test.ts
@@ -489,6 +489,27 @@ describe('migrate command', () => {
     expect(migratedHooks).toHaveProperty('AfterTool');
   });
 
+  it('should transform compact matchers to compress', async () => {
+    const claudeSettings = {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: 'compact',
+            hooks: [{ type: 'command', command: 'echo "test"' }],
+          },
+        ],
+      },
+    };
+
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify(claudeSettings));
+
+    await handleMigrateFromClaude();
+
+    const migratedHooks = mockSetValue.mock.calls[0][2];
+    expect(migratedHooks.SessionStart[0].matcher).toBe('compress');
+  });
+
   it('should display migration instructions after successful migration', async () => {
     const claudeSettings = {
       hooks: {

--- a/packages/cli/src/commands/hooks/migrate.ts
+++ b/packages/cli/src/commands/hooks/migrate.ts
@@ -59,6 +59,9 @@ function transformMatcher(matcher: string | undefined): string | undefined {
     );
   }
 
+  // Translate 'compact' matchers to 'compress'
+  transformed = transformed.replace(/\bcompact\b/g, 'compress');
+
   return transformed;
 }
 

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -608,6 +608,8 @@ export enum SessionStartSource {
   Startup = 'startup',
   Resume = 'resume',
   Clear = 'clear',
+  Compress = 'compress',
+  Compact = 'compact',
 }
 
 /**


### PR DESCRIPTION
fixes #14724

Original Issue: https://github.com/google-gemini/gemini-cli/issues/14724

### Context & Problem
Hook configurations migrated from Claude Code use `compact` matchers for session compression starts. However, Gemini CLI uses `compress` as the source value for compression-triggered session starts, and its `SessionStartSource` enum lacks both values, causing matcher and hook incompatibility.

### Detailed Changes
- **packages/core/src/hooks/types.ts**: Added `Compress = 'compress'` and `Compact = 'compact'` to the `SessionStartSource` enum so that both compression source values are supported.
- **packages/cli/src/commands/hooks/migrate.ts**: Updated the matcher transformation helper `transformMatcher` to automatically replace `compact` matchers with `compress` during migration.
- **packages/cli/src/commands/hooks/migrate.test.ts**: Added a unit test verifying that `compact` matchers in Claude Code settings are correctly translated to `compress` upon migrating.

### Verification
- Added and executed a targeted Vitest unit test in `packages/cli/src/commands/hooks/migrate.test.ts` to confirm that the matcher translation from `compact` to `compress` succeeds.