### PR TITLE
Fix/28944 symlink skills dedupe

### DIFF
--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -63,14 +63,14 @@ All hooks receive these common fields via `stdin`:
 
 Most hooks support these fields in their `stdout` JSON:
 
-| Field            | Type      | Description                                                                    |
-| :--------------- | :-------- | :----------------------------------------------------------------------------- |
-| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                             |
-| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                   |
-| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                           |
-| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                              |
-| `decision`       | `string`  | `"allow"` or `"deny"` (alias `"block"`). Specific impact depends on the event. |
-| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.             |
+| Field            | Type      | Description                                                                                    |
+| :--------------- | :-------- | :--------------------------------------------------------------------------------------------- |
+| `systemMessage`  | `string`  | Displayed immediately to the user in the terminal.                                             |
+| `suppressOutput` | `boolean` | If `true`, hides internal hook metadata from logs/telemetry.                                   |
+| `continue`       | `boolean` | If `false`, stops the entire agent loop immediately.                                           |
+| `stopReason`     | `string`  | Displayed to the user when `continue` is `false`.                                              |
+| `decision`       | `string`  | `"ask"`, `"approve"`, `"block"`, `"allow"`, or `"deny"`. Specific impact depends on the event. |
+| `reason`         | `string`  | The feedback/error message provided when a `decision` is `"deny"`.                             |
 
 ---
 

--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -5,12 +5,14 @@
  */
 
 import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { Storage } from '../config/storage.js';
 import { type SkillDefinition, loadSkillsFromDir } from './skillLoader.js';
 import type { GeminiCLIExtension } from '../config/config.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { coreEvents } from '../utils/events.js';
+import { normalizePath } from '../utils/paths.js';
 
 export { type SkillDefinition };
 
