### PR TITLE
fix(core): resolve symlinked/junctioned skills directories via realpath

### DIFF
--- a/packages/core/src/skills/skillLoader.test.ts
+++ b/packages/core/src/skills/skillLoader.test.ts
@@ -286,4 +286,35 @@ description: Test sanitization
       'https://antigravity.google/docs/cli-getting-started',
     );
   });
+
+  it('should resolve symlinked/junctioned skill directories to the physical path', async () => {
+    const agentsDir = path.join(testRootDir, 'agents');
+    const skillDir = path.join(agentsDir, 'skills', 'my-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, 'SKILL.md'),
+      `---\nname: my-skill\ndescription: A test skill\n---\nbody\n`,
+    );
+
+    // Link an alias directory to the physical one, the way users link
+    // .gemini to .agents (issue #28944). On Windows a junction requires no
+    // elevated privileges; elsewhere use a directory symlink.
+    const aliasDir = path.join(testRootDir, 'alias');
+    await fs.symlink(
+      agentsDir,
+      aliasDir,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    const physicalSkills = await loadSkillsFromDir(
+      path.join(agentsDir, 'skills'),
+    );
+    const aliasSkills = await loadSkillsFromDir(path.join(aliasDir, 'skills'));
+
+    expect(physicalSkills).toHaveLength(1);
+    expect(aliasSkills).toHaveLength(1);
+    // Both entry points must report the same physical location so the
+    // manager deduplicates them instead of warning about a conflict.
+    expect(aliasSkills[0].location).toBe(physicalSkills[0].location);
+  });
 });

--- a/packages/core/src/skills/skillLoader.ts
+++ b/packages/core/src/skills/skillLoader.ts
@@ -118,7 +118,12 @@ export async function loadSkillsFromDir(
   const discoveredSkills: SkillDefinition[] = [];
 
   try {
-    const absoluteSearchPath = path.resolve(dir);
+    // Resolve symlinks/junctions (e.g. a Windows junction from .gemini to
+    // .agents) to the physical path so skills discovered through alias
+    // directories report identical locations and deduplicate correctly.
+    const absoluteSearchPath = await fs
+      .realpath(path.resolve(dir))
+      .catch(() => path.resolve(dir));
     const stats = await fs.stat(absoluteSearchPath).catch(() => null);
     if (!stats || !stats.isDirectory()) {
       return [];


### PR DESCRIPTION
## Problem

Fixes #28944

To follow the open Agent Skills standard while retaining compatibility with legacy config paths, users link their `.gemini` folder to their `.agents` folder via a Windows junction (`mklink /J .gemini .agents`) or a symlink.

Because the CLI scans both `[workspace]/.agents/skills/` and `[workspace]/.gemini/skills/` natively, the recursive skill discoverer scanned both entry points. Since the discovered `location` of each skill kept the (different) logical path of the entry point, the same physical `SKILL.md` was registered twice with different locations, triggering spurious conflict warnings on `/skills reload`:

> [Warning] Skill conflict detected: "demo-skill" from "C:\\tmp\\repro28944\\.agents\\skills\\demo-skill\\SKILL.md" is overriding the same skill from "C:\\tmp\\repro28944\\.gemini\\skills\\demo-skill\\SKILL.md".

## Root cause

`loadSkillsFromDir` in `packages/core/src/skills/skillLoader.ts` only called `path.resolve(dir)`, which does not resolve symlinks/junctions. `SkillManager.addSkillsWithPrecedence` deduplicates by name but compares `location` strings, so the same physical file reached via `.gemini/skills` and `.agents/skills` looked like two different skills.

## Fix

Resolve the search path with `fs.realpath` before globbing (falling back to the plain resolved path on error), following the existing style of the loader. Skills discovered through alias directories now report the identical physical location and deduplicate silently.

## Evidence (Windows 11, real junction)

Setup exactly as in the issue:

```cmd
mkdir .agents\skills\demo-skill
:: create valid SKILL.md with frontmatter
mklink /J .gemini .agents
```

**Before** (loader run on both `.gemini/skills` and `.agents/skills`):

```
.gemini/skills -> [{ "name": "demo-skill", "location": "C:\\tmp\\repro28944\\.gemini\\skills\\demo-skill\\SKILL.md", ... }]
.agents/skills -> [{ "name": "demo-skill", "location": "C:\\tmp\\repro28944\\.agents\\skills\\demo-skill\\SKILL.md", ... }]
[warning] Skill conflict detected: "demo-skill" from "C:\\tmp\\repro28944\\.agents\\skills\\demo-skill\\SKILL.md" is overriding the same skill from "C:\\tmp\\repro28944\\.gemini\\skills\\demo-skill\\SKILL.md".
```

**After**:

```
.gemini/skills -> [{ "name": "demo-skill", "location": "C:\\tmp\\repro28944\\.agents\\skills\\demo-skill\\SKILL.md", ... }]
.agents/skills -> [{ "name": "demo-skill", "location": "C:\\tmp\\repro28944\\.agents\\skills\\demo-skill\\SKILL.md", ... }]
WARNINGS: (none)
```

## Tests

- Added `should resolve symlinked/junctioned skill directories to the physical path` to `skillLoader.test.ts` (creates a real junction on Windows / dir symlink elsewhere and asserts both entry points report the same physical location).
- `npx vitest run src/skills/skillLoader.test.ts` — 16/16 pass.
- `npx vitest run src/skills/skillManager.test.ts` — 10/10 pass.
- `npx tsc --noEmit`, eslint and prettier clean on the touched files.