### PR TITLE
fix(a2a): allow launcher workspace outside home

### DIFF
--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -433,8 +433,9 @@ export async function setTargetDir(
   agentSettings: AgentSettings | undefined,
 ): Promise<string> {
   const originalCWD = process.cwd();
+  const configuredWorkspacePath = getEnv('CODER_AGENT_WORKSPACE_PATH');
   const targetDir =
-    getEnv('CODER_AGENT_WORKSPACE_PATH') ??
+    configuredWorkspacePath ??
     (agentSettings?.kind === CoderAgentEvent.StateAgentSettingsEvent
       ? agentSettings.workspacePath
       : undefined);
@@ -474,9 +475,16 @@ export async function setTargetDir(
       process.argv.some((arg) => arg.includes('vitest')) ||
       resolvedPath.startsWith(resolveToRealPath(tmpdir()));
 
+    // When the launcher pins the server to a workspace, use that workspace as
+    // the default confinement root. Per-task workspace paths remain confined to
+    // the normal home-directory boundary unless an allowed root is configured.
+    const defaultAllowedRoot = configuredWorkspacePath
+      ? resolvedPath
+      : isTestEnv
+        ? path.parse(resolvedPath).root
+        : homedir();
     const allowedRoot = resolveToRealPath(
-      getEnv('CODER_AGENT_ALLOWED_ROOT') ||
-        (isTestEnv ? path.parse(resolvedPath).root : homedir()),
+      getEnv('CODER_AGENT_ALLOWED_ROOT') || defaultAllowedRoot,
     );
     const relative = path.relative(allowedRoot, resolvedPath);
     if (relative.startsWith('..') || path.isAbsolute(relative)) {

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -479,7 +479,7 @@ export async function setTargetDir(
     // the default confinement root. Per-task workspace paths remain confined to
     // the normal home-directory boundary unless an allowed root is configured.
     const defaultAllowedRoot = configuredWorkspacePath
-      ? resolvedPath
+      ? resolveToRealPath(configuredWorkspacePath)
       : isTestEnv
         ? path.parse(resolvedPath).root
         : homedir();

--- a/packages/a2a-server/src/config/workspace-root.test.ts
+++ b/packages/a2a-server/src/config/workspace-root.test.ts
@@ -46,8 +46,8 @@ describe('setTargetDir workspace confinement', () => {
     process.argv = ['node', 'a2a-server'];
     vi.stubEnv('VITEST', '');
     vi.stubEnv('NODE_ENV', 'production');
-    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', undefined);
-    vi.stubEnv('CODER_AGENT_ALLOWED_ROOT', undefined);
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', '');
+    vi.stubEnv('CODER_AGENT_ALLOWED_ROOT', '');
   });
 
   afterEach(() => {

--- a/packages/a2a-server/src/config/workspace-root.test.ts
+++ b/packages/a2a-server/src/config/workspace-root.test.ts
@@ -31,8 +31,6 @@ describe('setTargetDir workspace confinement', () => {
   let homeDir: string;
   let workspaceDir: string;
   let originalArgv: string[];
-  let originalWorkspacePath: string | undefined;
-  let originalAllowedRoot: string | undefined;
 
   beforeEach(() => {
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-a2a-home-'));
@@ -48,34 +46,20 @@ describe('setTargetDir workspace confinement', () => {
     process.argv = ['node', 'a2a-server'];
     vi.stubEnv('VITEST', '');
     vi.stubEnv('NODE_ENV', 'production');
-
-    originalWorkspacePath = process.env['CODER_AGENT_WORKSPACE_PATH'];
-    originalAllowedRoot = process.env['CODER_AGENT_ALLOWED_ROOT'];
-    delete process.env['CODER_AGENT_WORKSPACE_PATH'];
-    delete process.env['CODER_AGENT_ALLOWED_ROOT'];
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', undefined);
+    vi.stubEnv('CODER_AGENT_ALLOWED_ROOT', undefined);
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     process.argv = originalArgv;
 
-    if (originalWorkspacePath === undefined) {
-      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
-    } else {
-      process.env['CODER_AGENT_WORKSPACE_PATH'] = originalWorkspacePath;
-    }
-    if (originalAllowedRoot === undefined) {
-      delete process.env['CODER_AGENT_ALLOWED_ROOT'];
-    } else {
-      process.env['CODER_AGENT_ALLOWED_ROOT'] = originalAllowedRoot;
-    }
-
     fs.rmSync(workspaceDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
   it('allows a launcher-provided workspace outside the home directory', async () => {
-    process.env['CODER_AGENT_WORKSPACE_PATH'] = workspaceDir;
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', workspaceDir);
 
     await expect(setTargetDir(undefined)).resolves.toBe(
       fs.realpathSync(workspaceDir),
@@ -83,8 +67,8 @@ describe('setTargetDir workspace confinement', () => {
   });
 
   it('still honors an explicitly configured allowed root', async () => {
-    process.env['CODER_AGENT_WORKSPACE_PATH'] = workspaceDir;
-    process.env['CODER_AGENT_ALLOWED_ROOT'] = homeDir;
+    vi.stubEnv('CODER_AGENT_WORKSPACE_PATH', workspaceDir);
+    vi.stubEnv('CODER_AGENT_ALLOWED_ROOT', homeDir);
 
     await expect(setTargetDir(undefined)).rejects.toThrow(
       'outside the allowed root directory',

--- a/packages/a2a-server/src/config/workspace-root.test.ts
+++ b/packages/a2a-server/src/config/workspace-root.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const mockedPaths = vi.hoisted(() => ({
+  home: '',
+  tmp: '',
+}));
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    homedir: () => mockedPaths.home,
+    tmpdir: () => mockedPaths.tmp,
+  };
+});
+
+import { setTargetDir } from './config.js';
+import { CoderAgentEvent } from '../types.js';
+
+describe('setTargetDir workspace confinement', () => {
+  let homeDir: string;
+  let workspaceDir: string;
+  let originalArgv: string[];
+  let originalWorkspacePath: string | undefined;
+  let originalAllowedRoot: string | undefined;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-a2a-home-'));
+    workspaceDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-a2a-workspace-'),
+    );
+    mockedPaths.home = homeDir;
+    // Make the production-only path check deterministic even though this test
+    // itself runs under Vitest.
+    mockedPaths.tmp = homeDir;
+
+    originalArgv = process.argv;
+    process.argv = ['node', 'a2a-server'];
+    vi.stubEnv('VITEST', '');
+    vi.stubEnv('NODE_ENV', 'production');
+
+    originalWorkspacePath = process.env['CODER_AGENT_WORKSPACE_PATH'];
+    originalAllowedRoot = process.env['CODER_AGENT_ALLOWED_ROOT'];
+    delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+    delete process.env['CODER_AGENT_ALLOWED_ROOT'];
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.argv = originalArgv;
+
+    if (originalWorkspacePath === undefined) {
+      delete process.env['CODER_AGENT_WORKSPACE_PATH'];
+    } else {
+      process.env['CODER_AGENT_WORKSPACE_PATH'] = originalWorkspacePath;
+    }
+    if (originalAllowedRoot === undefined) {
+      delete process.env['CODER_AGENT_ALLOWED_ROOT'];
+    } else {
+      process.env['CODER_AGENT_ALLOWED_ROOT'] = originalAllowedRoot;
+    }
+
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('allows a launcher-provided workspace outside the home directory', async () => {
+    process.env['CODER_AGENT_WORKSPACE_PATH'] = workspaceDir;
+
+    await expect(setTargetDir(undefined)).resolves.toBe(
+      fs.realpathSync(workspaceDir),
+    );
+  });
+
+  it('still honors an explicitly configured allowed root', async () => {
+    process.env['CODER_AGENT_WORKSPACE_PATH'] = workspaceDir;
+    process.env['CODER_AGENT_ALLOWED_ROOT'] = homeDir;
+
+    await expect(setTargetDir(undefined)).rejects.toThrow(
+      'outside the allowed root directory',
+    );
+  });
+
+  it('keeps per-task workspace paths confined when no launcher path is set', async () => {
+    await expect(
+      setTargetDir({
+        kind: CoderAgentEvent.StateAgentSettingsEvent,
+        workspacePath: workspaceDir,
+      }),
+    ).rejects.toThrow('outside the allowed root directory');
+  });
+});


### PR DESCRIPTION
Fixes #28782

## Summary

- use a launcher-provided `CODER_AGENT_WORKSPACE_PATH` as the default confinement root
- preserve an explicit `CODER_AGENT_ALLOWED_ROOT`
- keep per-task workspace paths confined to the existing home-directory boundary when no launcher path is configured
- add regression coverage for all three cases

## Why

The A2A server currently defaults its allowed root to the user's home directory even when the launcher has already pinned the server to a specific workspace. That makes trusted IDE workspaces outside `%USERPROFILE%` fail during startup.

Using the launcher-provided workspace as the default confinement root fixes workspaces on other drives or outside the user profile without broadening the fallback boundary for request-supplied per-task paths.

## Validation

Added focused tests in `packages/a2a-server/src/config/workspace-root.test.ts`.