### PR TITLE
feat(triage-eval): standardize golden issue generator schema

### DIFF
--- a/tools/caretaker-agent/evals/triage/tests/test_generate_golden_issue.py
+++ b/tools/caretaker-agent/evals/triage/tests/test_generate_golden_issue.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+# Apache-2.0 License
+
+"""Unit tests for evals.triage.tools.generate_golden_issue."""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure caretaker root and evals are in sys.path
+TRIAGE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CARETAKER_ROOT = os.path.abspath(os.path.join(TRIAGE_DIR, "..", ".."))
+
+for p in (TRIAGE_DIR, CARETAKER_ROOT):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from evals.triage.tools.generate_golden_issue import (
+    batch_generate_golden_issues,
+    generate_golden_issue,
+    get_output_filename,
+    main,
+)
+
+
+def test_get_output_filename():
+    """Tests dynamic output filename generation based on repository name."""
+    assert get_output_filename("gemini-cli", 17733) == "gemini_cli_17733.json"
+    assert get_output_filename("custom-repo", 456) == "custom_repo_456.json"
+    assert get_output_filename("my_repo_name", 789) == "my_repo_name_789.json"
+
+
+def test_generate_golden_issue_firestore_format(tmp_path):
+    """Tests generating golden issue JSON in Firestore format."""
+    issue_data = {
+        "title": "Bug in config loader",
+        "body": "Detailed description of bug",
+        "createdAt": "2026-01-28T03:35:15Z",
+    }
+    pr_data = {
+        "baseRefOid": "abcd1234efgh5678",
+        "diff": "diff --git a/config.ts b/config.ts\n+fix",
+    }
+
+    mock_spec_res = {
+        "workable_spec": {
+            "summary": {"problem": "Config bug", "root_cause": "Typo", "context": "Loader"},
+            "implementation_plan": {"files_to_modify": ["config.ts"], "steps": ["Fix typo"]},
+            "testing_strategy": {"test_file": "config.test.ts", "framework": "Vitest"},
+        },
+        "golden_spec_rationale": "Pruned lockfiles and docs.",
+    }
+
+    with patch("evals.triage.tools.generate_golden_issue.generate_golden_spec", return_value=mock_spec_res):
+        out_file = generate_golden_issue(
+            owner="google-gemini",
+            repo="gemini-cli",
+            issue_number=17733,
+            pr_number=17734,
+            issue_data=issue_data,
+            pr_data=pr_data,
+            output_dir=tmp_path,
+        )
+
+    assert out_file.exists()
+    assert out_file.name == "gemini_cli_17733.json"
+
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert data["status"] == "TRIAGED"
+    assert data["triage_attempts"] == 0
+    assert data["generation_attempts"] == 0
+    assert data["github_metadata"]["owner"] == "google-gemini"
+    assert data["github_metadata"]["repo"] == "gemini-cli"
+    assert data["github_metadata"]["issue_number"] == 17733
+    assert data["github_metadata"]["pr_number"] == 17734
+    assert data["github_metadata"]["target_version"] == "abcd1234efgh5678"
+    assert data["workable_spec"]["summary"]["problem"] == "Config bug"
+    assert data["golden_spec_rationale"] == "Pruned lockfiles and docs."
+    assert "lock" in data
+    assert "error" in data
+
+
+def test_main_cli_dispatch(tmp_path):
+    """Tests CLI main function dispatching to generate_golden_issue."""
+    with patch("evals.triage.tools.generate_golden_issue.generate_golden_issue") as mock_gen:
+        test_args = [
+            "generate_golden_issue.py",
+            "--issue", "17733",
+            "--pr", "17734",
+            "--owner", "google-gemini",
+            "--repo", "gemini-cli",
+            "--output-dir", str(tmp_path),
+        ]
+        with patch("sys.argv", test_args):
+            main()
+
+        mock_gen.assert_called_once_with(
+            owner="google-gemini",
+            repo="gemini-cli",
+            issue_number=17733,
+            pr_number=17734,
+            output_dir=str(tmp_path),
+        )
+
+
+def test_batch_generate_golden_issues_concurrent(tmp_path):
+    """Tests batch generation with multiple issues executing concurrently."""
+    with patch("evals.triage.tools.generate_golden_issue.generate_golden_issue") as mock_gen:
+        test_args = [
+            "generate_golden_issue.py",
+            "--issue", "101", "102", "103",
+            "--pr", "201", "202",
+            "--max-workers", "4",
+        ]
+        with patch("sys.argv", test_args):
+            main()
+
+        assert mock_gen.call_count == 3
+        mock_gen.assert_any_call(
+            owner="google-gemini",
+            repo="gemini-cli",
+            issue_number=101,
+            pr_number=201,
+            output_dir=None,
+        )
+        mock_gen.assert_any_call(
+            owner="google-gemini",
+            repo="gemini-cli",
+            issue_number=102,
+            pr_number=202,
+            output_dir=None,
+        )
+        mock_gen.assert_any_call(
+            owner="google-gemini",
+            repo="gemini-cli",
+            issue_number=103,
+            pr_number=None,
+            output_dir=None,
+        )

