### PR TITLE
feat(cli): allow renaming the current chat session

### DIFF
--- a/packages/cli/src/ui/commands/chatCommand.rename.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.rename.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GeminiClient } from '@google/gemini-cli-core';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { CommandContext, SlashCommand } from './types.js';
+import { chatResumeSubCommands } from './chatCommand.js';
+
+describe('chat rename command', () => {
+  let context: CommandContext;
+  let saveSummary: ReturnType<typeof vi.fn>;
+  let getConversation: ReturnType<typeof vi.fn>;
+  let renameCommand: SlashCommand;
+
+  beforeEach(() => {
+    saveSummary = vi.fn();
+    getConversation = vi.fn().mockReturnValue({
+      sessionId: 'session-1',
+      messages: [],
+    });
+
+    const geminiClient = {
+      getChatRecordingService: vi.fn().mockReturnValue({
+        saveSummary,
+        getConversation,
+      }),
+    } as unknown as GeminiClient;
+
+    context = createMockCommandContext({
+      services: {
+        agentContext: {
+          geminiClient,
+        },
+      },
+    });
+
+    const command = chatResumeSubCommands.find(
+      (subCommand) => subCommand.name === 'rename',
+    );
+    if (!command?.action) {
+      throw new Error('rename command must have an action');
+    }
+    renameCommand = command;
+  });
+
+  it('persists a trimmed title for the active session', async () => {
+    const result = await renameCommand.action!(context, '  Release planning  ');
+
+    expect(saveSummary).toHaveBeenCalledWith('Release planning');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Conversation renamed to: Release planning.',
+    });
+  });
+
+  it('requires a non-empty title', async () => {
+    const result = await renameCommand.action!(context, '   ');
+
+    expect(saveSummary).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Missing title. Usage: /chat rename <title>',
+    });
+  });
+
+  it('reports when there is no active conversation', async () => {
+    getConversation.mockReturnValue(null);
+
+    const result = await renameCommand.action!(context, 'New title');
+
+    expect(saveSummary).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'No active conversation found to rename.',
+    });
+  });
+
+  it('reports when the chat client is unavailable', async () => {
+    const noClientContext = createMockCommandContext({
+      services: {
+        agentContext: {
+          geminiClient: undefined,
+        },
+      },
+    });
+
+    const result = await renameCommand.action!(noClientContext, 'New title');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'No chat client available to rename conversation.',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/chatCommand.test.ts
+++ b/packages/cli/src/ui/commands/chatCommand.test.ts
@@ -104,7 +104,7 @@ describe('chatCommand', () => {
       'Browse auto-saved conversations and manage chat checkpoints',
     );
     expect(chatCommand.autoExecute).toBe(true);
-    expect(chatCommand.subCommands).toHaveLength(6);
+    expect(chatCommand.subCommands).toHaveLength(7);
   });
 
   describe('list subcommand', () => {

--- a/packages/cli/src/ui/commands/chatCommand.ts
+++ b/packages/cli/src/ui/commands/chatCommand.ts
@@ -341,6 +341,49 @@ const shareCommand: SlashCommand = {
   },
 };
 
+const renameCommand: SlashCommand = {
+  name: 'rename',
+  description:
+    'Rename the current auto-saved conversation. Usage: /chat rename <title>',
+  kind: CommandKind.BUILT_IN,
+  autoExecute: false,
+  action: (context, args): MessageActionReturn => {
+    const title = args.trim();
+    if (!title) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Missing title. Usage: /chat rename <title>',
+      };
+    }
+
+    const client = context.services.agentContext?.geminiClient;
+    if (!client) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'No chat client available to rename conversation.',
+      };
+    }
+
+    const recordingService = client.getChatRecordingService();
+    if (!recordingService.getConversation()) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'No active conversation found to rename.',
+      };
+    }
+
+    recordingService.saveSummary(title);
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `Conversation renamed to: ${title}.`,
+    };
+  },
+};
+
 export const debugCommand: SlashCommand = {
   name: 'debug',
   description: 'Export the most recent API request as a JSON payload',
@@ -400,6 +443,7 @@ const checkpointCompatibilityCommand: SlashCommand = {
 };
 
 export const chatResumeSubCommands: SlashCommand[] = [
+  renameCommand,
   ...checkpointSubCommands.map((subCommand) => ({
     ...subCommand,
     suggestionGroup: CHECKPOINT_MENU_GROUP,


### PR DESCRIPTION
Fixes #28805

## Summary
- add `/chat rename <title>` and `/resume rename <title>`
- persist the custom title through the existing `ChatRecordingService.saveSummary()` path
- reuse the existing session-browser `summary` display field, so no new storage format is required
- add focused tests for successful rename, empty titles, missing conversations, and unavailable clients

## Why
The session browser already prefers a persisted session summary as its display name, but users have no command to set that value themselves. Long-running sessions are therefore identified only by their first prompt or generated summary.

This exposes the existing persistence mechanism as a small user-facing command without changing the session schema.

## Validation
- updated the existing chat command subcommand-count regression
- added `chatCommand.rename.test.ts` with focused command coverage
- no session storage schema changes

Maintainers may modify the fork branch.