### PR TITLE
fix(core): prevent formatTruncatedToolOutput output inflation on negative maxChars (#28620)

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -63,14 +63,14 @@ All hooks receive these common fields via `stdin`:
 
 Most hooks support these fields in their `stdout` JSON:
 
-| Field            | Type      | Description                                                                    |
-| :--------------- | :-------- | :----------------------------------------------------------------------------- |
-| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                             |
-| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                   |
-| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                           |
-| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                              |
-| `decision`       | `string`  | `"allow"` or `"deny"` (alias `"block"`). Specific impact depends on the event. |
-| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.             |
+| Field            | Type      | Description                                                                                    |
+| :--------------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                                             |
+| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                   |
+| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                                           |
+| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                                              |
+| `decision`       | `string`  | `"ask"`, `"approve"`, `"block"`, `"allow"`, or `"deny"`. Specific impact depends on the event. |
+| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.                             |
 
 ---
 

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1348,5 +1348,42 @@ describe('fileUtils', () => {
       expect(formatted).toContain('For full output see: /tmp/out.txt');
       expect(formatted).toContain('[46,000 characters omitted]'); // 50000 - 800 - 3200
     });
+
+    it('should return original content unchanged when content length <= maxChars', () => {
+      const content = 'Hello world!';
+      const outputFile = '/tmp/out.txt';
+
+      // maxChars larger than content length
+      expect(formatTruncatedToolOutput(content, outputFile, 100)).toBe(content);
+      // maxChars equal to content length
+      expect(
+        formatTruncatedToolOutput(content, outputFile, content.length),
+      ).toBe(content);
+    });
+
+    it('should handle maxChars === 0 without duplicating or returning full content', () => {
+      const content = 'B'.repeat(1000);
+      const outputFile = '/tmp/out.txt';
+
+      const formatted = formatTruncatedToolOutput(content, outputFile, 0);
+
+      expect(formatted).toContain('Showing first 0 and last 0 characters');
+      expect(formatted).toContain('[1,000 characters omitted]');
+      // Ensure the original content body is not included
+      expect(formatted).not.toContain(content);
+      expect(formatted.length).toBeLessThan(content.length);
+    });
+
+    it('should handle negative maxChars safely without output inflation or duplication', () => {
+      const content = 'A'.repeat(1000);
+      const outputFile = '/tmp/out.txt';
+
+      const formatted = formatTruncatedToolOutput(content, outputFile, -100);
+
+      expect(formatted).toContain('Showing first 0 and last 0 characters');
+      expect(formatted).toContain('[1,000 characters omitted]');
+      // Fixes #28620: formatted output length must NOT be inflated (~2,000 chars)
+      expect(formatted.length).toBeLessThan(content.length);
+    });
   });
 });

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -708,11 +708,12 @@ export function formatTruncatedToolOutput(
 ): string {
   if (contentStr.length <= maxChars) return contentStr;
 
-  const headChars = Math.floor(maxChars * 0.2);
-  const tailChars = maxChars - headChars;
+  const effectiveMax = Math.max(0, maxChars);
+  const headChars = Math.floor(effectiveMax * 0.2);
+  const tailChars = effectiveMax - headChars;
 
   const head = contentStr.slice(0, headChars);
-  const tail = contentStr.slice(-tailChars);
+  const tail = tailChars > 0 ? contentStr.slice(-tailChars) : '';
   const omittedChars = contentStr.length - headChars - tailChars;
 
   return `Output too large. Showing first ${headChars.toLocaleString()} and last ${tailChars.toLocaleString()} characters. For full output see: ${outputFile}


### PR DESCRIPTION
## Fixes [#28620](https://github.com/google-gemini/gemini-cli/issues/28620)

### Summary of Changes
Fixes an issue in `formatTruncatedToolOutput` where negative `maxChars` values caused JavaScript `String.prototype.slice()` negative-index behavior to inflate and duplicate output to approximately ~2x the original content size.

### Root Cause
When `maxChars < 0` (e.g. `-100`), `contentStr.length <= maxChars` evaluated to `false`. Negative character calculations (`headChars = Math.floor(maxChars * 0.2)` and `tailChars = maxChars - headChars`) resulted in `contentStr.slice(0, headChars)` slicing up to index `length - 20` and `contentStr.slice(-tailChars)` slicing from index `80` to the end, duplicating ~90% of the string content. Additionally, `tailChars === 0` caused `contentStr.slice(-0)` to evaluate as `contentStr.slice(0)`, returning the full string.

### Fix
1. Clamped `maxChars` defensively with `effectiveMax = Math.max(0, maxChars)` in `formatTruncatedToolOutput`.
2. Guarded `tail` slicing (`tailChars > 0 ? contentStr.slice(-tailChars) : ''`) to prevent `slice(-0)` string leaks when `tailChars === 0`.
3. Preserved existing 20%/80% truncation behavior for all positive `maxChars` values.

### Test Plan
Added comprehensive unit tests in `packages/core/src/utils/fileUtils.test.ts`:
- `maxChars < 0`: Verifies `0` head/tail characters are shown and output length is not inflated.
- `maxChars === 0`: Verifies `0` head/tail characters are shown and content body is omitted.
- `maxChars >= content.length`: Verifies original string returned unchanged.

Verified locally:
- `npx vitest run src/utils/fileUtils.test.ts -t "formatTruncatedToolOutput"` (10/10 passed)
- `npm run typecheck` (passed with code 0)
