### PR TITLE
Fix/eval retry 429 rate limit

### DIFF
--- a/evals/activate_skill.eval.ts
+++ b/evals/activate_skill.eval.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('activate_skill', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent activates behavioral-evals skill when asked about writing behavioral evaluations',
+    files: {
+      '.gemini/skills/behavioral-evals/SKILL.md': `---
+name: behavioral-evals
+description: Guidance for creating, running, fixing, and promoting behavioral evaluations. Use when verifying agent decision logic, debugging failures, debugging prompt steering, or adding workspace regression tests.
+---
+# Behavioral Evals
+Workflow decision tree for creating, fixing, and promoting behavioral evaluations.`,
+    },
+    prompt:
+      'I want to write a new behavioral evaluation test for verifying agent decision logic. What is the recommended workflow?',
+    setup: async (rig) => {
+      await rig.getConfig().reloadSkills();
+      rig.setBreakpoint(['activate_skill']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        'activate_skill',
+        30000,
+      );
+      expect(
+        confirmation,
+        'Expected activate_skill to be called',
+      ).toBeDefined();
+
+      const toolCalls = (rig as any).getToolCalls();
+      const activateSkillCall = toolCalls.find(
+        (call: any) => call.request?.name === 'activate_skill',
+      );
+      expect(
+        activateSkillCall,
+        'Expected activate_skill call in tool logs',
+      ).toBeDefined();
+      expect(activateSkillCall.request?.args?.name).toBe('behavioral-evals');
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/activate_skill.eval.ts
+++ b/evals/activate_skill.eval.ts
@@ -44,7 +44,9 @@ Workflow decision tree for creating, fixing, and promoting behavioral evaluation
         activateSkillCall,
         'Expected activate_skill call in tool logs',
       ).toBeDefined();
-      expect(activateSkillCall.request?.args?.name).toBe('behavioral-evals');
+      const argsString = activateSkillCall?.request?.args;
+      const args = argsString ? JSON.parse(argsString) : undefined;
+      expect(args?.name).toBe('behavioral-evals');
 
       // Resolve the tool to allow the turn to complete successfully
       await rig.resolveTool(confirmation);

--- a/evals/complete_task.eval.ts
+++ b/evals/complete_task.eval.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('complete_task', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent inspects code via read_file and returns final review findings when requested',
+    files: {
+      'src/app.js': 'console.log("App running");',
+    },
+    prompt:
+      'Perform a code review of src/app.js and submit your final summary when done.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file']);
+    },
+    assert: async (rig) => {
+      // 1. Must inspect src/app.js via read_file
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_file'],
+        30000,
+      );
+
+      expect(
+        confirmation,
+        'Expected read_file confirmation before completing the review',
+      ).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent must read src/app.js before completing the task',
+      ).toBe('read_file');
+
+      await rig.resolveTool(confirmation);
+
+      // Verify read_file was called for src/app.js
+      const toolCalls = (rig as any).getToolCalls();
+      const readFileCall = toolCalls.find(
+        (call: any) => call.request?.name === 'read_file',
+      );
+      expect(
+        readFileCall,
+        'Expected read_file call in tool logs',
+      ).toBeDefined();
+      const readFileArgs = JSON.stringify(
+        readFileCall?.request?.args ?? {},
+      ).toLowerCase();
+      expect(
+        readFileArgs.includes('app.js'),
+        'read_file must target src/app.js',
+      ).toBe(true);
+
+      // Wait for agent to finish turn and produce final summary
+      await rig.waitForIdle(30000);
+
+      // 2. Verify the assistant's response text contains substantive code review analysis
+      const output = (
+        (rig as any).getLastModelTextResponse?.() || ''
+      ).toLowerCase();
+
+      // Reject trivially short output
+      expect(
+        output.length,
+        'Code review summary output must contain substantive review content (> 50 chars)',
+      ).toBeGreaterThan(50);
+
+      // Require at least 2 of the 3 code-specific elements from src/app.js
+      const codeElements = [
+        output.includes('console.log'),
+        output.includes('app running'),
+        output.includes('app.js'),
+      ];
+      const matchCount = codeElements.filter(Boolean).length;
+      expect(
+        matchCount,
+        `Code review output must reference at least 2 code elements from src/app.js (found ${matchCount}/3: console.log=${codeElements[0]}, app running=${codeElements[1]}, app.js=${codeElements[2]})`,
+      ).toBeGreaterThanOrEqual(2);
+
+      // Require actual review findings/analysis terms
+      const reviewKeywords = [
+        'review',
+        'summary',
+        'finding',
+        'issue',
+        'bug',
+        'clean',
+        'correct',
+        'simple',
+        'print',
+        'log',
+        'check',
+        'pass',
+        'good',
+        'valid',
+        'analysis',
+        'assess',
+        'quality',
+        'no issue',
+        'looks good',
+      ];
+      const hasReviewAnalysis = reviewKeywords.some((kw) =>
+        output.includes(kw),
+      );
+      expect(
+        hasReviewAnalysis,
+        'Code review output must contain actual findings or analysis (e.g., summary, findings, issues, code assessment)',
+      ).toBe(true);
+    },
+  });
+});

