### PR TITLE
fix(core): keep truncated MCP tool names unique

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -585,8 +585,9 @@ Upon successful connection:
    requirements:
    - Characters other than letters, numbers, underscore (`_`), hyphen (`-`), dot
      (`.`), and colon (`:`) are replaced with underscores
-   - Names longer than 63 characters are truncated with middle replacement
-     (`...`)
+   - Names longer than 63 characters keep a leading and trailing portion of the
+     name, with a short hash of the full qualified name inserted between them so
+     that distinct tools keep distinct identifiers
 
 ### 3. Tool naming and namespaces
 

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -64,7 +64,7 @@ describe('generateValidName', () => {
 
   it('should truncate long names', () => {
     expect(generateValidName('x'.repeat(80))).toBe(
-      'mcp_xxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      'mcp_xxxxxxxxxxxxxxxxxxxxxxx_634ab198_xxxxxxxxxxxxxxxxxxxxxxxxxx',
     );
   });
 
@@ -1109,7 +1109,38 @@ describe('MCP Tool Naming Regression Fixes', () => {
       const longName = 'a'.repeat(40) + '__' + 'b'.repeat(40);
       const result = generateValidName(longName);
       expect(result.length).toBeLessThanOrEqual(63);
-      expect(result).toMatch(/^mcp_a{26}\.\.\.b{30}$/);
+      // head + '_' + 8-char digest + '_' + tail
+      expect(result).toMatch(/^mcp_a+_[0-9a-f]{8}_b+$/);
+    });
+
+    it('should keep truncated names unique when only the middle differs', () => {
+      // Both qualified names share their first and last characters and differ
+      // only in the middle, which is exactly the region a head+tail truncation
+      // discards.
+      const prefix = 'atlassian-remote-mcp-server__getConfluence';
+      const suffix = 'DetailedInformationByIdentifier';
+      const a = `${prefix}SpaceSpaceSpaceSpace${suffix}`;
+      const b = `${prefix}PagePagePagePagePage${suffix}`;
+
+      const nameA = generateValidName(a);
+      const nameB = generateValidName(b);
+
+      expect(a).not.toBe(b);
+      expect(nameA.length).toBeLessThanOrEqual(63);
+      expect(nameB.length).toBeLessThanOrEqual(63);
+      expect(nameA).not.toBe(nameB);
+    });
+
+    it('should be deterministic for the same input', () => {
+      const longName = `server__${'x'.repeat(80)}`;
+      expect(generateValidName(longName)).toBe(generateValidName(longName));
+    });
+
+    it('should produce API-valid names when truncating', () => {
+      const longName = `atlassian-mcp-server__${'tool'.repeat(20)}`;
+      const result = generateValidName(longName);
+      expect(result.length).toBeLessThanOrEqual(63);
+      expect(result).toMatch(/^[a-zA-Z_][a-zA-Z0-9_\-.:]{0,63}$/);
     });
 
     it('should handle very long names starting with a digit', () => {
@@ -1149,7 +1180,8 @@ describe('MCP Tool Naming Regression Fixes', () => {
 
       const qn = tool.getFullyQualifiedName();
       expect(qn.length).toBeLessThanOrEqual(63);
-      expect(qn).toContain('...');
+      // Truncated names embed a short digest of the full qualified name.
+      expect(qn).toMatch(/_[0-9a-f]{8}_/);
     });
 
     it('should handle server names starting with digits', () => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import {
@@ -589,6 +590,14 @@ function getStringifiedResultForDisplay(rawResponse: Part[]): string {
  */
 const MAX_FUNCTION_NAME_LENGTH = 64;
 
+/**
+ * Number of hex characters of the name digest embedded into truncated tool
+ * names. Eight hex characters (32 bits) keeps collisions negligible for the
+ * handful of tools a single MCP server exposes while leaving most of the
+ * budget for the readable head and tail.
+ */
+const NAME_DIGEST_LENGTH = 8;
+
 /** Visible for testing */
 export function generateValidName(name: string) {
   // Enforce the mcp_ prefix for all generated MCP tool names
@@ -603,15 +612,30 @@ export function generateValidName(name: string) {
     validToolname = `_${validToolname}`;
   }
 
-  // If longer than the API limit, replace middle with '...'
+  // If longer than the API limit, keep a head and a tail and put a short
+  // digest of the full name in between.
+  //
+  // The digest is what keeps this transform injective. Retaining only a head
+  // and a tail maps every name that shares those two windows onto the same
+  // result, so two tools on one server whose names differ only in the discarded
+  // middle collapse together. `ToolRegistry.registerTool` then overwrites one
+  // with the other and the displaced tool becomes unreachable by the model.
+  //
   // Note: We use 63 instead of 64 to be safe, as some environments have off-by-one behaviors.
   const safeLimit = MAX_FUNCTION_NAME_LENGTH - 1;
   if (validToolname.length > safeLimit) {
     debugLogger.warn(
       `Truncating MCP tool name "${validToolname}" to fit within the 64 character limit. This tool may require user approval.`,
     );
-    validToolname =
-      validToolname.slice(0, 30) + '...' + validToolname.slice(-30);
+    const digest = createHash('sha256')
+      .update(validToolname)
+      .digest('hex')
+      .slice(0, NAME_DIGEST_LENGTH);
+    // head + '_' + digest + '_' + tail === safeLimit characters.
+    const remaining = safeLimit - NAME_DIGEST_LENGTH - 2;
+    const headLength = Math.ceil(remaining / 2);
+    const tailLength = remaining - headLength;
+    validToolname = `${validToolname.slice(0, headLength)}_${digest}_${validToolname.slice(-tailLength)}`;
   }
 
   return validToolname;


### PR DESCRIPTION
## Summary

Qualified MCP tool names that exceed the Gemini API's function-name limit are shortened to their first 30 and last 30 characters. That transform is not injective, so two tools on the same server whose names agree on both ends collapse to the same registry name. `ToolRegistry.registerTool` then overwrites the first with the second and the displaced tool becomes unreachable by the model, leaving only a `debugLogger.warn` that is not surfaced in normal runs.

This PR embeds a short digest of the full qualified name between the retained head and tail, so distinct tools keep distinct names.

## Details

### Before

```ts
validToolname = validToolname.slice(0, 30) + '...' + validToolname.slice(-30);
```

Two different tools → one registry entry:

```
createConfluencePageWithAttachmentsAndPermissions
deleteConfluencePageWithAttachmentsAndPermissions
  ↓ both become
mcp_atlassian-rovo-mcp-server-...eWithAttachmentsAndPermissions
```

A `create` / `delete` prefix pair differs exactly in the discarded middle, so two
tools with different risk profiles collapse into one entry.

### After

```
mcp_atlassian-rovo-mcp-serv_3a89c837_hAttachmentsAndPermissions  (create)
mcp_atlassian-rovo-mcp-serv_8ab06c14_hAttachmentsAndPermissions  (delete)
```

### Design notes

- **Why a digest rather than a counter.** Names must stay stable across restarts and across processes; a registration-order counter would not be. The digest is a pure function of the fully qualified name, so the same tool always maps to the same identifier.
- **Length.** `head + '_' + 8 hex + '_' + tail` is exactly the 63-character budget, so the output still satisfies `^[a-zA-Z_][a-zA-Z0-9_\-.:]{0,63}$`. 32 bits of digest is ample for the number of tools one MCP server exposes.
- **User-visible strings are unchanged.** The digest only appears in the model-facing identifier (`name`). `displayName` remains `` `${serverToolName} (${serverName} MCP Server)` `` and the confirmation dialog still shows `serverToolName`, as the existing comment at `mcp-tool.ts` ("Display original tool name in confirmation") intends.
- **Scope.** Only names that already exceeded the limit change shape; short names are untouched.

### Why this is worth fixing rather than accepting

PR #20987, which introduced the truncation, describes it as implementing "a middle-truncation strategy **to preserve uniqueness** in long names." Uniqueness was the stated goal. The existing tests asserted only length and shape, so the gap went uncovered.

The overwrite is order-dependent and is not reported to the caller: `registerTool` returns `void`, so discovery cannot tell that a tool was displaced.

## Related Issues

Fixes #28970

## How to Validate

**Unit tests**

```bash
npm test -w @google/gemini-cli-core -- src/tools/mcp-tool.test.ts
```

New cases:
- `should keep truncated names unique when only the middle differs` — the regression this fixes
- `should be deterministic for the same input`
- `should produce API-valid names when truncating`

Two existing assertions were updated because they pinned the old `...` shape.

**End-to-end against a real MCP server**

A minimal stdio server advertising the two colliding tools above, driven through `discoverMcpTools`:

```
before: server advertised 2 tools → registry holds 1  ("already registered. Overwriting.")
after : server advertised 2 tools → registry holds 2, unique names: 2
```

**Full suite**

```bash
npm run preflight     # passes (exit 0)
```

**Docs**

`docs/tools/mcp-server.md` described the old rule ("Names longer than 63 characters are truncated with middle replacement (`...`)") and is updated to match. Notably the section immediately following it is titled "Tool naming and namespaces … To prevent collisions", which is the invariant this PR restores.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — `docs/tools/mcp-server.md` documented the old `...` middle-replacement rule
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — see note below
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [x] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
  - [ ] Linux

The change is pure string/hash logic with no platform-specific behavior, so it was validated on macOS only. `npx` was verified by rebuilding the bundle and confirming the bundled `generateValidName` carries the new logic, then connecting the bundle to a live stdio MCP server.

**Note on compatibility:** the generated identifier changes only for MCP tools whose qualified names already exceeded 63 characters.

Policy rules are unaffected in the cases that currently work:

- `mcpName` matching compares the **server name**, not the generated identifier.
- Wildcard rules (`mcp_server_*`) match on the server prefix, which is unchanged for servers whose own name fits.
- Short-name rules (`mcpName` + untruncated `toolName`) are compared through `formatMcpToolName`, which is plain string concatenation and does **not** apply `generateValidName`. For names over the limit, that comparison already failed against the old `...`-truncated identifier, so this PR does not regress it.

The only rules that change behavior are ones hardcoding a previously-`...`-truncated identifier — which were matching a name that is itself ambiguous between the colliding tools. Happy to add a release note if maintainers want this called out.