### PR TITLE
docs(extensions): correct excludeTools examples that never match

### DIFF
--- a/docs/extensions/best-practices.md
+++ b/docs/extensions/best-practices.md
@@ -66,18 +66,30 @@ Only request the permissions your MCP server needs to function. Avoid giving the
 model broad access (such as full shell access) if restricted tools are
 sufficient.
 
-If your extension uses powerful tools like `run_shell_command`, restrict them in
-your `gemini-extension.json` file:
+If your extension does not need a powerful tool like `run_shell_command` at all,
+exclude it in your `gemini-extension.json` file. `excludeTools` matches whole
+tool names:
 
 ```json
 {
   "name": "my-safe-extension",
-  "excludeTools": ["run_shell_command(rm -rf *)"]
+  "excludeTools": ["run_shell_command"]
 }
 ```
 
-This ensures the CLI blocks dangerous commands even if the model attempts to
-execute them.
+To block individual commands rather than the whole tool, ship a policy rule in
+your extension's `policies/` directory instead:
+
+```toml
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = "rm -rf"
+decision = "deny"
+priority = 100
+```
+
+The CLI then blocks those commands even if the model attempts to run them. See
+[Policy engine](../reference/policy-engine.md) for the full rule syntax.
 
 ### Validate inputs
 

--- a/docs/extensions/reference.md
+++ b/docs/extensions/reference.md
@@ -159,12 +159,13 @@ The manifest file defines the extension's behavior and configuration.
   extension. This will be used to load the context from the extension directory.
   If this property is not used but a `GEMINI.md` file is present in your
   extension directory, then that file will be loaded.
-- `excludeTools`: An array of tool names to exclude from the model. You can also
-  specify command-specific restrictions for tools that support it, like the
-  `run_shell_command` tool. For example,
-  `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf`
-  command. Note that this differs from the MCP server `excludeTools`
-  functionality, which can be listed in the MCP server config.
+- `excludeTools`: An array of tool names to exclude from the model. Entries are
+  matched against whole tool names, so `"excludeTools": ["run_shell_command"]`
+  removes that tool entirely. To restrict individual commands instead of the
+  whole tool, define a rule in your extension's `policies/` directory; see
+  [Policy engine](../reference/policy-engine.md). Note that this differs from
+  the MCP server `excludeTools` functionality, which can be listed in the MCP
+  server config.
 - `plan`: Planning features configuration.
   - `directory`: The directory where planning artifacts are stored. This serves
     as a fallback if the user hasn't specified a plan directory in their

--- a/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
+++ b/packages/cli/src/commands/extensions/examples/exclude-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "excludeTools",
   "version": "1.0.0",
-  "excludeTools": ["run_shell_command(rm -rf)"]
+  "excludeTools": ["run_shell_command"]
 }


### PR DESCRIPTION
Extension excludeTools entries are matched by exact tool name, so forms like run_shell_command(rm -rf *) never exclude anything. Update docs and the shipped example to use bare tool names, and point command-level blocking at the policy engine.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
