### PR TITLE
fix(core): buffer partial stdout chunks in WhisperTranscriptionProvider (#28648)

### DIFF
--- a/packages/core/src/voice/whisperTranscriptionProvider.test.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.test.ts
@@ -28,4 +28,105 @@ describe('WhisperTranscriptionProvider', () => {
       'The `whisper-stream` command is required for local voice mode. Please install it (e.g., `brew install whisper-cpp` on macOS).',
     );
   });
+
+  it('should parse a single complete stdout line', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    provider.parseOutput('[00:00:00.000 --> 00:00:02.000]   Hello world.\n');
+
+    expect(onTranscription).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith('Hello world.');
+    expect(provider.getTranscription()).toBe('Hello world.');
+  });
+
+  it('should correctly buffer and assemble lines split across multiple stdout chunks', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    // Chunk 1: timestamp prefix split
+    provider.parseOutput('[00:00:00.000 --> 00:00:');
+    expect(onTranscription).not.toHaveBeenCalled();
+
+    // Chunk 2: timestamp completion + message
+    provider.parseOutput('02.000]   Hello world.\n');
+    expect(onTranscription).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith('Hello world.');
+  });
+
+  it('should correctly buffer text split across stdout chunks', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    // Chunk 1: partial text without newline
+    provider.parseOutput('[00:00:00.000 --> 00:00:02.000]   Hello ');
+    expect(onTranscription).not.toHaveBeenCalled();
+
+    // Chunk 2: remainder of text with newline
+    provider.parseOutput('world!\n');
+    expect(onTranscription).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith('Hello world!');
+  });
+
+  it('should handle multiple lines in a single stdout chunk', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    provider.parseOutput(
+      '[00:00:00.000 --> 00:00:02.000]   First line.\n[00:00:02.000 --> 00:00:04.000]   Second line.\n',
+    );
+
+    expect(onTranscription).toHaveBeenCalledTimes(2);
+    expect(onTranscription).toHaveBeenNthCalledWith(1, 'First line.');
+    expect(onTranscription).toHaveBeenNthCalledWith(
+      2,
+      'First line. Second line.',
+    );
+    expect(provider.getTranscription()).toBe('First line. Second line.');
+  });
+
+  it('should flush incomplete line when isFinal is true', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    // Output without trailing newline
+    provider.parseOutput('[00:00:00.000 --> 00:00:02.000]   Final utterance');
+    expect(onTranscription).not.toHaveBeenCalled();
+
+    // Final flush on stream close
+    provider.parseOutput('', true);
+    expect(onTranscription).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith('Final utterance');
+    expect(provider.getTranscription()).toBe('Final utterance');
+  });
+
+  it('should filter out silence and bracketed annotations', () => {
+    const provider = new WhisperTranscriptionProvider({
+      modelPath: 'test-model.bin',
+    });
+    const onTranscription = vi.fn();
+    provider.on('transcription', onTranscription);
+
+    provider.parseOutput(
+      '[00:00:00.000 --> 00:00:02.000]   [Silence]\n[00:00:02.000 --> 00:00:04.000]   [music] (laughter) Real speech.\n',
+    );
+
+    expect(onTranscription).toHaveBeenCalledTimes(1);
+    expect(onTranscription).toHaveBeenCalledWith('Real speech.');
+  });
 });

--- a/packages/core/src/voice/whisperTranscriptionProvider.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.ts
@@ -32,6 +32,7 @@ export class WhisperTranscriptionProvider
 {
   private process: ChildProcessWithoutNullStreams | null = null;
   private currentTranscription = '';
+  private stdoutBuffer = '';
 
   constructor(private readonly options: WhisperProviderOptions) {
     super();
@@ -53,6 +54,7 @@ export class WhisperTranscriptionProvider
     const { modelPath, threads = 4, step = 0, length = 5000 } = this.options;
 
     this.currentTranscription = '';
+    this.stdoutBuffer = '';
 
     const available = await WhisperTranscriptionProvider.isAvailable();
     if (!available) {
@@ -124,6 +126,10 @@ export class WhisperTranscriptionProvider
           debugLogger.debug(
             `[WhisperTranscription] Process closed with code ${code}`,
           );
+          // Flush any remaining partial output
+          if (this.stdoutBuffer.trim()) {
+            this.parseOutput('', true);
+          }
           this.emit('close');
           this.process = null;
         });
@@ -151,33 +157,47 @@ export class WhisperTranscriptionProvider
     });
   }
 
