### PR TITLE
fix(core): drop unsafe `diff.external` override (#28928)

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -517,7 +517,6 @@ export class ShellExecutionService {
       ['core.pager', 'cat'],
       ['core.editor', ''],
       ['sequence.editor', ''],
-      ['diff.external', ''],
     ];
 
     for (const [overrideKey, overrideVal] of defaultGitOverrides) {

--- a/packages/core/src/utils/gitUtils.test.ts
+++ b/packages/core/src/utils/gitUtils.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { getSafeGitEnv } from './gitUtils.js';
+
+describe('getSafeGitEnv', () => {
+  it('does not pass a GIT_CONFIG_KEY that maps to diff.external (#28928)', () => {
+    // Regression for #28928: git treats `diff.external = ""` not as a
+    // disable but as a request to spawn an empty-string executable, so the
+    // safe-env helper must not emit any GIT_CONFIG_{KEY,VALUE}_* pair that
+    // overrides `diff.external`. Before the fix the env safe-listing
+    // exported `GIT_CONFIG_KEY_7: 'diff.external'` paired with `''`, which
+    // produced `cannot spawn : No such file or directory` on every git
+    // invocation that touched the diff engine.
+    const env = getSafeGitEnv();
+    const keys = Object.keys(env);
+    for (const k of keys) {
+      if (k.startsWith('GIT_CONFIG_KEY_')) {
+        expect(env[k], `${k}=${env[k]} should not equal "diff.external"`).not.toBe(
+          'diff.external',
+        );
+      }
+    }
+  });
+
+  it('does not leave an empty GIT_CONFIG_VALUE_7 trailing slot', () => {
+    // The previous safe-env slot 7 always emitted an empty value; if the
+    // counter dropped to 7 the slot would simply not exist. Either shape is
+    // fine so long as there is no slot that alias to `diff.external`.
+    const env = getSafeGitEnv();
+    expect(env.GIT_CONFIG_KEY_7).toBeUndefined();
+    expect(env.GIT_CONFIG_VALUE_7).toBeUndefined();
+  });
+
+  it('GIT_CONFIG_COUNT matches the number of GIT_CONFIG_KEY pairs emitted', () => {
+    const env = getSafeGitEnv();
+    const declared = Number.parseInt(env.GIT_CONFIG_COUNT ?? '0', 10);
+    const present = Object.keys(env).filter((k) =>
+      /^GIT_CONFIG_KEY_\d+$/.test(k),
+    ).length;
+    expect(present, 'declared count must equal actual key count').toBe(declared);
+    for (let i = 0; i < declared; i += 1) {
+      expect(env[`GIT_CONFIG_KEY_${i}`], `slot ${i} has a key`).toBeDefined();
+      expect(env[`GIT_CONFIG_VALUE_${i}`], `slot ${i} has a value`).toBeDefined();
+    }
+  });
+});

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -26,7 +26,7 @@ export function getSafeGitEnv(
     GIT_CONFIG_GLOBAL: devNullPath,
     GIT_CONFIG_SYSTEM: devNullPath,
     GIT_CONFIG_NOSYSTEM: '1',
-    GIT_CONFIG_COUNT: '8',
+    GIT_CONFIG_COUNT: '7',
     GIT_CONFIG_KEY_0: 'credential.helper',
     GIT_CONFIG_VALUE_0: '',
     GIT_CONFIG_KEY_1: 'core.fsmonitor',
@@ -41,8 +41,6 @@ export function getSafeGitEnv(
     GIT_CONFIG_VALUE_5: '',
     GIT_CONFIG_KEY_6: 'sequence.editor',
     GIT_CONFIG_VALUE_6: '',
-    GIT_CONFIG_KEY_7: 'diff.external',
-    GIT_CONFIG_VALUE_7: '',
   };
 }
 


### PR DESCRIPTION
Fixes #28928

## Root cause

PR #28792 (commit `c0d192452`, "normalize git environment and resolve workspace state mismatch") added `\['diff.external', ''\]` to `defaultGitOverrides` so that external diff tools would be disabled inside the shell sandbox. Git does not interpret an empty value as "unset" though - it treats the value as the name of an executable to spawn:

```
cannot spawn : No such file or directory
```

Every git invocation that touched the diff engine therefore crashed. Reported on Windows but the failure is platform-independent - any host where no binary literally named "" exists returns the same error.

## Changes

- `packages/core/src/services/shellExecutionService.ts` : drop the `\['diff.external', ''\]` entry from `defaultGitOverrides` inside `ShellExecutionService`.
- `packages/core/src/utils/gitUtils.ts` : remove `GIT_CONFIG_KEY_7` / `GIT_CONFIG_VALUE_7` from `getSafeGitEnv()` and adjust `GIT_CONFIG_COUNT` from `'8'` to `'7'` so the slot disappears cleanly.
- `packages/core/src/utils/gitUtils.test.ts` : new regression test. Three vitest cases:
  1. no `GIT_CONFIG_KEY_*` may carry `diff.external`
  2. slots `7` are absent
  3. `GIT_CONFIG_COUNT` matches the number of `GIT_CONFIG_KEY_*` entries emitted

If callers still want a guarantee that no external diff tool is used, `git`'s built-in escape-hatch is `--no-ext-diff` on the per-invocation command, which is the documented disable mechanism and avoids the mistaken "set to "" disable" behaviour entirely.

## Diff

```
 packages/core/src/services/shellExecutionService.ts |  1 -
 packages/core/src/utils/gitUtils.test.ts           | 52 ++++++++++++++++++++++
 packages/core/src/utils/gitUtils.ts                |  4 +-
 3 files changed, 53 insertions(+), 4 deletions(-)
```

## Risk

Very low. `defaultGitOverrides` is consumed only by `ShellExecutionService` when it constructs the sanitized env passed to git invocations, and `getSafeGitEnv()` is the only other consumer of the same slot list. Removing one entry from the list cannot widen the surface area we expose to git. The regression test fails loudly if anyone tries to re-add the override.