### PR TITLE
fix: honor maxDepth in flat memory imports

### DIFF
--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -695,6 +695,60 @@ describe('memoryImportProcessor', () => {
       expect(result.content).toContain('A @./b.md');
       expect(result.content).toContain('B content');
     });
+
+    it('flat format honors maxDepth=5 exactly like tree format', async () => {
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+      const N = 12;
+      const files = new Map<string, string>();
+      for (let i = 0; i < N; i++) {
+        const next = i + 1 < N ? ` @f${i + 1}.md` : '';
+        files.set(
+          path.resolve(basePath, `f${i}.md`),
+          `CONTENT-F${i}${next}\n`,
+        );
+      }
+
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockImplementation(async (file: unknown) => {
+        const content = files.get(path.resolve(String(file)));
+        if (content === undefined) {
+          throw new Error(`File not found: ${String(file)}`);
+        }
+        return content;
+      });
+
+      const root = files.get(path.resolve(basePath, 'f0.md'))!;
+      const tree = await processImports(
+        root,
+        basePath,
+        false,
+        undefined,
+        projectRoot,
+        'tree',
+      );
+      const flat = await processImports(
+        root,
+        basePath,
+        false,
+        undefined,
+        projectRoot,
+        'flat',
+      );
+
+      const uniqueFiles = (content: string) =>
+        [...new Set(content.match(/CONTENT-F\d+/g) ?? [])].sort();
+      const expected = [
+        'CONTENT-F0',
+        'CONTENT-F1',
+        'CONTENT-F2',
+        'CONTENT-F3',
+        'CONTENT-F4',
+        'CONTENT-F5',
+      ];
+      expect(uniqueFiles(tree.content)).toEqual(expected);
+      expect(uniqueFiles(flat.content)).toEqual(expected);
+    });
   });
 
   describe('validateImportPath', () => {

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -230,6 +230,17 @@ export async function processImports(
       filePath: string,
       depth: number,
     ) {
+      // Honor the same max depth limit as the tree format. Use `>` so the
+      // file at depth == maxDepth is included with unresolved imports.
+      if (depth > importState.maxDepth) {
+        if (debugMode) {
+          logger.warn(
+            `Maximum import depth (${importState.maxDepth}) reached at ${filePath}. Stopping flat import processing.`,
+          );
+        }
+        return;
+      }
+
       // Normalize the file path to ensure consistent comparison
       const normalizedPath = path.normalize(filePath);
 
@@ -299,7 +310,8 @@ export async function processImports(
     const rootPath = path.normalize(
       importState.currentFile || path.resolve(basePath),
     );
-    await processFlat(content, basePath, rootPath, 0);
+    // Budget from the same origin as tree mode (not a fresh 0).
+    await processFlat(content, basePath, rootPath, importState.currentDepth);
 
     // Concatenate all unique files in order, Claude-style
     const flatContent = flatFiles


### PR DESCRIPTION
## Summary

`processFlat` accepted a `depth` argument but never compared it to `importState.maxDepth`. A long `@import` chain was fully expanded in `flat` mode while `tree` mode stopped at 5 (CLAUDE.md-parity).

Guard the same way tree does (`depth > maxDepth` return) so the file at `depth == maxDepth` is still included with unresolved imports. Recursion starts from `importState.currentDepth` rather than a fresh 0.

Closes #28974

## Test plan

- [x] 12-file `@import` chain: both `tree` and `flat` yield exactly `CONTENT-F0`..`CONTENT-F5`
- [x] `packages/core` `memoryImportProcessor.test.ts` (27 tests)