### PR TITLE
fix(core): preserve explicit flash model IDs

### DIFF
--- a/packages/core/src/config/models.explicit-flash.test.ts
+++ b/packages/core/src/config/models.explicit-flash.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_GEMINI_FLASH_MODEL,
+  GEMINI_MODEL_ALIAS_FLASH,
+  PREVIEW_GEMINI_FLASH_MODEL,
+  resolveModel,
+} from './models.js';
+
+describe('explicit flash model resolution', () => {
+  it.each([
+    'gemini-3.6-flash',
+    'gemini-3.7-flash',
+    'gemini-3.9-flash',
+    'gemini-4.2-flash',
+  ])('preserves explicit model id %s during the Gemini 3.5 Flash rollout', (model) => {
+    expect(resolveModel(model, false, false, true, undefined, true)).toBe(model);
+  });
+
+  it('still promotes the flash alias during the Gemini 3.5 Flash rollout', () => {
+    expect(
+      resolveModel(
+        GEMINI_MODEL_ALIAS_FLASH,
+        false,
+        false,
+        true,
+        undefined,
+        true,
+      ),
+    ).toBe(DEFAULT_GEMINI_FLASH_MODEL);
+  });
+
+  it('still preserves an explicitly selected preview flash model', () => {
+    expect(
+      resolveModel(
+        PREVIEW_GEMINI_FLASH_MODEL,
+        false,
+        false,
+        true,
+        undefined,
+        true,
+      ),
+    ).toBe(PREVIEW_GEMINI_FLASH_MODEL);
+  });
+});

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -229,8 +229,11 @@ export function resolveModel(
 
   if (
     useGemini3_5Flash &&
-    isFlashModel(resolved) &&
-    normalizedModel !== PREVIEW_GEMINI_FLASH_MODEL
+    normalizedModel !== PREVIEW_GEMINI_FLASH_MODEL &&
+    (resolved === DEFAULT_GEMINI_FLASH_MODEL ||
+      resolved === DEFAULT_GEMINI_3_5_FLASH_MODEL ||
+      resolved === SECONDARY_GEMINI_3_5_FLASH_MODEL ||
+      normalizedModel === GEMINI_MODEL_ALIAS_FLASH)
   ) {
     return DEFAULT_GEMINI_FLASH_MODEL;
   }
@@ -257,17 +260,6 @@ export function resolveModel(
   }
 
   return resolved;
-}
-
-function isFlashModel(model: string): boolean {
-  return (
-    model === DEFAULT_GEMINI_FLASH_MODEL ||
-    model === PREVIEW_GEMINI_FLASH_MODEL ||
-    model === DEFAULT_GEMINI_3_5_FLASH_MODEL ||
-    model === SECONDARY_GEMINI_3_5_FLASH_MODEL ||
-    model === 'flash' ||
-    model.endsWith('flash')
-  );
 }
 
 /**


### PR DESCRIPTION
Fixes #28859

## Summary

- restrict the Gemini 3.5 Flash rollout rewrite to the generic `flash` alias and known rollout IDs
- preserve explicit model IDs such as `gemini-3.6-flash` and `gemini-3.7-flash`
- allow invalid explicit IDs to pass through so the API rejects them instead of silently substituting another model
- add focused regression coverage

## Why

The static resolver could rewrite explicit model IDs ending in `flash` to the Gemini 3.5 Flash rollout target. This made published models unreachable by name and allowed nonexistent model IDs to appear to work.

## Validation

Added focused unit coverage in `packages/core/src/config/models.explicit-flash.test.ts`.