### PR TITLE
fix(core): dedupe symlinked/junctioned skills directories during discovery

### DIFF
--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Storage } from '../config/storage.js';
@@ -58,6 +59,10 @@ export class SkillManager {
   ): Promise<void> {
     this.clearSkills();
 
+    // Directories already scanned, tracked by their physical (real) path so
+    // that symlinked/junctioned aliases are not discovered twice.
+    const visitedDirs = new Set<string>();
+
     // 1. Built-in skills (lowest precedence)
     await this.discoverBuiltinSkills();
 
@@ -69,12 +74,16 @@ export class SkillManager {
     }
 
     // 3. User skills
-    const userSkills = await loadSkillsFromDir(Storage.getUserSkillsDir());
+    const userSkills = await this.loadSkillsFromUniqueDir(
+      Storage.getUserSkillsDir(),
+      visitedDirs,
+    );
     this.addSkillsWithPrecedence(userSkills);
 
     // 3.1 User agent skills alias (.agents/skills)
-    const userAgentSkills = await loadSkillsFromDir(
+    const userAgentSkills = await this.loadSkillsFromUniqueDir(
       Storage.getUserAgentSkillsDir(),
+      visitedDirs,
     );
     this.addSkillsWithPrecedence(userAgentSkills);
 
@@ -86,16 +95,45 @@ export class SkillManager {
       return;
     }
 
-    const projectSkills = await loadSkillsFromDir(
+    const projectSkills = await this.loadSkillsFromUniqueDir(
       storage.getProjectSkillsDir(),
+      visitedDirs,
     );
     this.addSkillsWithPrecedence(projectSkills);
 
     // 4.1 Workspace agent skills alias (.agents/skills)
-    const projectAgentSkills = await loadSkillsFromDir(
+    const projectAgentSkills = await this.loadSkillsFromUniqueDir(
       storage.getProjectAgentSkillsDir(),
+      visitedDirs,
     );
     this.addSkillsWithPrecedence(projectAgentSkills);
+  }
+
+  /**
+   * Loads skills from a directory unless it resolves to a physical directory
+   * that was already scanned. This prevents duplicate skill warnings when
+   * e.g. `.gemini` is a symlink or Windows junction pointing at `.agents`
+   * (or vice versa), which would otherwise cause the same skills to be
+   * discovered once per alias path.
+   */
+  private async loadSkillsFromUniqueDir(
+    dir: string,
+    visitedDirs: Set<string>,
+  ): Promise<SkillDefinition[]> {
+    let realDir = path.resolve(dir);
+    try {
+      realDir = await fs.realpath(realDir);
+    } catch {
+      // The directory may not exist; fall back to the resolved path.
+    }
+    if (visitedDirs.has(realDir)) {
+      debugLogger.debug(
+        `Skipping skill discovery for "${dir}": it resolves to "${realDir}", which has already been scanned.`,
+      );
+      return [];
+    }
+    visitedDirs.add(realDir);
+    return loadSkillsFromDir(dir);
   }
 
   /**

--- a/packages/core/src/skills/skillManagerAlias.test.ts
+++ b/packages/core/src/skills/skillManagerAlias.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import { SkillManager } from './skillManager.js';
 import { Storage } from '../config/storage.js';
 import { loadSkillsFromDir } from './skillLoader.js';
+import { coreEvents } from '../utils/events.js';
 
 vi.mock('./skillLoader.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./skillLoader.js')>();
@@ -174,5 +175,120 @@ describe('SkillManager Alias', () => {
     const skills = service.getSkills();
     expect(skills).toHaveLength(1);
     expect(skills[0].description).toBe('agent-desc');
+  });
+
+  describe('symlinked/junctioned alias directories', () => {
+    /**
+     * Creates `linkDir` as a link pointing at `targetDir`. Returns true if the
+     * platform allowed creating the link (junctions on Windows do not require
+     * elevated privileges, symlinks elsewhere may).
+     */
+    async function tryCreateDirLink(
+      targetDir: string,
+      linkDir: string,
+    ): Promise<boolean> {
+      try {
+        if (process.platform === 'win32') {
+          await fs.symlink(targetDir, linkDir, 'junction');
+        } else {
+          await fs.symlink(targetDir, linkDir, 'dir');
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    it('should not report duplicate skills when .gemini is linked to .agents', async () => {
+      // Real layout from the issue: workspace/.agents/skills/<skill>/SKILL.md
+      // with workspace/.gemini created as a junction/symlink to .agents.
+      const agentsDir = path.join(testRootDir, 'workspace', '.agents');
+      const skillsDir = path.join(agentsDir, 'skills', 'my-skill');
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        '---\nname: my-skill\ndescription: A test skill\n---\nBody',
+      );
+
+      const geminiLink = path.join(testRootDir, 'workspace', '.gemini');
+      if (!(await tryCreateDirLink(agentsDir, geminiLink))) {
+        return; // Platform does not permit directory links; nothing to assert.
+      }
+
+      // Isolate discovery from any real user-level skills directories.
+      vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+        path.join(testRootDir, 'user', '.gemini', 'skills'),
+      );
+      vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+        path.join(testRootDir, 'user', '.agents', 'skills'),
+      );
+
+      const storage = new Storage(path.join(testRootDir, 'workspace'));
+      const service = new SkillManager();
+      // @ts-expect-error accessing private method for testing
+      vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+      const feedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+      await service.discoverSkills(storage, [], true);
+
+      const skills = service.getSkills();
+      expect(
+        skills.filter((s) => s.name === 'my-skill' && !s.isBuiltin),
+      ).toHaveLength(1);
+
+      const conflictWarnings = feedbackSpy.mock.calls.filter(
+        ([type, message]) =>
+          type === 'warning' &&
+          typeof message === 'string' &&
+          message.includes('my-skill'),
+      );
+      expect(conflictWarnings).toHaveLength(0);
+    });
+
+    it('should scan aliased directories only once when they resolve to the same physical path', async () => {
+      // User-tier layout: ~/.agents/skills/<skill>/SKILL.md with ~/.gemini
+      // created as a junction/symlink to .agents.
+      const agentsDir = path.join(testRootDir, 'user', '.agents');
+      const skillsDir = path.join(agentsDir, 'skills', 'shared-skill');
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        '---\nname: shared-skill\ndescription: desc\n---\nBody',
+      );
+
+      const geminiLink = path.join(testRootDir, 'user', '.gemini');
+      if (!(await tryCreateDirLink(agentsDir, geminiLink))) {
+        return; // Platform does not permit directory links; nothing to assert.
+      }
+
+      vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+        path.join(geminiLink, 'skills'),
+      );
+      vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+        path.join(agentsDir, 'skills'),
+      );
+
+      const storage = new Storage(path.join(testRootDir, 'workspace'));
+      const service = new SkillManager();
+      // @ts-expect-error accessing private method for testing
+      vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+      const feedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+      await service.discoverSkills(storage, [], true);
+
+      expect(
+        service.getSkills().filter((s) => s.name === 'shared-skill'),
+      ).toHaveLength(1);
+
+      const conflictWarnings = feedbackSpy.mock.calls.filter(
+        ([type, message]) =>
+          type === 'warning' &&
+          typeof message === 'string' &&
+          message.includes('shared-skill'),
+      );
+      expect(conflictWarnings).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #28944

When a user links their .gemini folder to .agents (Windows junction via \mklink /J .gemini .agents\, or a symlink) to follow the open Agent Skills standard while retaining compatibility, the CLI scanned both configured entry points (.gemini/skills and .agents/skills) as if they were separate directories. Since discovery did not resolve aliases to their physical paths, identical skills were registered twice, producing duplicate-skill conflict warnings on every startup and \/skills reload\.

## Changes

- \SkillManager.discoverSkills\ now tracks scanned directories by their **physical (real) path** (\s.realpath\) and skips any directory that resolves to an already-scanned location.
- Applies to both tiers where the alias exists: user-level (\~/.gemini/skills\ / \~/.agents/skills\) and workspace-level (\<ws>/.gemini/skills\ / \<ws>/.agents/skills\). Built-in and extension skills are unaffected.
- Non-existent directories fall back to their resolved path, preserving existing behavior.

## Behavior after the fix

With \.gemini -> .agents\: skills are discovered exactly once from the first entry point; no \Skill conflict detected: ... overriding ...\ warnings. With two genuinely distinct directories, behavior is unchanged (including existing alias precedence).

## Testing

- Added end-to-end tests in \skillManagerAlias.test.ts\:
  - Workspace tier: \.agents/skills/my-skill/SKILL.md\ with \.gemini\ created as a real junction/symlink → skill discovered once, zero conflict warnings (skips gracefully on platforms that disallow directory links).
  - User tier: same scenario for \~/.gemini -> ~/.agents\.
- Full \src/skills\ suite passes (29 tests), plus eslint, prettier, and \	sc --noEmit\ on \@google/gemini-cli-core\.

## Documentation

- [x] I have updated the documentation accordingly (N/A — no user-facing docs describe this internal dedupe; behavior now matches the expectations in #28944).