### PR TITLE
fix(core): keep glob results for symlinked workspace roots

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+import { WorkspaceContext } from '../utils/workspaceContext.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
 import { createMockMessageBus } from '../test-utils/mock-message-bus.js';
@@ -523,6 +524,79 @@ describe.skipIf(process.platform === 'win32')(
     }, 30000);
   },
 );
+
+describe('GlobTool workspace boundaries', () => {
+  let tempDir: string;
+  let workspaceDir: string;
+  let secondRootDir: string;
+  let outsideDir: string;
+  const abortSignal = new AbortController().signal;
+
+  const buildTool = (roots: string[]) => {
+    const workspaceContext = new WorkspaceContext(roots[0], roots.slice(1));
+    const mockConfig = {
+      getTargetDir: () => roots[0],
+      getWorkspaceContext: () => workspaceContext,
+      getFileService: () => new FileDiscoveryService(roots[0]),
+      getFileFilteringOptions: () => DEFAULT_FILE_FILTERING_OPTIONS,
+      getFileExclusions: () => ({ getGlobExcludes: () => [] }),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue(path.join(tempDir, 'tmp')),
+      },
+      isPathAllowed(this: Config, absolutePath: string): boolean {
+        return this.getWorkspaceContext().isPathWithinWorkspace(absolutePath);
+      },
+      validatePathAccess(this: Config, absolutePath: string): string | null {
+        return this.isPathAllowed(absolutePath)
+          ? null
+          : `Path not in workspace: ${absolutePath}`;
+      },
+    } as unknown as Config;
+
+    return new GlobTool(mockConfig, createMockMessageBus());
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'glob-tool-boundary-')),
+    );
+    workspaceDir = path.join(tempDir, 'workspace');
+    secondRootDir = path.join(tempDir, 'second-root');
+    outsideDir = path.join(tempDir, 'outside');
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(secondRootDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, 'inside.txt'), 'inside');
+    await fs.writeFile(path.join(secondRootDir, 'second.txt'), 'second');
+    await fs.writeFile(path.join(outsideDir, 'secret.txt'), 'secret');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it('should not report files a traversing pattern matches outside the workspace', async () => {
+    const globTool = buildTool([workspaceDir]);
+    const params: GlobToolParams = { pattern: '../outside/*.txt' };
+    const invocation = globTool.build(params);
+    const result = await invocation.execute({ abortSignal });
+
+    expect(result.llmContent).toContain('No files found');
+    expect(result.llmContent).not.toContain('secret.txt');
+  }, 30000);
+
+  it('should still report files in additional workspace directories', async () => {
+    const globTool = buildTool([workspaceDir, secondRootDir]);
+    const params: GlobToolParams = { pattern: '**/*.txt' };
+    const invocation = globTool.build(params);
+    const result = await invocation.execute({ abortSignal });
+
+    expect(result.llmContent).toContain('Found 2 file(s)');
+    expect(result.llmContent).toContain(path.join(workspaceDir, 'inside.txt'));
+    expect(result.llmContent).toContain(path.join(secondRootDir, 'second.txt'));
+  }, 30000);
+});
 
 describe('sortFileEntries', () => {
   const now = 1000000;

--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -454,6 +454,76 @@ describe('GlobTool', () => {
   });
 });
 
