### PR TITLE
ci: set explicit permissions on workflows missing them

### DIFF
--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: |-
     ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') }}
 
+permissions:
+  contents: 'read'
+
 jobs:
   deflake_e2e_linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'

--- a/.github/workflows/docs-rebuild.yml
+++ b/.github/workflows/docs-rebuild.yml
@@ -5,6 +5,8 @@ on:
       - 'main'
     paths:
       - 'docs/**'
+permissions: {}
+
 jobs:
   trigger-rebuild:
     if: "github.repository == 'google-gemini/gemini-cli'"

--- a/.github/workflows/issue-opened-labeler.yml
+++ b/.github/workflows/issue-opened-labeler.yml
@@ -5,6 +5,9 @@ on:
     types:
       - 'opened'
 
+permissions:
+  issues: 'write'
+
 jobs:
   label-issue:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/issue-opened-labeler.yml
+++ b/.github/workflows/issue-opened-labeler.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           app-id: '${{ secrets.APP_ID }}'
           private-key: '${{ secrets.PRIVATE_KEY }}'
+          permission-issues: 'write'
 
       - name: 'Add need-triage label'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '00 18 * * *'
 
+permissions:
+  contents: 'read'
+
 jobs:
   linkChecker:
     if: |-

--- a/.github/workflows/tools-python-ci.yml
+++ b/.github/workflows/tools-python-ci.yml
@@ -18,6 +18,9 @@ defaults:
   run:
     shell: 'bash'
 
+permissions:
+  contents: 'read'
+
 jobs:
   python-tests:
     name: 'Python Tests'

--- a/.github/workflows/trigger_e2e.yml
+++ b/.github/workflows/trigger_e2e.yml
@@ -13,6 +13,9 @@ on:
         type: 'string'
   pull_request:
 
+permissions:
+  contents: 'read'
+
 jobs:
   save_repo_name:
     if: "github.repository == 'google-gemini/gemini-cli'"


### PR DESCRIPTION
## Summary

Adds an explicit `permissions:` block to the six workflows that didn't have one, scoped to what each actually needs.

## Details

Without a `permissions:` block a workflow's `GITHUB_TOKEN` inherits the repository/org default rather than being scoped to its job. The other 41 workflows here already declare one, and the repo is otherwise careful about this (actions pinned to full SHAs with `# ratchet:` comments, `persist-credentials: false` on checkouts), so these six looked like oversights.

I read each workflow before choosing a scope rather than blanket-applying `contents: read`:

| Workflow | Set to | Why |
| --- | --- | --- |
| `deflake.yml` | `contents: 'read'` | checkout, `npm ci`, build, docker |
| `links.yml` | `contents: 'read'` | checkout + lychee link check |
| `tools-python-ci.yml` | `contents: 'read'` | checkout + setup-python + tests |
| `trigger_e2e.yml` | `contents: 'read'` | shell steps + upload-artifact |
| `issue-opened-labeler.yml` | `issues: 'write'` | needs write; see below |
| `docs-rebuild.yml` | `{}` | never touches the GitHub API |

Two that aren't just `contents: read`:

**`issue-opened-labeler.yml` needs `issues: write`.** It prefers a GitHub App token but falls back to `secrets.GITHUB_TOKEN` when `APP_ID` is unset (`github-token: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'`), then calls `issues.get` and `issues.addLabels`. Pinning it to `read` would look tidier but would break labeling on that fallback path.

**`docs-rebuild.yml` gets `permissions: {}`.** Its only step `curl`s `secrets.DOCS_REBUILD_URL` — no checkout, no API calls — so it needs no token scopes at all.

This is hardening rather than a bug fix: if the repo default is already read-only, nothing changes at runtime. Formatting follows the existing convention in this repo (quoted scalar values).

## Related Issues

Fixes #29014

## How to Validate

1. `for f in .github/workflows/*.yml; do grep -q "permissions:" "$f" || echo "$f"; done` — lists the six before the change, nothing after.
2. Parsed all six with a YAML parser after editing to confirm they still load and that `permissions` resolves as intended (`{'contents': 'read'}`, `{'issues': 'write'}`, `{}`) with each file's job list unchanged.
3. Traced each workflow's steps to justify the scope — in particular confirming the labeler's `GITHUB_TOKEN` fallback path and its `issues.addLabels` call, and that `docs-rebuild.yml` makes no API calls.

The real confirmation is that these workflows behave identically after merge; the labeler is the one to watch, since it's the only one needing write.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed) — n/a
- [ ] Added/updated tests (if needed) — n/a, workflow config
- [ ] Noted breaking changes (if any) — none intended; see the labeler note above
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux

Platform matrix left unchecked deliberately — this changes GitHub Actions config only, with no code path to exercise per platform, and I can't run these workflows from a fork. `npm run preflight` not run for the same reason.