@@ -58,6 +60,11 @@ export class SkillManager {
   ): Promise<void> {
     this.clearSkills();
 
+    // Track real (canonicalized) paths already scanned to prevent duplicate
+    // loading when .gemini and .agents are symlinked/junctioned to the same
+    // physical directory (see GitHub issue #28944).
+    const visitedRealPaths = new Set<string>();
+
     // 1. Built-in skills (lowest precedence)
     await this.discoverBuiltinSkills();
 
@@ -69,12 +76,16 @@ export class SkillManager {
     }
 
     // 3. User skills
-    const userSkills = await loadSkillsFromDir(Storage.getUserSkillsDir());
+    const userSkills = await this.loadSkillsFromUniqueDir(
+      Storage.getUserSkillsDir(),
+      visitedRealPaths,
+    );
     this.addSkillsWithPrecedence(userSkills);
 
     // 3.1 User agent skills alias (.agents/skills)
-    const userAgentSkills = await loadSkillsFromDir(
+    const userAgentSkills = await this.loadSkillsFromUniqueDir(
       Storage.getUserAgentSkillsDir(),
+      visitedRealPaths,
     );
     this.addSkillsWithPrecedence(userAgentSkills);
 
@@ -86,16 +97,57 @@ export class SkillManager {
       return;
     }
 
-    const projectSkills = await loadSkillsFromDir(
+    const projectSkills = await this.loadSkillsFromUniqueDir(
       storage.getProjectSkillsDir(),
+      visitedRealPaths,
     );
     this.addSkillsWithPrecedence(projectSkills);
 
     // 4.1 Workspace agent skills alias (.agents/skills)
-    const projectAgentSkills = await loadSkillsFromDir(
+    const projectAgentSkills = await this.loadSkillsFromUniqueDir(
       storage.getProjectAgentSkillsDir(),
+      visitedRealPaths,
     );
     this.addSkillsWithPrecedence(projectAgentSkills);
+  }
+
+  /**
+   * Loads skills from `dir` unless its real (canonical) path has already been
+   * scanned in this discovery pass.  This prevents duplicate skill loading and
+   * spurious conflict warnings when two logical paths (e.g. `.gemini/skills`
+   * and `.agents/skills`) are symlinked or junctioned to the same physical
+   * directory.
+   *
+   * Resolution failures (ENOENT, broken symlinks, permission errors) are
+   * handled gracefully: the raw `dir` path is used as the fallback key so
+   * that the subsequent `loadSkillsFromDir` call can produce its own
+   * informative error or empty result.
+   */
+  private async loadSkillsFromUniqueDir(
+    dir: string,
+    visitedRealPaths: Set<string>,
+  ): Promise<SkillDefinition[]> {
+    let realKey: string;
+    try {
+      const realPath = await fs.realpath(dir);
+      realKey = normalizePath(realPath);
+    } catch {
+      // Path doesn't exist, is a broken symlink, or we lack permission to
+      // resolve it.  Fall back to a normalized lexical key so that the
+      // directory isn't silently skipped — loadSkillsFromDir will return []
+      // for non-existent paths without any additional warning.
+      realKey = normalizePath(path.resolve(dir));
+    }
+
+    if (visitedRealPaths.has(realKey)) {
+      debugLogger.debug(
+        `Skipping duplicate skill directory (same physical path): ${dir}`,
+      );
+      return [];
+    }
+
+    visitedRealPaths.add(realKey);
+    return loadSkillsFromDir(dir);
   }
 
   /**

--- a/packages/core/src/skills/skillManagerAlias.test.ts
+++ b/packages/core/src/skills/skillManagerAlias.test.ts
@@ -176,3 +176,354 @@ describe('SkillManager Alias', () => {
     expect(skills[0].description).toBe('agent-desc');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression tests for GitHub issue #28944
+//
+// When .gemini/skills and .agents/skills are symlinked / junctioned to the
+// same physical directory, discoverSkills() must scan that directory exactly
+// once and must not emit any spurious "Skill conflict detected" warnings.
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a directory link (junction on Windows, symlink on POSIX).
+ * Returns true if the link was created successfully, false if the platform
+ * does not support the required link type or the operation was refused (e.g.
+ * missing privileges).  Tests that receive `false` are skipped.
+ */
+async function tryCreateDirLink(
+  target: string,
+  linkPath: string,
+): Promise<boolean> {
+  try {
+    if (process.platform === 'win32') {
+      // 'junction' is the Windows-native directory link type that does not
+      // require elevated privileges (unlike directory symlinks on Windows).
+      await fs.symlink(target, linkPath, 'junction');
+    } else {
+      await fs.symlink(target, linkPath);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Writes a minimal SKILL.md file into `skillSubdir` inside `baseDir`. */
+async function writeSkillFile(
+  baseDir: string,
+  skillSubdir: string,
+  name: string,
+  description: string,
+): Promise<string> {
+  const skillDir = path.join(baseDir, skillSubdir);
+  await fs.mkdir(skillDir, { recursive: true });
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  await fs.writeFile(
+    skillFile,
+    `---\nname: ${name}\ndescription: ${description}\n---\nbody`,
+  );
+  return skillFile;
+}
+
+describe('SkillManager — symlink/junction deduplication (#28944)', () => {
+  let testRootDir: string;
+
+  beforeEach(async () => {
+    testRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'skill-manager-symlink-test-'),
+    );
+    // Use the real loadSkillsFromDir so the filesystem I/O is exercised.
+    vi.mocked(loadSkillsFromDir).mockRestore();
+  });
+
+  afterEach(async () => {
+    await fs.rm(testRootDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: workspace-tier — .agents/skills is a junction/symlink to .gemini/skills
+  // -------------------------------------------------------------------------
+  it('should not produce a conflict warning when workspace .agents/skills is linked to .gemini/skills', async () => {
+    // Create the real skills directory under .gemini/skills
+    const realSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.gemini',
+      'skills',
+    );
+    await writeSkillFile(
+      realSkillsDir,
+      'my-skill',
+      'my-skill',
+      'A shared skill',
+    );
+
+    // Create the .agents/skills directory as a link to the real dir
+    const agentSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.agents',
+      'skills',
+    );
+    await fs.mkdir(path.dirname(agentSkillsDir), { recursive: true });
+    const linked = await tryCreateDirLink(realSkillsDir, agentSkillsDir);
+    if (!linked) {
+      // Platform does not support the required link type — skip gracefully.
+      return;
+    }
+
+    const storage = new Storage(path.join(testRootDir, 'workspace'));
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(realSkillsDir);
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      agentSkillsDir,
+    );
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user'),
+    );
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user-agent'),
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+    // Spy on coreEvents to detect any spurious conflict warning.
+    const { coreEvents } = await import('../utils/events.js');
+    const emitSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+    await service.discoverSkills(storage, [], true);
+
+    const skills = service.getSkills();
+    // The skill must appear exactly once.
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-skill');
+
+    // No conflict warning should have been emitted.
+    const warningCalls = emitSpy.mock.calls.filter(
+      ([level]) => level === 'warning',
+    );
+    expect(warningCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: workspace-tier — .gemini/skills is a junction/symlink to .agents/skills
+  //         (reverse arrangement)
+  // -------------------------------------------------------------------------
+  it('should not produce a conflict warning when workspace .gemini/skills is linked to .agents/skills', async () => {
+    // Create the real skills directory under .agents/skills
+    const realSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.agents',
+      'skills',
+    );
+    await writeSkillFile(
+      realSkillsDir,
+      'my-skill',
+      'my-skill',
+      'A shared skill',
+    );
+
+    // Create the .gemini/skills directory as a link to the real dir
+    const geminiSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.gemini',
+      'skills',
+    );
+    await fs.mkdir(path.dirname(geminiSkillsDir), { recursive: true });
+    const linked = await tryCreateDirLink(realSkillsDir, geminiSkillsDir);
+    if (!linked) {
+      return;
+    }
+
+    const storage = new Storage(path.join(testRootDir, 'workspace'));
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(geminiSkillsDir);
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      realSkillsDir,
+    );
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user'),
+    );
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user-agent'),
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+    const { coreEvents } = await import('../utils/events.js');
+    const emitSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+    await service.discoverSkills(storage, [], true);
+
+    const skills = service.getSkills();
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-skill');
+
+    const warningCalls = emitSpy.mock.calls.filter(
+      ([level]) => level === 'warning',
+    );
+    expect(warningCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: user-tier — same symlink scenario at the global (~/.gemini) level
+  // -------------------------------------------------------------------------
+  it('should not produce a conflict warning when user .agents/skills is linked to .gemini/skills', async () => {
+    const realSkillsDir = path.join(testRootDir, 'home', '.gemini', 'skills');
+    await writeSkillFile(
+      realSkillsDir,
+      'my-skill',
+      'my-skill',
+      'A shared skill',
+    );
+
+    const agentSkillsDir = path.join(testRootDir, 'home', '.agents', 'skills');
+    await fs.mkdir(path.dirname(agentSkillsDir), { recursive: true });
+    const linked = await tryCreateDirLink(realSkillsDir, agentSkillsDir);
+    if (!linked) {
+      return;
+    }
+
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(realSkillsDir);
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(agentSkillsDir);
+
+    const storage = new Storage('/dummy');
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-project'),
+    );
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-project-agent'),
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+    const { coreEvents } = await import('../utils/events.js');
+    const emitSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+    await service.discoverSkills(storage, [], true);
+
+    const skills = service.getSkills();
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-skill');
+
+    const warningCalls = emitSpy.mock.calls.filter(
+      ([level]) => level === 'warning',
+    );
+    expect(warningCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: Different real directories must NOT be deduplicated
+  // -------------------------------------------------------------------------
+  it('should keep two genuinely different directories independent', async () => {
+    const geminiSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.gemini',
+      'skills',
+    );
+    const agentSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.agents',
+      'skills',
+    );
+    await writeSkillFile(geminiSkillsDir, 'skill-a', 'skill-a', 'Gemini skill');
+    await writeSkillFile(agentSkillsDir, 'skill-b', 'skill-b', 'Agent skill');
+
+    const storage = new Storage(path.join(testRootDir, 'workspace'));
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(geminiSkillsDir);
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      agentSkillsDir,
+    );
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user'),
+    );
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user-agent'),
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+    await service.discoverSkills(storage, [], true);
+
+    const skills = service.getSkills();
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name);
+    expect(names).toContain('skill-a');
+    expect(names).toContain('skill-b');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: Genuine duplicate skill definitions still trigger a warning
+  // (fix must NOT suppress real conflicts)
+  // -------------------------------------------------------------------------
+  it('should still emit a conflict warning for genuinely different directories with the same skill name', async () => {
+    const geminiSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.gemini',
+      'skills',
+    );
+    const agentSkillsDir = path.join(
+      testRootDir,
+      'workspace',
+      '.agents',
+      'skills',
+    );
+    // Both real directories contain a skill with the same name.
+    await writeSkillFile(
+      geminiSkillsDir,
+      'shared-skill',
+      'shared-skill',
+      'From gemini',
+    );
+    await writeSkillFile(
+      agentSkillsDir,
+      'shared-skill',
+      'shared-skill',
+      'From agents',
+    );
+
+    const storage = new Storage(path.join(testRootDir, 'workspace'));
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(geminiSkillsDir);
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      agentSkillsDir,
+    );
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user'),
+    );
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+      path.join(testRootDir, 'non-existent-user-agent'),
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+    const { coreEvents } = await import('../utils/events.js');
+    const emitSpy = vi.spyOn(coreEvents, 'emitFeedback');
+
+    await service.discoverSkills(storage, [], true);
+
+    // One skill in the map (the later one wins per precedence).
+    const skills = service.getSkills();
+    expect(skills).toHaveLength(1);
+
+    // A conflict warning must still be emitted.
+    const warningCalls = emitSpy.mock.calls.filter(
+      ([level]) => level === 'warning',
+    );
+    expect(warningCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1348,5 +1348,42 @@ describe('fileUtils', () => {
       expect(formatted).toContain('For full output see: /tmp/out.txt');
       expect(formatted).toContain('[46,000 characters omitted]'); // 50000 - 800 - 3200
     });
+
+    it('should return original content unchanged when content length <= maxChars', () => {
+      const content = 'Hello world!';
+      const outputFile = '/tmp/out.txt';
+
+      // maxChars larger than content length
+      expect(formatTruncatedToolOutput(content, outputFile, 100)).toBe(content);
+      // maxChars equal to content length
+      expect(
+        formatTruncatedToolOutput(content, outputFile, content.length),
+      ).toBe(content);
+    });
+
+    it('should handle maxChars === 0 without duplicating or returning full content', () => {
+      const content = 'B'.repeat(1000);
+      const outputFile = '/tmp/out.txt';
+
+      const formatted = formatTruncatedToolOutput(content, outputFile, 0);
+
+      expect(formatted).toContain('Showing first 0 and last 0 characters');
+      expect(formatted).toContain('[1,000 characters omitted]');
+      // Ensure the original content body is not included
+      expect(formatted).not.toContain(content);
+      expect(formatted.length).toBeLessThan(content.length);
+    });
+
+    it('should handle negative maxChars safely without output inflation or duplication', () => {
+      const content = 'A'.repeat(1000);
+      const outputFile = '/tmp/out.txt';
+
+      const formatted = formatTruncatedToolOutput(content, outputFile, -100);
+
+      expect(formatted).toContain('Showing first 0 and last 0 characters');
+      expect(formatted).toContain('[1,000 characters omitted]');
+      // Fixes #28620: formatted output length must NOT be inflated (~2,000 chars)
+      expect(formatted.length).toBeLessThan(content.length);
+    });
   });
 });

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -708,11 +708,12 @@ export function formatTruncatedToolOutput(
 ): string {
   if (contentStr.length <= maxChars) return contentStr;
 
-  const headChars = Math.floor(maxChars * 0.2);
-  const tailChars = maxChars - headChars;
+  const effectiveMax = Math.max(0, maxChars);
+  const headChars = Math.floor(effectiveMax * 0.2);
+  const tailChars = effectiveMax - headChars;
 
   const head = contentStr.slice(0, headChars);
-  const tail = contentStr.slice(-tailChars);
+  const tail = tailChars > 0 ? contentStr.slice(-tailChars) : '';
   const omittedChars = contentStr.length - headChars - tailChars;
 
   return `Output too large. Showing first ${headChars.toLocaleString()} and last ${tailChars.toLocaleString()} characters. For full output see: ${outputFile}


### PR DESCRIPTION
# Title
fix(core): dedupe symlinked/junctioned skill directories during discovery (#28944)

## Summary
Fixes #28944

When a workspace or user directory links `.gemini` to `.agents` (e.g. via Windows junction `mklink /J .gemini .agents` or a POSIX symlink) to support open Agent Skills standards alongside legacy paths, `SkillManager.discoverSkills()` scanned both entry points (`.gemini/skills` and `.agents/skills`). 

Because paths were evaluated as raw strings, identical skills were discovered twice under different logical paths, triggering false `Skill conflict detected` warnings on startup and during `/skills reload`.

This PR canonicalizes directory paths prior to scanning, ensuring each physical directory is scanned exactly once per discovery pass.

---

## Root Cause
`SkillManager.discoverSkills()` scans four locations per pass:
1. User `.gemini/skills`
2. User `.agents/skills`
3. Project `.gemini/skills`
4. Project `.agents/skills`

When `.gemini` is symlinked or junctioned to `.agents`, paths #3 and #4 point to the same physical folder on disk. Scanning both paths causes glob matches to produce different logical file paths (e.g., `.gemini/skills/foo/SKILL.md` vs `.agents/skills/foo/SKILL.md`), which leads `addSkillsWithPrecedence()` to flag a false conflict:
```typescript
if (existingSkill && existingSkill.location !== newSkill.location) {
  // False positive conflict warning triggered!
}
