### PR TITLE
docs(hooks): document missing HookDecision values (ask, approve) (#28977)

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -63,14 +63,14 @@ All hooks receive these common fields via `stdin`:
 
 Most hooks support these fields in their `stdout` JSON:
 
-| Field            | Type      | Description                                                                    |
-| :--------------- | :-------- | :----------------------------------------------------------------------------- |
-| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                             |
-| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                   |
-| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                           |
-| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                              |
-| `decision`       | `string`  | `"allow"` or `"deny"` (alias `"block"`). Specific impact depends on the event. |
-| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.             |
+| Field            | Type      | Description                                                                                    |
+| :--------------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                                             |
+| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                   |
+| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                                           |
+| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                                              |
+| `decision`       | `string`  | `"ask"`, `"approve"`, `"block"`, `"allow"`, or `"deny"`. Specific impact depends on the event. |
+| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.                             |
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the hooks specification table in `docs/hooks/reference.md` to document all supported `HookDecision` values defined in `packages/core/src/hooks/types.ts`.

Previously, the specification table only listed `"allow"` or `"deny"` (alias `"block"`). This update explicitly documents `'ask'`, `'approve'`, `'block'`, `'allow'`, and `'deny'` to ensure the reference documentation is complete and up-to-date with the core TypeScript definitions.

Fixes #28977

## Type of Change

- [x] Documentation fix / update (non-breaking change which fixes missing or inaccurate documentation)

## Changes Made

- Updated the `decision` field description row in `docs/hooks/reference.md` (Line 72) to list `"ask"`, `"approve"`, `"block"`, `"allow"`, or `"deny"`.

## Verification

- Ran `npm run preflight` to ensure markdown linting, formatting, and doc checks pass.
- Verified visual alignment of the updated specification table in Markdown preview.

## Checklist

- [x] Linked to existing issue (`Fixes #28977`)
- [x] Followed conventional commit format for PR title (`docs(hooks): ...`)
- [x] Ran `npm run preflight` locally
- [x] Updated documentation in `/docs`
