### PR TITLE
docs(auth): correct individual Google account guidance

### DIFF
--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -11,8 +11,13 @@ using the CLI.
 > To compare features and find the right quota for your needs, see our
 > [Plans page](https://geminicli.com/plans/).
 
-For most users, we recommend starting Gemini CLI and logging in with your
-personal Google account.
+> [!IMPORTANT]
+> As of June 18, 2026, Gemini CLI no longer serves requests authenticated with
+> individual Google accounts, including free tier, Google AI Pro, and Google AI
+> Ultra accounts. Individual users should migrate their subscription-backed
+> terminal workflows to [Antigravity CLI](https://antigravity.google/) or use a
+> [Gemini API key](#gemini-api) with Gemini CLI. API-key usage has separate quota
+> and billing from Google AI subscriptions.
 
 ## Choose your authentication method <a id="auth-methods"></a>
 
@@ -20,7 +25,7 @@ Select the authentication method that matches your situation in the table below:
 
 | User Type / Scenario                                                   | Recommended Authentication Method                                | Google Cloud Project Required                               |
 | :--------------------------------------------------------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------- |
-| Individual Google accounts                                             | [Sign in with Google](#login-google)                             | No, with exceptions                                         |
+| Individual Google accounts                                             | [Antigravity CLI](https://antigravity.google/) or [Gemini API key](#gemini-api) | No (for Gemini API Key)                                     |
 | Organization users with a company, school, or Google Workspace account | [Sign in with Google](#login-google)                             | [Yes](#set-gcp)                                             |
 | AI Studio user with a Gemini API key                                   | [Use Gemini API Key](#gemini-api)                                | No                                                          |
 | Google Cloud Vertex AI user                                            | [Vertex AI](#vertex-ai)                                          | [Yes](#set-gcp)                                             |
@@ -31,7 +36,8 @@ Select the authentication method that matches your situation in the table below:
 - **Individual Google accounts:** Includes all
   [free tier accounts](../resources/quota-and-pricing.md#free-usage) such as
   Gemini Code Assist for individuals, as well as paid subscriptions for
-  [Google AI Pro and Ultra](https://gemini.google/subscriptions/).
+  [Google AI Pro and Ultra](https://gemini.google/subscriptions/). These account
+  types should use Antigravity CLI for subscription-backed terminal access.
 
 - **Organization accounts:** Accounts using paid licenses through an
   organization such as a company, school, or
@@ -39,15 +45,15 @@ Select the authentication method that matches your situation in the table below:
   [Google AI Ultra for Business](https://support.google.com/a/answer/16345165)
   subscriptions.
 
-## (Recommended) Sign in with Google <a id="login-google"></a>
+## Sign in with Google <a id="login-google"></a>
 
-If you run Gemini CLI on your local machine, the simplest authentication method
-is logging in with your Google account. This method requires a web browser on a
-machine that can communicate with the terminal running Gemini CLI (for example,
-your local machine).
+Use Google-account sign-in with a supported organization account. This method
+requires a web browser on a machine that can communicate with the terminal
+running Gemini CLI (for example, your local machine).
 
-If you are a **Google AI Pro** or **Google AI Ultra** subscriber, use the Google
-account associated with your subscription.
+Individual free tier, Google AI Pro, and Google AI Ultra accounts are no longer
+supported by Gemini CLI's Google-account sign-in. Use Antigravity CLI for those
+subscription-backed accounts, or use a Gemini API key with Gemini CLI.
 
 To authenticate and use Gemini CLI:
 
@@ -63,9 +69,8 @@ To authenticate and use Gemini CLI:
 
 ### Do I need to set my Google Cloud project?
 
-Most individual Google accounts (free and paid) don't require a Google Cloud
-project for authentication. However, you'll need to set a Google Cloud project
-when you meet at least one of the following conditions:
+When using a supported organization account, you'll need to set a Google Cloud
+project when you meet at least one of the following conditions:
 
 - You are using a company, school, or Google Workspace account.
 - You are using a Gemini Code Assist license from the Google Developer Program.
@@ -310,8 +315,9 @@ Remove-Item Env:\GOOGLE_API_KEY, Env:\GEMINI_API_KEY -ErrorAction Ignore
 ## Set your Google Cloud project <a id="set-gcp"></a>
 
 > [!IMPORTANT]
-> Most individual Google accounts (free and paid) don't require a
-> Google Cloud project for authentication.
+> Individual free tier, Google AI Pro, and Google AI Ultra accounts no longer
+> use Google-account authentication with Gemini CLI. This section applies to
+> supported organization and Google Cloud authentication flows.
 
 When you sign in using your Google account, you may need to configure a Google
 Cloud project for Gemini CLI to use. This applies when you meet at least one of
@@ -340,7 +346,7 @@ To configure Gemini CLI to use a Google Cloud project, do the following:
       <TabItem label="macOS/Linux">
 
       ```bash
-        # Replace YOUR_PROJECT_ID with your actual Google Cloud project ID
+        # Replace YOUR_PROJECT_ID with your actual project ID
         export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
       ```
 
@@ -348,7 +354,7 @@ To configure Gemini CLI to use a Google Cloud project, do the following:
       <TabItem label="Windows (PowerShell)">
 
       ```powershell
-        # Replace YOUR_PROJECT_ID with your actual Google Cloud project ID
+        # Replace YOUR_PROJECT_ID with your actual project ID
         $env:GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"
       ```
 


### PR DESCRIPTION
Fixes #28745

## Summary

- remove the stale recommendation for individual Google accounts to use Gemini CLI Google-account sign-in
- direct free tier, Google AI Pro, and Google AI Ultra individual users to Antigravity CLI for subscription-backed terminal access
- keep Gemini API-key authentication available for Gemini CLI and clarify that its quota/billing is separate
- preserve organization, Vertex AI, and headless authentication guidance

## Why

Gemini CLI stopped serving requests authenticated with individual Google accounts on June 18, 2026, but the authentication guide still recommends `Sign in with Google` for those accounts and specifically tells Google AI Pro/Ultra subscribers to use their subscription account.

That sends users into a login path that now returns `UNSUPPORTED_CLIENT`, which is the behavior reported in #28745.

## Validation

Documentation-only change in `docs/get-started/authentication.mdx`. The updated table and sign-in section now match the published Gemini CLI transition announcement and the current backend error behavior.

Maintainers can modify the fork branch.