### PR TITLE
feat(tool): retain ask_user question in text history

### DIFF
--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -84,6 +84,7 @@ they appear in the UI.
 | Show Spinner                         | `ui.showSpinner`                       | Show the spinner during operations.                                                                                                                               | `true`  |
 | Loading Phrases                      | `ui.loadingPhrases`                    | What to show while the model is working: tips, witty comments, all, or off.                                                                                       | `"off"` |
 | Error Verbosity                      | `ui.errorVerbosity`                    | Controls whether recoverable errors are hidden (low) or fully shown (full).                                                                                       | `"low"` |
+| Keep Ask User Questions In History   | `ui.keepAskUserQuestionsInHistory`     | Keep the questions from the ask_user tool visible in the chat history instead of hiding them after answering.                                                     | `false` |
 | Screen Reader Mode                   | `ui.accessibility.screenReader`        | Render output in plain-text to be more screen reader accessible                                                                                                   | `false` |
 
 ### IDE

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -466,6 +466,12 @@ their corresponding top-level category object in your `settings.json` file.
   - **Default:** `"low"`
   - **Values:** `"low"`, `"full"`
 
+- **`ui.keepAskUserQuestionsInHistory`** (boolean):
+
+  - **Description:** Keep the questions from the ask_user tool visible in the
+    chat history instead of hiding them after answering.
+  - **Default:** `false`
+
 - **`ui.customWittyPhrases`** (array):
 
   - **Description:** Custom witty phrases to display during loading. When

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -3884,3 +3884,51 @@ describe('loadCliConfig acpMode and clientName', () => {
     expect(config.getClientName()).toBe('tui');
   });
 });
