### PR TITLE
fix(core): guard formatTruncatedToolOutput against non-positive maxChars

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1348,5 +1348,21 @@ describe('fileUtils', () => {
       expect(formatted).toContain('For full output see: /tmp/out.txt');
       expect(formatted).toContain('[46,000 characters omitted]'); // 50000 - 800 - 3200
     });
+
+    it('should return content unchanged when maxChars is negative', () => {
+      const content = 'a'.repeat(50000);
+      const outputFile = '/tmp/out.txt';
+
+      expect(formatTruncatedToolOutput(content, outputFile, -1000)).toBe(
+        content,
+      );
+    });
+
+    it('should treat maxChars of 0 as truncation disabled', () => {
+      const content = 'a'.repeat(50000);
+      const outputFile = '/tmp/out.txt';
+
+      expect(formatTruncatedToolOutput(content, outputFile, 0)).toBe(content);
+    });
   });
 });

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -700,13 +700,14 @@ export function sanitizeFilenamePart(part: string): string {
 /**
  * Formats a truncated message for tool output.
  * Shows the first 20% and last 80% of the allowed characters with a marker in between.
+ * A non-positive `maxChars` disables truncation and returns the content unchanged.
  */
 export function formatTruncatedToolOutput(
   contentStr: string,
   outputFile: string,
   maxChars: number,
 ): string {
-  if (contentStr.length <= maxChars) return contentStr;
+  if (maxChars <= 0 || contentStr.length <= maxChars) return contentStr;
 
   const headChars = Math.floor(maxChars * 0.2);
   const tailChars = maxChars - headChars;


### PR DESCRIPTION
## Summary

Fixes #28620

`formatTruncatedToolOutput()` (re-exported from `@google/gemini-cli-core`) had no `maxChars > 0` guard. With a non-positive budget it silently produced corrupt output:

- **Negative `maxChars`**: `headChars = Math.floor(maxChars * 0.2)` goes negative, so `slice(0, headChars)` becomes an offset-from-end returning almost the whole string, and `slice(-0)` returns the entire string — the result was ~**2x** the input wrapped in a misleading "Output too large" header.
- **`maxChars = 0`**: callers using `0` to mean "disable truncation" instead got the full content embedded in a truncation wrapper.

The in-tree callers in `tool-executor.ts` pre-clamp with `threshold > 0`, but the function is public API and must uphold its own invariant.

## Changes

One-line guard plus documentation of the contract:

```ts
if (maxChars <= 0 || contentStr.length <= maxChars) return contentStr;
```

This matches the convention already relied upon by the internal call sites.

## Testing

Added unit tests to `fileUtils.test.ts`:

- negative `maxChars` returns content unchanged
- `maxChars = 0` returns content unchanged

Both fail on `main` before the fix and pass after. Full `fileUtils.test.ts` suite passes (the only failing test, `getRealPath > should resolve symbolic links`, is a pre-existing Windows symlink-privilege environment failure that reproduces identically on unmodified `main`). eslint and `tsc --noEmit` are clean.
