### PR TITLE
fix(sandbox): normalize DEBUG environment variable truthiness (#28885)

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -1181,5 +1181,102 @@ describe('sandbox', () => {
         expect.objectContaining({ stdio: 'inherit' }),
       );
     });
+
+    it.each([
+      { debugValue: 'false', shouldPublish: false },
+      { debugValue: '0', shouldPublish: false },
+      { debugValue: 'true', shouldPublish: true },
+      { debugValue: '1', shouldPublish: true },
+    ])(
+      'should publish debug port: $shouldPublish when DEBUG=$debugValue',
+      async ({ debugValue, shouldPublish }) => {
+        process.env['DEBUG'] = debugValue;
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'docker',
+          image: 'gemini-cli-sandbox',
+        });
+
+        interface MockProcessWithStdout extends EventEmitter {
+          stdout: EventEmitter;
+        }
+        const mockImageCheckProcess =
+          new EventEmitter() as MockProcessWithStdout;
+        mockImageCheckProcess.stdout = new EventEmitter();
+        vi.mocked(spawn).mockImplementationOnce(() => {
+          setTimeout(() => {
+            mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
+            mockImageCheckProcess.emit('close', 0);
+          }, 1);
+          return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+        });
+
+        const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+          typeof spawn
+        >;
+        mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+          if (event === 'close') {
+            setTimeout(() => cb(0), 10);
+          }
+          return mockSpawnProcess;
+        });
+        vi.mocked(spawn).mockImplementationOnce(() => mockSpawnProcess);
+
+        await start_sandbox(config, [], undefined, ['arg1']);
+
+        const dockerArgs = vi.mocked(spawn).mock.calls[1]?.[1];
+        if (shouldPublish) {
+          expect(dockerArgs).toContain('--publish');
+          expect(dockerArgs).toContain('9229:9229');
+        } else {
+          expect(dockerArgs).not.toContain('--publish');
+          expect(dockerArgs).not.toContain('9229:9229');
+        }
+      },
+    );
+
+    it.each([
+      { debugValue: 'false', shouldInspectBrk: false },
+      { debugValue: '0', shouldInspectBrk: false },
+      { debugValue: 'true', shouldInspectBrk: true },
+      { debugValue: '1', shouldInspectBrk: true },
+    ])(
+      'should add --inspect-brk: $shouldInspectBrk to seatbelt NODE_OPTIONS when DEBUG=$debugValue',
+      async ({ debugValue, shouldInspectBrk }) => {
+        vi.mocked(os.platform).mockReturnValue('darwin');
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        process.env['DEBUG'] = debugValue;
+
+        const config: SandboxConfig = createMockSandboxConfig({
+          command: 'sandbox-exec',
+          image: 'some-image',
+        });
+
+        interface MockProcess extends EventEmitter {
+          stdout: EventEmitter;
+          stderr: EventEmitter;
+        }
+        const mockSpawnProcess = new EventEmitter() as MockProcess;
+        mockSpawnProcess.stdout = new EventEmitter();
+        mockSpawnProcess.stderr = new EventEmitter();
+        vi.mocked(spawn).mockReturnValue(
+          mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+        );
+
+        const promise = start_sandbox(config, [], undefined, ['arg1']);
+        setTimeout(() => {
+          mockSpawnProcess.emit('close', 0);
+        }, 10);
+
+        await expect(promise).resolves.toBe(0);
+
+        const spawnArgs = vi.mocked(spawn).mock.calls[0]?.[1];
+        const shellCmd = spawnArgs?.[spawnArgs.length - 1];
+        if (shouldInspectBrk) {
+          expect(shellCmd).toContain('--inspect-brk');
+        } else {
+          expect(shellCmd).not.toContain('--inspect-brk');
+        }
+      },
+    );
   });
 });

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -34,6 +34,7 @@ import {
   parseImageName,
   ports,
   entrypoint,
+  isDebugModeEnabled,
   LOCAL_DEV_SANDBOX_IMAGE_NAME,
   SANDBOX_NETWORK_NAME,
   SANDBOX_PROXY_NAME,
@@ -51,7 +52,7 @@ export async function start_sandbox(
   cliArgs: string[] = [],
 ): Promise<number> {
   const patcher = new ConsolePatcher({
-    debugMode: cliConfig?.getDebugMode() || !!process.env['DEBUG'],
+    debugMode: isDebugModeEnabled(cliConfig),
     stderr: true,
   });
   patcher.patch();
@@ -153,7 +154,7 @@ export async function start_sandbox(
         debugLogger.log(`using macos seatbelt (profile: ${profile}) ...`);
         // if DEBUG is set, convert to --inspect-brk in NODE_OPTIONS
         const nodeOptions = [
-          ...(process.env['DEBUG'] ? ['--inspect-brk'] : []),
+          ...(isDebugModeEnabled(cliConfig) ? ['--inspect-brk'] : []),
           ...nodeArgs,
         ].join(' ');
 
@@ -512,7 +513,7 @@ export async function start_sandbox(
     ports().forEach((p) => args.push('--publish', `${p}:${p}`));
 
     // if DEBUG is set, expose debugging port
-    if (process.env['DEBUG']) {
+    if (isDebugModeEnabled(cliConfig)) {
       const debugPort = process.env['DEBUG_PORT'] || '9229';
       args.push(`--publish`, `${debugPort}:${debugPort}`);
     }
@@ -1184,7 +1185,7 @@ async function pullImage(
     let stderrData = '';
 
     const onStdoutData = (data: Buffer) => {
-      if (cliConfig?.getDebugMode() || process.env['DEBUG']) {
+      if (isDebugModeEnabled(cliConfig)) {
         debugLogger.log(data.toString().trim()); // Show pull progress
       }
     };

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -14,6 +14,7 @@ import {
   ports,
   entrypoint,
   shouldUseCurrentUserInSandbox,
+  isDebugModeEnabled,
 } from './sandboxUtils.js';
 
 vi.mock('node:os');
@@ -236,6 +237,42 @@ describe('sandboxUtils', () => {
       delete process.env['SANDBOX_SET_UID_GID'];
       vi.mocked(os.platform).mockReturnValue('darwin');
       expect(await shouldUseCurrentUserInSandbox()).toBe(false);
+    });
+  });
+
+  describe('isDebugModeEnabled', () => {
+    it('should return true if cliConfig.getDebugMode() returns true', () => {
+      const mockConfig = {
+        getDebugMode: () => true,
+      } as unknown as Parameters<typeof isDebugModeEnabled>[0];
+      expect(isDebugModeEnabled(mockConfig)).toBe(true);
+    });
+
+    it.each(['true', '1'])('should return true when DEBUG is %s', (val) => {
+      process.env['DEBUG'] = val;
+      expect(isDebugModeEnabled()).toBe(true);
+    });
+
+    it.each(['true', '1'])(
+      'should return true when DEBUG_MODE is %s',
+      (val) => {
+        process.env['DEBUG_MODE'] = val;
+        expect(isDebugModeEnabled()).toBe(true);
+      },
+    );
+
+    it.each(['false', '0', '', 'random'])(
+      'should return false when DEBUG is %s',
+      (val) => {
+        process.env['DEBUG'] = val;
+        expect(isDebugModeEnabled()).toBe(false);
+      },
+    );
+
+    it('should return false when DEBUG and DEBUG_MODE are unset', () => {
+      delete process.env['DEBUG'];
+      delete process.env['DEBUG_MODE'];
+      expect(isDebugModeEnabled()).toBe(false);
     });
   });
 });

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -8,7 +8,21 @@ import os from 'node:os';
 import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { quote } from 'shell-quote';
-import { debugLogger, GEMINI_DIR } from '@google/gemini-cli-core';
+import { debugLogger, GEMINI_DIR, type Config } from '@google/gemini-cli-core';
+
+export function isDebugModeEnabled(cliConfig?: Config): boolean {
+  if (cliConfig?.getDebugMode()) {
+    return true;
+  }
+  const debugEnv = process.env['DEBUG'];
+  const debugModeEnv = process.env['DEBUG_MODE'];
+  return (
+    debugEnv === 'true' ||
+    debugEnv === '1' ||
+    debugModeEnv === 'true' ||
+    debugModeEnv === '1'
+  );
+}
 
 export const LOCAL_DEV_SANDBOX_IMAGE_NAME = 'gemini-cli-sandbox';
 export const SANDBOX_NETWORK_NAME = 'gemini-cli-sandbox';
@@ -149,8 +163,7 @@ export function entrypoint(workdir: string, cliArgs: string[]): string[] {
   );
 
   const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
-  const isDebugMode =
-    process.env['DEBUG'] === 'true' || process.env['DEBUG'] === '1';
+  const isDebugMode = isDebugModeEnabled();
   const cliCmd =
     process.env['NODE_ENV'] === 'development'
       ? isDebugMode


### PR DESCRIPTION


## Summary

Normalizes the interpretation of the `DEBUG` environment variable across sandbox utilities. This prevents string values like `"false"` and `"0"` from inadvertently enabling debug features such as port publishing, pull logging, and **`--inspect-brk`** execution pauses in Docker, Podman, and macOS Seatbelt sandboxes.

## Problem

Previously, **`packages/cli/src/utils/sandbox.ts` evaluated `process.env.DEBUG`** using standard JavaScript string truthiness. Because non-empty strings like `"false"` and `"0"` evaluate to `true` in JavaScript, this caused several unintended behaviors:

- **Docker/Podman Sandboxes:** Unnecessarily published the debug port (`--publish 9229:9229`).
- **macOS Seatbelt Sandboxes:** Injected `--inspect-brk` into `NODE_OPTIONS`, unexpectedly pausing CLI execution.
- **General Overhead:** Enabled debug console patching and image-pull logging even when debugging was explicitly disabled by the user.

## Fix

Introduced a centralized `isDebugModeEnabled()` helper in `sandboxUtils.ts`. 

Instead of relying on string truthiness, this helper strictly checks for explicitly enabled values (`"true"`, `"1"`, or an active CLI debug mode flag). This aligns the sandbox logic with existing behaviors in the entrypoint and `config.ts`.

## Related Issues

Fixes #28885

## Validation

Run the unit tests for the sandbox utilities:

```bash
npm test -w @google/gemini-cli -- src/utils/sandboxUtils.test.ts src/utils/sandbox.test.ts
```

Verify that all parameterized test cases pass, specifically covering:
- `DEBUG=false`
- `DEBUG=0`
- `DEBUG=true`
- `DEBUG=1`
- Unset/empty states

## Pre-Merge Checklist

- [x] Added or updated tests where needed
- [x] Validated on required platforms/methods
- [x] Windows
- [x] Verified relevant npm scripts pass (`npm run ...`)


---