-  private parseOutput(output: string): void {
-    // whisper-stream output format: "[00:00:00.000 --> 00:00:02.000]   Hello world."
-    const lines = output.split('\n');
+  /**
+   * Parses stdout chunks from whisper-stream, buffering partial lines until a newline is received.
+   */
+  parseOutput(output: string, isFinal = false): void {
+    this.stdoutBuffer += output;
+    const lines = this.stdoutBuffer.split('\n');
+
+    if (isFinal) {
+      this.stdoutBuffer = '';
+    } else {
+      this.stdoutBuffer = lines.pop() ?? '';
+    }
 
     for (const line of lines) {
-      const match = line.match(/\[.* --> .*\]\s+(.*)/);
-      if (match && match[1]) {
-        let text = match[1].trim();
+      this.parseLine(line);
+    }
+  }
 
-        // Filter out [Silence], [music], (laughter), etc.
-        text = text
-          .replace(/\[[^\]]*\]/g, '')
-          .replace(/\([^)]*\)/g, '')
-          .trim();
+  private parseLine(line: string): void {
+    // whisper-stream output format: "[00:00:00.000 --> 00:00:02.000]   Hello world."
+    const match = line.match(/\[.* --> .*\]\s+(.*)/);
+    if (match && match[1]) {
+      let text = match[1].trim();
 
-        if (text) {
-          // In VAD mode (step=0), each line is a completed speech block.
-          // Append it to the buffer to ensure it doesn't disappear.
-          this.currentTranscription = this.currentTranscription
-            ? `${this.currentTranscription} ${text}`
-            : text;
+      // Filter out [Silence], [music], (laughter), etc.
+      text = text
+        .replace(/\[[^\]]*\]/g, '')
+        .replace(/\([^)]*\)/g, '')
+        .trim();
 
-          debugLogger.debug(
-            `[WhisperTranscription] Transcription updated (Local-VAD): "${this.currentTranscription}"`,
-          );
-          this.emit('transcription', this.currentTranscription);
-        }
+      if (text) {
+        // In VAD mode (step=0), each line is a completed speech block.
+        // Append it to the buffer to ensure it doesn't disappear.
+        this.currentTranscription = this.currentTranscription
+          ? `${this.currentTranscription} ${text}`
+          : text;
+
+        debugLogger.debug(
+          `[WhisperTranscription] Transcription updated (Local-VAD): "${this.currentTranscription}"`,
+        );
+        this.emit('transcription', this.currentTranscription);
       }
     }
   }
@@ -195,5 +215,6 @@ export class WhisperTranscriptionProvider
       this.process.kill('SIGTERM');
       this.process = null;
     }
+    this.stdoutBuffer = '';
   }
 }

--- a/packages/core/src/voice/whisperTranscriptionProvider.ts
+++ b/packages/core/src/voice/whisperTranscriptionProvider.ts
@@ -76,7 +76,7 @@ export class WhisperTranscriptionProvider
         // whisper-stream -m <model_path> -t <threads> --step 0 --length <length> -vth 0.6
         // Setting step == 0 enables sliding window mode with VAD, which outputs
         // non-overlapping transcription blocks suitable for appending.
-        this.process = spawn('whisper-stream', [
+        const proc = spawn('whisper-stream', [
           '-m',
           modelPath,
           '-t',
@@ -88,13 +88,14 @@ export class WhisperTranscriptionProvider
           '-vth',
           '0.6',
         ]);
+        this.process = proc;
 
-        this.process.stdout.on('data', (data: Buffer) => {
+        proc.stdout.on('data', (data: Buffer) => {
           const output = data.toString();
           this.parseOutput(output);
         });
 
-        this.process.stderr.on('data', (data: Buffer) => {
+        proc.stderr.on('data', (data: Buffer) => {
           const msg = data.toString();
           if (msg.includes('error')) {
             debugLogger.error(`[WhisperTranscription] stderr: ${msg}`);
@@ -113,7 +114,7 @@ export class WhisperTranscriptionProvider
           }
         });
 
-        this.process.on('error', (err) => {
+        proc.on('error', (err) => {
           debugLogger.error('[WhisperTranscription] Process error:', err);
           this.emit('error', err);
           if (!isResolved) {
@@ -122,7 +123,7 @@ export class WhisperTranscriptionProvider
           }
         });
 
-        this.process.on('close', (code) => {
+        proc.on('close', (code) => {
           debugLogger.debug(
             `[WhisperTranscription] Process closed with code ${code}`,
           );
@@ -131,7 +132,9 @@ export class WhisperTranscriptionProvider
             this.parseOutput('', true);
           }
           this.emit('close');
-          this.process = null;
+          if (this.process === proc) {
+            this.process = null;
+          }
         });
 
         // Fallback timeout in case "main: processing" is never seen


### PR DESCRIPTION
## Summary

Fixes #28648 by introducing stdout chunk line-buffering in `WhisperTranscriptionProvider`. This ensures timestamped transcription lines split across arbitrary stdout `data` events are correctly assembled rather than dropped.

## Details

- **Problem**: In local voice mode, `WhisperTranscriptionProvider` previously called `parseOutput()` directly on raw stdout chunks. When stdout chunks split across line boundaries or within timestamp prefixes (e.g. `[00:00:00.000 --> 00:00:` in chunk 1, `02.000] Hello world.\n` in chunk 2), the line regex failed to match on either chunk, silently dropping transcriptions.
- **Solution**:
  - Maintained `stdoutBuffer` to accumulate incoming stream chunks.
  - Parsed only complete newline-delimited lines on each chunk, holding incomplete fragments for subsequent chunks.
  - Flushed any remaining partial buffer on process close / stream end (`isFinal: true`).
  - Cleared buffer on disconnect and connect.
  - Added unit test suite covering split timestamps, split text bodies, multi-line chunks, final flush, and noise filtering.

## Related Issues

Fixes #28648

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/voice/whisperTranscriptionProvider.test.ts
npm run typecheck
npm run lint
```

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Verified no breaking changes
- [x] Lint and typecheck pass cleanly