--- a/tools/caretaker-agent/evals/triage/tools/generate_golden_issue.py
+++ b/tools/caretaker-agent/evals/triage/tools/generate_golden_issue.py
@@ -1,87 +1,192 @@
-"""
-Golden Issue Generator CLI Tool (Main Entrypoint).
+# Copyright 2026 Google LLC
+# Apache-2.0 License
+
+"""Golden Issue Generator CLI Tool (Main Entrypoint).
+
+Generates golden issue JSON files adhering to the production Firestore schema
+(status='TRIAGED', generation_attempts=0, lock, workable_spec, and github_metadata).
 
 CLI usage:
-  python3 -m evals.triage.tools.generate_golden_issue --issue <number> [--pr <number>]
+  python3 -m evals.triage.tools.generate_golden_issue --issue <number...> [--pr <number...>] [--output-dir <path>] [--max-workers <n>]
 """
 
-import json
 import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from evals.triage.helpers.github_api import (
     get_issue_details,
     get_pr_details,
-    resolve_target_version
+    resolve_target_version,
 )
 from evals.triage.helpers.generate_golden_spec import generate_golden_spec
 
-OUTPUT_DIR = Path(__file__).parent.parent / "dataset" / "golden-issues"
+TRIAGE_DIR = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = TRIAGE_DIR / "dataset" / "golden-issues"
 
 
-def generate_golden_issue(owner: str, repo: str, issue_number: int, pr_number: int = None):
-    """Main orchestrator for generating a brand-new Golden Issue JSON file."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    file_path = OUTPUT_DIR / f"gemini_cli_{issue_number}.json"
+def get_output_filename(repo: str, issue_number: int) -> str:
+    """Generates dynamic filename based on repository name and issue number."""
+    safe_repo = repo.replace("-", "_")
+    return f"{safe_repo}_{issue_number}.json"
 
-    print(f"Fetching Issue #{issue_number} details from {owner}/{repo}...")
-    issue_data = get_issue_details(owner, repo, issue_number)
-    
-    pr_data = {}
-    if pr_number:
+
+def generate_golden_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    pr_number: Optional[int] = None,
+    issue_data: Optional[Dict[str, Any]] = None,
+    pr_data: Optional[Dict[str, Any]] = None,
+    output_dir: Optional[Union[str, Path]] = None,
+) -> Path:
+    """Main orchestrator for generating a single Golden Issue JSON file in Firestore format."""
+    if issue_data is None:
+        print(f"Fetching Issue #{issue_number} details from {owner}/{repo}...")
+        issue_data = get_issue_details(owner, repo, issue_number)
+
+    if pr_number and pr_data is None:
         print(f"Fetching PR #{pr_number} details from {owner}/{repo}...")
         pr_data = get_pr_details(owner, repo, pr_number)
+    elif pr_data is None:
+        pr_data = {}
 
-    workable_spec = {}
+    workable_spec: Dict[str, Any] = {}
     golden_spec_rationale = ""
 
     if pr_number:
         print(f"[EVAL] Generating Golden Workable Spec for Issue #{issue_number} using PR #{pr_number}...")
         spec_res = generate_golden_spec(owner, repo, issue_number, issue_data, pr_data)
-        workable_spec = spec_res["workable_spec"]
-        golden_spec_rationale = spec_res["golden_spec_rationale"]
+        workable_spec = spec_res.get("workable_spec", {})
+        golden_spec_rationale = spec_res.get("golden_spec_rationale", "")
 
-    # Extract effort from labels if present
-    labels = [l.get("name", "").lower() for l in issue_data.get("labels", []) if isinstance(l, dict)]
-    effort_from_labels = ""
-    for effort in ["small", "medium", "large"]:
-        if f"effort/{effort}" in labels:
-            effort_from_labels = effort.upper()
-            break
+    target_ver = (
+        resolve_target_version(owner, repo, issue_data, pr_data)
+        if resolve_target_version
+        else (pr_data.get("baseRefOid") if pr_data else "main")
+    )
 
-    # Default quality to 'OK' if a PR is attached, otherwise empty string ''
-    expected_quality_default = "OK" if pr_number else ""
-
+    # Production Firestore document schema for evaluation and ingestion
     template = {
-        "owner": owner,
-        "repo": repo,
-        "issue_number": issue_number,
-        "issue_title": issue_data.get("title", ""),
-        "issue_body": issue_data.get("body", ""),
-        "pr_number": pr_number or 0,
-        "target_version": resolve_target_version(owner, repo, issue_data, pr_data),
-        "expected_quality": expected_quality_default,
-        "expected_effort": effort_from_labels,
-        "notes": f"Created at {issue_data.get('createdAt', '')} by automated generate_golden_issue.py",
+        "status": "TRIAGED",
+        "triage_attempts": 0,
+        "generation_attempts": 0,
+        "workable_spec": workable_spec,
+        "github_metadata": {
+            "owner": owner,
+            "repo": repo,
+            "issue_number": issue_number,
+            "title": issue_data.get("title", ""),
+            "target_version": target_ver,
+            "pr_number": pr_number or 0,
+        },
         "golden_spec_rationale": golden_spec_rationale,
-        "expected_workable_spec": workable_spec
+        "lock": {
+            "holder": None,
+            "expires_at": None,
+        },
+        "error": "",
     }
