### PR TITLE
fix(cli): only honor DEBUG=true/1 in sandbox launcher

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -509,7 +509,7 @@ describe('sandbox', () => {
           image: 'gemini-cli-sandbox',
         });
 
-        process.env['DEBUG'] = debugValue;
+        vi.stubEnv('DEBUG', debugValue);
 
         // Mock image check to return true (image exists)
         interface MockProcessWithStdout extends EventEmitter {
@@ -569,7 +569,7 @@ describe('sandbox', () => {
           image: 'gemini-cli-sandbox',
         });
 
-        process.env['DEBUG'] = debugValue;
+        vi.stubEnv('DEBUG', debugValue);
 
         // Mock image check to return true (image exists)
         interface MockProcessWithStdout extends EventEmitter {

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -501,6 +501,126 @@ describe('sandbox', () => {
       );
     });
 
+    it.each(['true', '1'])(
+      'should publish the debug port when DEBUG=%s',
+      async (debugValue) => {
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'docker',
+          image: 'gemini-cli-sandbox',
+        });
+
+        process.env['DEBUG'] = debugValue;
+
+        // Mock image check to return true (image exists)
+        interface MockProcessWithStdout extends EventEmitter {
+          stdout: EventEmitter;
+        }
+        const mockImageCheckProcess =
+          new EventEmitter() as MockProcessWithStdout;
+        mockImageCheckProcess.stdout = new EventEmitter();
+        vi.mocked(spawn).mockImplementationOnce((_cmd, args) => {
+          if (args && args[0] === 'images') {
+            setTimeout(() => {
+              mockImageCheckProcess.stdout.emit(
+                'data',
+                Buffer.from('image-id'),
+              );
+              mockImageCheckProcess.emit('close', 0);
+            }, 1);
+            return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+        vi.mocked(spawn).mockImplementationOnce((cmd, args) => {
+          if (cmd === 'docker' && args && args[0] === 'run') {
+            return mockSpawnProcess;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        await expect(
+          start_sandbox(config, [], undefined, ['arg1']),
+        ).resolves.toBe(0);
+
+        expect(spawn).toHaveBeenNthCalledWith(
+          2,
+          'docker',
+          expect.arrayContaining(['--publish', '9229:9229']),
+          expect.objectContaining({ stdio: 'inherit' }),
+        );
+      },
+    );
+
+    it.each(['false', '0', ''])(
+      'should not publish the debug port when DEBUG=%s',
+      async (debugValue) => {
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'docker',
+          image: 'gemini-cli-sandbox',
+        });
+
+        process.env['DEBUG'] = debugValue;
+
+        // Mock image check to return true (image exists)
+        interface MockProcessWithStdout extends EventEmitter {
+          stdout: EventEmitter;
+        }
+        const mockImageCheckProcess =
+          new EventEmitter() as MockProcessWithStdout;
+        mockImageCheckProcess.stdout = new EventEmitter();
+        vi.mocked(spawn).mockImplementationOnce((_cmd, args) => {
+          if (args && args[0] === 'images') {
+            setTimeout(() => {
+              mockImageCheckProcess.stdout.emit(
+                'data',
+                Buffer.from('image-id'),
+              );
+              mockImageCheckProcess.emit('close', 0);
+            }, 1);
+            return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+        vi.mocked(spawn).mockImplementationOnce((cmd, args) => {
+          if (cmd === 'docker' && args && args[0] === 'run') {
+            return mockSpawnProcess;
+          }
+          return new EventEmitter() as unknown as ReturnType<typeof spawn>;
+        });
+
+        await expect(
+          start_sandbox(config, [], undefined, ['arg1']),
+        ).resolves.toBe(0);
+
+        expect(spawn).toHaveBeenNthCalledWith(
+          2,
+          'docker',
+          expect.not.arrayContaining(['--publish', '9229:9229']),
+          expect.objectContaining({ stdio: 'inherit' }),
+        );
+      },
+    );
+
     it('should preserve the integration-test prefix for random container names', async () => {
       const config: SandboxConfig = createMockSandboxConfig({
         command: 'docker',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -34,6 +34,7 @@ import {
   parseImageName,
   ports,
   entrypoint,
+  isDebugEnvEnabled,
   LOCAL_DEV_SANDBOX_IMAGE_NAME,
   SANDBOX_NETWORK_NAME,
   SANDBOX_PROXY_NAME,
@@ -51,7 +52,7 @@ export async function start_sandbox(
   cliArgs: string[] = [],
 ): Promise<number> {
   const patcher = new ConsolePatcher({
-    debugMode: cliConfig?.getDebugMode() || !!process.env['DEBUG'],
+    debugMode: cliConfig?.getDebugMode() || isDebugEnvEnabled(),
     stderr: true,
   });
   patcher.patch();
@@ -153,7 +154,7 @@ export async function start_sandbox(
         debugLogger.log(`using macos seatbelt (profile: ${profile}) ...`);
         // if DEBUG is set, convert to --inspect-brk in NODE_OPTIONS
         const nodeOptions = [
-          ...(process.env['DEBUG'] ? ['--inspect-brk'] : []),
+          ...(isDebugEnvEnabled() ? ['--inspect-brk'] : []),
           ...nodeArgs,
         ].join(' ');
 
@@ -512,7 +513,7 @@ export async function start_sandbox(
     ports().forEach((p) => args.push('--publish', `${p}:${p}`));
 
     // if DEBUG is set, expose debugging port
-    if (process.env['DEBUG']) {
+    if (isDebugEnvEnabled()) {
       const debugPort = process.env['DEBUG_PORT'] || '9229';
       args.push(`--publish`, `${debugPort}:${debugPort}`);
     }
@@ -1184,7 +1185,7 @@ async function pullImage(
     let stderrData = '';
 
     const onStdoutData = (data: Buffer) => {
-      if (cliConfig?.getDebugMode() || process.env['DEBUG']) {
+      if (cliConfig?.getDebugMode() || isDebugEnvEnabled()) {
         debugLogger.log(data.toString().trim()); // Show pull progress
       }
     };

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -41,6 +41,7 @@ describe('sandboxUtils', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   describe('getContainerPath', () => {
@@ -90,20 +91,20 @@ describe('sandboxUtils', () => {
 
   describe('isDebugEnvEnabled', () => {
     it.each(['true', '1'])('should return true when DEBUG=%s', (value) => {
-      process.env['DEBUG'] = value;
+      vi.stubEnv('DEBUG', value);
       expect(isDebugEnvEnabled()).toBe(true);
     });
 
     it.each(['false', '0', ''])(
       'should return false when DEBUG=%s',
       (value) => {
-        process.env['DEBUG'] = value;
+        vi.stubEnv('DEBUG', value);
         expect(isDebugEnvEnabled()).toBe(false);
       },
     );
 
     it('should return false when DEBUG is unset', () => {
-      delete process.env['DEBUG'];
+      vi.stubEnv('DEBUG', '');
       expect(isDebugEnvEnabled()).toBe(false);
     });
   });
@@ -146,13 +147,13 @@ describe('sandboxUtils', () => {
     });
 
     it('should use the debug command when DEBUG=true', () => {
-      process.env['DEBUG'] = 'true';
+      vi.stubEnv('DEBUG', 'true');
       const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
       expect(args[2]).toContain('--inspect-brk=0.0.0.0:9229');
     });
 
     it('should use the debug command when DEBUG=1', () => {
-      process.env['DEBUG'] = '1';
+      vi.stubEnv('DEBUG', '1');
       const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
       expect(args[2]).toContain('--inspect-brk=0.0.0.0:9229');
     });
@@ -160,7 +161,7 @@ describe('sandboxUtils', () => {
     it.each(['false', '0', ''])(
       'should not use the debug command when DEBUG=%s',
       (value) => {
-        process.env['DEBUG'] = value;
+        vi.stubEnv('DEBUG', value);
         const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
         expect(args[2]).not.toContain('--inspect-brk');
       },

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -13,6 +13,7 @@ import {
   parseImageName,
   ports,
   entrypoint,
+  isDebugEnvEnabled,
   shouldUseCurrentUserInSandbox,
 } from './sandboxUtils.js';
 
@@ -87,6 +88,26 @@ describe('sandboxUtils', () => {
     });
   });
 
+  describe('isDebugEnvEnabled', () => {
+    it.each(['true', '1'])('should return true when DEBUG=%s', (value) => {
+      process.env['DEBUG'] = value;
+      expect(isDebugEnvEnabled()).toBe(true);
+    });
+
+    it.each(['false', '0', ''])(
+      'should return false when DEBUG=%s',
+      (value) => {
+        process.env['DEBUG'] = value;
+        expect(isDebugEnvEnabled()).toBe(false);
+      },
+    );
+
+    it('should return false when DEBUG is unset', () => {
+      delete process.env['DEBUG'];
+      expect(isDebugEnvEnabled()).toBe(false);
+    });
+  });
+
   describe('entrypoint', () => {
     beforeEach(() => {
       vi.mocked(os.platform).mockReturnValue('linux');
@@ -123,6 +144,27 @@ describe('sandboxUtils', () => {
       const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
       expect(args[2]).toContain('npm rebuild && npm run start --');
     });
+
+    it('should use the debug command when DEBUG=true', () => {
+      process.env['DEBUG'] = 'true';
+      const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
+      expect(args[2]).toContain('--inspect-brk=0.0.0.0:9229');
+    });
+
+    it('should use the debug command when DEBUG=1', () => {
+      process.env['DEBUG'] = '1';
+      const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
+      expect(args[2]).toContain('--inspect-brk=0.0.0.0:9229');
+    });
+
+    it.each(['false', '0', ''])(
+      'should not use the debug command when DEBUG=%s',
+      (value) => {
+        process.env['DEBUG'] = value;
+        const args = entrypoint('/work', ['node', 'gemini', 'arg1']);
+        expect(args[2]).not.toContain('--inspect-brk');
+      },
+    );
   });
 
   describe('shouldUseCurrentUserInSandbox', () => {

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -99,6 +99,15 @@ export function ports(): string[] {
     .map((p) => p.trim());
 }
 
+/**
+ * Returns whether debug mode is enabled via the DEBUG environment variable.
+ * Only the explicit values 'true' and '1' enable it; 'false', '0', empty
+ * values, and unset values all leave debug mode disabled.
+ */
+export function isDebugEnvEnabled(): boolean {
+  return process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1';
+}
+
 export function entrypoint(workdir: string, cliArgs: string[]): string[] {
   const isWindows = os.platform() === 'win32';
   const containerWorkdir = getContainerPath(workdir);
@@ -149,8 +158,7 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
   );
 
   const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
-  const isDebugMode =
-    process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1';
+  const isDebugMode = isDebugEnvEnabled();
   const cliCmd =
     process.env['NODE_ENV'] === 'development'
       ? isDebugMode


### PR DESCRIPTION
## Summary

The sandbox launcher (`packages/cli/src/utils/sandbox.ts`) used truthy checks on the `DEBUG` environment variable, while the container entrypoint (`sandboxUtils.ts`) and the CLI config only honor the explicit values `true`/`1`. As a result `DEBUG=false` and `DEBUG=0` — values that conventionally disable a flag — still partially enabled sandbox debugging:

- published the debugger port (`--publish 9229:9229`) for Docker/Podman-style sandboxes even though the entrypoint does not start the inspector;
- injected `--inspect-brk` into `NODE_OPTIONS` on macOS Seatbelt;
- enabled debug-only console behavior and image-pull progress logging.

## Details

- Added a single shared parser, `isDebugEnvEnabled()` in `sandboxUtils.ts`, that returns `true` only for `DEBUG=true` or `DEBUG=1` (matching the existing `isDebugMode()` convention in `packages/cli/src/config/config.ts`).
- Replaced the four truthy checks in `sandbox.ts` with the shared helper so the launcher and entrypoint can never disagree.
- Added regression tests covering enabled (`true`, `1`) and disabled (`false`, `0`, empty, unset) values at both the helper/entrypoint level and the Docker debug-port-publish level.

## Related Issues

Fixes #28885

## How to Validate

```
npm ci
npm run build --workspace=@google/gemini-cli-core
npx vitest run --root packages/cli src/utils/sandbox.test.ts src/utils/sandboxUtils.test.ts
```

Expected: all tests pass. Reverting the source change makes the `DEBUG=false`/`DEBUG=0` regression tests fail (8 tests).

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] Docker
