### PR TITLE
docs(extensions): correct excludeTools examples that never match

### DIFF
--- a/docs/extensions/best-practices.md
+++ b/docs/extensions/best-practices.md
@@ -66,18 +66,30 @@ Only request the permissions your MCP server needs to function. Avoid giving the
 model broad access (such as full shell access) if restricted tools are
 sufficient.
 
-If your extension uses powerful tools like `run_shell_command`, restrict them in
-your `gemini-extension.json` file:
+If your extension does not need a powerful tool like `run_shell_command` at all,
+exclude it in your `gemini-extension.json` file. `excludeTools` matches whole
+tool names:
 
 ```json
 {
   "name": "my-safe-extension",
-  "excludeTools": ["run_shell_command(rm -rf *)"]
+  "excludeTools": ["run_shell_command"]
 }
 ```
 
-This ensures the CLI blocks dangerous commands even if the model attempts to
-execute them.
+To block individual commands rather than the whole tool, ship a policy rule in
+your extension's `policies/` directory instead:
+
+```toml
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = "rm -rf"
+decision = "deny"
+priority = 100
+```
+
+The CLI then blocks those commands even if the model attempts to run them. See
+[Policy engine](../reference/policy-engine.md) for the full rule syntax.
 
 ### Validate inputs
 

--- a/docs/extensions/reference.md
+++ b/docs/extensions/reference.md
@@ -159,12 +159,13 @@ The manifest file defines the extension's behavior and configuration.
   extension. This will be used to load the context from the extension directory.
   If this property is not used but a `GEMINI.md` file is present in your
   extension directory, then that file will be loaded.
-- `excludeTools`: An array of tool names to exclude from the model. You can also
-  specify command-specific restrictions for tools that support it, like the
-  `run_shell_command` tool. For example,
-  `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf`
-  command. Note that this differs from the MCP server `excludeTools`
-  functionality, which can be listed in the MCP server config.
+- `excludeTools`: An array of tool names to exclude from the model. Entries are
+  matched against whole tool names, so `"excludeTools": ["run_shell_command"]`
+  removes that tool entirely. To restrict individual commands instead of the
+  whole tool, define a rule in your extension's `policies/` directory; see
+  [Policy engine](../reference/policy-engine.md). Note that this differs from
+  the MCP server `excludeTools` functionality, which can be listed in the MCP
+  server config.
 - `plan`: Planning features configuration.
   - `directory`: The directory where planning artifacts are stored. This serves
     as a fallback if the user hasn't specified a plan directory in their

--- a/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "excludeTools",
   "version": "1.0.0",
-  "excludeTools": ["run_shell_command(rm -rf)"]
+  "excludeTools": ["run_shell_command"]
 }


### PR DESCRIPTION
## Summary

`docs/extensions/best-practices.md` told extension authors to write

```json
{ "excludeTools": ["run_shell_command(rm -rf *)"] }
```

and stated that this "ensures the CLI blocks dangerous commands". It does not.
Extension `excludeTools` entries are compared against whole tool names, so an
entry containing `(...)` matches nothing and is silently dropped — the tool stays
available to the model with no warning.

This corrects the two extension doc pages and the shipped example manifest to
show a form that actually takes effect.

## Details

`Config.getExcludeTools()` folds `extension.excludeTools` into a `Set`
(`packages/core/src/config/config.ts:2431-2439`), and `ToolRegistry.isActiveTool`
tests membership directly (`packages/core/src/tools/tool-registry.ts:637`):

```ts
return !possibleNames.some((name) => excludeTools?.has(name));
```

`possibleNames` holds the tool's real names — `run_shell_command`, its class
name, and MCP-qualified variants — none of which equal
`"run_shell_command(rm -rf *)"`.

The parenthesised `toolName(args)` shape is real syntax, but it belongs to
`tools.core` / `tools.allowed`, which are parsed by `mapToolsToRules`
(`packages/core/src/policy/config.ts:445-476`). Extension `excludeTools` never
goes through that path.

For the "block one specific command" case the page was describing, that
capability now lives in the policy engine: the settings-level `tools.exclude` was
deprecated in its favour (#18508, documented at `docs/tools/shell.md:158` and
`docs/cli/enterprise.md:267`), and extensions can ship rules in a `policies/`
directory. The TOML snippet added here mirrors the shipped example extension in
`packages/cli/src/commands/extensions/examples/policies/`.

Note on `decision`: that example extension uses `ask_user` for `rm -rf`, but the
original prose promised the CLI "blocks" the command, so `deny` preserves the
stated intent. Happy to switch it to `ask_user` if you'd rather the two examples
match exactly.

## Related Issues

Related to #28962

## How to Validate

The exclusion behaviour, using the real `Config` and `ToolRegistry`:

```ts
const config = new Config(params);
vi.spyOn(config, 'getExcludeTools').mockReturnValue(new Set(entry));
const registry = await config.createToolRegistry();
registry.getAllTools().some((t) => t.name === 'run_shell_command');
```

| `excludeTools` entry | `run_shell_command` still registered |
| --- | --- |
| `[]` | yes |
| `["run_shell_command"]` | **no** — excluded |
| `["run_shell_command(rm -rf)"]` | yes — entry ignored |
| `["run_shell_command(rm -rf *)"]` | yes — entry ignored |

The policy snippet added to `best-practices.md`, loaded through the real
extension policy loader and evaluated by `PolicyEngine`:

```
loadExtensionPolicies('my-safe-extension', '<ext>/policies')
  -> 0 errors, 1 rule
run_shell_command {"command":"rm -rf /tmp/victim"}  ->  deny
run_shell_command {"command":"ls -la"}              ->  allow
```

Docs checks:

```bash
npx prettier --check docs/extensions/best-practices.md docs/extensions/reference.md \
  packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
npm run lint
```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — this PR is the
      documentation change
- [x] Added/updated tests (if needed) — n/a, no source behaviour changes
- [x] Noted breaking changes (if any) — none; docs and one example manifest only
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
