### PR TITLE
fix(cli): reject fetchJson on malformed JSON or response stream errors

### DIFF
--- a/packages/cli/src/config/extensions/github_fetch.test.ts
+++ b/packages/cli/src/config/extensions/github_fetch.test.ts
@@ -120,6 +120,37 @@ describe('fetchJson', () => {
     );
   });
 
+  it('should reject on malformed JSON instead of throwing', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('data', Buffer.from('{invalid'));
+      res.emit('end');
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(
+      fetchJson('https://example.com/malformed.json'),
+    ).rejects.toThrow(
+      /Failed to parse JSON from https:\/\/example\.com\/malformed\.json/,
+    );
+  });
+
+  it('should reject on response stream error', async () => {
+    getMock.mockImplementationOnce((_url, _options, callback) => {
+      const res = new EventEmitter() as IncomingMessage;
+      res.statusCode = 200;
+      (callback as (res: IncomingMessage) => void)(res);
+      res.emit('error', new Error('socket hang up'));
+      return new EventEmitter() as ClientRequest;
+    });
+
+    await expect(
+      fetchJson('https://example.com/broken-stream'),
+    ).rejects.toThrow(/Response stream error while fetching/);
+  });
+
   it('should reject on request error', async () => {
     const error = new Error('Network error');
     getMock.mockImplementationOnce(() => {

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -47,10 +47,27 @@ export async function fetchJson<T>(
         }
         const chunks: Buffer[] = [];
         res.on('data', (chunk) => chunks.push(chunk));
+        res.on('error', (err) => {
+          reject(
+            new Error(
+              `Response stream error while fetching ${url} (status ${res.statusCode}): ${err.message}`,
+            ),
+          );
+        });
         res.on('end', () => {
           const data = Buffer.concat(chunks).toString();
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          resolve(JSON.parse(data) as T);
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            resolve(JSON.parse(data) as T);
+          } catch (err) {
+            reject(
+              new Error(
+                `Failed to parse JSON from ${url} (status ${res.statusCode}): ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              ),
+            );
+          }
         });
       })
       .on('error', reject);

--- a/packages/cli/src/config/extensions/github_fetch.ts
+++ b/packages/cli/src/config/extensions/github_fetch.ts
@@ -50,7 +50,7 @@ export async function fetchJson<T>(
         res.on('error', (err) => {
           reject(
             new Error(
-              `Response stream error while fetching ${url} (status ${res.statusCode}): ${err.message}`,
+              `Response stream error while fetching ${url} (status ${res.statusCode ?? 'unknown'}): ${err.message}`,
             ),
           );
         });
@@ -62,7 +62,7 @@ export async function fetchJson<T>(
           } catch (err) {
             reject(
               new Error(
-                `Failed to parse JSON from ${url} (status ${res.statusCode}): ${
+                `Failed to parse JSON from ${url} (status ${res.statusCode ?? 'unknown'}): ${
                   err instanceof Error ? err.message : String(err)
                 }`,
               ),


### PR DESCRIPTION
## Summary

`fetchJson()` in `packages/cli/src/config/extensions/github_fetch.ts` collects
response chunks and calls `JSON.parse(data)` inside the response's `end` event
callback with no `try/catch`, and the response stream has no `error` listener.
A malformed or truncated JSON body returned with HTTP 200 throws a
`SyntaxError` from that callback instead of rejecting the returned promise,
so extension commands can crash instead of receiving an actionable error.

## Fix

- Wrap `JSON.parse` in `try/catch` and reject with a contextual error
  including the URL and status code.
- Add a response stream `error` listener that rejects with a contextual
  error instead of leaving the promise pending or throwing unhandled.

This is a minimal, targeted fix scoped to the exact defect described in the
issue; it does not change redirect handling, header handling, or any other
behavior of `fetchJson()`.

## Related Issues

Fixes #28646

## Tests

Added two regression tests to `github_fetch.test.ts`:
- malformed JSON returned with HTTP 200 now rejects with a contextual
  "Failed to parse JSON from ..." error instead of throwing.
- a response stream `error` event now rejects with a contextual
  "Response stream error while fetching ..." error.

Verified both new tests fail against the pre-fix code
(`git checkout HEAD~1 -- packages/cli/src/config/extensions/github_fetch.ts`)
with:

```
FAIL  packages/cli/src/config/extensions/github_fetch.test.ts > fetchJson > should reject on malformed JSON instead of throwing
AssertionError: expected [Function] to throw error matching /Failed to parse JSON from .../ but got
'Expected property name or '}' in JSON at position 1 (line 1 column 2)'

FAIL  packages/cli/src/config/extensions/github_fetch.test.ts > fetchJson > should reject on response stream error
AssertionError: expected [Function] to throw error matching /Response stream error while fetching/ but got
'socket hang up'
```

And passing after restoring the fix:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## How to Validate

```
npx vitest run packages/cli/src/config/extensions/github_fetch.test.ts
npx eslint packages/cli/src/config/extensions/github_fetch.ts packages/cli/src/config/extensions/github_fetch.test.ts
npx prettier --check packages/cli/src/config/extensions/github_fetch.ts packages/cli/src/config/extensions/github_fetch.test.ts
npm run typecheck --workspace @google/gemini-cli
```

All pass:
- `github_fetch.test.ts`: 10/10 tests passing
- `packages/cli/src/config/extensions/`: 181/181 tests passing (no regressions)
- eslint: clean
- prettier: clean
- typecheck: clean

## Pre-Merge Checklist

- [x] Added/updated tests
- [ ] Noted breaking changes — none; previously-uncaught exceptions now
      surface as promise rejections with more context, matching the
      existing behavior for other `fetchJson()` failure modes.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent
(Claude, Anthropic) operating under human supervision.