+
+    target_dir = Path(output_dir) if output_dir else OUTPUT_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    filename = get_output_filename(repo, issue_number)
+    file_path = target_dir / filename
 
     with open(file_path, "w", encoding="utf-8") as f:
         json.dump(template, f, indent=2)
 
     print(f"Successfully saved golden issue file to: {file_path}")
+    return file_path
+
+
+def batch_generate_golden_issues(
+    owner: str,
+    repo: str,
+    issue_pr_pairs: List[Tuple[int, Optional[int]]],
+    output_dir: Optional[Union[str, Path]] = None,
+    max_workers: int = 4,
+):
+    """Concurrently generates golden issue JSON files for multiple (issue, pr) pairs."""
+    if len(issue_pr_pairs) == 1:
+        issue, pr = issue_pr_pairs[0]
+        generate_golden_issue(
+            owner=owner,
+            repo=repo,
+            issue_number=issue,
+            pr_number=pr,
+            output_dir=output_dir,
+        )
+        return
+
+    print(f"\n==========================================================")
+    print(f" Starting Concurrent Golden Issue Generation ({len(issue_pr_pairs)} items)")
+    print(f" Target Repository: {owner}/{repo}")
+    print(f" Max Workers:       {max_workers}")
+    print(f"==========================================================\n")
+
+    def _worker(pair: Tuple[int, Optional[int]]) -> Tuple[int, Optional[int], bool, Optional[str]]:
+        issue, pr = pair
+        try:
+            generate_golden_issue(
+                owner=owner,
+                repo=repo,
+                issue_number=issue,
+                pr_number=pr,
+                output_dir=output_dir,
+            )
+            return (issue, pr, True, None)
+        except Exception as e:
+            print(f"❌ Error generating golden issue #{issue} (PR #{pr}): {e}")
+            return (issue, pr, False, str(e))
+
+    success_count = 0
+    failure_count = 0
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(issue_pr_pairs))) as executor:
+        futures = [executor.submit(_worker, pair) for pair in issue_pr_pairs]
+        for future in as_completed(futures):
+            issue, pr, success, err = future.result()
+            if success:
+                success_count += 1
+            else:
+                failure_count += 1
+
+    print(f"\n==========================================================")
+    print(f" Batch Golden Issue Generation Complete")
+    print(f" Total Issues: {len(issue_pr_pairs)} | Success: {success_count} | Failed: {failure_count}")
+    print(f"==========================================================\n")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate a Golden Issue JSON file.")
-    parser.add_argument("--issue", type=int, required=True, help="GitHub Issue number")
-    parser.add_argument("--pr", type=int, default=None, help="Associated PR number (optional)")
+    parser = argparse.ArgumentParser(description="Generate Golden Issue JSON file(s) in Firestore format.")
+    parser.add_argument("--issue", "--issues", type=int, nargs="+", required=True, help="GitHub Issue number(s)")
+    parser.add_argument("--pr", "--prs", type=int, nargs="+", default=None, help="Associated PR number(s) (optional)")
     parser.add_argument("--owner", type=str, default="google-gemini", help="Repository owner")
     parser.add_argument("--repo", type=str, default="gemini-cli", help="Repository name")
-    
+    parser.add_argument("--output-dir", type=str, default=None, help="Custom output directory path for generated JSON specs")
+    parser.add_argument("--max-workers", type=int, default=4, help="Max concurrent worker threads")
+
     args = parser.parse_args()
-    generate_golden_issue(args.owner, args.repo, args.issue, args.pr)
+
+    issues = args.issue
+    prs = args.pr or []
+
+    # Match issue and PR arguments by position
+    pairs = []
+    for idx, issue in enumerate(issues):
+        pr = prs[idx] if idx < len(prs) else None
+        pairs.append((issue, pr))
+
+    batch_generate_golden_issues(
+        owner=args.owner,
+        repo=args.repo,
+        issue_pr_pairs=pairs,
+        output_dir=args.output_dir,
+        max_workers=args.max_workers,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Upgrade generate_golden_issue.py to output the production Firestore document schema (status='TRIAGED', workable_spec, github_metadata, lock) and support multi-threaded batch generation.

### Motivation
Triage benchmark golden issues require schema compatibility with Firestore and the PR Generator state machine without conversion steps. Generating multiple golden issues required concurrent batching to avoid serial network bottlenecks.

### Key Changes
- Standardized generate_golden_issue JSON output to Firestore schema.
- Added batch_generate_golden_issues with ThreadPoolExecutor and configurable --max-workers.
- Added get_output_filename for dynamic <repo>_<issue>.json naming.
- Supported --issue/--issues and --pr/--prs with nargs='+' in CLI main().
- Added unit test suite in evals/triage/tests/test_generate_golden_issue.py.