### PR TITLE
[SSR Agent] Issue Fix (28512): Prevent unhandled promise rejection on OAuth callback timeout

### DIFF
--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -447,6 +447,32 @@ describe('oauth-flow', () => {
         vi.useRealTimers();
       }
     });
+
+    it('should not produce an unhandled promise rejection on timeout, and still reject on await', async () => {
+      vi.useFakeTimers();
+      let unhandledRejectionError: unknown;
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejectionError = reason;
+      };
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      try {
+        const server = startCallbackServer('timeout-state');
+        await server.port;
+
+        // Advance timers by 5 minutes to trigger the timeout
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        // Verify no unhandled promise rejection has been emitted
+        expect(unhandledRejectionError).toBeUndefined();
+
+        // Ensure awaiting server.response correctly rejects with the timeout error
+        await expect(server.response).rejects.toThrow('OAuth callback timeout');
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('exchangeCodeForToken', () => {

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -279,10 +279,15 @@ export function startCallbackServer(
       abortController.signal.addEventListener('abort', onAbort, { once: true });
 
       server.on('close', () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
         abortController.signal.removeEventListener('abort', onAbort);
       });
     },
   );
+
+  responsePromise.catch(() => {});
 
   return {
     port: portPromise,


### PR DESCRIPTION
fixes #28512
Original Issue URL: https://github.com/google-gemini/gemini-cli/issues/28512

### Context & Problem
An unhandled promise rejection occurred during the authentication flow when the OAuth callback server timed out after 5 minutes, as the rejection of the callback server's promise was not caught or handled if the authenticated state was abandoned.

### Detailed Changes
- **packages/core/src/utils/oauth-flow.ts**: 
  - Attached a no-op `.catch(() => {})` handler to `responsePromise` inside `startCallbackServer` to prevent crashing Node.js with an unhandled rejection, while still allowing the returned promise to reject correctly for any callers awaiting it.
  - Registered a listener on the server `close` event to clear the timeout timer (`timeoutId`) if it exists, avoiding potential leaks of the timer.
- **packages/core/src/utils/oauth-flow.test.ts**:
  - Added a unit test validating that when `startCallbackServer` times out after 5 minutes, no unhandled rejection event is emitted globally, and that awaiting the returned `response` promise still correctly rejects with the timeout error.

### Verification
Verified with Vitest unit tests in `packages/core/src/utils/oauth-flow.test.ts` that fake timers advanced past 5 minutes do not trigger unhandled promise rejections and that the promise rejects as expected.
Our ESLint linter check succeeded cleanly.