### PR TITLE
[SSR Agent] Issue Fix (14722): Fire SessionEnd Logout hook event during cli logout

### DIFF
--- a/packages/cli/src/ui/commands/authCommand.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.test.ts
@@ -9,10 +9,15 @@ import { authCommand } from './authCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { SettingScope } from '../../config/settings.js';
-import type { GeminiClient } from '@google/gemini-cli-core';
+import {
+  type GeminiClient,
+  clearCachedCredentialFile,
+  SessionEndReason,
+} from '@google/gemini-cli-core';
 
-vi.mock('@google/gemini-cli-core', async () => {
-  const actual = await vi.importActual('@google/gemini-cli-core');
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
   return {
     ...actual,
     clearCachedCredentialFile: vi.fn().mockResolvedValue(undefined),
@@ -78,10 +83,6 @@ describe('authCommand', () => {
       const logoutCommand = authCommand.subCommands?.[1];
       expect(logoutCommand?.name).toBe('signout');
 
-      const { clearCachedCredentialFile } = await import(
-        '@google/gemini-cli-core'
-      );
-
       await logoutCommand!.action!(mockContext, '');
 
       expect(clearCachedCredentialFile).toHaveBeenCalledOnce();
@@ -117,6 +118,34 @@ describe('authCommand', () => {
         mockContext.services.agentContext?.geminiClient
           .stripThoughtsFromHistory,
       ).toHaveBeenCalled();
+    });
+
+    it('should fire SessionEnd event with SessionEndReason.Logout', async () => {
+      const logoutCommand = authCommand.subCommands?.[1];
+      const mockFireSessionEndEvent = vi.fn();
+      const mockHookSystem = {
+        fireSessionEndEvent: mockFireSessionEndEvent,
+      };
+
+      mockContext = createMockCommandContext({
+        services: {
+          agentContext: {
+            geminiClient: {
+              stripThoughtsFromHistory: vi.fn(),
+            },
+            config: {
+              getHookSystem: vi.fn().mockReturnValue(mockHookSystem),
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+          },
+        },
+      });
+
+      await logoutCommand!.action!(mockContext, '');
+
+      expect(mockFireSessionEndEvent).toHaveBeenCalledWith(
+        SessionEndReason.Logout,
+      );
     });
 
     it('should return logout action to signal explicit state change', async () => {

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -10,7 +10,10 @@ import type {
   LogoutActionReturn,
 } from './types.js';
 import { CommandKind } from './types.js';
-import { clearCachedCredentialFile } from '@google/gemini-cli-core';
+import {
+  clearCachedCredentialFile,
+  SessionEndReason,
+} from '@google/gemini-cli-core';
 import { SettingScope } from '../../config/settings.js';
 
 const authLoginCommand: SlashCommand = {
@@ -40,6 +43,11 @@ const authLogoutCommand: SlashCommand = {
     );
     // Strip thoughts from history instead of clearing completely
     context.services.agentContext?.geminiClient.stripThoughtsFromHistory();
+    // Retrieve hook system and fire session end event for Logout
+    const hookSystem = context.services.agentContext?.config?.getHookSystem();
+    if (hookSystem) {
+      await hookSystem.fireSessionEndEvent(SessionEndReason.Logout);
+    }
     // Return logout action to signal explicit state change
     return {
       type: 'logout',

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -44,9 +44,13 @@ const authLogoutCommand: SlashCommand = {
     // Strip thoughts from history instead of clearing completely
     context.services.agentContext?.geminiClient.stripThoughtsFromHistory();
     // Retrieve hook system and fire session end event for Logout
-    const hookSystem = context.services.agentContext?.config?.getHookSystem();
-    if (hookSystem) {
-      await hookSystem.fireSessionEndEvent(SessionEndReason.Logout);
+    try {
+      const hookSystem = context.services.agentContext?.config?.getHookSystem();
+      if (hookSystem) {
+        await hookSystem.fireSessionEndEvent(SessionEndReason.Logout);
+      }
+    } catch (error) {
+      context.services.logger.error('Failed to fire SessionEnd event during logout:', error);
     }
     // Return logout action to signal explicit state change
     return {


### PR DESCRIPTION
fixes #14722

Issue URL: https://github.com/google-gemini/gemini-cli/issues/14722

### Context & Problem
The `SessionEndReason.Logout` enum value exists in the Gemini CLI core hook types, but it was never triggered when a user logs out. The action handler of `authLogoutCommand` correctly cleared credentials but failed to fire the session end event.

### Detailed Changes
- **packages/cli/src/ui/commands/authCommand.ts**: Imported `SessionEndReason` and updated `authLogoutCommand.action` to invoke the hook system's `fireSessionEndEvent(SessionEndReason.Logout)` before completing the logout process.
- **packages/cli/src/ui/commands/authCommand.test.ts**: Added a unit test to verify that calling the logout action triggers `fireSessionEndEvent` with `SessionEndReason.Logout`.

### Verification
Verified using Vitest: run and pass the newly added unit test in `packages/cli/src/ui/commands/authCommand.test.ts` to ensure full correctness and coverage. ESLint checks were verified in `linter_output.txt` and completed successfully.