### PR TITLE
fix(core): strip execution-affecting GIT_* env vars in getSafeGitEnv

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2271,8 +2271,8 @@ describe('ShellExecutionService environment variables', () => {
     // Ensure we exercise the default (non-strict) sanitization path, since
     // strict sanitization (e.g. in CI, via GITHUB_SHA) would already strip
     // these vars for unrelated reasons and mask a regression here.
-    vi.stubEnv('GITHUB_SHA', undefined);
-    vi.stubEnv('SURFACE', undefined);
+    vi.stubEnv('GITHUB_SHA', '');
+    vi.stubEnv('SURFACE', '');
     vi.stubEnv('GIT_EXEC_PATH', '/tmp/evil');
     vi.stubEnv('GIT_SSH_COMMAND', 'calc.exe');
     vi.stubEnv('GIT_PROXY_COMMAND', 'cmd /c calc.exe');
@@ -2281,6 +2281,10 @@ describe('ShellExecutionService environment variables', () => {
     vi.stubEnv('GIT_TEMPLATE_DIR', '/tmp/evil-template');
     vi.stubEnv('GIT_REPLACE_REF_BASE', 'refs/evil');
     vi.stubEnv('GIT_CEILING_DIRECTORIES', '/tmp/evil-ceiling');
+    // GIT_CONFIG_PARAMETERS is otherwise preserved by the GIT_CONFIG_* allow
+    // list below, so it must also be explicitly stripped as an
+    // execution-affecting variable.
+    vi.stubEnv('GIT_CONFIG_PARAMETERS', "'core.sshCommand=calc.exe'");
     vi.stubEnv('PATH', '/test/path'); // An unrelated var that should be kept
 
     const { ShellExecutionService } = await import(
@@ -2307,6 +2311,7 @@ describe('ShellExecutionService environment variables', () => {
     expect(cpEnv).not.toHaveProperty('GIT_TEMPLATE_DIR');
     expect(cpEnv).not.toHaveProperty('GIT_REPLACE_REF_BASE');
     expect(cpEnv).not.toHaveProperty('GIT_CEILING_DIRECTORIES');
+    expect(cpEnv).not.toHaveProperty('GIT_CONFIG_PARAMETERS');
     expect(cpEnv).toHaveProperty('PATH', '/test/path');
 
     // Ensure child_process exits

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -2266,6 +2266,57 @@ describe('ShellExecutionService environment variables', () => {
     vi.unstubAllEnvs();
   });
 
+  it('should strip execution-affecting GIT_* variables from the spawned environment', async () => {
+    vi.resetModules();
+    // Ensure we exercise the default (non-strict) sanitization path, since
+    // strict sanitization (e.g. in CI, via GITHUB_SHA) would already strip
+    // these vars for unrelated reasons and mask a regression here.
+    vi.stubEnv('GITHUB_SHA', undefined);
+    vi.stubEnv('SURFACE', undefined);
+    vi.stubEnv('GIT_EXEC_PATH', '/tmp/evil');
+    vi.stubEnv('GIT_SSH_COMMAND', 'calc.exe');
+    vi.stubEnv('GIT_PROXY_COMMAND', 'cmd /c calc.exe');
+    vi.stubEnv('GIT_SSH_VARIANT', 'ssh');
+    vi.stubEnv('GIT_ALTERNATE_OBJECT_DIRECTORIES', '/tmp/evil-objects');
+    vi.stubEnv('GIT_TEMPLATE_DIR', '/tmp/evil-template');
+    vi.stubEnv('GIT_REPLACE_REF_BASE', 'refs/evil');
+    vi.stubEnv('GIT_CEILING_DIRECTORIES', '/tmp/evil-ceiling');
+    vi.stubEnv('PATH', '/test/path'); // An unrelated var that should be kept
+
+    const { ShellExecutionService } = await import(
+      './shellExecutionService.js'
+    );
+
+    mockGetPty.mockResolvedValue(null); // Force child_process fallback
+    await ShellExecutionService.execute(
+      'test-cp-execution-affecting-git-vars',
+      '/',
+      vi.fn(),
+      new AbortController().signal,
+      false, // non-interactive
+      shellExecutionConfig,
+    );
+
+    expect(mockCpSpawn).toHaveBeenCalled();
+    const cpEnv = mockCpSpawn.mock.calls[0][2].env;
+    expect(cpEnv).not.toHaveProperty('GIT_EXEC_PATH');
+    expect(cpEnv).not.toHaveProperty('GIT_SSH_COMMAND');
+    expect(cpEnv).not.toHaveProperty('GIT_PROXY_COMMAND');
+    expect(cpEnv).not.toHaveProperty('GIT_SSH_VARIANT');
+    expect(cpEnv).not.toHaveProperty('GIT_ALTERNATE_OBJECT_DIRECTORIES');
+    expect(cpEnv).not.toHaveProperty('GIT_TEMPLATE_DIR');
+    expect(cpEnv).not.toHaveProperty('GIT_REPLACE_REF_BASE');
+    expect(cpEnv).not.toHaveProperty('GIT_CEILING_DIRECTORIES');
+    expect(cpEnv).toHaveProperty('PATH', '/test/path');
+
+    // Ensure child_process exits
+    mockChildProcess.emit('exit', 0, null);
+    mockChildProcess.emit('close', 0, null);
+    await new Promise(process.nextTick);
+
+    vi.unstubAllEnvs();
+  });
+
   it('should include headless git and gh environment variables in interactive fallback mode', async () => {
     vi.resetModules();
     vi.stubEnv('GIT_TERMINAL_PROMPT', undefined);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -30,6 +30,7 @@ import {
   sanitizeEnvironment,
   type EnvironmentSanitizationConfig,
 } from './environmentSanitization.js';
+import { EXECUTION_AFFECTING_GIT_ENV_VARS } from '../utils/gitUtils.js';
 import {
   NoopSandboxManager,
   type SandboxManager,
@@ -540,6 +541,15 @@ export class ShellExecutionService {
       DISPLAY: '',
       DBUS_SESSION_BUS_ADDRESS: '',
     });
+
+    // GIT_* variables that control which binaries/helpers git executes must
+    // never be inherited (e.g. from a project's .env file), or a
+    // trusted-but-malicious repository could use them to run arbitrary
+    // commands via otherwise ordinary shell commands that happen to invoke
+    // git.
+    for (const key of EXECUTION_AFFECTING_GIT_ENV_VARS) {
+      delete baseEnv[key];
+    }
 
     // 3. Prepare Sandboxed Command
     const sandboxedCommand = await sandboxManager.prepareCommand({

--- a/packages/core/src/utils/gitUtils.test.ts
+++ b/packages/core/src/utils/gitUtils.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getSafeGitEnv } from './gitUtils.js';
+
+describe('getSafeGitEnv', () => {
+  it('strips execution-affecting GIT_* variables from the base environment', () => {
+    const maliciousEnv: Record<string, string | undefined> = {
+      PATH: '/usr/bin',
+      GIT_EXEC_PATH: '/tmp/evil',
+      GIT_SSH_COMMAND: 'calc.exe',
+      GIT_PROXY_COMMAND: 'cmd /c calc.exe',
+      GIT_SSH_VARIANT: 'ssh',
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: '/tmp/evil-objects',
+      GIT_TEMPLATE_DIR: '/tmp/evil-template',
+      GIT_REPLACE_REF_BASE: 'refs/evil/',
+      GIT_CEILING_DIRECTORIES: '/tmp',
+    };
+
+    const safeEnv = getSafeGitEnv(maliciousEnv);
+
+    expect(safeEnv['GIT_EXEC_PATH']).toBeUndefined();
+    expect(safeEnv['GIT_SSH_COMMAND']).toBeUndefined();
+    expect(safeEnv['GIT_PROXY_COMMAND']).toBeUndefined();
+    expect(safeEnv['GIT_SSH_VARIANT']).toBeUndefined();
+    expect(safeEnv['GIT_ALTERNATE_OBJECT_DIRECTORIES']).toBeUndefined();
+    expect(safeEnv['GIT_TEMPLATE_DIR']).toBeUndefined();
+    expect(safeEnv['GIT_REPLACE_REF_BASE']).toBeUndefined();
+    expect(safeEnv['GIT_CEILING_DIRECTORIES']).toBeUndefined();
+    expect(safeEnv['PATH']).toBe('/usr/bin');
+  });
+
+  it('still strips GIT_CONFIG_* variables from the base environment', () => {
+    const env: Record<string, string | undefined> = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.pager',
+      GIT_CONFIG_VALUE_0: 'evil',
+      GIT_CONFIG_PARAMETERS: 'evil',
+    };
+
+    const safeEnv = getSafeGitEnv(env);
+
+    expect(safeEnv['GIT_CONFIG_KEY_0']).not.toBe('core.pager');
+    expect(safeEnv['GIT_CONFIG_PARAMETERS']).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -21,6 +21,7 @@ export const EXECUTION_AFFECTING_GIT_ENV_VARS = new Set([
   'GIT_TEMPLATE_DIR',
   'GIT_REPLACE_REF_BASE',
   'GIT_CEILING_DIRECTORIES',
+  'GIT_CONFIG_PARAMETERS',
 ]);
 
 export function getSafeGitEnv(

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -12,7 +12,7 @@ import { spawnAsync } from './shell-utils.js';
 // must never be inherited from a project's .env file (or elsewhere), or a
 // trusted-but-malicious repository could use them to run arbitrary commands
 // via otherwise ordinary, non-model git invocations.
-const EXECUTION_AFFECTING_GIT_ENV_VARS = new Set([
+export const EXECUTION_AFFECTING_GIT_ENV_VARS = new Set([
   'GIT_EXEC_PATH',
   'GIT_PROXY_COMMAND',
   'GIT_SSH_COMMAND',

--- a/packages/core/src/utils/gitUtils.ts
+++ b/packages/core/src/utils/gitUtils.ts
@@ -8,15 +8,35 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { spawnAsync } from './shell-utils.js';
 
+// GIT_* variables that control which binaries/helpers git executes. These
+// must never be inherited from a project's .env file (or elsewhere), or a
+// trusted-but-malicious repository could use them to run arbitrary commands
+// via otherwise ordinary, non-model git invocations.
+const EXECUTION_AFFECTING_GIT_ENV_VARS = new Set([
+  'GIT_EXEC_PATH',
+  'GIT_PROXY_COMMAND',
+  'GIT_SSH_COMMAND',
+  'GIT_SSH_VARIANT',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_TEMPLATE_DIR',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_CEILING_DIRECTORIES',
+]);
+
 export function getSafeGitEnv(
   baseEnv: Record<string, string | undefined> = process.env,
 ): Record<string, string | undefined> {
   const devNullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
 
-  // Strip pre-existing GIT_CONFIG_* and GIT_CONFIG_PARAMETERS variables to prevent environment pollution
+  // Strip pre-existing GIT_CONFIG_*, GIT_CONFIG_PARAMETERS, and
+  // execution-affecting GIT_* variables to prevent environment pollution.
   const cleanedEnv: Record<string, string | undefined> = {};
   for (const [key, value] of Object.entries(baseEnv)) {
-    if (!key.startsWith('GIT_CONFIG_') && key !== 'GIT_CONFIG_PARAMETERS') {
+    if (
+      !key.startsWith('GIT_CONFIG_') &&
+      key !== 'GIT_CONFIG_PARAMETERS' &&
+      !EXECUTION_AFFECTING_GIT_ENV_VARS.has(key)
+    ) {
       cleanedEnv[key] = value;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #29003.

Gemini CLI loads a trusted project's `.env` file into `process.env`. The
issue names three internal call sites that route git operations through an
environment derived from `process.env`, and reports that all three only
strip `GIT_CONFIG_*` / `GIT_CONFIG_PARAMETERS`, leaving execution-affecting
`GIT_*` variables such as `GIT_EXEC_PATH`, `GIT_SSH_COMMAND`, and
`GIT_PROXY_COMMAND` to pass straight through:

- `getSafeGitEnv()` in `packages/core/src/utils/gitUtils.ts`
- `GitService.getShadowRepoEnv()` (already chains into `getSafeGitEnv()`)
- `ShellExecutionService.prepareExecution()` in
  `packages/core/src/services/shellExecutionService.ts`, which builds its
  own environment via `sanitizeEnvironment()` and does not call
  `getSafeGitEnv()` at all

A trusted-but-malicious repository could ship a `.env` setting these
variables and get arbitrary code execution the moment Gemini CLI ran any
ordinary, non-model git call (checkpointing, worktrees, extension
install/update, `grep`'s `git ls-files` fallback) **or** any ordinary shell
command that happens to invoke git (e.g. `git status`) — no explicit user
approval step involved.

This PR extends sanitization in both places:

1. `getSafeGitEnv()` now also strips:
   - `GIT_EXEC_PATH`
   - `GIT_PROXY_COMMAND`
   - `GIT_SSH_COMMAND`
   - `GIT_SSH_VARIANT`
   - `GIT_ALTERNATE_OBJECT_DIRECTORIES`
   - `GIT_TEMPLATE_DIR`
   - `GIT_REPLACE_REF_BASE`
   - `GIT_CEILING_DIRECTORIES`

   `GitService.getShadowRepoEnv()`, extension install/update, and `grep`'s
   git fallback all route through this function, so they're covered
   transitively.

2. `ShellExecutionService.prepareExecution()` now deletes the same set of
   variables (exported from `gitUtils.ts` as
   `EXECUTION_AFFECTING_GIT_ENV_VARS`) from the environment it builds for
   every shell command, closing the gap for the shell-execution path.

## Test plan

Added `packages/core/src/utils/gitUtils.test.ts`, asserting the vars above
are stripped from `getSafeGitEnv()`'s returned environment while unrelated
variables (e.g. `PATH`) and the existing `GIT_CONFIG_*` stripping behavior
are preserved.

Added a test to `packages/core/src/services/shellExecutionService.test.ts`
("should strip execution-affecting GIT_* variables from the spawned
environment") asserting the same variables are absent from the environment
passed to `child_process.spawn`, while unrelated variables (e.g. `PATH`)
are preserved. This test explicitly unsets `GITHUB_SHA`/`SURFACE` so it
exercises the default (non-strict) sanitization path — the actual
vulnerable path for ordinary local usage — rather than being masked by the
stricter CI-only sanitization mode.

Confirmed both new tests fail without their respective source fix:

```
❯ src/utils/gitUtils.test.ts (2 tests | 1 failed)
   × getSafeGitEnv > strips execution-affecting GIT_* variables from the base environment
     → expected '/tmp/evil' to be undefined
   ✓ getSafeGitEnv > still strips GIT_CONFIG_* variables from the base environment
```

```
❯ src/services/shellExecutionService.test.ts (70 tests | 1 failed)
   × ShellExecutionService environment variables > should strip execution-affecting GIT_* variables from the spawned environment
     → expected { Object (...) } to not have property "GIT_EXEC_PATH"
```

And both pass with their fixes restored (150/150 across the directly
related suites):

```
npx vitest run src/services/shellExecutionService.test.ts src/utils/gitUtils.test.ts \
  src/services/gitService.test.ts src/services/worktreeService.test.ts src/tools/grep.test.ts
# 5 files, 150 tests passed
```

Also ran the full core package test suite:

```
npm run test:ci -w @google/gemini-cli-core
# 7815 passed, 53 skipped, 19 failed (all in sandboxManager.integration.test.ts)
```

The 19 failures are pre-existing and unrelated to this change: they
require the `bwrap` (bubblewrap) sandbox binary, which is not installed in
this environment.

Also ran `npm run lint` (repo-wide, `--max-warnings 0`) and
`tsc --noEmit` for `packages/core` — both clean.

## AI assistance disclosure

This change was implemented with AI assistance (an autonomous Claude-based
coding agent), with the diff, tests, and test output reviewed before
submission.
