### PR TITLE
fix(cli): prevent clearing terminal scrollback on static refresh (#28954)

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -3261,6 +3261,12 @@ describe('AppContainer State Management', () => {
 
       // Should be reset
       expect(capturedUIState.constrainHeight).toBe(true);
+      expect(mocks.mockStdout.write).toHaveBeenCalledWith(
+        ansiEscapes.eraseScreen + ansiEscapes.cursorTo(0, 0),
+      );
+      expect(mocks.mockStdout.write).not.toHaveBeenCalledWith(
+        ansiEscapes.clearTerminal,
+      );
       unmount();
     });
 
@@ -3295,7 +3301,10 @@ describe('AppContainer State Management', () => {
 
       // Should be reset
       expect(capturedUIState.constrainHeight).toBe(true);
-      // Should NOT refresh static's clearTerminal in alternate buffer
+      // Should NOT refresh static in alternate buffer
+      expect(mocks.mockStdout.write).not.toHaveBeenCalledWith(
+        ansiEscapes.eraseScreen + ansiEscapes.cursorTo(0, 0),
+      );
       expect(mocks.mockStdout.write).not.toHaveBeenCalledWith(
         ansiEscapes.clearTerminal,
       );

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -645,7 +645,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const refreshStatic = useCallback(() => {
     if (!isAlternateBuffer && !config.getUseTerminalBuffer()) {
-      stdout.write(ansiEscapes.clearTerminal);
+      stdout.write(ansiEscapes.eraseScreen + ansiEscapes.cursorTo(0, 0));
       setHistoryRemountKey((prev) => prev + 1);
     }
   }, [setHistoryRemountKey, isAlternateBuffer, stdout, config]);


### PR DESCRIPTION
## Description
Fixes #28954

In standard terminal mode (\useAlternateBuffer: false\ and \useTerminalBuffer: false\), \efreshStatic()\ in \AppContainer.tsx\ was calling \stdout.write(ansiEscapes.clearTerminal)\. On Linux/Unix terminal emulators (GNOME Terminal, xterm, Alacritty, Konsole, etc.), \clearTerminal\ emits the ANSI escape sequence \\x1b[3J\ (Erase Saved Lines), which permanently purges the entire terminal scrollback history.

This change replaces \nsiEscapes.clearTerminal\ with \nsiEscapes.eraseScreen + ansiEscapes.cursorTo(0, 0)\ (\\x1b[2J\x1b[1;1H\), ensuring only the visible viewport is erased and cursor repositioned without clearing the terminal's native scrollback buffer.

## Changes
- **\packages/cli/src/ui/AppContainer.tsx\**: Updated \efreshStatic()\ to use \eraseScreen\ and \cursorTo(0, 0)\ instead of \clearTerminal\.
- **\packages/cli/src/ui/AppContainer.test.tsx\**: Added assertions in the \Submission Handling\ suite verifying that \eraseScreen + cursorTo(0, 0)\ is emitted and \clearTerminal\ is never emitted on static refreshes.

## Verification
- Unit tests: \
pm test -w @google/gemini-cli -- src/ui/AppContainer.test.tsx\ (112 / 112 passed)
- Typecheck: \
pm run typecheck\ (Passed)
- Linter: \
pm run lint\ (Passed)