### PR TITLE
fix(core): stop Plan Mode from waiting on user feedback in non-interactive sessions

### DIFF
--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -561,6 +561,25 @@ describe('Core System Prompt (prompts.ts)', () => {
       expect(prompt).toMatchSnapshot();
     });
 
+    it('should not tell the agent to wait for user feedback in non-interactive PLAN mode', () => {
+      setupPlanMode();
+      vi.mocked(mockConfig.isInteractive).mockReturnValue(false);
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).not.toContain('STOP and wait');
+      expect(prompt).not.toContain('MUST wait for user feedback');
+      expect(prompt).toContain(
+        'proceed directly to Step 3 (Draft) without waiting for feedback',
+      );
+    });
+
+    it('should tell the agent to wait for user feedback in interactive PLAN mode', () => {
+      setupPlanMode();
+      vi.mocked(mockConfig.isInteractive).mockReturnValue(true);
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).toContain('STOP and wait');
+      expect(prompt).toContain('MUST wait for user feedback');
+    });
+
     it('should NOT include approval mode instructions for DEFAULT mode', () => {
       vi.mocked(mockConfig.getApprovalMode).mockReturnValue(
         ApprovalMode.DEFAULT,

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -546,6 +546,16 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     };
 
+    const setupPlanModeLegacy = () => {
+      vi.mocked(mockConfig.getActiveModel).mockReturnValue(
+        DEFAULT_GEMINI_MODEL,
+      );
+      vi.mocked(mockConfig.getApprovalMode).mockReturnValue(ApprovalMode.PLAN);
+      vi.mocked(mockConfig.toolRegistry.getAllTools).mockReturnValue(
+        planModeTools,
+      );
+    };
+
     it('should include PLAN mode instructions', () => {
       setupPlanMode();
       const prompt = getCoreSystemPrompt(mockConfig);
@@ -578,6 +588,27 @@ describe('Core System Prompt (prompts.ts)', () => {
       const prompt = getCoreSystemPrompt(mockConfig);
       expect(prompt).toContain('STOP and wait');
       expect(prompt).toContain('MUST wait for user feedback');
+    });
+
+    it('should not tell the agent to wait for user input in non-interactive PLAN mode (legacy prompt)', () => {
+      setupPlanModeLegacy();
+      vi.mocked(mockConfig.isInteractive).mockReturnValue(false);
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).not.toContain(
+        'Wait for user input before proceeding to the next phase',
+      );
+      expect(prompt).toContain(
+        'proceed directly to the next phase using your best judgement',
+      );
+    });
+
+    it('should tell the agent to wait for user input in interactive PLAN mode (legacy prompt)', () => {
+      setupPlanModeLegacy();
+      vi.mocked(mockConfig.isInteractive).mockReturnValue(true);
+      const prompt = getCoreSystemPrompt(mockConfig);
+      expect(prompt).toContain(
+        'Wait for user input before proceeding to the next phase',
+      );
     });
 
     it('should NOT include approval mode instructions for DEFAULT mode', () => {

--- a/packages/core/src/prompts/snippets.legacy.ts
+++ b/packages/core/src/prompts/snippets.legacy.ts
@@ -96,6 +96,7 @@ export interface FinalReminderOptions {
 }
 
 export interface PlanningWorkflowOptions {
+  interactive: boolean;
   planModeToolsList: string;
   plansDir: string;
   approvedPlanPath?: string;
@@ -454,12 +455,20 @@ ${options.planModeToolsList}
 
 ## Workflow Phases
 
-**IMPORTANT: Complete ONE phase at a time. Do NOT skip ahead or combine phases. Wait for user input before proceeding to the next phase.**
+${
+  options.interactive
+    ? '**IMPORTANT: Complete ONE phase at a time. Do NOT skip ahead or combine phases. Wait for user input before proceeding to the next phase.**'
+    : '**IMPORTANT: Complete ONE phase at a time. Do NOT skip ahead or combine phases. No user is available to consult in this non-interactive session, so proceed directly to the next phase using your best judgement instead of waiting for input.**'
+}
 
 ### Phase 1: Requirements Understanding
 - Analyze the user's request to identify core requirements and constraints
-- If critical information is missing or ambiguous, ask clarifying questions using the \`${ASK_USER_TOOL_NAME}\` tool
-- When using \`${ASK_USER_TOOL_NAME}\`, prefer providing multiple-choice options for the user to select from when possible
+${
+  options.interactive
+    ? `- If critical information is missing or ambiguous, ask clarifying questions using the \`${ASK_USER_TOOL_NAME}\` tool
+- When using \`${ASK_USER_TOOL_NAME}\`, prefer providing multiple-choice options for the user to select from when possible`
+    : '- If critical information is missing or ambiguous, make reasonable assumptions based on the codebase and conventions instead of asking, since no user is available to consult'
+}
 - Do NOT explore the project or create a plan yet
 
 ### Phase 2: Project Exploration

--- a/packages/core/src/prompts/snippets.ts
+++ b/packages/core/src/prompts/snippets.ts
@@ -628,12 +628,7 @@ Plan Mode uses an adaptive planning workflow where the research depth, plan stru
 Analyze requirements and use search/read tools to explore the codebase. Systematically map affected modules, trace data flow, and identify dependencies.
 
 ### 2. Consult
-The depth of your consultation should be proportional to the task's complexity. Before proceeding to Step 3 (Draft), you MUST discuss your findings and proposed strategy with the user to reach an informal agreement.
-- **Simple Tasks:** Briefly describe your proposed strategy in the chat to ensure alignment, then **STOP and wait** for the user to confirm agreement before drafting the plan.
-- **Standard Tasks:** If multiple viable approaches exist, present a concise summary (including pros/cons and your recommendation) via ${formatToolName(ASK_USER_TOOL_NAME)} and wait for a decision.
-- **Complex Tasks:** You MUST present at least two viable approaches with detailed trade-offs via ${formatToolName(ASK_USER_TOOL_NAME)} and obtain approval before drafting the plan.
-
-**CRITICAL:** You MUST NOT proceed to Step 3 (Draft) or Step 4 (Review & Approval) in the same turn as your initial strategy proposal. You MUST wait for user feedback and reach a clear agreement before drafting or submitting the plan.
+${renderPlanningConsultStep(options.interactive)}
 
 ### 3. Draft
 Write the implementation plan to \`${options.plansDir}/\`. The plan's structure adapts to the task:
@@ -642,7 +637,7 @@ Write the implementation plan to \`${options.plansDir}/\`. The plan's structure 
 - **Complex Tasks:** Include **Background & Motivation**, **Scope & Impact**, **Proposed Solution**, **Alternatives Considered**, a phased **Implementation Plan**, **Verification**, and **Migration & Rollback** strategies.${options.interactive ? '\n- **Alignment Check:** After drafting the plan, you MUST present it to the user in the chat (adhering to Rule 7 for presenting plans) to ensure alignment on the specific details. Ask for feedback or confirmation, and proceed to Step 4 (Review & Approval) once the user agrees with the detailed plan.' : ''}
 
 ### 4. Review & Approval
-ONLY use the built-in ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} tool to present the plan for formal approval AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy. **CRITICAL: NEVER attempt to call this tool via ${formatToolName(SHELL_TOOL_NAME)}.** When called, this tool will present the plan and ${options.interactive ? 'formally request approval.' : 'begin implementation.'}
+ONLY use the built-in ${formatToolName(EXIT_PLAN_MODE_TOOL_NAME)} tool to present the plan for formal approval ${options.interactive ? 'AFTER you have reached an informal agreement with the user in the chat regarding the proposed strategy.' : 'once the plan is drafted.'} **CRITICAL: NEVER attempt to call this tool via ${formatToolName(SHELL_TOOL_NAME)}.** When called, this tool will present the plan and ${options.interactive ? 'formally request approval.' : 'begin implementation.'}
 
 ${renderApprovedPlanSection(options.approvedPlanPath)}`.trim();
 }
@@ -755,6 +750,18 @@ function workflowStepStrategy(options: PrimaryWorkflowsOptions): string {
   return `2. **Strategy:** Formulate a grounded plan based on your research.${
     options.interactive ? ' Share a concise summary of your strategy.' : ''
   }`;
+}
+
+function renderPlanningConsultStep(interactive: boolean): string {
+  if (!interactive) {
+    return `The depth of your consultation should be proportional to the task's complexity. No user is available to consult in this non-interactive session, so briefly note your proposed strategy, then proceed directly to Step 3 (Draft) without waiting for feedback.`;
+  }
+  return `The depth of your consultation should be proportional to the task's complexity. Before proceeding to Step 3 (Draft), you MUST discuss your findings and proposed strategy with the user to reach an informal agreement.
+- **Simple Tasks:** Briefly describe your proposed strategy in the chat to ensure alignment, then **STOP and wait** for the user to confirm agreement before drafting the plan.
+- **Standard Tasks:** If multiple viable approaches exist, present a concise summary (including pros/cons and your recommendation) via ${formatToolName(ASK_USER_TOOL_NAME)} and wait for a decision.
+- **Complex Tasks:** You MUST present at least two viable approaches with detailed trade-offs via ${formatToolName(ASK_USER_TOOL_NAME)} and obtain approval before drafting the plan.
+
+**CRITICAL:** You MUST NOT proceed to Step 3 (Draft) or Step 4 (Review & Approval) in the same turn as your initial strategy proposal. You MUST wait for user feedback and reach a clear agreement before drafting or submitting the plan.`;
 }
 
 function workflowVerifyStandardsSuffix(interactive: boolean): string {


### PR DESCRIPTION
## Summary

Fixes #28913. In non-interactive mode (e.g. `gemini -p "..." -y`), Plan Mode's workflow instructions told the agent to stop and wait for a user turn that will never arrive, causing non-interactive Plan Mode runs to hang — exactly the behavior reported in #28913 and its predecessor #26004.

This runtime has **two parallel, structurally-independent prompt template files**, selected at runtime by `supportsModernFeatures(desiredModel)` in `packages/core/src/prompts/promptProvider.ts`:
- `packages/core/src/prompts/snippets.ts` ("modern" — used for Gemini 3 / custom models)
- `packages/core/src/prompts/snippets.legacy.ts` ("legacy" — used for all other models, including the default `gemini-2.5-pro`)

Both files had their own copy of the same bug in `renderPlanningWorkflow`, and both are fixed here.

## Details

### Modern path (`snippets.ts`)
- Extracted the Step 2 "Consult" instructions into a new `renderPlanningConsultStep(interactive: boolean)` helper, mirroring the existing pattern used elsewhere in this file (e.g. `mandateContinueWork`, `workflowVerifyStandardsSuffix`) for branching prompt text on `options.interactive`.
  - Interactive sessions keep the exact original text (STOP-and-wait, `ask_user` consultation, etc.) — verified byte-for-byte via existing prompt snapshot tests, which still pass unmodified.
  - Non-interactive sessions now get: "No user is available to consult in this non-interactive session, so briefly note your proposed strategy, then proceed directly to Step 3 (Draft) without waiting for feedback."
- Also guarded the Step 4 "Review & Approval" sentence that unconditionally referenced reaching "an informal agreement with the user in the chat" — same bug, same fix shape, since that step follows directly from Step 2/3.

### Legacy path (`snippets.legacy.ts`)
An initial version of this PR only patched the modern file. A review caught that `snippets.legacy.ts` has its own `renderPlanningWorkflow` with the identical defect, reachable by any session resolving to a non-"modern" model (e.g. OAuth users without confirmed preview-model access, or `--model gemini-2.5-pro`/`gemini-2.5-flash`) — a real, non-theoretical subset of non-interactive users that the original fix left broken.

- Added `interactive: boolean` to `PlanningWorkflowOptions` in `snippets.legacy.ts` (it was previously omitted from the type even though the caller already passed it — see `promptProvider.ts:202-220`, `interactive: interactiveMode`).
- Guarded the "**IMPORTANT: ... Wait for user input before proceeding to the next phase.**" line in `renderPlanningWorkflow`: non-interactive sessions now get "No user is available to consult in this non-interactive session, so proceed directly to the next phase using your best judgement instead of waiting for input."
- Guarded the Phase 1 `ask_user` clarifying-questions guidance the same way: non-interactive sessions are told to make reasonable assumptions instead of asking, since no user is available.

No changes to policy engine, tool availability, or non-prompt logic — this is a prompt-text fix only, touching only the two snippet files and their shared test file.

## Testing

Added tests to `packages/core/src/core/prompts.test.ts`, covering both prompt paths:
- `should not tell the agent to wait for user feedback in non-interactive PLAN mode` (modern)
- `should tell the agent to wait for user feedback in interactive PLAN mode` (modern)
- `should not tell the agent to wait for user input in non-interactive PLAN mode (legacy prompt)`
- `should tell the agent to wait for user input in interactive PLAN mode (legacy prompt)`

Verified the new legacy-path test fails without the legacy fix:
```
$ git checkout HEAD~1 -- packages/core/src/prompts/snippets.legacy.ts
$ npx vitest run src/core/prompts.test.ts -t "legacy prompt"
 FAIL  src/core/prompts.test.ts > ... > should not tell the agent to wait for user input in non-interactive PLAN mode (legacy prompt)
 AssertionError: expected '...Wait for user input before proceeding to the next phase...' not to contain 'Wait for user input before proceeding to the next phase'
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed | 71 skipped (74)
$ git checkout HEAD -- packages/core/src/prompts/snippets.legacy.ts
```

(The modern-path revert-and-fail was verified identically in the prior review pass: reverting `snippets.ts` alone causes the modern non-interactive test to fail with `AssertionError: expected '...STOP and wait...' not to contain 'STOP and wait'`.)

With the fix applied:
```
$ npx vitest run src/core/prompts.test.ts
 Test Files  1 passed (1)
      Tests  74 passed (74)
$ npx vitest run src/prompts src/core/prompts.test.ts   # full prompts + provider suite
 Test Files  6 passed (6)
      Tests  135 passed (135)
```

Also ran:
```
$ npx eslint packages/core/src/prompts/snippets.legacy.ts packages/core/src/core/prompts.test.ts   # clean
$ npx tsc -p packages/core/tsconfig.json --noEmit                                                  # clean
```

## AI assistance disclosure

This change (analysis, implementation, and tests) was prepared with AI assistance (Claude Code / Anthropic).
