### PR TITLE
[SSR Agent] Issue Fix (17448): Reset UI state and clarify context limit warning

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2903,14 +2903,14 @@ describe('useGeminiStream', () => {
           requestTokens: 20,
           remainingTokens: 80,
           expectedMessage:
-            'Sending this message (20 tokens) might exceed the context window limit (80 tokens left).',
+            'This message was not sent because the estimated token count (20 tokens) exceeds the remaining context window limit (80 tokens left).',
         },
         {
           name: 'with suggestion when remaining tokens are < 75% of limit',
           requestTokens: 30,
           remainingTokens: 70,
           expectedMessage:
-            'Sending this message (30 tokens) might exceed the context window limit (70 tokens left). Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
+            'This message was not sent because the estimated token count (30 tokens) exceeds the remaining context window limit (70 tokens left). Please try reducing the size of your message or use the `/compress` command to compress the chat history.',
         },
       ])(
         'should add message $name',
@@ -2938,6 +2938,7 @@ describe('useGeminiStream', () => {
               type: 'info',
               text: expectedMessage,
             });
+            expect(result.current.streamingState).toBe(StreamingState.Idle);
           });
         },
       );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1402,13 +1402,14 @@ export const useGeminiStream = (
   const handleContextWindowWillOverflowEvent = useCallback(
     (estimatedRequestTokenCount: number, remainingTokenCount: number) => {
       onCancelSubmit(true);
+      setIsResponding(false);
 
       const limit = tokenLimit(config.getModel());
 
       const isMoreThan25PercentUsed =
         limit > 0 && remainingTokenCount < limit * 0.75;
 
-      let text = `Sending this message (${estimatedRequestTokenCount} tokens) might exceed the context window limit (${remainingTokenCount.toLocaleString()} tokens left).`;
+      let text = `This message was not sent because the estimated token count (${estimatedRequestTokenCount} tokens) exceeds the remaining context window limit (${remainingTokenCount.toLocaleString()} tokens left).`;
 
       if (isMoreThan25PercentUsed) {
         text +=
@@ -1420,7 +1421,7 @@ export const useGeminiStream = (
         text,
       });
     },
-    [addItem, onCancelSubmit, config],
+    [addItem, onCancelSubmit, setIsResponding, config],
   );
 
   const handleChatModelEvent = useCallback(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -709,7 +709,13 @@ export class GeminiClient {
     if (estimatedRequestTokenCount > remainingTokenCount) {
       yield {
         type: GeminiEventType.ContextWindowWillOverflow,
-        value: { estimatedRequestTokenCount, remainingTokenCount },
+        value: {
+          estimatedRequestTokenCount,
+          remainingTokenCount,
+          message:
+            'The request was blocked because the estimated token count exceeds the remaining context window limit.',
+          blocked: true,
+        },
       };
       return turn;
     }

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -100,6 +100,8 @@ export type ServerGeminiContextWindowWillOverflowEvent = {
   value: {
     estimatedRequestTokenCount: number;
     remainingTokenCount: number;
+    message?: string;
+    blocked?: boolean;
   };
 };
 


### PR DESCRIPTION
fixes #17448
Original Issue: https://github.com/google-gemini/gemini-cli/issues/17448

### Context & Problem
When a tool execution yields massive outputs, the resulting context token count can dramatically exceed the remaining context window limit. The client correctly halts execution, but the CLI UI previously displayed an incorrect warning stating 'Sending this message... might exceed', which led to user confusion and lack of clarity on the execution state.

### Detailed Changes
- **packages/cli/src/ui/hooks/useGeminiStream.ts**:
  - Updated `handleContextWindowWillOverflowEvent` to explicitly clarify that the message is not sent because the estimated token count exceeds the remaining limit.
  - Reset the responding/sending UI state by setting `setIsResponding(false)`.
  - Added `setIsResponding` to the dependency array of `useCallback`.
- **packages/cli/src/ui/hooks/useGeminiStream.test.tsx**:
  - Updated mock/expected messages in assertions to align with the new warning copy.
  - Added assertions to verify that `streamingState` properly transitions to `StreamingState.Idle`.
- **packages/core/src/core/client.ts**:
  - Enriched the emitted `ContextWindowWillOverflow` event to include explicit message and blocked status flags.
- **packages/core/src/core/turn.ts**:
  - Declared optional message and blocked properties in `ServerGeminiContextWindowWillOverflowEvent` types.

### Verification
- Checked that workspace ESLint execution succeeded without errors.
- Verified that all unit tests correctly execute and assert against the streamlined handler behaviors.