### PR TITLE
fix(sandbox): bump sandbox image from EOL node:20-slim to node:22-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Builder ----
-FROM docker.io/library/node:20-slim AS builder
+FROM docker.io/library/node:22-slim AS builder
 
 # Install git (needed by generate-git-commit-info.js script)
 RUN apt-get update && apt-get install -y --no-install-recommends git \
@@ -39,7 +39,7 @@ RUN HUSKY=0 npm run build && \
     npm pack -w packages/cli --pack-destination packages/cli/dist/
 
 # ---- Stage 2: Runtime ----
-FROM docker.io/library/node:20-slim
+FROM docker.io/library/node:22-slim
 
 ARG SANDBOX_NAME="gemini-cli-sandbox"
 ARG CLI_VERSION_ARG


### PR DESCRIPTION
## Summary

Fixes #28584

The sandbox image (repo-root `Dockerfile`) builds both the builder and the final runtime stage on `docker.io/library/node:20-slim`, but **Node.js 20 reached end-of-life on 2026-04-30** and no longer receives security fixes. Node's policy is explicit that EOL lines remain affected by every subsequent security release, including recent HIGH-severity CVEs fixed only in 22.x/24.x/26.x (e.g. CVE-2026-48933 WebCrypto integer overflow, CVE-2026-48618 TLS wildcard-depth bypass).

This is especially undesirable for the *sandbox* image — the security boundary inside which model-directed commands run.

## Changes

- `Dockerfile` line 2 (builder): `node:20-slim` → `node:22-slim`
- `Dockerfile` line 42 (runtime): `node:20-slim` → `node:22-slim`

Node 22 is an active LTS line and satisfies the repo's declared `engines` constraint (`>=20`), so no package.json changes are needed. This also restores consistency with #1038, which intentionally moved the Dockerfile to Node 22 in 2025.

## Testing

- Verified `node -e "require('./package.json').engines"` (`>=20`) is satisfied by 22.
- Reviewed all other `node:` references in the file (`chown node:node`, user `node`) — these are OS users provided by the base image and are unaffected.
- Docker build itself runs in CI; the change is limited to the two `FROM` pins.
