### PR TITLE
fix(core): clear OAuth callback timeout when the callback server closes

### DIFF
--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -447,6 +447,53 @@ describe('oauth-flow', () => {
         vi.useRealTimers();
       }
     });
+
+    it('should clear the callback timeout after a successful flow', async () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+      const server = startCallbackServer('cleanup-state');
+      const port = await server.port;
+
+      await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=abc&state=cleanup-state`,
+      );
+      await server.response;
+
+      // The timer must be released once the flow has settled; otherwise the
+      // retained closure keeps server/promise state alive for five minutes.
+      // server 'close' only fires after keep-alive sockets drain, so allow
+      // extra time beyond undici's default idle window.
+      await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalled(), {
+        timeout: 10000,
+        interval: 100,
+      });
+
+      clearTimeoutSpy.mockRestore();
+    }, 20000);
+
+    it('should clear the callback timeout when the flow fails with an OAuth error', async () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+      const server = startCallbackServer('cleanup-error-state');
+      const port = await server.port;
+
+      const responseResult = server.response.then(
+        () => new Error('Expected rejection'),
+        (e: Error) => e,
+      );
+
+      await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?error=access_denied&error_description=User+denied`,
+      ).catch(() => {
+        // Connection may be reset by server closing — expected
+      });
+
+      await responseResult;
+      await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalled(), {
+        timeout: 10000,
+        interval: 100,
+      });
+
+      clearTimeoutSpy.mockRestore();
+    }, 20000);
   });
 
   describe('exchangeCodeForToken', () => {

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -279,6 +279,13 @@ export function startCallbackServer(
       abortController.signal.addEventListener('abort', onAbort, { once: true });
 
       server.on('close', () => {
+        // Idempotent terminal-path cleanup: whatever caused the flow to end
+        // (success, OAuth error, state mismatch, parser error, or timeout),
+        // make sure no stale timer callback outlives the settled flow.
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
         abortController.signal.removeEventListener('abort', onAbort);
       });
     },


### PR DESCRIPTION
## Summary

Fixes #28652

`startCallbackServer()` creates a five-minute timeout for every OAuth flow, but the timer is never cleared on terminal paths. The server's `close` handler removed the abort listener only, so after a successful (or otherwise settled) flow the retained timer callback — with its closure over the server, controller, and promise — stayed alive for up to five more minutes. Repeated authentications in long-running CLI/SDK processes accumulate this state, and the stale callback fires later against an already-settled flow.

## Changes

The `close` handler now performs idempotent terminal cleanup:

```ts
server.on('close', () => {
  if (timeoutId) {
    clearTimeout(timeoutId);
    timeoutId = undefined;
  }
  abortController.signal.removeEventListener('abort', onAbort);
});
```

Every terminal path (success, OAuth error, state mismatch, parser error, timeout) routes through `server.close()`, so all of them now clear the timer exactly once. This mirrors the cleanup behavior the older Code Assist OAuth flow already implements.

## Testing

Two new tests in `oauth-flow.test.ts`:

1. **Successful flow** → `clearTimeout` is called once the callback server closes.
2. **OAuth error flow** (`error=access_denied`) → `clearTimeout` is called as well.

Both use `vi.waitFor` with an extended window because `server.close()` only emits `close` after keep-alive sockets drain (undici's idle window), and assert via a spy on the global `clearTimeout`. Full `oauth-flow.test.ts` suite passes (53 tests); prettier, eslint (`--max-warnings 0`), and `tsc --noEmit` for `@google/gemini-cli-core` are clean.
