### PR TITLE
fix(cli): ignore escaped @ symbols during completion mode detection

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.tsx
@@ -308,6 +308,15 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should not trigger AT completion mode for an escaped @ symbol', async () => {
+        const text = 'user\\@example.com';
+        const { result } = await renderCommandCompletionHook(text);
+
+        await waitFor(() => {
+          expect(result.current.completionMode).toBe(CompletionMode.IDLE);
+        });
+      });
+
       it('should correctly identify the completion context with multiple @ symbols', async () => {
         const text = '@file1 @file2';
         const cursorOffset = 3; // @fi|le1 @file2

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -149,6 +149,13 @@ export function useCommandCompletion({
           break;
         }
       } else if (char === '@') {
+        let backslashCount = 0;
+        for (let j = i - 1; j >= 0 && codePoints[j] === '\\'; j--) {
+          backslashCount++;
+        }
+        if (backslashCount % 2 !== 0) {
+          continue;
+        }
         let end = codePoints.length;
         for (let i = cursorCol; i < codePoints.length; i++) {
           if (codePoints[i] === ' ') {


### PR DESCRIPTION
When scanning backward for @ completion in useCommandCompletion, an @ preceded by an odd number of backslashes (e.g. \@) was treated as a valid completion trigger. Added a backslash count check before @ characters so escaped @ symbols do not activate AT completion mode.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