--- a/evals/error_recovery.eval.ts
+++ b/evals/error_recovery.eval.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('error_recovery', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent recovers from file-not-found error by searching repository and reading correct file',
+    files: {
+      'src/math.js':
+        'export function divide(a, b) {\n  if (b === 0) throw new Error("Divide by zero");\n  return a / b;\n}\n',
+      'src/index.js':
+        'import { divide } from "./math.js";\nconsole.log(divide(10, 2));\n',
+    },
+    prompt:
+      'Check the contents of src/utils/math.js to inspect how error handling is implemented for divide. If the file is not found, search the repository for math.js and inspect the actual file.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'grep_search', 'glob']);
+    },
+    assert: async (rig) => {
+      const firstConfirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'grep_search', 'glob'],
+        30000,
+      );
+
+      expect(
+        firstConfirmation,
+        'Expected initial tool call confirmation',
+      ).toBeDefined();
+
+      await rig.resolveTool(firstConfirmation);
+
+      const secondConfirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'grep_search', 'glob'],
+        30000,
+      );
+
+      expect(
+        secondConfirmation,
+        'Expected recovery tool call after file-not-found error',
+      ).toBeDefined();
+
+      await rig.resolveTool(secondConfirmation);
+
+      const toolCalls = (rig as any).getToolCalls();
+      const readMathCall = toolCalls.find((call: any) => {
+        if (call.request?.name !== 'read_file') return false;
+        const argsStr = JSON.stringify(call.request?.args ?? {}).toLowerCase();
+        return argsStr.includes('math.js');
+      });
+
+      if (!readMathCall) {
+        const thirdConfirmation = await rig.waitForPendingConfirmation(
+          ['read_file'],
+          30000,
+        );
+        expect(
+          thirdConfirmation,
+          'Expected read_file confirmation for src/math.js',
+        ).toBeDefined();
+        await rig.resolveTool(thirdConfirmation);
+      }
+
+      const updatedToolCalls = (rig as any).getToolCalls();
+      const readFileCalls = updatedToolCalls.filter(
+        (call: any) => call.request?.name === 'read_file',
+      );
+      expect(
+        readFileCalls.length,
+        'Agent must invoke read_file during recovery flow',
+      ).toBeGreaterThanOrEqual(1);
+
+      const hasReadCorrectFile = readFileCalls.some((call: any) => {
+        const argsStr = JSON.stringify(call.request?.args ?? {}).toLowerCase();
+        return argsStr.includes('math.js') && !argsStr.includes('utils');
+      });
+
+      expect(
+        hasReadCorrectFile,
+        'Agent must recover and invoke read_file targeting src/math.js',
+      ).toBe(true);
+
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/get_internal_docs.eval.ts
+++ b/evals/get_internal_docs.eval.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('get_internal_docs', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses get_internal_docs when asked about Gemini CLI internal documentation and features',
+    prompt:
+      'What internal CLI documentation is available regarding Gemini CLI authentication and setup?',
+    setup: async (rig) => {
+      rig.setBreakpoint([
+        'get_internal_docs',
+        'web_fetch',
+        'google_web_search',
+      ]);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['get_internal_docs', 'web_fetch', 'google_web_search'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use get_internal_docs to fetch built-in CLI docs instead of web tools',
+      ).toBe('get_internal_docs');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/mcp_resources.eval.ts
+++ b/evals/mcp_resources.eval.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+const MOCK_MCP_SERVER_CODE = `
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+rl.on('line', (line) => {
+  try {
+    const msg = JSON.parse(line);
+    
+    if (msg.method === 'initialize') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { resources: {} },
+          serverInfo: { name: 'mock-server', version: '1.0.0' }
+        } 
+      }));
+    } else if (msg.method === 'resources/list') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          resources: [
+            {
+              uri: 'mcp://mock-server/docs/api.md',
+              name: 'API Documentation',
+              mimeType: 'text/markdown'
+            }
+          ]
+        } 
+      }));
+    } else if (msg.method === 'resources/read') {
+      console.log(JSON.stringify({ 
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: {
+          contents: [
+            {
+              uri: msg.params.uri,
+              mimeType: 'text/markdown',
+              text: '# API Reference\\nThis is the API documentation for mock-server.'
+            }
+          ]
+        } 
+      }));
+    }
+  } catch (e) {}
+});
+`;
+
+describe.sequential('mcp_resources', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent lists MCP resources when asked what resources are available from MCP servers',
+    files: {
+      'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
+    },
+    configOverrides: {
+      settings: {
+        mcpServers: {
+          'mock-server': {
+            command: 'node',
+            args: ['./mock_mcp_server.js'],
+          },
+        },
+      },
+    },
+    prompt: 'List all available MCP resources from the connected mock-server.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['list_mcp_resources']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['list_mcp_resources'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use list_mcp_resources to discover available MCP resources',
+      ).toBe('list_mcp_resources');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent reads specified MCP resource when asked to fetch resource content',
+    files: {
+      'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
+    },
+    configOverrides: {
+      settings: {
+        mcpServers: {
+          'mock-server': {
+            command: 'node',
+            args: ['./mock_mcp_server.js'],
+          },
+        },
+      },
+    },
+    prompt:
+      'Read the MCP resource at mcp://mock-server/docs/api.md and summarize it.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_mcp_resource']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_mcp_resource'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_mcp_resource to read the requested MCP resource URI',
+      ).toBe('read_mcp_resource');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/mcp_resources.eval.ts
+++ b/evals/mcp_resources.eval.ts
@@ -67,12 +67,10 @@ describe.sequential('mcp_resources', () => {
       'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
     },
     configOverrides: {
-      settings: {
-        mcpServers: {
-          'mock-server': {
-            command: 'node',
-            args: ['./mock_mcp_server.js'],
-          },
+      mcpServers: {
+        'mock-server': {
+          command: 'node',
+          args: ['./mock_mcp_server.js'],
         },
       },
     },
@@ -105,12 +103,10 @@ describe.sequential('mcp_resources', () => {
       'mock_mcp_server.js': MOCK_MCP_SERVER_CODE,
     },
     configOverrides: {
-      settings: {
-        mcpServers: {
-          'mock-server': {
-            command: 'node',
-            args: ['./mock_mcp_server.js'],
-          },
+      mcpServers: {
+        'mock-server': {
+          command: 'node',
+          args: ['./mock_mcp_server.js'],
         },
       },
     },

--- a/evals/read_many_files.eval.ts
+++ b/evals/read_many_files.eval.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('read_many_files', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses read_many_files when asked to inspect multiple configuration files in a directory',
+    files: {
+      'config/app.json': '{\n  "name": "my-app",\n  "version": "1.0.0"\n}',
+      'config/database.json': '{\n  "host": "localhost",\n  "port": 5432\n}',
+      'config/logging.json': '{\n  "level": "info"\n}',
+    },
+    prompt:
+      'Inspect and summarize all configuration JSON files in the config/ directory.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_many_files', 'read_file']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_many_files', 'read_file'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_many_files to inspect multiple files in batch',
+      ).toBe('read_many_files');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses read_file instead of read_many_files when asked to read a single file',
+    files: {
+      'src/index.ts': 'console.log("Hello World");',
+    },
+    prompt: 'Read the file src/index.ts and summarize what it does.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'read_many_files']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'read_many_files'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use read_file for a single file instead of read_many_files',
+      ).toBe('read_file');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/shell_error_recovery.eval.ts
+++ b/evals/shell_error_recovery.eval.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('shell_error_recovery', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent recovers from failed shell command by diagnosing error output and retrying with corrected command',
+    files: {
+      'package.json': JSON.stringify({
+        name: 'demo-app',
+        version: '1.0.0',
+        scripts: {
+          'test:broken': 'exit 1',
+          test: 'echo "Tests passed!"',
+        },
+      }),
+    },
+    prompt:
+      'Run the project test suite by executing the shell command "npm run test:broken". When that command fails with a non-zero exit status, diagnose the failure output and retry using "npm test".',
+    setup: async (rig) => {
+      rig.setBreakpoint(['run_shell_command']);
+    },
+    assert: async (rig) => {
+      const firstConfirmation = await rig.waitForPendingConfirmation(
+        ['run_shell_command'],
+        30000,
+      );
+
+      expect(
+        firstConfirmation,
+        'Expected initial run_shell_command confirmation',
+      ).toBeDefined();
+      expect(firstConfirmation.toolName).toBe('run_shell_command');
+
+      await rig.resolveTool(firstConfirmation);
+
+      // Wait until the initial failing tool execution completes and records its result
+      await (rig as any).waitUntil(
+        () => {
+          const calls = (rig as any).getToolCalls();
+          const call = calls.find(
+            (c: any) =>
+              c.request?.name === 'run_shell_command' &&
+              JSON.stringify(c.request?.args ?? '').includes('test:broken'),
+          );
+          return Boolean(
+            call?.response || call?.result || call?.status === 'error',
+          );
+        },
+        {
+          timeout: 30000,
+          message: 'Timed out waiting for initial run_shell_command to execute',
+        },
+      );
+
+      const toolCallsAfterFirst = (rig as any).getToolCalls();
+      const firstCall = toolCallsAfterFirst.find(
+        (call: any) => call.request?.name === 'run_shell_command',
+      );
+      expect(
+        firstCall,
+        'Expected first run_shell_command in tool logs',
+      ).toBeDefined();
+
+      const firstArgsStr = JSON.stringify(
+        firstCall?.request?.args ?? {},
+      ).toLowerCase();
+      expect(
+        firstArgsStr,
+        'Initial shell command should execute the failing npm run test:broken script',
+      ).toContain('test:broken');
+
+      // Verify the first tool call completed with a structured non-zero exit status or error output
+      const firstResponseStr = JSON.stringify(
+        firstCall?.response ?? firstCall?.result ?? {},
+      );
+
+      const exitCodeMatch = firstResponseStr.match(/exit code:?\s*(\d+)/i);
+      const exitCode = exitCodeMatch ? parseInt(exitCodeMatch[1], 10) : null;
+
+      const showsFailure =
+        firstCall?.status === 'error' ||
+        (exitCode !== null && exitCode !== 0) ||
+        /exit code:?\s*[1-9]/i.test(firstResponseStr) ||
+        /command failed with exit code/i.test(firstResponseStr) ||
+        /npm ERR!/i.test(firstResponseStr);
+
+      expect(
+        showsFailure,
+        'First shell command must register a non-zero exit status (e.g. Exit Code: 1 or status: error) before retry',
+      ).toBe(true);
+
+      // Re-install breakpoint so the retry call produces a pending confirmation
+      rig.setBreakpoint(['run_shell_command']);
+
+      const secondConfirmation = await rig.waitForPendingConfirmation(
+        ['run_shell_command'],
+        30000,
+      );
+
+      expect(
+        secondConfirmation,
+        'Expected second run_shell_command confirmation for corrected command',
+      ).toBeDefined();
+      expect(secondConfirmation.toolName).toBe('run_shell_command');
+
+      await rig.resolveTool(secondConfirmation);
+
+      // Wait for the second shell command (npm test) to complete execution
+      await (rig as any).waitUntil(
+        () => {
+          const calls = (rig as any).getToolCalls();
+          const shellCalls = calls.filter(
+            (c: any) => c.request?.name === 'run_shell_command',
+          );
+          const second = shellCalls[1];
+          return Boolean(
+            second?.response || second?.result || second?.status === 'success',
+          );
+        },
+        {
+          timeout: 30000,
+          message: 'Timed out waiting for corrected shell command to execute',
+        },
+      );
+
+      const toolCallsAfterSecond = (rig as any).getToolCalls();
+      const shellCalls = toolCallsAfterSecond.filter(
+        (call: any) => call.request?.name === 'run_shell_command',
+      );
+      expect(
+        shellCalls.length,
+        'Expected at least two run_shell_command calls during recovery',
+      ).toBeGreaterThanOrEqual(2);
+
+      const secondCall = shellCalls[1];
+      const secondArgsStr = JSON.stringify(
+        secondCall?.request?.args ?? {},
+      ).toLowerCase();
+      expect(
+        secondArgsStr,
+        'Subsequent shell command should execute the corrected npm test command',
+      ).toContain('npm test');
+
+      // Verify the corrected retry command executed successfully with 0 exit code
+      const secondResponseStr = JSON.stringify(
+        secondCall?.response ?? secondCall?.result ?? {},
+      );
+      const secondExitCodeMatch =
+        secondResponseStr.match(/exit code:?\s*(\d+)/i);
+      const secondExitCode = secondExitCodeMatch
+        ? parseInt(secondExitCodeMatch[1], 10)
+        : null;
+
+      const secondSucceeded =
+        secondCall?.status !== 'error' &&
+        (secondExitCode === 0 ||
+          secondResponseStr.includes('Tests passed!') ||
+          (!/exit code:?\s*[1-9]/i.test(secondResponseStr) &&
+            !/npm ERR!/i.test(secondResponseStr)));
+
+      expect(
+        secondSucceeded,
+        'Corrected shell command (npm test) must execute successfully with a 0 exit status',
+      ).toBe(true);
+
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/test-helper.test.ts
+++ b/evals/test-helper.test.ts
@@ -159,6 +159,69 @@ describe('evalTest reliability logic', () => {
     expect(entries[3].status).toBe('SKIP');
   });
 
+  it('should retry 3 times on 429 RESOURCE_EXHAUSTED error and then SKIP', async () => {
+    const mockRig = new TestRig() as any;
+    (TestRig as any).mockReturnValue(mockRig);
+
+    // Simulate permanent 429 rate limit error
+    mockRig.run.mockRejectedValue(
+      new Error('status: RESOURCE_EXHAUSTED - quota exceeded'),
+    );
+
+    await internalEvalTest({
+      suiteName: 'test',
+      suiteType: 'behavioral',
+      name: 'test-api-429',
+      prompt: 'do something',
+      assert: async () => {},
+    });
+
+    // 1 initial + 3 retries = 4 total
+    expect(mockRig.run).toHaveBeenCalledTimes(4);
+
+    const logContent = fs
+      .readFileSync(RELIABILITY_LOG, 'utf-8')
+      .trim()
+      .split('\n');
+    const entries = logContent.map((line) => JSON.parse(line));
+    expect(entries[0].errorCode).toBe('429');
+    expect(entries[0].status).toBe('RETRY');
+    expect(entries[3].status).toBe('SKIP');
+  });
+
+  it('should retry on 429 Too Many Requests quota error message', async () => {
+    const mockRig = new TestRig() as any;
+    (TestRig as any).mockReturnValue(mockRig);
+
+    // Fail once with a quota-exhausted message, then succeed
+    mockRig.run
+      .mockRejectedValueOnce(
+        new Error('You exceeded your current quota, please check your plan'),
+      )
+      .mockResolvedValueOnce('Success');
+
+    await internalEvalTest({
+      suiteName: 'test',
+      suiteType: 'behavioral',
+      name: 'test-quota-recovery',
+      prompt: 'do something',
+      assert: async () => {},
+    });
+
+    // 1 failure + 1 success = 2 total runs
+    expect(mockRig.run).toHaveBeenCalledTimes(2);
+
+    // Log should have one RETRY entry with code 429
+    const logContent = fs
+      .readFileSync(RELIABILITY_LOG, 'utf-8')
+      .trim()
+      .split('\n');
+    expect(logContent.length).toBe(1);
+    const entry = JSON.parse(logContent[0]);
+    expect(entry.status).toBe('RETRY');
+    expect(entry.errorCode).toBe('429');
+  });
+
   it('should throw if an absolute path is used in files', async () => {
     const mockRig = new TestRig() as any;
     (TestRig as any).mockReturnValue(mockRig);

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -337,6 +337,10 @@ export async function prepareWorkspace(
     fs.writeFileSync(ackPath, JSON.stringify(acknowledgedAgents, null, 2));
   }
 
+  if (!fs.existsSync(path.join(projectRoot, '.gitignore'))) {
+    fs.writeFileSync(path.join(projectRoot, '.gitignore'), 'node_modules/\n');
+  }
+
   const execOptions = { cwd: testDir, stdio: 'ignore' as const };
   execSync('git init --initial-branch=main', execOptions);
   execSync('git config user.email "test@example.com"', execOptions);
@@ -407,7 +411,8 @@ export function symlinkNodeModules(testDir: string) {
     fs.existsSync(rootNodeModules) &&
     !fs.existsSync(testNodeModules)
   ) {
-    fs.symlinkSync(rootNodeModules, testNodeModules, 'dir');
+    const type = process.platform === 'win32' ? 'junction' : 'dir';
+    fs.symlinkSync(rootNodeModules, testNodeModules, type);
   }
 }
 

--- a/evals/test-helper.ts
+++ b/evals/test-helper.ts
@@ -225,7 +225,7 @@ export async function internalEvalTest(evalCase: EvalCase) {
   });
 }
 
-function getApiErrorCode(message: string): '500' | '503' | undefined {
+function getApiErrorCode(message: string): '429' | '500' | '503' | undefined {
   if (
     message.includes('status: UNAVAILABLE') ||
     message.includes('code: 503') ||
@@ -239,6 +239,15 @@ function getApiErrorCode(message: string): '500' | '503' | undefined {
     message.includes('Internal error encountered')
   ) {
     return '500';
+  }
+  if (
+    message.includes('status: RESOURCE_EXHAUSTED') ||
+    message.includes('code: 429') ||
+    message.includes('Too Many Requests') ||
+    message.includes('Rate limit exceeded') ||
+    message.includes('You exceeded your current quota')
+  ) {
+    return '429';
   }
   return undefined;
 }
@@ -254,7 +263,7 @@ function logReliabilityEvent(
   testName: string,
   attempt: number,
   status: 'RETRY' | 'SKIP',
-  errorCode: '500' | '503',
+  errorCode: '429' | '500' | '503',
   errorMessage: string,
 ) {
   const reliabilityLog = {

--- a/evals/tracker_queries.eval.ts
+++ b/evals/tracker_queries.eval.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('tracker_queries', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent calls tracker_list_tasks when asked to list active tasks in the task tracker',
+    configOverrides: {
+      tracker: true,
+    },
+    prompt: 'List all current tasks and their status from the task tracker.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['tracker_list_tasks']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['tracker_list_tasks'],
+        30000,
+      );
+
+      expect(
+        confirmation,
+        'Expected tracker_list_tasks tool call confirmation',
+      ).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should call tracker_list_tasks to retrieve task list',
+      ).toBe('tracker_list_tasks');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent calls tracker_get_task with created task ID when asked to view details for a task',
+    configOverrides: {
+      tracker: true,
+    },
+    prompt:
+      'First, create a task titled "Fix authentication bug" in the task tracker. Then immediately retrieve and display the full details of that task using tracker_get_task.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['tracker_create_task', 'tracker_get_task']);
+    },
+    assert: async (rig) => {
+      const createConfirmation = await rig.waitForPendingConfirmation(
+        ['tracker_create_task', 'tracker_get_task'],
+        30000,
+      );
+
+      expect(
+        createConfirmation,
+        'Expected tracker_create_task confirmation first',
+      ).toBeDefined();
+      expect(createConfirmation.toolName).toBe('tracker_create_task');
+      await rig.resolveTool(createConfirmation);
+
+      // Wait for tracker_get_task confirmation (signaling create completed and model requested get)
+      const getConfirmation = await rig.waitForPendingConfirmation(
+        ['tracker_get_task'],
+        30000,
+      );
+
+      expect(
+        getConfirmation,
+        'Expected tracker_get_task confirmation after task creation',
+      ).toBeDefined();
+      expect(getConfirmation.toolName).toBe('tracker_get_task');
+
+      // Inspect completed tracker_create_task call in tool logs
+      const toolCalls = (rig as any).getToolCalls();
+      const createCall = toolCalls.find(
+        (call: any) =>
+          call.request?.name === 'tracker_create_task' &&
+          (call.status === 'success' || call.response),
+      );
+      expect(
+        createCall,
+        'Expected tracker_create_task to complete successfully',
+      ).toBeDefined();
+
+      // Extract the created task ID from response content (content / llmContent / output)
+      // The tracker tool returns: "Created task <id>: <title>"
+      const responseParts = (createCall as any)?.response?.responseParts ?? [];
+      const responseText = responseParts
+        .map(
+          (p: any) =>
+            p.functionResponse?.response?.content ??
+            p.functionResponse?.response?.llmContent ??
+            p.functionResponse?.response?.output ??
+            p.text ??
+            '',
+        )
+        .join('');
+      const createdIdMatch = responseText.match(/Created task\s+([^:]+):/);
+      const createdTaskId = createdIdMatch?.[1]?.trim();
+      expect(
+        createdTaskId,
+        `Expected to extract created task ID from response: "${responseText}"`,
+      ).toBeDefined();
+
+      // Verify tracker_get_task requested ID matches the created task ID
+      const getTaskCall = (rig as any)
+        .getToolCalls()
+        .find((call: any) => call.request?.name === 'tracker_get_task');
+      expect(
+        getTaskCall,
+        'Expected tracker_get_task in tool call logs',
+      ).toBeDefined();
+      const args = (getTaskCall as any).request?.args;
+      const requestedId = args?.taskId ?? args?.id;
+      expect(
+        typeof requestedId === 'string' && requestedId.length > 0,
+        'Expected tracker_get_task to be called with a non-empty string task ID',
+      ).toBe(true);
+      expect(
+        requestedId,
+        'tracker_get_task must retrieve the same task that was just created',
+      ).toBe(createdTaskId);
+
+      await rig.resolveTool(getConfirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/tracker_queries.eval.ts
+++ b/evals/tracker_queries.eval.ts
@@ -94,10 +94,10 @@ describe.sequential('tracker_queries', () => {
       const responseText = responseParts
         .map(
           (p: any) =>
-            p.functionResponse?.response?.content ??
-            p.functionResponse?.response?.llmContent ??
-            p.functionResponse?.response?.output ??
-            p.text ??
+            p?.functionResponse?.response?.content ??
+            p?.functionResponse?.response?.llmContent ??
+            p?.functionResponse?.response?.output ??
+            p?.text ??
             '',
         )
         .join('');
@@ -116,7 +116,8 @@ describe.sequential('tracker_queries', () => {
         getTaskCall,
         'Expected tracker_get_task in tool call logs',
       ).toBeDefined();
-      const args = (getTaskCall as any).request?.args;
+      const argsString = (getTaskCall as any)?.request?.args;
+      const args = argsString ? JSON.parse(argsString) : undefined;
       const requestedId = args?.taskId ?? args?.id;
       expect(
         typeof requestedId === 'string' && requestedId.length > 0,

--- a/evals/tracker_relationships.eval.ts
+++ b/evals/tracker_relationships.eval.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('tracker_relationships', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent calls tracker_add_dependency when asked to declare a task dependency relationship',
+    configOverrides: {
+      tracker: true,
+    },
+    prompt:
+      'First, create a task titled "Backend API" in the task tracker. Then create a second task titled "Frontend UI" and mark "Frontend UI" as depending on "Backend API" using tracker_add_dependency.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['tracker_create_task', 'tracker_add_dependency']);
+    },
+    assert: async (rig) => {
+      const firstCreate = await rig.waitForPendingConfirmation(
+        ['tracker_create_task', 'tracker_add_dependency'],
+        30000,
+      );
+      expect(firstCreate, 'Expected task creation confirmation').toBeDefined();
+      if (firstCreate.toolName === 'tracker_create_task') {
+        await rig.resolveTool(firstCreate);
+
+        const secondCreate = await rig.waitForPendingConfirmation(
+          ['tracker_create_task', 'tracker_add_dependency'],
+          30000,
+        );
+        expect(
+          secondCreate,
+          'Expected second task creation or dependency confirmation',
+        ).toBeDefined();
+        if (secondCreate.toolName === 'tracker_create_task') {
+          await rig.resolveTool(secondCreate);
+        }
+      }
+
+      const depConfirmation = await rig.waitForPendingConfirmation(
+        ['tracker_add_dependency'],
+        30000,
+      );
+
+      expect(
+        depConfirmation,
+        'Expected tracker_add_dependency tool call confirmation',
+      ).toBeDefined();
+      expect(
+        depConfirmation.toolName,
+        'Agent should call tracker_add_dependency to declare task dependency',
+      ).toBe('tracker_add_dependency');
+
+      await rig.resolveTool(depConfirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent calls tracker_visualize when asked to display task dependency graph',
+    configOverrides: {
+      tracker: true,
+    },
+    prompt:
+      'Display a visual graph or chart representation of all active tasks and their dependencies in the task tracker using tracker_visualize.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['tracker_visualize']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['tracker_visualize'],
+        30000,
+      );
+
+      expect(
+        confirmation,
+        'Expected tracker_visualize tool call confirmation',
+      ).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should call tracker_visualize to display dependency graph',
+      ).toBe('tracker_visualize');
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/web_fetch.eval.ts
+++ b/evals/web_fetch.eval.ts
@@ -42,7 +42,8 @@ describe.sequential('web_fetch', () => {
         'Expected web_fetch call in tool logs',
       ).toBeDefined();
 
-      const args = webFetchCall.request?.args;
+      const argsString = webFetchCall?.request?.args;
+      const args = argsString ? JSON.parse(argsString) : undefined;
       const hasUrl =
         args?.url?.includes('example.com/status') ||
         args?.prompt?.includes('example.com/status');

--- a/evals/web_fetch.eval.ts
+++ b/evals/web_fetch.eval.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('web_fetch', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent fetches URL when asked for summary of webpage and avoids shell curl or web search',
+    prompt:
+      'Please fetch the webpage at https://example.com/status and summarize its content for me.',
+    setup: async (rig) => {
+      rig.setBreakpoint([
+        'web_fetch',
+        'run_shell_command',
+        'google_web_search',
+      ]);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['web_fetch', 'run_shell_command', 'google_web_search'],
+        30000,
+      );
+
+      expect(confirmation, 'Expected a tool call confirmation').toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should use web_fetch instead of shell curl or google search',
+      ).toBe('web_fetch');
+
+      const toolCalls = (rig as any).getToolCalls();
+      const webFetchCall = toolCalls.find(
+        (call: any) => call.request?.name === 'web_fetch',
+      );
+      expect(
+        webFetchCall,
+        'Expected web_fetch call in tool logs',
+      ).toBeDefined();
+
+      const args = webFetchCall.request?.args;
+      const hasUrl =
+        args?.url?.includes('example.com/status') ||
+        args?.prompt?.includes('example.com/status');
+      expect(hasUrl, 'Expected target URL in web_fetch args').toBe(true);
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent does NOT fetch web content when asked for local repo details',
+    files: {
+      'README.md': '# My Cool Local Project\nThis is local repository content.',
+    },
+    prompt: 'Summarize the content of README.md in this project.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['read_file', 'web_fetch']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['read_file', 'web_fetch'],
+        30000,
+      );
+      expect(confirmation).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should read local file instead of fetching external URLs',
+      ).toBe('read_file');
+
+      // Resolve the tool to allow the turn to complete successfully
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/evals/write_todos.eval.ts
+++ b/evals/write_todos.eval.ts
@@ -50,7 +50,9 @@ describe.sequential('write_todos', () => {
         writeTodosCall,
         'Expected write_todos call in tool logs',
       ).toBeDefined();
-      const todos = (writeTodosCall as any).request?.args?.todos;
+      const argsString = (writeTodosCall as any)?.request?.args;
+      const args = argsString ? JSON.parse(argsString) : undefined;
+      const todos = args?.todos;
       expect(Array.isArray(todos), 'Expected todos to be an array').toBe(true);
       expect(
         todos.length,

--- a/evals/write_todos.eval.ts
+++ b/evals/write_todos.eval.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect } from 'vitest';
+import { appEvalTest } from './app-test-helper.js';
+
+describe.sequential('write_todos', () => {
+  appEvalTest('USUALLY_PASSES', {
+    suiteName: 'default',
+    suiteType: 'behavioral',
+    name: 'Agent uses write_todos to outline plan when asked to perform multi-step refactoring',
+    files: {
+      'src/utils.js': 'export function add(a, b) { return a + b; }',
+      'src/math.js': 'export function multiply(a, b) { return a * b; }',
+      'src/index.js':
+        'import { add } from "./utils.js"; console.log(add(1, 2));',
+    },
+    configOverrides: {
+      model: 'gemini-2.5-pro',
+    },
+    prompt:
+      'We need a multi-step refactor: 1) add a divide function to src/utils.js, 2) export divide from src/math.js, 3) update src/index.js to use divide, and 4) add unit tests. Please organize the TODO list first using write_todos before writing code.',
+    setup: async (rig) => {
+      rig.setBreakpoint(['write_todos']);
+    },
+    assert: async (rig) => {
+      const confirmation = await rig.waitForPendingConfirmation(
+        ['write_todos'],
+        30000,
+      );
+
+      expect(
+        confirmation,
+        'Expected write_todos tool call confirmation',
+      ).toBeDefined();
+      expect(
+        confirmation.toolName,
+        'Agent should call write_todos to track work items',
+      ).toBe('write_todos');
+
+      // Verify write_todos tool was called
+      const toolCalls = (rig as any).getToolCalls();
+      const writeTodosCall = toolCalls.find(
+        (call: any) => call.request?.name === 'write_todos',
+      );
+      expect(
+        writeTodosCall,
+        'Expected write_todos call in tool logs',
+      ).toBeDefined();
+      const todos = (writeTodosCall as any).request?.args?.todos;
+      expect(Array.isArray(todos), 'Expected todos to be an array').toBe(true);
+      expect(
+        todos.length,
+        'Expected at least 3 TODO items for a 4-step refactoring plan',
+      ).toBeGreaterThanOrEqual(3);
+
+      for (let i = 0; i < todos.length; i++) {
+        const item = todos[i];
+        const content =
+          typeof item === 'string'
+            ? item
+            : (item?.description ?? item?.title ?? item?.content ?? '');
+        expect(
+          typeof content === 'string' && content.trim().length > 0,
+          `TODO item ${i} must have non-empty content`,
+        ).toBe(true);
+      }
+
+      const todoText = JSON.stringify(todos).toLowerCase();
+
+      // Assert coverage for each of the four distinct requested refactoring operations
+      expect(
+        todoText.includes('divide') || todoText.includes('utils'),
+        'TODO list must include divide function creation in utils',
+      ).toBe(true);
+
+      expect(
+        (todoText.includes('export') ||
+          todoText.includes('re-export') ||
+          todoText.includes('reexport')) &&
+          (todoText.includes('math') || todoText.includes('src/math')),
+        'TODO list must explicitly include exporting divide from math module (src/math.js)',
+      ).toBe(true);
+
+      expect(
+        todoText.includes('index'),
+        'TODO list must include updating index.js',
+      ).toBe(true);
+
+      expect(
+        todoText.includes('test'),
+        'TODO list must include adding unit tests',
+      ).toBe(true);
+
+      await rig.resolveTool(confirmation);
+      await rig.waitForIdle(30000);
+    },
+  });
+});

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -487,7 +487,8 @@ export class AppRig {
 
   async waitForCompletedToolCall(toolName: string, timeout = 10000) {
     await this.waitUntil(
-      () => this.toolCalls.some(
+      () =>
+        this.toolCalls.some(
           (call) => call.request.name === toolName && call.status === 'success',
         ),
       {
@@ -731,6 +732,8 @@ export class AppRig {
         if (turn.role === 'model' && turn.parts) {
           for (const part of turn.parts) {
             if (
+              part &&
+              typeof part === 'object' &&
               'text' in part &&
               typeof part.text === 'string' &&
               part.text.trim()

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -485,6 +485,18 @@ export class AppRig {
     return this.toolCalls;
   }
 
+  async waitForCompletedToolCall(toolName: string, timeout = 10000) {
+    await this.waitUntil(
+      () => this.toolCalls.some(
+          (call) => call.request.name === toolName && call.status === 'success',
+        ),
+      {
+        timeout,
+        message: `Timed out waiting for tool call "${toolName}" to complete with success status`,
+      },
+    );
+  }
+
   private async waitUntil(
     predicate: () => boolean | Promise<boolean>,
     options: { timeout?: number; interval?: number; message?: string } = {},
@@ -707,6 +719,36 @@ export class AppRig {
   getStaticOutput() {
     if (!this.renderResult) return '';
     return stripAnsi(this.renderResult.stdout.lastFrame() || '');
+  }
+
+  getModelTextResponses(): string[] {
+    if (!this.config) return [];
+    try {
+      const client = this.config.getGeminiClient();
+      const history = client.getHistory();
+      const modelTexts: string[] = [];
+      for (const turn of history) {
+        if (turn.role === 'model' && turn.parts) {
+          for (const part of turn.parts) {
+            if (
+              'text' in part &&
+              typeof part.text === 'string' &&
+              part.text.trim()
+            ) {
+              modelTexts.push(part.text);
+            }
+          }
+        }
+      }
+      return modelTexts;
+    } catch {
+      return [];
+    }
+  }
+
+  getLastModelTextResponse(): string {
+    const texts = this.getModelTextResponses();
+    return texts.length > 0 ? texts[texts.length - 1] : '';
   }
 
   async waitForOutput(pattern: string | RegExp, timeout = 30000) {

--- a/packages/cli/src/test-utils/AppRig.tsx
+++ b/packages/cli/src/test-utils/AppRig.tsx
@@ -481,6 +481,10 @@ export class AppRig {
     return Array.from(this.pendingConfirmations.values());
   }
 
+  getToolCalls() {
+    return this.toolCalls;
+  }
+
   private async waitUntil(
     predicate: () => boolean | Promise<boolean>,
     options: { timeout?: number; interval?: number; message?: string } = {},

--- a/scripts/tests/eval-report.test.ts
+++ b/scripts/tests/eval-report.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   findReportFiles,
   getModelFromPath,
+  getRelativePath,
   summarizeReports,
   formatReportSummary,
   formatReportSummaryJson,
@@ -94,6 +95,22 @@ describe('eval-report utility', () => {
     it('falls back to unknown-model if no env var or folder match exists', () => {
       const reportPath = path.join(tmpDir, 'some-other-folder', 'report.json');
       expect(getModelFromPath(reportPath)).toBe('unknown-model');
+    });
+  });
+
+  describe('getRelativePath', () => {
+    it('correctly handles Windows drive letter paths on any platform', () => {
+      const winPath = 'C:\\coding\\gemini-cli\\evals\\my_test.eval.ts';
+      expect(getRelativePath(winPath, '/home/runner/work/repo')).toBe(
+        'evals/my_test.eval.ts',
+      );
+    });
+
+    it('extracts relative path when starts with rootDir', () => {
+      const fullPath = '/home/runner/work/repo/evals/my_test.eval.ts';
+      expect(getRelativePath(fullPath, '/home/runner/work/repo')).toBe(
+        'evals/my_test.eval.ts',
+      );
     });
   });
 
@@ -294,6 +311,197 @@ describe('eval-report utility', () => {
       expect(c2.policy).toBe('USUALLY_PASSES');
       expect(c2.passed).toBe(0);
       expect(c2.total).toBe(1);
+    });
+
+    it('ignores skipped, pending, and todo assertions in pass rate calculation', async () => {
+      const modelDir = path.join(tmpDir, 'eval-logs-gemini-2.5-flash-999');
+      fs.mkdirSync(modelDir);
+
+      const dummyReport = {
+        testResults: [
+          {
+            name: '/repo/evals/test-one.eval.ts',
+            status: 'passed',
+            assertionResults: [
+              { title: 'passed case', status: 'passed' },
+              { title: 'failed case', status: 'failed' },
+              { title: 'skipped case', status: 'skipped' },
+              { title: 'pending case', status: 'pending' },
+              { title: 'todo case', status: 'todo' },
+            ],
+          },
+        ],
+      };
+
+      fs.writeFileSync(
+        path.join(modelDir, 'report.json'),
+        JSON.stringify(dummyReport),
+      );
+
+      const mockInventory: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 5,
+        repoRoot: '/repo',
+        files: [],
+        cases: [
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'passed case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 1, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'failed case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 2, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'skipped case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 3, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'pending case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 4, column: 1 },
+          },
+          {
+            filePath: '/repo/evals/test-one.eval.ts',
+            relativePath: 'evals/test-one.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'todo case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 5, column: 1 },
+          },
+        ],
+        diagnostics: [],
+      };
+
+      const result = await summarizeReports(tmpDir, mockInventory);
+
+      expect(result.models).toHaveLength(1);
+      const modelSummary = result.models[0];
+      // Only passed case and failed case should be processed.
+      // Skipped, pending, and todo assertions should be completely ignored.
+      expect(modelSummary.totalCases).toBe(2);
+      expect(modelSummary.totalRuns).toBe(2);
+      expect(modelSummary.passedRuns).toBe(1);
+      expect(modelSummary.overallPassRate).toBe(0.5);
+
+      const passedCase = modelSummary.cases.find(
+        (c) => c.name === 'passed case',
+      )!;
+      expect(passedCase.total).toBe(1);
+      expect(passedCase.passed).toBe(1);
+
+      const failedCase = modelSummary.cases.find(
+        (c) => c.name === 'failed case',
+      )!;
+      expect(failedCase.total).toBe(1);
+      expect(failedCase.passed).toBe(0);
+
+      const skippedCase = modelSummary.cases.find(
+        (c) => c.name === 'skipped case',
+      );
+      expect(skippedCase).toBeUndefined();
+    });
+
+    it('matches policy cases across different absolute checkouts and path prefixes', async () => {
+      const modelDir = path.join(tmpDir, 'eval-logs-gemini-2.5-flash-999');
+      fs.mkdirSync(modelDir);
+
+      // Report has an absolute path from a CI environment
+      const dummyReport = {
+        testResults: [
+          {
+            name: '/home/runner/work/gemini-cli/gemini-cli/evals/my-test.eval.ts',
+            status: 'passed',
+            assertionResults: [
+              { title: 'my evaluation case', status: 'passed' },
+            ],
+          },
+        ],
+      };
+
+      fs.writeFileSync(
+        path.join(modelDir, 'report.json'),
+        JSON.stringify(dummyReport),
+      );
+
+      // Inventory uses absolute paths from a local checkout
+      const mockInventory: InventoryResult = {
+        totalFiles: 1,
+        totalCases: 1,
+        repoRoot: '/Users/local/gemini-cli',
+        files: [],
+        cases: [
+          {
+            filePath: '/Users/local/gemini-cli/evals/my-test.eval.ts',
+            relativePath: 'evals/my-test.eval.ts',
+            helperName: 'evalTest',
+            baseHelperName: 'evalTest',
+            policy: 'ALWAYS_PASSES',
+            name: 'my evaluation case',
+            hasFiles: false,
+            hasPrompt: true,
+            hasAssert: true,
+            toolReferences: [],
+            location: { line: 1, column: 1 },
+          },
+        ],
+        diagnostics: [],
+      };
+
+      const result = await summarizeReports(
+        tmpDir,
+        mockInventory,
+        '/Users/local/gemini-cli',
+      );
+
+      expect(result.models).toHaveLength(1);
+      const modelSummary = result.models[0];
+      expect(modelSummary.cases).toHaveLength(1);
+
+      const caseSummary = modelSummary.cases[0];
+      expect(caseSummary.name).toBe('my evaluation case');
+      // Verify that it correctly resolved the policy as ALWAYS_PASSES instead of 'unknown'
+      expect(caseSummary.policy).toBe('ALWAYS_PASSES');
     });
   });
 

--- a/scripts/utils/eval-report.ts
+++ b/scripts/utils/eval-report.ts
@@ -81,12 +81,53 @@ export function getModelFromPath(reportPath: string): string {
 }
 
 /**
+ * Resolves an absolute path and turns it into a checkout-independent relative path.
+ * If the path contains standard repository subdirectories, it extracts starting from there
+ * to support cross-checkout/CI-produced absolute paths.
+ */
+export function getRelativePath(filePath: string, rootDir: string): string {
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  const root = path.resolve(rootDir).replace(/\\/g, '/');
+
+  // Handle Windows absolute paths with drive letters on POSIX systems
+  if (/^[a-zA-Z]:\//.test(normalizedPath)) {
+    if (normalizedPath.startsWith(root + '/')) {
+      return normalizedPath.slice(root.length + 1);
+    }
+    const match = normalizedPath.match(
+      /(?:^|\/)(evals|packages|scripts|integration-tests|memory-tests)\/(.+)$/,
+    );
+    if (match) {
+      return `${match[1]}/${match[2]}`;
+    }
+    return normalizedPath.split('/').pop() || '';
+  }
+
+  const absolute = path.resolve(rootDir, filePath).replace(/\\/g, '/');
+  if (absolute.startsWith(root + '/')) {
+    return absolute.slice(root.length + 1);
+  } else if (absolute === root) {
+    return '';
+  }
+  // Try matching standard subdirectories of the repository
+  const match = absolute.match(
+    /(?:^|\/)(evals|packages|scripts|integration-tests|memory-tests)\/(.+)$/,
+  );
+  if (match) {
+    return `${match[1]}/${match[2]}`;
+  }
+  return path.basename(filePath);
+}
+
+/**
  * Summarizes the pass rate stats by test case and model from report.json files.
  */
 export async function summarizeReports(
   reportsDir: string,
   inventory?: InventoryResult,
+  repoRoot?: string,
 ): Promise<ReportSummaryResult> {
+  const rootDir = repoRoot || process.cwd();
   const reportPaths = findReportFiles(reportsDir);
   const modelSummariesMap = new Map<
     string,
@@ -114,14 +155,20 @@ export async function summarizeReports(
           if (filePath.includes('\0')) {
             continue;
           }
-          const normalizedPath = path.resolve(filePath).replace(/\\/g, '/');
+          const relTestPath = getRelativePath(filePath, rootDir);
           if (Array.isArray(fileResult.assertionResults)) {
             for (const assertion of fileResult.assertionResults) {
               if (!assertion || typeof assertion.title !== 'string') {
                 continue;
               }
+              if (
+                assertion.status !== 'passed' &&
+                assertion.status !== 'failed'
+              ) {
+                continue;
+              }
               const testName = assertion.title;
-              const compoundKey = `${normalizedPath}::${testName}`;
+              const compoundKey = `${relTestPath}::${testName}`;
               if (!testCasesMap.has(compoundKey)) {
                 testCasesMap.set(compoundKey, {
                   name: testName,
@@ -148,10 +195,8 @@ export async function summarizeReports(
   const policyMap = new Map<string, string>();
   if (inventory) {
     for (const caseRec of inventory.cases) {
-      const normalizedCasePath = path
-        .resolve(caseRec.filePath)
-        .replace(/\\/g, '/');
-      const key = `${normalizedCasePath}::${caseRec.name}`;
+      const relCasePath = getRelativePath(caseRec.filePath, rootDir);
+      const key = `${relCasePath}::${caseRec.name}`;
       policyMap.set(key, caseRec.policy);
     }
   }
@@ -163,8 +208,8 @@ export async function summarizeReports(
     let passedRuns = 0;
 
     for (const stats of testCasesMap.values()) {
-      const normalizedPath = path.resolve(stats.filePath).replace(/\\/g, '/');
-      const key = `${normalizedPath}::${stats.name}`;
+      const relTestPath = getRelativePath(stats.filePath, rootDir);
+      const key = `${relTestPath}::${stats.name}`;
       const policy = policyMap.get(key) || 'unknown';
       const passRate = stats.total > 0 ? stats.passed / stats.total : 0;
       cases.push({
@@ -232,10 +277,9 @@ export function formatReportSummary(
     lines.push('');
     lines.push('  Test Cases:');
     for (const c of model.cases) {
-      const relPath =
-        repoRoot && path.isAbsolute(c.filePath)
-          ? path.relative(repoRoot, c.filePath).replace(/\\/g, '/')
-          : c.filePath;
+      const relPath = repoRoot
+        ? getRelativePath(c.filePath, repoRoot)
+        : c.filePath;
       const indicator =
         c.passRate === 1.0 ? '✓' : c.passRate === 0 ? '✗' : '⚠';
       lines.push(
@@ -279,10 +323,7 @@ export function formatReportSummaryJson(
         total: c.total,
         passRate: c.passRate,
         policy: c.policy,
-        filePath:
-          repoRoot && path.isAbsolute(c.filePath)
-            ? path.relative(repoRoot, c.filePath).replace(/\\/g, '/')
-            : c.filePath,
+        filePath: repoRoot ? getRelativePath(c.filePath, repoRoot) : c.filePath,
       })),
     })),
   };


### PR DESCRIPTION
fixes #28696
## Summary

The eval retry helper (`withEvalRetries`) silently missed **429 rate-limit / quota-exhaustion errors** from the Gemini API. When a `RESOURCE_EXHAUSTED` error hit during an eval run it propagated as an uncaught failure, causing the test to fail as if it were a real assertion error rather than a transient API hiccup — unnecessarily blocking PRs and nightly runs.

This PR extends `getApiErrorCode()` to detect 429 patterns and updates the reliability log type accordingly, so rate-limit errors are retried and skipped on exhaustion, consistent with existing 500/503 handling.

## Details

- `evals/test-helper.ts` — **[MODIFIED]** Extended `getApiErrorCode()` to detect 429 `RESOURCE_EXHAUSTED` errors:
  - Matches patterns from real Gemini API responses: `status: RESOURCE_EXHAUSTED`, `code: 429`, `Too Many Requests`, `Rate limit exceeded`, `You exceeded your current quota`
  - Updated return type: `'500' | '503'` → `'429' | '500' | '503'`
  - Updated `logReliabilityEvent()` signature to accept `'429'`

- `evals/test-helper.test.ts` — **[MODIFIED]** Added 2 new unit tests covering the new behaviour:
  - *Retry-then-skip*: Asserts that a permanent `RESOURCE_EXHAUSTED` error triggers 3 retries then gracefully skips, logging 4 reliability events with code `'429'`
  - *Recovery*: Asserts that when a 429 is followed by a successful attempt, the eval passes and only one `RETRY` event is logged

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker