### PR TITLE
[SSR Agent] Issue Fix (20079): Support symlinked agent markdown files

### DIFF
--- a/packages/core/src/agents/agentLoader.test.ts
+++ b/packages/core/src/agents/agentLoader.test.ts
@@ -707,6 +707,50 @@ Hidden`,
       expect(result.agents).toHaveLength(0);
       expect(result.errors).toHaveLength(1);
     });
+
+    it('should load a symlinked agent markdown file', async () => {
+      const sourceDir = path.join(tempDir, 'source');
+      await fs.mkdir(sourceDir, { recursive: true });
+      const targetFilePath = path.join(sourceDir, 'real-agent.md');
+      await fs.writeFile(
+        targetFilePath,
+        `---
+name: symlinked-agent
+description: A symlinked agent definition
+---
+Hello from a symlinked agent!`,
+      );
+
+      const symlinkPath = path.join(tempDir, 'link-agent.md');
+      await fs.symlink(targetFilePath, symlinkPath);
+
+      const result = await loadAgentsFromDirectory(tempDir);
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0]).toMatchObject({
+        name: 'symlinked-agent',
+        description: 'A symlinked agent definition',
+        kind: 'local',
+        promptConfig: {
+          systemPrompt: 'Hello from a symlinked agent!',
+        },
+      });
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should report error when symlink target is a directory or non-regular file', async () => {
+      const targetDir = path.join(tempDir, 'target-directory');
+      await fs.mkdir(targetDir, { recursive: true });
+
+      const symlinkPath = path.join(tempDir, 'dir-link.md');
+      await fs.symlink(targetDir, symlinkPath);
+
+      const result = await loadAgentsFromDirectory(tempDir);
+      expect(result.agents).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain(
+        'Symbolic link does not point to a regular file',
+      );
+    });
   });
 
   describe('remote agent auth configuration', () => {

--- a/packages/core/src/agents/agentLoader.ts
+++ b/packages/core/src/agents/agentLoader.ts
@@ -664,7 +664,7 @@ export async function loadAgentsFromDirectory(
 
   const files = dirEntries.filter(
     (entry) =>
-      entry.isFile() &&
+      (entry.isFile() || entry.isSymbolicLink()) &&
       !entry.name.startsWith('_') &&
       entry.name.endsWith('.md'),
   );
@@ -672,7 +672,18 @@ export async function loadAgentsFromDirectory(
   for (const entry of files) {
     const filePath = path.join(dir, entry.name);
     try {
-      const content = await fs.readFile(filePath, 'utf-8');
+      let targetPath = filePath;
+      if (entry.isSymbolicLink()) {
+        targetPath = await fs.realpath(filePath);
+        const stat = await fs.stat(targetPath);
+        if (!stat.isFile()) {
+          throw new AgentLoadError(
+            filePath,
+            'Symbolic link does not point to a regular file',
+          );
+        }
+      }
+      const content = await fs.readFile(targetPath, 'utf-8');
       const hash = crypto.createHash('sha256').update(content).digest('hex');
       const agentDefs = await parseAgentMarkdown(filePath, content);
       for (const def of agentDefs) {

--- a/packages/core/src/services/FolderTrustDiscoveryService.test.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.test.ts
@@ -174,4 +174,27 @@ describe('FolderTrustDiscoveryService', () => {
       'This project contains custom agents.',
     );
   });
+
+  it('should discover custom agents when they are symbolic links', async () => {
+    const geminiDir = path.join(tempDir, GEMINI_DIR);
+    await fs.mkdir(geminiDir, { recursive: true });
+
+    const agentsDir = path.join(geminiDir, 'agents');
+    await fs.mkdir(agentsDir);
+
+    const sourceDir = path.join(tempDir, 'source');
+    await fs.mkdir(sourceDir, { recursive: true });
+    const targetFilePath = path.join(sourceDir, 'real-agent.md');
+    await fs.writeFile(targetFilePath, 'body');
+
+    const symlinkPath = path.join(agentsDir, 'symlinked-agent.md');
+    await fs.symlink(targetFilePath, symlinkPath);
+
+    const results = await FolderTrustDiscoveryService.discover(tempDir);
+
+    expect(results.agents).toContain('symlinked-agent');
+    expect(results.securityWarnings).toContain(
+      'This project contains custom agents.',
+    );
+  });
 });

--- a/packages/core/src/services/FolderTrustDiscoveryService.ts
+++ b/packages/core/src/services/FolderTrustDiscoveryService.ts
@@ -112,7 +112,7 @@ export class FolderTrustDiscoveryService {
         const entries = await fs.readdir(agentsDir, { withFileTypes: true });
         for (const entry of entries) {
           if (
-            entry.isFile() &&
+            (entry.isFile() || entry.isSymbolicLink()) &&
             entry.name.endsWith('.md') &&
             !entry.name.startsWith('_')
           ) {


### PR DESCRIPTION
fixes #20079
Original issue URL: https://github.com/google-gemini/gemini-cli/issues/20079

### Context & Problem
Subagent markdown files stored in agent directories (such as `~/.gemini/agents/`) are not recognized or loaded if they are symbolic links because the discovery and loader functions filtered entries specifically using `entry.isFile()`, which returns `false` for symbolic links.

### Detailed Changes
- In [agentLoader.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/agents/agentLoader.ts), updated [loadAgentsFromDirectory](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/agents/agentLoader.ts#L640) directory entry filtering to include symbolic links via `(entry.isFile() || entry.isSymbolicLink())`.
- In [FolderTrustDiscoveryService.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/services/FolderTrustDiscoveryService.ts), updated [discoverAgents](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/services/FolderTrustDiscoveryService.ts#L105) to check `(entry.isFile() || entry.isSymbolicLink())` when identifying files.
- In [agentLoader.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/agents/agentLoader.test.ts), added a test case asserting that [loadAgentsFromDirectory](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/agents/agentLoader.ts#L640) successfully loads symbolic link agent markdown files.
- In [FolderTrustDiscoveryService.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_20079/tmp/eval/gemini-cli-clone/packages/core/src/services/FolderTrustDiscoveryService.test.ts), added a test case verifying that symlinked custom agents are properly discovered.

### Verification
Vitest unit/integration tests were added and successfully verify that the symlinked markdown files are recognized, loaded, and parsed correctly without errors.