### PR TITLE
docs: document missing CLI flags

### DIFF
--- a/docs/cli/cli-reference.md
+++ b/docs/cli/cli-reference.md
@@ -60,14 +60,20 @@ These commands are available within the interactive REPL.
 | `--experimental-zed-integration` | -     | boolean | -         | Run in Zed editor integration mode. **Experimental feature.**                                                                                                          |
 | `--allowed-mcp-server-names`     | -     | array   | -         | Allowed MCP server names (comma-separated or multiple flags)                                                                                                           |
 | `--allowed-tools`                | -     | array   | -         | **Deprecated.** Use the [Policy Engine](../reference/policy-engine.md) instead. Tools that are allowed to run without confirmation (comma-separated or multiple flags) |
+| `--policy`                       | -     | array   | -         | Additional policy files or directories to load (comma-separated or multiple flags)                                                                                     |
+| `--admin-policy`                 | -     | array   | -         | Additional admin policy files or directories to load (comma-separated or multiple flags)                                                                               |
 | `--extensions`                   | `-e`  | array   | -         | List of extensions to use. If not provided, all extensions are enabled (comma-separated or multiple flags)                                                             |
 | `--list-extensions`              | `-l`  | boolean | -         | List all available extensions and exit                                                                                                                                 |
 | `--resume`                       | `-r`  | string  | -         | Resume a previous session. Use `"latest"` for most recent or index number (for example `--resume 5`)                                                                   |
 | `--list-sessions`                | -     | boolean | -         | List available sessions for the current project and exit                                                                                                               |
 | `--delete-session`               | -     | string  | -         | Delete a session by index number (use `--list-sessions` to see available sessions)                                                                                     |
+| `--session-id`                   | -     | string  | -         | Start a new session with a manually provided UUID.                                                                                                                     |
+| `--session-file`                 | -     | string  | -         | Load a session from a JSON file                                                                                                                                        |
 | `--include-directories`          | -     | array   | -         | Additional directories to include in the workspace (comma-separated or multiple flags)                                                                                 |
 | `--screen-reader`                | -     | boolean | -         | Enable screen reader mode for accessibility                                                                                                                            |
 | `--output-format`                | `-o`  | string  | `text`    | The format of the CLI output. Choices: `text`, `json`, `stream-json`                                                                                                   |
+| `--raw-output`                   | -     | boolean | -         | Disable sanitization of model output (for example, allow ANSI escape sequences). **Warning:** this can be a security risk if the model output is untrusted.            |
+| `--accept-raw-output-risk`       | -     | boolean | -         | Suppress the security warning shown when using `--raw-output`.                                                                                                         |
 
 ## Model selection
 


### PR DESCRIPTION
## Summary

Adds six flags to the CLI reference table that are registered in `config.ts` but weren't documented: `--policy`, `--admin-policy`, `--session-id`, `--session-file`, `--raw-output` and `--accept-raw-output-risk`.

## Details

All six are registered with `.option(...)` in `packages/cli/src/config/config.ts` and none carry `hidden: true`, so they already show up in `gemini --help` — the reference table was just behind.

The pair I'd draw attention to is `--raw-output` / `--accept-raw-output-risk`. `--raw-output` disables sanitization of model output, and its own description in the source warns "This can be a security risk if the model output is untrusted"; `--accept-raw-output-risk` exists solely to suppress that warning. I carried the warning into the table rather than describing the flag neutrally, since a reader deciding whether to use it needs that context.

`--policy` and `--admin-policy` matter because the table already links to the Policy Engine from the `--allowed-tools` row but never mentioned the flags that load policy files.

Descriptions are taken from the `description` fields in `config.ts` rather than written from scratch, lightly edited for the table (spelling out "for example", and using the table's existing bold-warning style). Rows are placed next to related flags: policy flags after `--allowed-tools`, session flags after `--delete-session`, output flags after `--output-format`. The diff is additive only — no existing row or the column alignment is touched.

## Related Issues

Fixes #29012

## How to Validate

Docs-only, verified by comparison:

1. Parsed every `.option('<name>', { ... })` registration out of `packages/cli/src/config/config.ts` (they span multiple lines, so a plain grep misses some) and diffed the names against the flags in the reference table. That produced exactly these six, plus `--acp`, which I've handled separately.
2. Confirmed none of the six are hidden — only `fake-responses`, `fake-responses-non-strict` and `record-responses` set `hidden: true` — so all six really do appear in help output.
3. Checked each one's `type` in the source matches the type column I wrote.
4. Re-ran the comparison after the edit; the only remaining undocumented flags are the three hidden test ones, which shouldn't be documented.

A reviewer can confirm with `gemini --help`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed) — n/a, no code changed
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux

Platform matrix intentionally unchecked rather than ticked without being exercised — single `.md` table, no code path. `npm run preflight` not run for the same reason; happy to if you'd like it recorded.

Note: this edits the same file as #29011 (ACP flag rows) but different rows, so whichever lands second may need a trivial rebase. Happy to combine them if you'd prefer one PR.