+
+describe('loadCliConfig keepAskUserQuestionsInHistory', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(os.homedir).mockReturnValue('/mock/home/user');
+    vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
+    vi.spyOn(ExtensionManager.prototype, 'getExtensions').mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should default keepAskUserQuestionsInHistory to false when not specified in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments(createTestMergedSettings());
+    const config = await loadCliConfig(
+      createTestMergedSettings(),
+      'test-session',
+      argv,
+    );
+    expect(config.getKeepAskUserQuestionsInHistory()).toBe(false);
+  });
+
+  it('should set keepAskUserQuestionsInHistory to true when specified as true in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      ui: {
+        keepAskUserQuestionsInHistory: true,
+      },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getKeepAskUserQuestionsInHistory()).toBe(true);
+  });
+
+  it('should set keepAskUserQuestionsInHistory to false when specified as false in settings', async () => {
+    process.argv = ['node', 'script.js'];
+    const settings = createTestMergedSettings({
+      ui: {
+        keepAskUserQuestionsInHistory: false,
+      },
+    });
+    const argv = await parseArguments(settings);
+    const config = await loadCliConfig(settings, 'test-session', argv);
+    expect(config.getKeepAskUserQuestionsInHistory()).toBe(false);
+  });
+});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -975,6 +975,8 @@ export async function loadCliConfig(
     debugMode,
     question,
     worktreeSettings,
+    keepAskUserQuestionsInHistory:
+      settings.ui?.keepAskUserQuestionsInHistory ?? false,
 
     coreTools: settings.tools?.core || undefined,
     experimentalContextManagementConfig: profileSelector,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -104,6 +104,16 @@ describe('SettingsSchema', () => {
       expect(definition?.options?.map((o) => o.value)).toEqual(['low', 'full']);
     });
 
+    it('should have keepAskUserQuestionsInHistory property configured', () => {
+      const definition =
+        getSettingsSchema().ui?.properties?.keepAskUserQuestionsInHistory;
+      expect(definition).toBeDefined();
+      expect(definition?.type).toBe('boolean');
+      expect(definition?.default).toBe(false);
+      expect(definition?.requiresRestart).toBe(false);
+      expect(definition?.showInDialog).toBe(true);
+    });
+
     it('should have checkpointing nested properties', () => {
       expect(
         getSettingsSchema().general?.properties?.checkpointing.properties

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -491,6 +491,16 @@ const SETTINGS_SCHEMA = {
     description: 'User interface settings.',
     showInDialog: false,
     properties: {
+      keepAskUserQuestionsInHistory: {
+        type: 'boolean',
+        label: 'Keep Ask User Questions in History',
+        category: 'UI',
+        requiresRestart: false,
+        default: false,
+        description:
+          'Keep the questions from the ask_user tool visible in the chat history instead of hiding them after answering.',
+        showInDialog: true,
+      },
       debugRainbow: {
         type: 'boolean',
         label: 'Debug Rainbow',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -325,6 +325,29 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('keepAskUserQuestionsInHistory', () => {
+    it('should default to false when keepAskUserQuestionsInHistory is not specified', () => {
+      const config = new Config(baseParams);
+      expect(config.getKeepAskUserQuestionsInHistory()).toBe(false);
+    });
+
+    it('should use provided keepAskUserQuestionsInHistory if set to true', () => {
+      const config = new Config({
+        ...baseParams,
+        keepAskUserQuestionsInHistory: true,
+      });
+      expect(config.getKeepAskUserQuestionsInHistory()).toBe(true);
+    });
+
+    it('should use provided keepAskUserQuestionsInHistory if set to false', () => {
+      const config = new Config({
+        ...baseParams,
+        keepAskUserQuestionsInHistory: false,
+      });
+      expect(config.getKeepAskUserQuestionsInHistory()).toBe(false);
+    });
+  });
+
   describe('setShellExecutionConfig', () => {
     it('should preserve existing shell execution fields that are not being updated', () => {
       const config = new Config({

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -748,6 +748,7 @@ export interface ConfigParameters {
   };
   vertexAiRouting?: VertexAiRoutingConfig;
   logRagSnippets?: boolean;
+  keepAskUserQuestionsInHistory?: boolean;
 }
 
 export class Config implements McpContext, AgentLoopContext {
@@ -987,12 +988,15 @@ export class Config implements McpContext, AgentLoopContext {
   private lastModeSwitchTime: number = performance.now();
   readonly injectionService: InjectionService;
   private approvedPlanPath: string | undefined;
+  private readonly keepAskUserQuestionsInHistory: boolean;
 
   constructor(params: ConfigParameters) {
     this._sessionId = params.sessionId;
     this.clientName = params.clientName;
     this._clientVersion = params.clientVersion ?? 'unknown';
     this.approvedPlanPath = undefined;
+    this.keepAskUserQuestionsInHistory =
+      params.keepAskUserQuestionsInHistory ?? false;
 
     this.embeddingModel =
       params.embeddingModel ?? DEFAULT_GEMINI_EMBEDDING_MODEL;
@@ -1821,6 +1825,10 @@ export class Config implements McpContext, AgentLoopContext {
 
   getSessionId(): string {
     return this.promptId;
+  }
+
+  getKeepAskUserQuestionsInHistory(): boolean {
+    return this.keepAskUserQuestionsInHistory;
   }
 
   getWorktreeSettings(): WorktreeSettings | undefined {
@@ -4031,7 +4039,7 @@ export class Config implements McpContext, AgentLoopContext {
       registry.registerTool(new WebSearchTool(this, this.messageBus)),
     );
     maybeRegister(AskUserTool, () =>
-      registry.registerTool(new AskUserTool(this.messageBus)),
+      registry.registerTool(new AskUserTool(this, this.messageBus)),
     );
     if (this.getUseWriteTodos()) {
       maybeRegister(WriteTodosTool, () =>

--- a/packages/core/src/tools/ask-user.test.ts
+++ b/packages/core/src/tools/ask-user.test.ts
@@ -16,6 +16,7 @@ import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { ToolConfirmationOutcome } from './tools.js';
 import { ToolErrorType } from './tool-error.js';
 import { ASK_USER_DISPLAY_NAME } from './tool-names.js';
+import type { Config } from '../config/config.js';
 
 describe('AskUserTool Helpers', () => {
   describe('isCompletedAskUserTool', () => {
@@ -52,15 +53,19 @@ describe('AskUserTool Helpers', () => {
 
 describe('AskUserTool', () => {
   let mockMessageBus: MessageBus;
+  let mockConfig: Config;
   let tool: AskUserTool;
 
   beforeEach(() => {
+    mockConfig = {
+      getKeepAskUserQuestionsInHistory: vi.fn().mockReturnValue(false),
+    } as unknown as Config;
     mockMessageBus = {
       publish: vi.fn().mockResolvedValue(undefined),
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
     } as unknown as MessageBus;
-    tool = new AskUserTool(mockMessageBus);
+    tool = new AskUserTool(mockConfig, mockMessageBus);
   });
 
   it('should have correct metadata', () => {
@@ -595,6 +600,125 @@ describe('AskUserTool', () => {
           dismissed: true,
         },
       });
+    });
+
+    it('should format questions and answers together when getKeepAskUserQuestionsInHistory is true', async () => {
+      vi.mocked(mockConfig.getKeepAskUserQuestionsInHistory).mockReturnValue(
+        true,
+      );
+
+      const questions: Question[] = [
+        {
+          question: 'How should we proceed with this task?',
+          header: 'Approach',
+          type: QuestionType.CHOICE,
+          options: [
+            {
+              label: 'Quick fix (Recommended)',
+              description: 'Apply the most direct solution.',
+            },
+            {
+              label: 'Comprehensive refactor',
+              description: 'Restructure the affected code.',
+            },
+          ],
+        },
+      ];
+
+      const invocation = tool.build({ questions });
+      const details = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      if (details && 'onConfirm' in details) {
+        const answers = { '0': 'Quick fix (Recommended)' };
+        await details.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+          answers,
+        });
+      }
+
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+      expect(result.returnDisplay).toBe(
+        '**Question:** How should we proceed with this task?\n**Answer:** Quick fix (Recommended)',
+      );
+    });
+
+    it('should format multiple questions and answers together when getKeepAskUserQuestionsInHistory is true', async () => {
+      vi.mocked(mockConfig.getKeepAskUserQuestionsInHistory).mockReturnValue(
+        true,
+      );
+
+      const questions: Question[] = [
+        {
+          question: 'First question?',
+          header: 'Q1',
+          type: QuestionType.TEXT,
+        },
+        {
+          question: 'Second question?',
+          header: 'Q2',
+          type: QuestionType.TEXT,
+        },
+      ];
+
+      const invocation = tool.build({ questions });
+      const details = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      if (details && 'onConfirm' in details) {
+        const answers = { '0': 'First answer', '1': 'Second answer' };
+        await details.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+          answers,
+        });
+      }
+
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+      expect(result.returnDisplay).toBe(
+        '**Question:** First question?\n**Answer:** First answer\n\n**Question:** Second question?\n**Answer:** Second answer',
+      );
+    });
+
+    it('should handle empty or missing answers gracefully when getKeepAskUserQuestionsInHistory is true', async () => {
+      vi.mocked(mockConfig.getKeepAskUserQuestionsInHistory).mockReturnValue(
+        true,
+      );
+
+      const questions: Question[] = [
+        {
+          question: 'First question?',
+          header: 'Q1',
+          type: QuestionType.TEXT,
+        },
+        {
+          question: 'Second question?',
+          header: 'Q2',
+          type: QuestionType.TEXT,
+        },
+      ];
+
+      const invocation = tool.build({ questions });
+      const details = await invocation.shouldConfirmExecute(
+        new AbortController().signal,
+      );
+
+      if (details && 'onConfirm' in details) {
+        const answers = { '0': 'First answer' }; // '1' is missing
+        await details.onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+          answers,
+        });
+      }
+
+      const result = await invocation.execute({
+        abortSignal: new AbortController().signal,
+      });
+      expect(result.returnDisplay).toBe(
+        '**Question:** First question?\n**Answer:** First answer\n\n**Question:** Second question?\n**Answer:** (No answer)',
+      );
     });
   });
 });

--- a/packages/core/src/tools/ask-user.ts
+++ b/packages/core/src/tools/ask-user.ts
@@ -20,6 +20,7 @@ import { QuestionType, type Question } from '../confirmation-bus/types.js';
 import { ASK_USER_TOOL_NAME, ASK_USER_DISPLAY_NAME } from './tool-names.js';
 import { ASK_USER_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
+import type { Config } from '../config/config.js';
 
 export interface AskUserParams {
   questions: Question[];
@@ -30,8 +31,9 @@ export class AskUserTool extends BaseDeclarativeTool<
   ToolResult
 > {
   static readonly Name = ASK_USER_TOOL_NAME;
+  private readonly config: Config;
 
-  constructor(messageBus: MessageBus) {
+  constructor(config: Config, messageBus: MessageBus) {
     super(
       AskUserTool.Name,
       ASK_USER_DISPLAY_NAME,
@@ -40,6 +42,7 @@ export class AskUserTool extends BaseDeclarativeTool<
       ASK_USER_DEFINITION.base.parametersJsonSchema,
       messageBus,
     );
+    this.config = config;
   }
 
   protected override validateToolParamValues(
@@ -120,6 +123,7 @@ export class AskUserTool extends BaseDeclarativeTool<
     };
 
     return new AskUserInvocation(
+      this.config,
       normalizedParams,
       messageBus,
       toolName,
@@ -155,6 +159,16 @@ export class AskUserInvocation extends BaseToolInvocation<
 > {
   private confirmationOutcome: ToolConfirmationOutcome | null = null;
   private userAnswers: { [questionIndex: string]: string } = {};
+
+  constructor(
+    private readonly config: Config,
+    params: AskUserParams,
+    messageBus: MessageBus,
+    toolName: string,
+    toolDisplayName: string,
+  ) {
+    super(params, messageBus, toolName, toolDisplayName);
+  }
 
   override async shouldConfirmExecute(
     _abortSignal: AbortSignal,
@@ -212,19 +226,33 @@ export class AskUserInvocation extends BaseToolInvocation<
       },
     };
 
-    const returnDisplay = hasAnswers
-      ? `**User answered:**\n${answerEntries
-          .map(([index, answer]) => {
-            const question = this.params.questions[parseInt(index, 10)];
-            const category = question?.header ?? `Q${index}`;
-            const prefix = `  ${category} → `;
-            const indent = ' '.repeat(prefix.length);
+    let returnDisplay: string;
+    if (this.config.getKeepAskUserQuestionsInHistory()) {
+      returnDisplay = this.params.questions
+        .map((q, index) => {
+          const answer = this.userAnswers[String(index)];
+          const answerText =
+            answer !== undefined && answer.trim() !== ''
+              ? answer
+              : '(No answer)';
+          return `**Question:** ${q.question}\n**Answer:** ${answerText}`;
+        })
+        .join('\n\n');
+    } else {
+      returnDisplay = hasAnswers
+        ? `**User answered:**\n${answerEntries
+            .map(([index, answer]) => {
+              const question = this.params.questions[parseInt(index, 10)];
+              const category = question?.header ?? `Q${index}`;
+              const prefix = `  ${category} → `;
+              const indent = ' '.repeat(prefix.length);
 
-            const lines = answer.split('\n');
-            return prefix + lines.join('\n' + indent);
-          })
-          .join('\n')}`
-      : 'User submitted without answering questions.';
+              const lines = answer.split('\n');
+              return prefix + lines.join('\n' + indent);
+            })
+            .join('\n')}`
+        : 'User submitted without answering questions.';
+    }
 
     return {
       llmContent: JSON.stringify({ answers: this.userAnswers }),


### PR DESCRIPTION
## Summary

Implements `ui.keepAskUserQuestionsInHistory` settings option.

## Details

When ask_user tool is used, we have a nice question GUI, but after answering, the question is lost and if/when we resume a session or simply want to remember what were our choices during a session, it's impossible as there's no question visible. Gemini might still have it in it's context, but the human context is completely lost.

## Related Issues

Closes #29021

## How to Validate

Set the following in .gemini/settings.json

```
  "ui": {
    "keepAskUserQuestionsInHistory": true
  }
```

Prompt gemini to ask you a random question using `ask_user` tool, examples:

- ask me a random question using ask_user tool
- use ask_user tool to ask me 3 questions at once so I can see the multiple question flow


## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker


## Examples

*Current behavior/keepAskUserQuestionsInHistory=false or not set*

<img width="688" height="96" alt="image" src="https://github.com/user-attachments/assets/c3a4bdf1-98d5-4c4a-880e-9355b69aeea0" />
<img width="705" height="131" alt="image" src="https://github.com/user-attachments/assets/a9f93dd9-f41b-4de1-b859-0b029d95d3d4" />

*keepAskUserQuestionsInHistory=true*

<img width="560" height="120" alt="image" src="https://github.com/user-attachments/assets/5583865d-b061-4dba-91c9-2fe96643e093" />

<img width="556" height="240" alt="image" src="https://github.com/user-attachments/assets/8cf76dee-3332-43d7-82a6-32a0e5e45c44" />

