### PR TITLE
feat(triage-eval): add schema-agnostic accessors and harden worktree

### DIFF
--- a/tools/caretaker-agent/evals/triage/helpers/dataset.py
+++ b/tools/caretaker-agent/evals/triage/helpers/dataset.py
@@ -44,13 +44,37 @@ def load_issues(filter_issues: Optional[List[int]] = None) -> List[Dict[str, Any
     return issues
 
 
+def get_expected_quality(data: Dict[str, Any]) -> str:
+    """Extracts expected quality across legacy and unified schemas."""
+    for key in ("status", "expected_quality"):
+        val = data.get(key)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return data.get("triage_metadata", {}).get("quality", "")
+
+
+def get_expected_effort(data: Dict[str, Any]) -> str:
+    """Extracts expected effort across schemas, preserving empty string semantics for non-OK issues."""
+    for key in ("effort", "expected_effort"):
+        val = data.get(key)
+        if val is not None:
+            return str(val).strip()
+    return data.get("triage_metadata", {}).get("effort_estimate", "")
+
+
+def get_workable_spec(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Extracts workable spec dictionary across legacy and unified schemas."""
+    spec = data.get("workable_spec") or data.get("expected_workable_spec")
+    return spec if isinstance(spec, dict) else {}
+
+
 def prep_payload(item: Dict[str, Any]) -> Dict[str, Any]:
     """Preprocesses and wraps title & body to simulate production Ingestion Layer safety encapsulation."""
-    raw_body = item.get("issue_body") or ""
+    raw_body = item.get("issue_body") or item.get("body") or ""
     escaped_body = raw_body.replace("</untrusted_context>", "\\</untrusted_context>")
     sanitized_body = f"<untrusted_context>\n{escaped_body}\n</untrusted_context>"
 
-    raw_title = item.get("issue_title") or ""
+    raw_title = item.get("issue_title") or item.get("title") or ""
     escaped_title = raw_title.replace("</untrusted_context>", "\\</untrusted_context>")
     sanitized_title = f"<untrusted_context>\n{escaped_title}\n</untrusted_context>"
 

--- a/tools/caretaker-agent/evals/triage/helpers/worktrees.py
+++ b/tools/caretaker-agent/evals/triage/helpers/worktrees.py
@@ -31,11 +31,30 @@ def add_worktree(worker_id: int, version: str) -> Tuple[str, str]:
     subprocess.run(["git", "worktree", "remove", "--force", worktree_dir], cwd=TARGET_REPO_DIR, capture_output=True)
 
     actual_version = version
-    res = subprocess.run(["git", "worktree", "add", "-f", worktree_dir, version], cwd=TARGET_REPO_DIR, capture_output=True, text=True)
+    res = subprocess.run(["git", "worktree", "add", "-f", "--", worktree_dir, version], cwd=TARGET_REPO_DIR, capture_output=True, text=True)
     if res.returncode != 0:
-        print(f"  [EVAL] Warning: Could not checkout commit '{version[:10]}' for worker {worker_id}. Falling back to 'main'.")
-        subprocess.run(["git", "worktree", "add", "-f", worktree_dir, "main"], cwd=TARGET_REPO_DIR, capture_output=True)
-        actual_version = "main"
+        # Attempt to fetch the explicit commit from origin with timeout before falling back
+        fetch_res = subprocess.run(
+            ["git", "fetch", "origin", "--", version],
+            cwd=TARGET_REPO_DIR,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if fetch_res.returncode == 0:
+            res = subprocess.run(["git", "worktree", "add", "-f", "--", worktree_dir, version], cwd=TARGET_REPO_DIR, capture_output=True, text=True)
+        else:
+            err_msg = fetch_res.stderr.strip() or "commit not found on origin"
+            print(f"  [EVAL WARNING] 'git fetch origin {version[:10]}' failed: {err_msg}")
+
+        if res.returncode != 0:
+            print(f"  [EVAL] Warning: Could not checkout commit '{version[:10]}' for worker {worker_id}. Falling back to 'main'.")
+            subprocess.run(["git", "worktree", "add", "-f", "--", worktree_dir, "main"], cwd=TARGET_REPO_DIR, capture_output=True)
+            actual_version = "main"
+
+    # Reset hard and clean to ensure pristine workspace at the target version
+    subprocess.run(["git", "reset", "--hard", actual_version], cwd=worktree_dir, capture_output=True)
+    subprocess.run(["git", "clean", "-fd"], cwd=worktree_dir, capture_output=True)
 
     return worktree_dir, actual_version
 

--- a/tools/caretaker-agent/evals/triage/judge.py
+++ b/tools/caretaker-agent/evals/triage/judge.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from google import genai
+from evals.triage.helpers.dataset import get_expected_quality, get_expected_effort
 
 PROMPT_FILE = Path(__file__).parent / "judge.md"
 if not PROMPT_FILE.exists():
@@ -45,19 +46,19 @@ def evaluate_categorization(predicted: Dict[str, Any], expected: Dict[str, Any])
               If expected quality is non-OK (SPAM, NEEDS_INFO, FEATURE), predicted effort must be empty ("").
     """
     pred_quality = predicted.get("quality")
-    exp_quality = expected.get("expected_quality")
+    exp_quality = get_expected_quality(expected)
     
     # 1. Quality match check
     quality_match = (pred_quality == exp_quality)
 
     # 2. Effort match check
     pred_effort = predicted.get("effort_estimate")
-    exp_effort = expected.get("expected_effort")
+    exp_effort = get_expected_effort(expected)
 
     if exp_quality == "OK":
         effort_match = (pred_effort == exp_effort)
     else:
-        effort_match = (pred_effort == "")
+        effort_match = (pred_effort == "" or pred_effort is None)
 
     return {
         "quality_match": quality_match,

--- a/tools/caretaker-agent/evals/triage/tools/dataset_metrics.py
+++ b/tools/caretaker-agent/evals/triage/tools/dataset_metrics.py
@@ -6,7 +6,12 @@ CLI Usage:
 """
 
 from collections import Counter
-from evals.triage.helpers.dataset import load_issues
+from evals.triage.helpers.dataset import (
+    get_expected_effort,
+    get_expected_quality,
+    get_workable_spec,
+    load_issues,
+)
 
 VALID_QUALITIES = ["OK", "SPAM", "EMPTY", "NEEDS_INFO", "FEATURE"]
 VALID_EFFORTS = ["SMALL", "MEDIUM", "LARGE"]
@@ -23,9 +28,9 @@ def _validate_spec_integrity(issues) -> bool:
     errors = []
     for data in issues:
         issue_num = data.get("issue_number", 0)
-        quality = data.get("expected_quality", "")
-        effort = data.get("expected_effort", "")
-        spec = data.get("expected_workable_spec", {})
+        quality = get_expected_quality(data)
+        effort = get_expected_effort(data)
+        spec = get_workable_spec(data)
         has_spec = bool(spec and isinstance(spec, dict) and len(spec) > 0)
 
         # 1. Quality validity check
@@ -69,8 +74,8 @@ def compute_metrics() -> bool:
     ok_efforts = Counter()
 
     for data in issues:
-        quality = data.get("expected_quality", "")
-        effort = data.get("expected_effort", "")
+        quality = get_expected_quality(data)
+        effort = get_expected_effort(data)
 
         qualities[quality] += 1
         if quality == "OK":


### PR DESCRIPTION
Unify the two schemas used in the eval setups:
- Add centralized get_expected_quality, get_expected_effort, and get_workable_spec helper accessors in helpers/dataset.py supporting both legacy and unified schemas.
- Preserve empty-string effort semantics for non-OK issues using explicit non-null checks in get_expected_effort.
- Update prep_payload to accept title and body alongside legacy issue_title and issue_body.
- Harden add_worktree in helpers/worktrees.py with origin fetch fallback, timeout, argument injection guard, and pristine workspace cleaning.
- Update evaluate_categorization in judge.py and dataset diagnostic metrics to use centralized schema accessors.