### PR TITLE
docs: correct env var redaction setting keys

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2794,16 +2794,22 @@ from the system or loaded from `.env` files.
 
 You can customize this behavior in your `settings.json` file:
 
-- **`security.allowedEnvironmentVariables`**: A list of variable names to
-  _never_ redact, even if they match sensitive patterns.
-- **`security.blockedEnvironmentVariables`**: A list of variable names to
-  _always_ redact, even if they don't match sensitive patterns.
+- **`security.environmentVariableRedaction.enabled`**: Turns redaction on. This
+  defaults to `false`, so the behavior described above only applies once you
+  enable it.
+- **`security.environmentVariableRedaction.allowed`**: A list of variable names
+  to _never_ redact, even if they match sensitive patterns.
+- **`security.environmentVariableRedaction.blocked`**: A list of variable names
+  to _always_ redact, even if they don't match sensitive patterns.
 
 ```json
 {
   "security": {
-    "allowedEnvironmentVariables": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
-    "blockedEnvironmentVariables": ["INTERNAL_IP_ADDRESS"]
+    "environmentVariableRedaction": {
+      "enabled": true,
+      "allowed": ["MY_PUBLIC_KEY", "NOT_A_SECRET_TOKEN"],
+      "blocked": ["INTERNAL_IP_ADDRESS"]
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary

The environment variable redaction section of `docs/reference/configuration.md` documented two setting keys that don't exist, and omitted the one that actually turns the feature on. This corrects the section to match the schema and the code.

## Details

The section told readers to configure redaction with `security.allowedEnvironmentVariables` and `security.blockedEnvironmentVariables`. Neither key exists anywhere in `schemas/settings.schema.json`, and since `security` is declared `"additionalProperties": false`, the documented JSON example is schema-invalid — an editor using the published schema flags it as an error.

The real settings sit one level deeper. `packages/cli/src/config/config.ts` reads `settings.security?.environmentVariableRedaction?.blocked`, `...?.allowed` and `...?.enabled`, and the schema defines exactly those three under `security.environmentVariableRedaction`. The same documentation page already lists them correctly in the settings reference further up, so the page was contradicting itself.

I also added `enabled` to the section. It defaults to `false` (`packages/core/src/config/config.ts`: `params.enableEnvironmentVariableRedaction ?? false`), but the section describes the redaction rules at length without mentioning that any of it requires opting in. Since this is a security feature, the failure mode is quiet and bad: you add the documented keys, nothing reads them, the feature is off anyway, and you believe your secrets are being redacted.

The example now uses the nested shape with `enabled: true`, so copying it produces working config rather than ignored config.

## Related Issues

Fixes #29007

## How to Validate

This is docs-only, so I verified against the schema and the code rather than at runtime:

1. Confirm the old keys don't exist — `grep -c "allowedEnvironmentVariables\|blockedEnvironmentVariables" schemas/settings.schema.json` returns `0`.
2. Confirm the new keys do — the schema defines `security.environmentVariableRedaction` with exactly `allowed`, `blocked` and `enabled` (itself `additionalProperties: false`).
3. Validate both examples against the schema's `security` properties: the old example's two keys are both unknown (so invalid under `additionalProperties: false`), the new example's single `environmentVariableRedaction` key is known. I checked this by loading `settings.schema.json` and diffing each example's keys against `properties.security.properties`.
4. Confirm the default — `packages/core/src/config/config.ts` sets `this.enableEnvironmentVariableRedaction = params.enableEnvironmentVariableRedaction ?? false`, and the schema's `enabled` default is `false`.
5. Cross-check against the settings list in the same file (the `security.environmentVariableRedaction.*` entries), which the section now agrees with.

A reviewer can confirm quickly by putting the old example in a `settings.json` with `$schema` set and watching the editor flag both keys.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) — n/a, no code changed
- [ ] Noted breaking changes (if any) — none; this documents existing behavior
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux

I left the platform matrix unchecked deliberately rather than ticking boxes I didn't exercise: this touches a single `.md` file with no code path, so there's nothing platform-specific to validate. I also didn't run `npm run preflight` for the same reason — happy to if you'd like it on the record.
