### PR TITLE
[SSR Agent] Issue Fix (24935): Force terminal buffer rerender after exiting external editors

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -46,9 +46,10 @@ const mockIdeClient = vi.hoisted(() => ({
   getInstance: vi.fn().mockReturnValue(new Promise(() => {})),
 }));
 
-// Mock stdout
+// Mock stdout and ink app
 const mocks = vi.hoisted(() => ({
   mockStdout: { write: vi.fn() },
+  mockRerender: vi.fn(),
 }));
 const terminalNotificationsMocks = vi.hoisted(() => ({
   notifyViaTerminal: vi.fn().mockResolvedValue(true),
@@ -113,12 +114,15 @@ import {
   type OverflowActions,
 } from './contexts/OverflowContext.js';
 
-// Mock useStdout to capture terminal title writes
+// Mock useStdout and useApp to capture terminal title writes and spy on re-renders
 vi.mock('ink', async (importOriginal) => {
   const actual = await importOriginal<typeof import('ink')>();
   return {
     ...actual,
     useStdout: () => ({ stdout: mocks.mockStdout }),
+    useApp: () => ({
+      rerender: mocks.mockRerender,
+    }),
     measureElement: vi.fn(),
   };
 });
@@ -2916,6 +2920,33 @@ describe('AppContainer State Management', () => {
         }),
         expect.any(Number),
       );
+      unmount!();
+    });
+
+    it('calls app.rerender() when ExternalEditorClosed event is received in terminalBuffer mode', async () => {
+      vi.spyOn(mockConfig, 'getUseTerminalBuffer').mockReturnValue(true);
+      vi.spyOn(mockConfig, 'getUseAlternateBuffer').mockReturnValue(false);
+      vi.spyOn(mockConfig, 'getScreenReader').mockReturnValue(false);
+
+      mocks.mockRerender.mockClear();
+
+      let unmount: () => void;
+      await act(async () => {
+        const result = await renderAppContainer();
+        unmount = result.unmount;
+      });
+      await waitFor(() => expect(capturedUIState).toBeTruthy());
+
+      const handler = mockCoreEvents.on.mock.calls.find(
+        (call: unknown[]) => call[0] === CoreEvent.ExternalEditorClosed,
+      )?.[1];
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler();
+      });
+
+      expect(mocks.mockRerender).toHaveBeenCalledTimes(1);
       unmount!();
     });
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -663,10 +663,12 @@ export const AppContainer = (props: AppContainerProps) => {
       enableMouseEvents();
       disableLineWrapping();
       app.rerender();
+    } else if (config.getUseTerminalBuffer()) {
+      app.rerender();
     }
     terminalCapabilityManager.enableSupportedModes();
     refreshStatic();
-  }, [refreshStatic, shouldUseAlternateScreen, app]);
+  }, [refreshStatic, shouldUseAlternateScreen, app, config]);
 
   const [editorError, setEditorError] = useState<string | null>(null);
   const {


### PR DESCRIPTION
fixes #24935
https://github.com/google-gemini/gemini-cli/issues/24935

### Context & Problem
Terminal screen corruption occurs after exiting an external editor when operating in terminalBuffer mode. This happens because the buffer is not forced to rerender unless shouldUseAlternateScreen is true.

### Detailed Changes
- In [AppContainer.tsx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_24935/tmp/eval/gemini-cli-clone/packages/cli/src/ui/AppContainer.tsx), modified `handleEditorClose` to call `app.rerender()` when `config.getUseTerminalBuffer()` is true.
- Added `config` to the dependency array of the `handleEditorClose` callback.
- In [AppContainer.test.tsx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_24935/tmp/eval/gemini-cli-clone/packages/cli/src/ui/AppContainer.test.tsx), added a unit test that mocks `getUseTerminalBuffer` to return true and verifies that `app.rerender` is called when the `ExternalEditorClosed` event is triggered.

### Verification
- Executed unit tests in [AppContainer.test.tsx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_24935/tmp/eval/gemini-cli-clone/packages/cli/src/ui/AppContainer.test.tsx) (using Vitest) verifying that `app.rerender()` is correctly called on `ExternalEditorClosed` in terminalBuffer mode.
- Inspected the ESLint checks in `linter_output.txt` which succeeded without errors.