### PR TITLE
[SSR Agent] Issue Fix (21752): Fix error handling of internal AbortErrors in sendMessageStream

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -814,7 +814,27 @@ describe('Gemini Client (client.ts)', () => {
       );
     });
 
-    it('yields UserCancelled when processTurn throws AbortError', async () => {
+    it('yields UserCancelled when processTurn throws AbortError with an aborted signal', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      vi.spyOn(client['loopDetector'], 'turnStarted').mockRejectedValueOnce(
+        abortError,
+      );
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        controller.signal,
+        'prompt-id-abort-error',
+      );
+      const events = await fromAsync(stream);
+
+      expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
+    });
+
+    it('yields Error event and rethrows when processTurn throws AbortError with a non-aborted signal', async () => {
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
       vi.spyOn(client['loopDetector'], 'turnStarted').mockRejectedValueOnce(
@@ -824,11 +844,26 @@ describe('Gemini Client (client.ts)', () => {
       const stream = client.sendMessageStream(
         [{ text: 'Hi' }],
         new AbortController().signal,
-        'prompt-id-abort-error',
+        'prompt-id-abort-error-non-aborted',
       );
-      const events = await fromAsync(stream);
 
-      expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
+      const events: unknown[] = [];
+      let caughtError: unknown = null;
+      try {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      } catch (err) {
+        caughtError = err;
+      }
+
+      expect(caughtError).toBe(abortError);
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: { error: abortError },
+        },
+      ]);
     });
 
     it.each([

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -35,7 +35,7 @@ import {
   type RetryAvailabilityContext,
 } from '../utils/retry.js';
 import type { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
-import { getErrorMessage, isAbortError } from '../utils/errors.js';
+import { getErrorMessage } from '../utils/errors.js';
 import { tokenLimit } from './tokenLimits.js';
 import type {
   ChatRecordingService,
@@ -1034,10 +1034,11 @@ export class GeminiClient {
         }
       }
     } catch (error) {
-      if (signal?.aborted || isAbortError(error)) {
+      if (signal?.aborted) {
         yield { type: GeminiEventType.UserCancelled };
         return turn;
       }
+      yield { type: GeminiEventType.Error, value: { error } };
       throw error;
     } finally {
       if (!continuationHandled) {


### PR DESCRIPTION
fixes #21752
Original Issue URL: https://github.com/google-gemini/gemini-cli/issues/21752

### Context & Problem
Internal request errors (such as those from timeout-triggered `AbortError` instances inside `google-auth-library` or `node-fetch`) were being incorrectly caught and treated as manual user cancellation even when the user-controlled abort signal remained unaborted. This caused unexpected/silent process termination.

### Detailed Changes
- **packages/core/src/core/client.ts**: Updated the `catch` block in `sendMessageStream` to only yield `UserCancelled` if `signal?.aborted` is true. All other errors (including non-user aborted timeouts/AbortErrors) yield a `GeminiEventType.Error` event and get appropriately rethrown.
- **packages/core/src/core/client.test.ts**: Adapted the existing test suite and added a new unit test verifying that `sendMessageStream` yields the `Error` event and propagates the error when an internal `AbortError` is thrown and the signal is not aborted.

### Verification
- Verified by asserting expected behavior under both states (signal aborted vs signal not aborted) in the Vitest test file.