+describe.skipIf(process.platform === 'win32')(
+  'GlobTool with a symlinked workspace root',
+  () => {
+    let tempDir: string;
+    let realRootDir: string;
+    let symlinkedRootDir: string;
+    let globTool: GlobTool;
+    const abortSignal = new AbortController().signal;
+
+    beforeEach(async () => {
+      tempDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), 'glob-tool-symlink-')),
+      );
+      realRootDir = path.join(tempDir, 'real-root');
+      symlinkedRootDir = path.join(tempDir, 'symlinked-root');
+      await fs.mkdir(path.join(realRootDir, 'sub'), { recursive: true });
+      await fs.writeFile(
+        path.join(realRootDir, 'sub', 'fileA.txt'),
+        'contentA',
+      );
+      await fs.symlink(realRootDir, symlinkedRootDir, 'dir');
+
+      // Mirrors production: the target directory is the path the user launched
+      // with, while WorkspaceContext stores its realpath-resolved form.
+      const workspaceContext = createMockWorkspaceContext(symlinkedRootDir);
+      const mockConfig = {
+        getTargetDir: () => symlinkedRootDir,
+        getWorkspaceContext: () => workspaceContext,
+        getFileService: () => new FileDiscoveryService(realRootDir),
+        getFileFilteringOptions: () => DEFAULT_FILE_FILTERING_OPTIONS,
+        getFileExclusions: () => ({ getGlobExcludes: () => [] }),
+        storage: {
+          getProjectTempDir: vi.fn().mockReturnValue(path.join(tempDir, 'tmp')),
+        },
+        isPathAllowed: () => true,
+        validatePathAccess: () => null,
+      } as unknown as Config;
+
+      globTool = new GlobTool(mockConfig, createMockMessageBus());
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      vi.resetAllMocks();
+    });
+
+    it('should return matches as canonical paths', async () => {
+      const params: GlobToolParams = { pattern: '**/*.txt' };
+      const invocation = globTool.build(params);
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.llmContent).toContain('Found 1 file(s)');
+      expect(result.llmContent).toContain(
+        path.join(realRootDir, 'sub', 'fileA.txt'),
+      );
+    }, 30000);
+
+    it('should return matches as canonical paths when dir_path is given', async () => {
+      const params: GlobToolParams = { pattern: '*.txt', dir_path: 'sub' };
+      const invocation = globTool.build(params);
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.llmContent).toContain('Found 1 file(s)');
+      expect(result.llmContent).toContain(
+        path.join(realRootDir, 'sub', 'fileA.txt'),
+      );
+    }, 30000);
+  },
+);
+
 describe('sortFileEntries', () => {
   const now = 1000000;
   const threshold = 10000;

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -235,7 +235,7 @@ class GlobToolInvocation extends BaseToolInvocation<
         });
 
       const filteredAbsolutePaths = new Set(
-        filteredPaths.map((p) => path.resolve(this.config.getTargetDir(), p)),
+        filteredPaths.map((p) => path.resolve(realTargetDir, p)),
       );
 
       const filteredEntries = allEntries.filter((entry) =>

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -235,7 +235,9 @@ class GlobToolInvocation extends BaseToolInvocation<
         });
 
       const filteredAbsolutePaths = new Set(
-        filteredPaths.map((p) => path.resolve(realTargetDir, p)),
+        filteredPaths
+          .map((p) => path.resolve(realTargetDir, p))
+          .filter((p) => !this.config.validatePathAccess(p, 'read')),
       );
 
       const filteredEntries = allEntries.filter((entry) =>


### PR DESCRIPTION
## Summary

`glob` returns **`No files found`** for patterns that do match files, whenever the workspace root is
reached through a symlink. On macOS this is the default for any project opened under `/tmp`, which is
a symlink to `/private/tmp`.

This is issue #28416, but the impact is broader than the report: the matches are not returned in a
non-canonical form — they are dropped entirely, and the model is told the pattern matched nothing.

## Details

`GlobToolInvocation.execute()` derives each match's path twice, in two different forms:

```ts
let realTargetDir = this.config.getTargetDir();
try { realTargetDir = resolveToRealPath(realTargetDir); } catch {}

const relativePaths = allEntries.map((p) => {
  let realFullPath = p.fullpath();
  try { realFullPath = resolveToRealPath(realFullPath); } catch {}
  return path.relative(realTargetDir, realFullPath);   // relative to the REAL root
});

const { filteredPaths } = fileDiscovery.filterFilesWithReport(relativePaths, ...);

const filteredAbsolutePaths = new Set(
  filteredPaths.map((p) => path.resolve(this.config.getTargetDir(), p)),  // back onto the RAW root
);

const filteredEntries = allEntries.filter((entry) =>
  filteredAbsolutePaths.has(entry.fullpath()),
);
```

`filteredPaths` are relative to `realTargetDir`, but they are resolved back against the raw
`getTargetDir()`, and then intersected with `entry.fullpath()`.

The entries are always canonical: `glob` is run with `cwd: searchDir`, and every `searchDir` is
already realpath-resolved — `WorkspaceContext.resolveAndValidateDir()` stores `fs.realpathSync()`
results, and the `dir_path` branch calls `resolveToRealPath()` itself.

So when the root is a symlink, the set holds `/tmp/proj/src/index.ts` while the entries report
`/private/tmp/proj/src/index.ts`. Nothing intersects, `filteredEntries` is empty, and execute()
returns the "No files found" branch.

The fix resolves the filtered paths against `realTargetDir`, so both sides of the intersection use
the same form. No new `fs` calls — `realTargetDir` is already computed a few lines above.

Because the entries are canonical, the paths handed to the model are canonical too, which is what
`read_file`, `edit` and `write_file` expect after their own resolution. This is the outcome #28416
asked for; it needs no change at the output site.

### Residual, not addressed here

A symlinked *file* inside the workspace still drops out of the results: `glob` runs with
`follow: false`, so its `fullpath()` stays inside the workspace while `resolveToRealPath()` sends the
relative path off to the link target. Both sides now agree on "real", so the entry is filtered out
rather than mismatched. That predates this change and is a separate question about whether such files
should be reported under their workspace path or their target path.


## Second commit: workspace boundaries

Review flagged that the resolved matches are never checked against the workspace. That is real and
independent of the symlink bug: nothing validates the *pattern*, so `../outside/*.txt` matches above
the workspace root and those paths are reported to the model. It reproduces unchanged on `main`.
Closed here because it sits on the same line.

The matches now go through `validatePathAccess` before the intersection. It has to be the workspace
check rather than a `..` prefix test: `relativePaths` are relative to `realTargetDir`, so a match in a
second workspace directory is legitimately `../second-root/file.txt`, and a prefix test would drop
multi-root results.

Note for a maintainer: `isPathWithinWorkspace` also blocks `.git`, `node_modules` and `.env`
segments. The first two are already in `getGlobExcludes()`, but `.env` is not — so glob stops
reporting `.env` files, consistent with the other tools. Easy to narrow if that is unwanted.

## Contribution gating

`#28416` does not carry the `help wanted` label, which per the contribution bot is what guarantees a
PR gets reviewed rather than auto-closed at 14 days. I have asked on the issue for a maintainer to
add it if the fix looks worth taking — happy to close this myself if the area is not one you want
outside changes in.

## Related Issues

Fixes #28416

The root cause differs from the one proposed in the issue, which pointed at `entry.fullpath()` in the
output. Credit to @Saisharathchandranandnetha for the report and the symlink reproduction.

## How to Validate

```bash
npm ci
npx vitest run src/tools/glob.test.ts --root packages/core
```

Two regression tests are added under `GlobTool with a symlinked workspace root`, one for the default
path and one for the `dir_path` branch, plus two under `GlobTool workspace boundaries` — a traversing
pattern must report nothing, and a two-root workspace must still report both files. Both mirror production: `getTargetDir()` returns the symlink,
`WorkspaceContext` holds the resolved directory. They are skipped on Windows, in line with the other
symlink tests in the repo.

Against `main` both fail with `No files found matching pattern`; with the fix both report
`Found 1 file(s)` at the canonical path.

Manual check on macOS:

```sh
mkdir -p /tmp/realproject/src && echo 'export const x = 1;' > /tmp/realproject/src/index.ts
ln -s /tmp/realproject /tmp/symproject
# launch the CLI with /tmp/symproject as the target, then ask for all TypeScript files
```

Full `packages/core` suite: 7451 passed, 4 pre-existing failures in
`src/services/modelConfig.golden.test.ts` ("Golden file not found"), which fail the same way on a
clean checkout of `main`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
