### PR TITLE
fix(core): atomic download and failure cleanup in WhisperModelManager (#28644)

### DIFF
--- a/packages/core/src/voice/whisperModelManager.test.ts
+++ b/packages/core/src/voice/whisperModelManager.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { WhisperModelManager } from './whisperModelManager.js';
+
+describe('WhisperModelManager', () => {
+  let tmpDir: string;
+  let manager: WhisperModelManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'whisper-test-'));
+    vi.stubEnv('HOME', tmpDir);
+    vi.stubEnv('USERPROFILE', tmpDir);
+    manager = new WhisperModelManager();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('should throw for unauthorized model names', () => {
+    expect(() => manager.isModelInstalled('unauthorized.bin')).toThrow(
+      'Unauthorized model name: unauthorized.bin',
+    );
+    expect(() => manager.getModelPath('malicious/path.bin')).toThrow(
+      'Unauthorized model name: malicious/path.bin',
+    );
+  });
+
+  it('should correctly report if a model is installed', () => {
+    const modelName = 'ggml-tiny.en.bin';
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+
+    const modelPath = manager.getModelPath(modelName);
+    fs.mkdirSync(path.dirname(modelPath), { recursive: true });
+    fs.writeFileSync(modelPath, 'fake-model-content');
+
+    expect(manager.isModelInstalled(modelName)).toBe(true);
+  });
+
+  it('should download a model successfully and atomically rename', async () => {
+    const modelName = 'ggml-tiny.en.bin';
+    const fakeContent = new Uint8Array([1, 2, 3, 4, 5]);
+
+    const mockResponse = {
+      ok: true,
+      headers: new Headers({ 'content-length': '5' }),
+      body: {
+        getReader: () => {
+          let read = false;
+          return {
+            read: async () => {
+              if (!read) {
+                read = true;
+                return { done: false, value: fakeContent };
+              }
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const progressEvents: unknown[] = [];
+    manager.on('progress', (p) => progressEvents.push(p));
+
+    await manager.downloadModel(modelName);
+
+    expect(manager.isModelInstalled(modelName)).toBe(true);
+    const destPath = manager.getModelPath(modelName);
+    const downloadedData = fs.readFileSync(destPath);
+    expect(downloadedData).toEqual(Buffer.from(fakeContent));
+
+    // .downloading file should not remain
+    expect(fs.existsSync(`${destPath}.downloading`)).toBe(false);
+    expect(progressEvents.length).toBeGreaterThan(0);
+  });
+
+  it('should clean up .downloading file if download is interrupted or fails', async () => {
+    const modelName = 'ggml-tiny.en.bin';
+    const fakeContent = new Uint8Array([1, 2]);
+
+    const mockResponse = {
+      ok: true,
+      headers: new Headers({ 'content-length': '100' }), // Declared 100 bytes, but only sending 2
+      body: {
+        getReader: () => {
+          let read = false;
+          return {
+            read: async () => {
+              if (!read) {
+                read = true;
+                return { done: false, value: fakeContent };
+              }
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    await expect(manager.downloadModel(modelName)).rejects.toThrow(
+      'Incomplete download for ggml-tiny.en.bin: received 2 of 100 bytes',
+    );
+
+    const destPath = manager.getModelPath(modelName);
+    expect(fs.existsSync(destPath)).toBe(false);
+    expect(fs.existsSync(`${destPath}.downloading`)).toBe(false);
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+  });
+
+  it('should clean up .downloading file on stream error', async () => {
+    const modelName = 'ggml-tiny.en.bin';
+
+    const mockResponse = {
+      ok: true,
+      headers: new Headers({ 'content-length': '50' }),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            throw new Error('Network dropped');
+          },
+        }),
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    await expect(manager.downloadModel(modelName)).rejects.toThrow(
+      'Network dropped',
+    );
+
+    const destPath = manager.getModelPath(modelName);
+    expect(fs.existsSync(destPath)).toBe(false);
+    expect(fs.existsSync(`${destPath}.downloading`)).toBe(false);
+    expect(manager.isModelInstalled(modelName)).toBe(false);
+  });
+});

--- a/packages/core/src/voice/whisperModelManager.ts
+++ b/packages/core/src/voice/whisperModelManager.ts
@@ -121,13 +121,33 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
       }
 
       await new Promise<void>((resolve, reject) => {
-        writer.end(() => {
-          if (writeError) reject(writeError);
-          else resolve();
-        });
+        if (writeError) {
+          reject(writeError);
+          return;
+        }
+        const onFinish = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
+          reject(err);
+        };
+        const cleanup = () => {
+          writer.off('finish', onFinish);
+          writer.off('error', onError);
+        };
+        writer.once('finish', onFinish);
+        writer.once('error', onError);
+        writer.end();
       });
     } catch (err) {
-      writer.destroy();
+      if (!writer.destroyed) {
+        await new Promise<void>((resolve) => {
+          writer.once('close', () => resolve());
+          writer.destroy();
+        });
+      }
       if (fs.existsSync(tmpPath)) {
         try {
           fs.unlinkSync(tmpPath);

--- a/packages/core/src/voice/whisperModelManager.ts
+++ b/packages/core/src/voice/whisperModelManager.ts
@@ -57,6 +57,15 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
     }
 
     const destination = path.join(this.modelsDir, modelName);
+    const tmpPath = `${destination}.downloading`;
+    if (fs.existsSync(tmpPath)) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        // ignore
+      }
+    }
+
     const url = `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/${modelName}`;
 
     debugLogger.debug(
@@ -76,15 +85,25 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
       throw new Error('Response body is not readable');
     }
 
-    const writer = fs.createWriteStream(destination);
+    const writer = fs.createWriteStream(tmpPath);
+    let writeError: Error | null = null;
+    writer.on('error', (err) => {
+      writeError = err;
+    });
 
     try {
       while (true) {
+        if (writeError) {
+          throw writeError;
+        }
         const { done, value } = await reader.read();
         if (done) break;
 
         transferred += value.length;
-        writer.write(value);
+        const writeOk = writer.write(value);
+        if (!writeOk) {
+          await new Promise<void>((resolve) => writer.once('drain', resolve));
+        }
 
         const percentage = total > 0 ? transferred / total : 0;
         this.emit('progress', {
@@ -94,9 +113,32 @@ export class WhisperModelManager extends EventEmitter<WhisperModelManagerEvents>
           percentage,
         });
       }
-    } finally {
-      writer.end();
+
+      if (total > 0 && transferred < total) {
+        throw new Error(
+          `Incomplete download for ${modelName}: received ${transferred} of ${total} bytes`,
+        );
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        writer.end(() => {
+          if (writeError) reject(writeError);
+          else resolve();
+        });
+      });
+    } catch (err) {
+      writer.destroy();
+      if (fs.existsSync(tmpPath)) {
+        try {
+          fs.unlinkSync(tmpPath);
+        } catch {
+          // ignore
+        }
+      }
+      throw err;
     }
+
+    fs.renameSync(tmpPath, destination);
   }
 
   private validateModelName(modelName: string): void {


### PR DESCRIPTION
## Summary

Fixes #28644 by ensuring `WhisperModelManager.downloadModel()` writes to a temporary file (`.downloading`), respects write stream backpressure, handles stream errors, verifies downloaded length, cleans up temporary files on failure, and atomically renames to the destination path only after successful completion.

## Details

- **Problem**: `WhisperModelManager` previously wrote directly to the final model path without waiting for write stream completion, handling backpressure, or removing partial files on failure. If a download was interrupted, disconnected, or incomplete, the corrupt partial file remained at the destination path and was falsely treated as a valid installed model by `isModelInstalled()` (`fs.existsSync(destination)`).
- **Solution**:
  - Download to a sibling `.downloading` temporary path.
  - Added backpressure handling (`writer.once('drain')`) when `writer.write()` returns `false`.
  - Added download completion verification (`transferred === total` when `total > 0`).
  - Added error listeners and robust cleanup on failure / stream aborts (`fs.unlinkSync(tmpPath)`).
  - Atomically renamed `.downloading` to destination via `fs.renameSync` only after `writer.end` completes.
  - Added comprehensive unit tests in `whisperModelManager.test.ts` verifying atomic rename, progress events, length validation, and cleanup on network/stream errors.

## Related Issues

Fixes #28644

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/voice/whisperModelManager.test.ts
npm run typecheck
npm run lint
```

## Pre-Merge Checklist

- [x] Added/updated tests
- [x] Verified no breaking changes
- [x] Lint and typecheck pass cleanly
