### PR TITLE
[SSR Agent] Issue Fix (23154): Fix sticky model persistence on rewind and cancellation

### DIFF
--- a/packages/cli/src/ui/commands/rewindCommand.tsx
+++ b/packages/cli/src/ui/commands/rewindCommand.tsx
@@ -44,6 +44,7 @@ async function rewindConversation(
   newText: string,
 ) {
   try {
+    client.clearCurrentSequenceModel();
     const conversation = recordingService.rewindTo(messageId);
     if (!conversation) {
       const errorMsg = 'Could not fetch conversation file';

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -849,6 +849,7 @@ export const useGeminiStream = (
 
       turnCancelledRef.current = true;
       setRetryStatus(null);
+      geminiClient.clearCurrentSequenceModel();
 
       // A full cancellation means no tools have produced a final result yet.
       // This determines if we show a generic "Request cancelled" message.
@@ -928,6 +929,7 @@ export const useGeminiStream = (
       toolCalls,
       activeShellPtyId,
       setIsResponding,
+      geminiClient,
     ],
   );
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -349,6 +349,25 @@ describe('Gemini Client (client.ts)', () => {
 
       expect(uiTelemetryService.setLastPromptTokenCount).toHaveBeenCalled();
     });
+
+    it('should reset currentSequenceModel to null when history is set', () => {
+      client['currentSequenceModel'] = 'gemini-1.5-flash';
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'some message' }] },
+      ];
+      client.setHistory(history);
+      expect(client.getCurrentSequenceModel()).toBeNull();
+    });
+  });
+
+  describe('clearCurrentSequenceModel', () => {
+    it('should reset currentSequenceModel to null', () => {
+      client['currentSequenceModel'] = 'gemini-1.5-flash';
+      expect(client.getCurrentSequenceModel()).toBe('gemini-1.5-flash');
+
+      client.clearCurrentSequenceModel();
+      expect(client.getCurrentSequenceModel()).toBeNull();
+    });
   });
 
   describe('resumeChat', () => {
@@ -814,7 +833,8 @@ describe('Gemini Client (client.ts)', () => {
       );
     });
 
-    it('yields UserCancelled when processTurn throws AbortError', async () => {
+    it('yields UserCancelled and resets currentSequenceModel when processTurn throws AbortError', async () => {
+      client['currentSequenceModel'] = 'gemini-1.5-flash';
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
       vi.spyOn(client['loopDetector'], 'turnStarted').mockRejectedValueOnce(
@@ -829,6 +849,7 @@ describe('Gemini Client (client.ts)', () => {
       const events = await fromAsync(stream);
 
       expect(events).toEqual([{ type: GeminiEventType.UserCancelled }]);
+      expect(client.getCurrentSequenceModel()).toBeNull();
     });
 
     it.each([

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -296,6 +296,7 @@ export class GeminiClient {
   }
 
   setHistory(history: ReadonlyArray<Content | HistoryTurn>) {
+    this.currentSequenceModel = null;
     this.getChat().setHistory(history);
     this.updateTelemetryTokenCount();
     this.forceFullIdeContext = true;
@@ -1035,6 +1036,7 @@ export class GeminiClient {
       }
     } catch (error) {
       if (signal?.aborted || isAbortError(error)) {
+        this.currentSequenceModel = null;
         yield { type: GeminiEventType.UserCancelled };
         return turn;
       }


### PR DESCRIPTION
fixes #23154
Original Issue: https://github.com/google-gemini/gemini-cli/issues/23154

### Context & Problem

When a request is cancelled or rewound, GeminiClient's internal sticky state (`currentSequenceModel`) is not cleared. Consequently, subsequent requests route to the stale sticky model from the aborted/rewound turn instead of the primary configured model.

### Detailed Changes

The following changes were implemented to reset sticky model overrides across rewinds or aborted turns:

- **[client.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_23154/tmp/eval/gemini-cli-clone/packages/core/src/core/client.ts)**: Safely reset `this.currentSequenceModel` inside `setHistory()` and within the stream's error catch block when handling a stream abort/cancellation event.
- **[rewindCommand.tsx](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_23154/tmp/eval/gemini-cli-clone/packages/cli/src/ui/commands/rewindCommand.tsx)**: Explicitly invoke `client.clearCurrentSequenceModel()` during conversation rewinds to clear state when jumping back in chat history.
- **[useGeminiStream.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_23154/tmp/eval/gemini-cli-clone/packages/cli/src/ui/hooks/useGeminiStream.ts)**: Call `geminiClient.clearCurrentSequenceModel()` when handling user-triggered cancellation.
- **[client.test.ts](file:///usr/local/google/home/joneba/ssr-prototype/gcli-intern-project/tools/caretaker-agent/evals/pr-generation/run_outputs/onboarded_triaged_3.5_flash/agent_environments/issue_23154/tmp/eval/gemini-cli-clone/packages/core/src/core/client.test.ts)**: Added unit tests validating model sequence state resetting during history changes, manual clearing, and stream abort operations.

### Verification

Integrated unit-level verification matches expectations:
- Verified that `clearCurrentSequenceModel()` resets the internal sequence model state.
- Verified that setting chat history or encountering abort exceptions properly clears the sticky sequence model.