### PR TITLE
[SSR Agent] Issue Fix (18062): Handle 404 API error in Cloud Shell default project

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -666,6 +666,28 @@ describe('CodeAssistServer', () => {
     ).rejects.toThrow(/Access to the default Cloud Shell Gemini project/);
   });
 
+  it('should throw friendly error for 404 on cloudshell-gca project', async () => {
+    const { server } = createTestServer();
+    const mock404Error = {
+      response: {
+        status: 404,
+        data: {
+          error: {
+            message: 'Requested entity was not found',
+          },
+        },
+      },
+    };
+    vi.spyOn(server, 'requestPost').mockRejectedValue(mock404Error);
+
+    await expect(
+      server.loadCodeAssist({
+        cloudaicompanionProject: 'cloudshell-gca',
+        metadata: {},
+      }),
+    ).rejects.toThrow(/Access to the default Cloud Shell Gemini project/);
+  });
+
   it('should call the listExperiments endpoint with metadata', async () => {
     const { server } = createTestServer();
     const mockResponse = {

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -278,7 +278,7 @@ export class CodeAssistServer implements ContentGenerator {
           currentTier: { id: UserTierId.STANDARD },
         };
       } else if (
-        isPermissionDeniedError(e) &&
+        (isPermissionDeniedError(e) || isNotFoundError(e)) &&
         req.cloudaicompanionProject === 'cloudshell-gca'
       ) {
         throw new Error(
@@ -596,5 +596,17 @@ function isPermissionDeniedError(error: unknown): boolean {
     typeof error.response === 'object' &&
     'status' in error.response &&
     error.response.status === 403
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    !!error.response &&
+    typeof error.response === 'object' &&
+    'status' in error.response &&
+    error.response.status === 404
   );
 }


### PR DESCRIPTION
fixes #18062
Issue URL: https://github.com/google-gemini/gemini-cli/issues/18062

### Context & Problem

When running Gemini CLI in Cloud Shell with a Google Cloud Lab account, the default project `cloudshell-gca` is missing or not found, causing the API to return a 404 'Requested entity was not found' error. This 404 error was previously unhandled, causing it to fall through to an unfriendly and unhandled API error instead of showing clear, friendly user-facing guidance.

### Detailed Changes

- **packages/core/src/code_assist/server.ts**: Added helper function `isNotFoundError` to identify 404 response errors, and updated the `loadCodeAssist` method's exception handling to catch 404 error alongside the existing 403 (Permission Denied) error on the default `cloudshell-gca` project to return the same descriptive, friendly troubleshooting error message.
- **packages/core/src/code_assist/server.test.ts**: Added a unit test to mock a 404 Not Found error with the `cloudshell-gca` project to verify that `loadCodeAssist` successfully catches the error and throws the expected user-friendly message.

### Verification

- Added a unit test in `packages/core/src/code_assist/server.test.ts` to assert the error response behaviour when a 404 error is encountered.