### PR TITLE
docs: clarify Gemini CLI support status

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,14 @@ Gemini CLI brings the power of Gemini models directly into your terminal. Use it
 to understand code, automate tasks, and build workflows with your local project
 context.
 
+> [!IMPORTANT]
+> Gemini CLI remains supported. If you are moving an individual
+> subscription-backed terminal workflow to Antigravity CLI, see the
+> [Antigravity documentation](https://antigravity.google/docs/cli-getting-started).
+> Gemini CLI continues to support other authentication and deployment paths;
+> see [Authentication](./get-started/authentication.mdx) for the available
+> options.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Fixes #28845

## Summary
- add a support-status notice to the documentation landing page
- clarify that Gemini CLI remains supported
- point users moving individual subscription-backed terminal workflows to Antigravity CLI
- link to the authentication guide for supported Gemini CLI authentication and deployment options

## Why
The docs homepage currently gives no context about the transition to Antigravity, which makes account-specific migration changes easy to misread as a full Gemini CLI deprecation.

The notice makes the distinction explicit without implying that Gemini CLI itself has been retired.

## Validation
Documentation-only change in `docs/index.md`.

Maintainers may modify the fork branch.