### PR TITLE
fix(core): prevent SSRF in MCP OAuth metadata discovery and authentication

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -260,8 +260,14 @@ export type { MCPOAuthConfig } from './mcp/oauth-provider.js';
 export type {
   OAuthAuthorizationServerMetadata,
   OAuthProtectedResourceMetadata,
+  OAuthUrlValidationOptions,
 } from './mcp/oauth-utils.js';
-export { OAuthUtils } from './mcp/oauth-utils.js';
+export {
+  OAuthUtils,
+  OAuthSecurityError,
+  isLoopbackUrl,
+  validateOAuthEndpointUrl,
+} from './mcp/oauth-utils.js';
 
 // Export telemetry functions
 export * from './telemetry/index.js';

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -2269,4 +2269,54 @@ describe('MCPOAuthProvider', () => {
       expect(result.metadata).toBe(oktaMetadata);
     });
   });
+
+  describe('remote MCP server loopback restriction enforcement', () => {
+    it('rejects dynamic client registration to loopback when mcpServerUrl is remote', async () => {
+      const authProvider = new MCPOAuthProvider();
+      const providerWithAccess = authProvider as unknown as {
+        registerClient: (
+          registrationUrl: string,
+          config: MCPOAuthConfig,
+          redirectPort: number,
+          mcpServerUrl?: string,
+        ) => Promise<unknown>;
+      };
+
+      await expect(
+        providerWithAccess.registerClient(
+          'http://127.0.0.1:18080/register',
+          mockConfig,
+          7777,
+          'https://remote-mcp.example.com',
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('passes allowLoopback=false during metadata discovery when mcpServerUrl is remote', async () => {
+      const authProvider = new MCPOAuthProvider();
+      const providerWithAccess = authProvider as unknown as {
+        discoverAuthServerMetadataForRegistration: (
+          issuer: string,
+          mcpServerUrl?: string,
+        ) => Promise<unknown>;
+      };
+
+      const spy = vi
+        .spyOn(OAuthUtils, 'discoverAuthorizationServerMetadata')
+        .mockResolvedValueOnce({
+          issuer: 'https://remote-auth.example.com',
+          authorization_endpoint: 'https://remote-auth.example.com/authorize',
+          token_endpoint: 'https://remote-auth.example.com/token',
+        });
+
+      await providerWithAccess.discoverAuthServerMetadataForRegistration(
+        'https://remote-auth.example.com',
+        'https://remote-mcp.example.com',
+      );
+
+      expect(spy).toHaveBeenCalledWith('https://remote-auth.example.com', {
+        allowLoopback: false,
+      });
+    });
+  });
 });

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -56,6 +56,13 @@ vi.mock('node:readline', () => ({
 
 import * as http from 'node:http';
 import * as crypto from 'node:crypto';
+import * as dnsPromises from 'node:dns/promises';
+import type { LookupAddress, LookupAllOptions } from 'node:dns';
+import ipaddr from 'ipaddr.js';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
 import {
   MCPOAuthProvider,
   type MCPOAuthConfig,
@@ -172,6 +179,18 @@ describe('MCPOAuthProvider', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.mocked(
+      dnsPromises.lookup as (
+        hostname: string,
+        options: LookupAllOptions,
+      ) => Promise<LookupAddress[]>,
+    ).mockImplementation(async (hostname: string) => {
+      if (ipaddr.isValid(hostname)) {
+        return [{ address: hostname, family: hostname.includes(':') ? 6 : 4 }];
+      }
+      return [{ address: '93.184.216.34', family: 4 }];
+    });
 
     // Mock crypto functions
     vi.mocked(crypto.randomBytes).mockImplementation((size: number) => {
@@ -2197,8 +2216,8 @@ describe('MCPOAuthProvider', () => {
       expect(
         vi.mocked(OAuthUtils.discoverAuthorizationServerMetadata).mock.calls,
       ).toEqual([
-        ['http://localhost:8888'],
-        ['http://localhost:8888/realms/my-realm'],
+        ['http://localhost:8888', { allowLoopback: true }],
+        ['http://localhost:8888/realms/my-realm', { allowLoopback: true }],
       ]);
       expect(result.issuerUrl).toBe('http://localhost:8888/realms/my-realm');
       expect(result.metadata).toBe(registrationMetadata);

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -106,9 +106,9 @@ export class MCPOAuthProvider {
     redirectPort: number,
     mcpServerUrl?: string,
   ): Promise<OAuthClientRegistrationResponse> {
-    const allowLoopback =
-      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
-      isLoopbackUrl(registrationUrl);
+    const allowLoopback = mcpServerUrl
+      ? isLoopbackUrl(mcpServerUrl)
+      : isLoopbackUrl(registrationUrl);
     const validatedRegistrationUrl = await validateOAuthEndpointUrl(
       registrationUrl,
       {
@@ -168,9 +168,9 @@ export class MCPOAuthProvider {
       Awaited<ReturnType<typeof OAuthUtils.discoverAuthorizationServerMetadata>>
     >;
   }> {
-    const allowLoopback =
-      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
-      isLoopbackUrl(issuer);
+    const allowLoopback = mcpServerUrl
+      ? isLoopbackUrl(mcpServerUrl)
+      : isLoopbackUrl(issuer);
     const authUrl = new URL(issuer);
 
     // Preserve path components for issuers with path-based discovery (e.g., Keycloak)
@@ -454,12 +454,12 @@ export class MCPOAuthProvider {
       );
     }
 
-    const allowLoopback =
-      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
-      (config.authorizationUrl
-        ? isLoopbackUrl(config.authorizationUrl)
-        : false) ||
-      (config.tokenUrl ? isLoopbackUrl(config.tokenUrl) : false);
+    const allowLoopback = mcpServerUrl
+      ? isLoopbackUrl(mcpServerUrl)
+      : (config.authorizationUrl
+          ? isLoopbackUrl(config.authorizationUrl)
+          : false) ||
+        (config.tokenUrl ? isLoopbackUrl(config.tokenUrl) : false);
     await validateOAuthEndpointUrl(config.authorizationUrl, {
       allowLoopback,
     });

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -10,7 +10,13 @@ import { openBrowserSecurely } from '../utils/secure-browser-launcher.js';
 import type { OAuthToken } from './token-storage/types.js';
 import { MCPOAuthTokenStorage } from './oauth-token-storage.js';
 import { getErrorMessage, FatalCancellationError } from '../utils/errors.js';
-import { OAuthUtils, ResourceMismatchError } from './oauth-utils.js';
+import {
+  OAuthUtils,
+  ResourceMismatchError,
+  OAuthSecurityError,
+  isLoopbackUrl,
+  validateOAuthEndpointUrl,
+} from './oauth-utils.js';
 import { coreEvents } from '../utils/events.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { getConsentForOauth } from '../utils/authConsent.js';
@@ -98,7 +104,18 @@ export class MCPOAuthProvider {
     registrationUrl: string,
     config: MCPOAuthConfig,
     redirectPort: number,
+    mcpServerUrl?: string,
   ): Promise<OAuthClientRegistrationResponse> {
+    const allowLoopback =
+      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
+      isLoopbackUrl(registrationUrl);
+    const validatedRegistrationUrl = await validateOAuthEndpointUrl(
+      registrationUrl,
+      {
+        allowLoopback,
+      },
+    );
+
     const redirectUri = getRedirectUri(config, redirectPort);
 
     const registrationRequest: OAuthClientRegistrationRequest = {
@@ -110,7 +127,7 @@ export class MCPOAuthProvider {
       scope: config.scopes?.join(' ') || '',
     };
 
-    const response = await fetch(registrationUrl, {
+    const response = await fetch(validatedRegistrationUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -144,12 +161,16 @@ export class MCPOAuthProvider {
 
   private async discoverAuthServerMetadataForRegistration(
     issuer: string,
+    mcpServerUrl?: string,
   ): Promise<{
     issuerUrl: string;
     metadata: NonNullable<
       Awaited<ReturnType<typeof OAuthUtils.discoverAuthorizationServerMetadata>>
     >;
   }> {
+    const allowLoopback =
+      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
+      isLoopbackUrl(issuer);
     const authUrl = new URL(issuer);
 
     // Preserve path components for issuers with path-based discovery (e.g., Keycloak)
@@ -197,12 +218,14 @@ export class MCPOAuthProvider {
       Awaited<ReturnType<typeof OAuthUtils.discoverAuthorizationServerMetadata>>
     > | null = null;
 
-    for (const issuer of attemptedIssuers) {
-      debugLogger.debug(`   Trying issuer URL: ${issuer}`);
-      const metadata =
-        await OAuthUtils.discoverAuthorizationServerMetadata(issuer);
+    for (const issuerCandidate of attemptedIssuers) {
+      debugLogger.debug(`   Trying issuer URL: ${issuerCandidate}`);
+      const metadata = await OAuthUtils.discoverAuthorizationServerMetadata(
+        issuerCandidate,
+        { allowLoopback },
+      );
       if (metadata) {
-        selectedIssuer = issuer;
+        selectedIssuer = issuerCandidate;
         discoveredMetadata = metadata;
         break;
       }
@@ -330,7 +353,10 @@ export class MCPOAuthProvider {
         }
       } catch (error) {
         // Re-throw security validation errors
-        if (error instanceof ResourceMismatchError) {
+        if (
+          error instanceof ResourceMismatchError ||
+          error instanceof OAuthSecurityError
+        ) {
           throw error;
         }
 
@@ -392,7 +418,10 @@ export class MCPOAuthProvider {
 
         debugLogger.debug('→ Attempting dynamic client registration...');
         const { metadata: authServerMetadata } =
-          await this.discoverAuthServerMetadataForRegistration(config.issuer);
+          await this.discoverAuthServerMetadataForRegistration(
+            config.issuer,
+            mcpServerUrl,
+          );
         registrationUrl = authServerMetadata.registration_endpoint;
       }
 
@@ -402,6 +431,7 @@ export class MCPOAuthProvider {
           registrationUrl,
           config,
           redirectPort,
+          mcpServerUrl,
         );
 
         config.clientId = clientRegistration.client_id;
@@ -423,6 +453,19 @@ export class MCPOAuthProvider {
         'Missing required OAuth configuration after discovery and registration',
       );
     }
+
+    const allowLoopback =
+      (mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false) ||
+      (config.authorizationUrl
+        ? isLoopbackUrl(config.authorizationUrl)
+        : false) ||
+      (config.tokenUrl ? isLoopbackUrl(config.tokenUrl) : false);
+    await validateOAuthEndpointUrl(config.authorizationUrl, {
+      allowLoopback,
+    });
+    await validateOAuthEndpointUrl(config.tokenUrl, {
+      allowLoopback,
+    });
 
     // Build flow config for shared utilities
     const flowConfig: OAuthFlowConfig = {

--- a/packages/core/src/mcp/oauth-utils.test.ts
+++ b/packages/core/src/mcp/oauth-utils.test.ts
@@ -5,11 +5,21 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as dnsPromises from 'node:dns/promises';
+import type { LookupAddress, LookupAllOptions } from 'node:dns';
+import ipaddr from 'ipaddr.js';
 import {
   OAuthUtils,
+  OAuthSecurityError,
+  validateOAuthEndpointUrl,
+  isLoopbackUrl,
   type OAuthAuthorizationServerMetadata,
   type OAuthProtectedResourceMetadata,
 } from './oauth-utils.js';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -21,6 +31,18 @@ describe('OAuthUtils', () => {
     vi.spyOn(console, 'debug').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.mocked(
+      dnsPromises.lookup as (
+        hostname: string,
+        options: LookupAllOptions,
+      ) => Promise<LookupAddress[]>,
+    ).mockImplementation(async (hostname: string) => {
+      if (ipaddr.isValid(hostname)) {
+        return [{ address: hostname, family: hostname.includes(':') ? 6 : 4 }];
+      }
+      return [{ address: '93.184.216.34', family: 4 }];
+    });
   });
 
   afterEach(() => {
@@ -505,6 +527,189 @@ describe('OAuthUtils', () => {
       const token = `header.${Buffer.from('{ not valid json').toString('base64')}.signature`;
       const result = OAuthUtils.parseTokenExpiry(token);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('validateOAuthEndpointUrl & SSRF Protections', () => {
+    it('should allow valid public HTTPS URLs', async () => {
+      const validated = await validateOAuthEndpointUrl(
+        'https://auth.example.com/authorize',
+      );
+      expect(validated).toBe('https://auth.example.com/authorize');
+    });
+
+    it('should allow localhost URLs when allowLoopback is true', async () => {
+      const validated = await validateOAuthEndpointUrl(
+        'http://localhost:3000/oauth',
+        { allowLoopback: true },
+      );
+      expect(validated).toBe('http://localhost:3000/oauth');
+    });
+
+    it('should reject HTTP URLs for remote hosts', async () => {
+      await expect(
+        validateOAuthEndpointUrl('http://auth.example.com/authorize'),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should reject loopback URLs when allowLoopback is false', async () => {
+      await expect(
+        validateOAuthEndpointUrl('http://127.0.0.1:18080/authorize', {
+          allowLoopback: false,
+        }),
+      ).rejects.toThrow(OAuthSecurityError);
+
+      await expect(
+        validateOAuthEndpointUrl('https://localhost:8080/authorize', {
+          allowLoopback: false,
+        }),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should reject private IPv4 addresses (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)', async () => {
+      await expect(
+        validateOAuthEndpointUrl('https://10.0.0.1/oauth'),
+      ).rejects.toThrow(OAuthSecurityError);
+
+      await expect(
+        validateOAuthEndpointUrl('https://172.16.0.1/oauth'),
+      ).rejects.toThrow(OAuthSecurityError);
+
+      await expect(
+        validateOAuthEndpointUrl('https://192.168.1.1/oauth'),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should reject cloud instance metadata endpoints (169.254.169.254)', async () => {
+      await expect(
+        validateOAuthEndpointUrl('http://169.254.169.254/latest/meta-data'),
+      ).rejects.toThrow(OAuthSecurityError);
+
+      await expect(
+        validateOAuthEndpointUrl('https://169.254.169.254/computeMetadata/v1'),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should reject domains resolving to private IPs (DNS rebinding / SSRF)', async () => {
+      vi.mocked(
+        dnsPromises.lookup as (
+          hostname: string,
+          options: LookupAllOptions,
+        ) => Promise<LookupAddress[]>,
+      ).mockImplementationOnce(async () => [
+        { address: '127.0.0.1', family: 4 },
+      ]);
+
+      await expect(
+        validateOAuthEndpointUrl('https://attacker-domain.com/metadata'),
+      ).rejects.toThrow(/resolves to private network address/);
+    });
+
+    it('should reject domains resolving to AWS/GCP metadata IP', async () => {
+      vi.mocked(
+        dnsPromises.lookup as (
+          hostname: string,
+          options: LookupAllOptions,
+        ) => Promise<LookupAddress[]>,
+      ).mockImplementationOnce(async () => [
+        { address: '169.254.169.254', family: 4 },
+      ]);
+
+      await expect(
+        validateOAuthEndpointUrl('https://rebinding-cloud.com/metadata'),
+      ).rejects.toThrow(/resolves to private network address/);
+    });
+
+    it('should enforce origin matching when expectedOrigin is specified', async () => {
+      await expect(
+        validateOAuthEndpointUrl('https://attacker.com/metadata', {
+          expectedOrigin: 'https://legit-mcp.com',
+        }),
+      ).rejects.toThrow(/does not match expected origin/);
+
+      const validated = await validateOAuthEndpointUrl(
+        'https://legit-mcp.com/metadata',
+        {
+          expectedOrigin: 'https://legit-mcp.com',
+        },
+      );
+      expect(validated).toBe('https://legit-mcp.com/metadata');
+    });
+
+    it('should resolve and validate relative URLs with baseUri', async () => {
+      const validated = await validateOAuthEndpointUrl(
+        '/.well-known/metadata',
+        {
+          allowRelative: true,
+          baseUri: 'https://legit-mcp.com/mcp',
+          expectedOrigin: 'https://legit-mcp.com',
+        },
+      );
+      expect(validated).toBe('https://legit-mcp.com/.well-known/metadata');
+    });
+
+    it('should identify loopback URLs correctly', () => {
+      expect(isLoopbackUrl('http://localhost:3000')).toBe(true);
+      expect(isLoopbackUrl('http://127.0.0.1:8080/mcp')).toBe(true);
+      expect(isLoopbackUrl('http://[::1]:9000')).toBe(true);
+      expect(isLoopbackUrl('https://example.com')).toBe(false);
+      expect(isLoopbackUrl('http://10.0.0.1')).toBe(false);
+    });
+  });
+
+  describe('SSRF Chained Attack Scenarios', () => {
+    it('should block chained SSRF when attacker server points authorization_servers to 127.0.0.1', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            resource: 'https://mcp.attacker.com/mcp',
+            authorization_servers: ['http://127.0.0.1:18080'],
+          }),
+      });
+
+      await expect(
+        OAuthUtils.discoverOAuthFromWWWAuthenticate(
+          'Bearer resource_metadata="https://mcp.attacker.com/metadata"',
+          'https://mcp.attacker.com/mcp',
+        ),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should block chained SSRF when attacker server points resource_metadata to internal IP', async () => {
+      await expect(
+        OAuthUtils.discoverOAuthFromWWWAuthenticate(
+          'Bearer resource_metadata="http://127.0.0.1:18080/metadata"',
+          'https://mcp.attacker.com/mcp',
+        ),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should block chained SSRF when attacker server points resource_metadata to cloud metadata IP', async () => {
+      await expect(
+        OAuthUtils.discoverOAuthFromWWWAuthenticate(
+          'Bearer resource_metadata="http://169.254.169.254/computeMetadata/v1"',
+          'https://mcp.attacker.com/mcp',
+        ),
+      ).rejects.toThrow(OAuthSecurityError);
+    });
+
+    it('should block chained SSRF when attacker returns authorization_servers pointing to 169.254.169.254', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            resource: 'https://mcp.attacker.com/mcp',
+            authorization_servers: ['http://169.254.169.254'],
+          }),
+      });
+
+      await expect(
+        OAuthUtils.discoverOAuthFromWWWAuthenticate(
+          'Bearer resource_metadata="https://mcp.attacker.com/metadata"',
+          'https://mcp.attacker.com/mcp',
+        ),
+      ).rejects.toThrow(OAuthSecurityError);
     });
   });
 });

--- a/packages/core/src/mcp/oauth-utils.ts
+++ b/packages/core/src/mcp/oauth-utils.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { lookup } from 'node:dns/promises';
 import type { MCPOAuthConfig } from './oauth-provider.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { debugLogger } from '../utils/debugLogger.js';
+import {
+  isAddressPrivate,
+  isLoopbackHost,
+  sanitizeHostname,
+} from '../utils/fetch.js';
 
 /**
  * Error thrown when the discovered resource metadata does not match the expected resource.
@@ -16,6 +22,142 @@ export class ResourceMismatchError extends Error {
     super(message);
     this.name = 'ResourceMismatchError';
   }
+}
+
+/**
+ * Error thrown when an OAuth endpoint fails SSRF or URL security validation.
+ */
+export class OAuthSecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthSecurityError';
+  }
+}
+
+/**
+ * Checks if a given URL string points to a loopback address.
+ */
+export function isLoopbackUrl(urlStr: string): boolean {
+  try {
+    const url = new URL(urlStr);
+    return isLoopbackHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Options for validating OAuth endpoint URLs.
+ */
+export interface OAuthUrlValidationOptions {
+  allowLoopback?: boolean;
+  expectedOrigin?: string;
+  allowRelative?: boolean;
+  baseUri?: string;
+}
+
+/**
+ * Validates an OAuth endpoint URL against SSRF, scheme, and origin constraints per RFC 9728 Section 7.7.
+ */
+export async function validateOAuthEndpointUrl(
+  urlStr: string,
+  options?: OAuthUrlValidationOptions,
+): Promise<string> {
+  let resolvedUrl = urlStr.trim();
+  if (options?.allowRelative && options.baseUri) {
+    try {
+      resolvedUrl = new URL(resolvedUrl, options.baseUri).toString();
+    } catch (e) {
+      throw new OAuthSecurityError(
+        `Failed to resolve relative OAuth URL "${urlStr}" against base "${options.baseUri}": ${getErrorMessage(e)}`,
+      );
+    }
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(resolvedUrl);
+  } catch (e) {
+    throw new OAuthSecurityError(
+      `Invalid OAuth endpoint URL "${resolvedUrl}": ${getErrorMessage(e)}`,
+    );
+  }
+
+  const isHttp = parsed.protocol === 'http:';
+  const isHttps = parsed.protocol === 'https:';
+  if (!isHttp && !isHttps) {
+    throw new OAuthSecurityError(
+      `Invalid OAuth endpoint protocol "${parsed.protocol}". Only HTTPS (and HTTP for local development) is supported.`,
+    );
+  }
+
+  const hostname = sanitizeHostname(parsed.hostname);
+  const isLoopback = isLoopbackHost(hostname);
+
+  if (isHttp && (!options?.allowLoopback || !isLoopback)) {
+    throw new OAuthSecurityError(
+      `Insecure HTTP OAuth endpoint "${resolvedUrl}" is not allowed. OAuth endpoints must use HTTPS unless connecting to localhost.`,
+    );
+  }
+
+  if (options?.expectedOrigin) {
+    let expected: string;
+    try {
+      expected = new URL(options.expectedOrigin).origin;
+    } catch {
+      throw new OAuthSecurityError(
+        `Invalid expected origin "${options.expectedOrigin}".`,
+      );
+    }
+    if (parsed.origin !== expected) {
+      throw new OAuthSecurityError(
+        `OAuth endpoint origin "${parsed.origin}" does not match expected origin "${expected}".`,
+      );
+    }
+  }
+
+  if (isLoopback) {
+    if (!options?.allowLoopback) {
+      throw new OAuthSecurityError(
+        `Loopback OAuth endpoint "${resolvedUrl}" is not allowed for remote MCP servers.`,
+      );
+    }
+    return parsed.toString();
+  }
+
+  // Non-loopback host: check literal IP
+  if (isAddressPrivate(hostname)) {
+    throw new OAuthSecurityError(
+      `OAuth endpoint "${resolvedUrl}" points to private or reserved IP address which is blocked.`,
+    );
+  }
+
+  // Asynchronous DNS resolution to prevent DNS rebinding / SSRF
+  try {
+    const addresses = await lookup(hostname, { all: true });
+    if (!addresses || addresses.length === 0) {
+      throw new OAuthSecurityError(
+        `Failed to resolve hostname "${hostname}" for OAuth endpoint "${resolvedUrl}".`,
+      );
+    }
+
+    for (const addr of addresses) {
+      if (isAddressPrivate(addr.address)) {
+        throw new OAuthSecurityError(
+          `OAuth endpoint "${resolvedUrl}" resolves to private network address "${addr.address}" which is blocked.`,
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof OAuthSecurityError) {
+      throw error;
+    }
+    throw new OAuthSecurityError(
+      `DNS lookup failed for OAuth endpoint host "${hostname}": ${getErrorMessage(error)}`,
+    );
+  }
+
+  return parsed.toString();
 }
 
 /**
@@ -91,19 +233,29 @@ export class OAuthUtils {
    * Fetch OAuth protected resource metadata.
    *
    * @param resourceMetadataUrl The protected resource metadata URL
+   * @param options Validation options including loopback allowance and expected origin
    * @returns The protected resource metadata or null if not available
    */
   static async fetchProtectedResourceMetadata(
     resourceMetadataUrl: string,
+    options?: { allowLoopback?: boolean; expectedOrigin?: string },
   ): Promise<OAuthProtectedResourceMetadata | null> {
     try {
-      const response = await fetch(resourceMetadataUrl);
+      const validatedUrl = await validateOAuthEndpointUrl(resourceMetadataUrl, {
+        allowLoopback: options?.allowLoopback,
+        expectedOrigin: options?.expectedOrigin,
+      });
+
+      const response = await fetch(validatedUrl);
       if (!response.ok) {
         return null;
       }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       return (await response.json()) as OAuthProtectedResourceMetadata;
     } catch (error) {
+      if (error instanceof OAuthSecurityError) {
+        throw error;
+      }
       debugLogger.debug(
         `Failed to fetch protected resource metadata from ${resourceMetadataUrl}: ${getErrorMessage(error)}`,
       );
@@ -115,19 +267,31 @@ export class OAuthUtils {
    * Fetch OAuth authorization server metadata.
    *
    * @param authServerMetadataUrl The authorization server metadata URL
+   * @param options Validation options including loopback allowance
    * @returns The authorization server metadata or null if not available
    */
   static async fetchAuthorizationServerMetadata(
     authServerMetadataUrl: string,
+    options?: { allowLoopback?: boolean },
   ): Promise<OAuthAuthorizationServerMetadata | null> {
     try {
-      const response = await fetch(authServerMetadataUrl);
+      const validatedUrl = await validateOAuthEndpointUrl(
+        authServerMetadataUrl,
+        {
+          allowLoopback: options?.allowLoopback,
+        },
+      );
+
+      const response = await fetch(validatedUrl);
       if (!response.ok) {
         return null;
       }
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       return (await response.json()) as OAuthAuthorizationServerMetadata;
     } catch (error) {
+      if (error instanceof OAuthSecurityError) {
+        throw error;
+      }
       debugLogger.debug(
         `Failed to fetch authorization server metadata from ${authServerMetadataUrl}: ${getErrorMessage(error)}`,
       );
@@ -158,12 +322,18 @@ export class OAuthUtils {
    * trying the standard well-known endpoints.
    *
    * @param authServerUrl The authorization server URL
+   * @param options Validation options including loopback allowance
    * @returns The authorization server metadata or null if not found
    */
   static async discoverAuthorizationServerMetadata(
     authServerUrl: string,
+    options?: { allowLoopback?: boolean },
   ): Promise<OAuthAuthorizationServerMetadata | null> {
-    const authServerUrlObj = new URL(authServerUrl);
+    const validatedBaseUrl = await validateOAuthEndpointUrl(authServerUrl, {
+      allowLoopback: options?.allowLoopback,
+    });
+
+    const authServerUrlObj = new URL(validatedBaseUrl);
     const base = `${authServerUrlObj.protocol}//${authServerUrlObj.host}`;
 
     const endpointsToTry: string[] = [];
@@ -210,8 +380,10 @@ export class OAuthUtils {
     );
 
     for (const endpoint of endpointsToTry) {
-      const authServerMetadata =
-        await this.fetchAuthorizationServerMetadata(endpoint);
+      const authServerMetadata = await this.fetchAuthorizationServerMetadata(
+        endpoint,
+        options,
+      );
       if (authServerMetadata) {
         return authServerMetadata;
       }
@@ -233,11 +405,15 @@ export class OAuthUtils {
     serverUrl: string,
   ): Promise<MCPOAuthConfig | null> {
     try {
+      const allowLoopback = isLoopbackUrl(serverUrl);
+      const expectedOrigin = new URL(serverUrl).origin;
+
       // RFC 9728 §3.1: Construct well-known URL by inserting /.well-known/oauth-protected-resource
       // between the host and path. This is the RFC-compliant approach.
       const wellKnownUrls = this.buildWellKnownUrls(serverUrl);
       let resourceMetadata = await this.fetchProtectedResourceMetadata(
         wellKnownUrls.protectedResource,
+        { allowLoopback, expectedOrigin },
       );
 
       // Fallback: If path-based discovery fails and we have a path, try root-based discovery
@@ -248,6 +424,7 @@ export class OAuthUtils {
           const rootBasedUrls = this.buildWellKnownUrls(serverUrl, true);
           resourceMetadata = await this.fetchProtectedResourceMetadata(
             rootBasedUrls.protectedResource,
+            { allowLoopback, expectedOrigin },
           );
         }
       }
@@ -273,7 +450,9 @@ export class OAuthUtils {
         // Use the first authorization server
         const authServerUrl = resourceMetadata.authorization_servers[0];
         const authServerMetadata =
-          await this.discoverAuthorizationServerMetadata(authServerUrl);
+          await this.discoverAuthorizationServerMetadata(authServerUrl, {
+            allowLoopback,
+          });
 
         if (authServerMetadata) {
           const config = this.metadataToOAuthConfig(authServerMetadata);
@@ -289,8 +468,12 @@ export class OAuthUtils {
 
       // Fallback: try well-known endpoints at the base URL
       debugLogger.debug(`Trying OAuth discovery fallback at ${serverUrl}`);
-      const authServerMetadata =
-        await this.discoverAuthorizationServerMetadata(serverUrl);
+      const authServerMetadata = await this.discoverAuthorizationServerMetadata(
+        serverUrl,
+        {
+          allowLoopback,
+        },
+      );
 
       if (authServerMetadata) {
         const config = this.metadataToOAuthConfig(authServerMetadata);
@@ -305,7 +488,10 @@ export class OAuthUtils {
 
       return null;
     } catch (error) {
-      if (error instanceof ResourceMismatchError) {
+      if (
+        error instanceof ResourceMismatchError ||
+        error instanceof OAuthSecurityError
+      ) {
         throw error;
       }
       debugLogger.debug(
@@ -322,10 +508,10 @@ export class OAuthUtils {
    * @returns The resource metadata URI if found
    */
   static parseWWWAuthenticateHeader(header: string): string | null {
-    // Parse Bearer realm and resource_metadata
-    const match = header.match(/resource_metadata="([^"]+)"/);
+    // Parse Bearer realm and resource_metadata (quoted or unquoted token)
+    const match = header.match(/resource_metadata=(?:"([^"]+)"|([^\s,]+))/);
     if (match) {
-      return match[1];
+      return match[1] || match[2] || null;
     }
     return null;
   }
@@ -347,8 +533,28 @@ export class OAuthUtils {
       return null;
     }
 
-    const resourceMetadata =
-      await this.fetchProtectedResourceMetadata(resourceMetadataUri);
+    const allowLoopback = mcpServerUrl ? isLoopbackUrl(mcpServerUrl) : false;
+    const expectedOrigin = mcpServerUrl
+      ? new URL(mcpServerUrl).origin
+      : undefined;
+
+    const validatedResourceMetadataUrl = await validateOAuthEndpointUrl(
+      resourceMetadataUri,
+      {
+        allowLoopback,
+        expectedOrigin,
+        allowRelative: true,
+        baseUri: mcpServerUrl,
+      },
+    );
+
+    const resourceMetadata = await this.fetchProtectedResourceMetadata(
+      validatedResourceMetadataUrl,
+      {
+        allowLoopback,
+        expectedOrigin,
+      },
+    );
 
     if (resourceMetadata && mcpServerUrl) {
       // Validate resource parameter per RFC 9728 Section 7.3
@@ -370,8 +576,12 @@ export class OAuthUtils {
     }
 
     const authServerUrl = resourceMetadata.authorization_servers[0];
-    const authServerMetadata =
-      await this.discoverAuthorizationServerMetadata(authServerUrl);
+    const authServerMetadata = await this.discoverAuthorizationServerMetadata(
+      authServerUrl,
+      {
+        allowLoopback,
+      },
+    );
 
     if (authServerMetadata) {
       return this.metadataToOAuthConfig(authServerMetadata);

--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as dnsPromises from 'node:dns/promises';
+import type { LookupAddress, LookupAllOptions } from 'node:dns';
+import ipaddr from 'ipaddr.js';
 import type {
   OAuthFlowConfig,
   OAuthRefreshConfig,
@@ -19,6 +22,10 @@ import {
   refreshAccessToken,
   REDIRECT_PATH,
 } from './oauth-flow.js';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
 
 // Save real fetch for startCallbackServer tests (which hit a real local server)
 const realFetch = global.fetch;
@@ -59,6 +66,18 @@ describe('oauth-flow', () => {
   beforeEach(() => {
     vi.stubEnv('OAUTH_CALLBACK_PORT', '');
     mockFetch.mockReset();
+
+    vi.mocked(
+      dnsPromises.lookup as (
+        hostname: string,
+        options: LookupAllOptions,
+      ) => Promise<LookupAddress[]>,
+    ).mockImplementation(async (hostname: string) => {
+      if (ipaddr.isValid(hostname)) {
+        return [{ address: hostname, family: hostname.includes(':') ? 6 : 4 }];
+      }
+      return [{ address: '93.184.216.34', family: 4 }];
+    });
   });
 
   afterEach(() => {
@@ -795,6 +814,52 @@ describe('oauth-flow', () => {
 
       expect(result.access_token).toBe('refreshed-token');
       expect(result.expires_in).toBe(1800);
+    });
+
+    it('should reject token refresh when tokenUrl points to private IP or loopback from remote', async () => {
+      await expect(
+        refreshAccessToken(
+          refreshConfig,
+          'refresh-token',
+          'http://127.0.0.1:18080/token',
+          'https://mcp.remote.com',
+        ),
+      ).rejects.toThrow();
+
+      await expect(
+        refreshAccessToken(
+          refreshConfig,
+          'refresh-token',
+          'http://169.254.169.254/token',
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('should reject token exchange when tokenUrl points to private IP or loopback from remote', async () => {
+      await expect(
+        exchangeCodeForToken(
+          {
+            ...baseConfig,
+            tokenUrl: 'http://127.0.0.1:18080/token',
+          },
+          'code',
+          'verifier',
+          3000,
+          'https://mcp.remote.com',
+        ),
+      ).rejects.toThrow();
+
+      await expect(
+        exchangeCodeForToken(
+          {
+            ...baseConfig,
+            tokenUrl: 'http://169.254.169.254/token',
+          },
+          'code',
+          'verifier',
+          3000,
+        ),
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -16,6 +16,7 @@ import * as crypto from 'node:crypto';
 import type * as net from 'node:net';
 import { URL } from 'node:url';
 import { debugLogger } from './debugLogger.js';
+import { validateOAuthEndpointUrl, isLoopbackUrl } from '../mcp/oauth-utils.js';
 
 /**
  * Configuration for an OAuth 2.0 Authorization Code flow.
@@ -507,7 +508,14 @@ export async function exchangeCodeForToken(
     params.append('resource', resource);
   }
 
-  const response = await fetch(config.tokenUrl, {
+  const allowLoopback = resource
+    ? isLoopbackUrl(resource)
+    : isLoopbackUrl(config.tokenUrl);
+  const validatedTokenUrl = await validateOAuthEndpointUrl(config.tokenUrl, {
+    allowLoopback,
+  });
+
+  const response = await fetch(validatedTokenUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -560,7 +568,14 @@ export async function refreshAccessToken(
     params.append('resource', resource);
   }
 
-  const response = await fetch(tokenUrl, {
+  const allowLoopback = resource
+    ? isLoopbackUrl(resource)
+    : isLoopbackUrl(tokenUrl);
+  const validatedTokenUrl = await validateOAuthEndpointUrl(tokenUrl, {
+    allowLoopback,
+  });
+
+  const response = await fetch(validatedTokenUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Enforce RFC 9728 Section 7.7 and RFC 8414 security constraints during MCP OAuth discovery, dynamic client registration, and token exchange/refresh.

- Enforce HTTPS for remote OAuth endpoints (allow HTTP only for loopback when connecting to local MCP servers)
- Validate origin matching for resource_metadata in WWW-Authenticate challenges
- Block private IPv4/IPv6 address ranges, loopback endpoints from remote servers, link-local / IMDS (169.254.169.254), benchmark ranges (198.18.0.0/15), and multicast/broadcast
- Perform asynchronous DNS resolution to prevent DNS rebinding attacks against internal IP ranges
- Validate dynamic client registration endpoints and token exchange/refresh URLs prior to issuing requests
- Add comprehensive test coverage in oauth-utils.test.ts, oauth-provider.test.ts, and oauth-flow.test.ts

## Summary
Prevents Server-Side Request Forgery (SSRF) during Model Context Protocol (MCP) OAuth 2.0 metadata discovery, dynamic client registration, and token exchange/refresh flows by implementing strict URL validation, origin matching, and network boundary enforcement per **RFC 9728 Section 7.7** and **RFC 8414**.
## Details
Remote MCP servers returning unvalidated `WWW-Authenticate: Bearer resource_metadata="..."` challenge headers or `authorization_servers` URLs could previously trigger out-of-band HTTP requests to internal IP addresses, local services (`localhost`/`127.0.0.1`), or cloud instance metadata services (IMDS at `169.254.169.254`).
### Core Protections Implemented:
1. **Scheme & Loopback Enforcement**:
   - Requires `https:` for all remote endpoints.
   - Allows `http:` only for loopback addresses (`localhost`, `127.0.0.1`, `[::1]`) when explicitly connecting to a local MCP server (`allowLoopback: true`).
   - Disallows loopback redirection/discovery when connecting to a remote MCP server (`allowLoopback: false`).
2. **RFC 9728 §7.7 Origin Validation**:
   - Verifies that `resource_metadata` in `WWW-Authenticate` strictly matches the MCP server's origin.
   - Properly resolves relative metadata URLs against the MCP server base URI.
3. **Private IP & Cloud IMDS Blocking**:
   - Rejects private IPv4 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10`), link-local / IMDS (`169.254.169.254`), benchmark testing (`198.18.0.0/15`), IPv6 private/link-local ranges, and multicast/broadcast addresses.
4. **DNS Rebinding Prevention**:
   - Asynchronously resolves hostnames via `node:dns/promises` and validates all resolved IP addresses against private network boundaries before issuing HTTP requests.
5. **Flow Endpoint Validation**:
   - Validates dynamic client registration endpoints in `MCPOAuthProvider.registerClient()` before issuing registration POST requests.
   - Validates `tokenUrl` in `exchangeCodeForToken()` and `refreshAccessToken()` before issuing token requests.
   - Propagates `OAuthSecurityError` without swallowing security rejections.
## How to Validate
### 1. Automated Tests
Run the targeted OAuth unit tests covering SSRF attack scenarios, cloud metadata blocking, DNS rebinding, and origin matching:
```bash
npm test -w @google/gemini-cli-core -- src/mcp/oauth-utils.test.ts src/mcp/oauth-provider.test.ts src/utils/oauth-flow.test.ts
```
Run full typecheck and linting:
```bash
npm run typecheck
npm run lint
```
### 2. Edge Cases Verified:
- Remote MCP server returning `authorization_servers: ["http://127.0.0.1:18080"]` -> Throws `OAuthSecurityError`.
- Remote MCP server returning `resource_metadata="http://169.254.169.254/computeMetadata/v1"` -> Throws `OAuthSecurityError`.
- Domain name resolving to `127.0.0.1` or `169.254.169.254` (DNS rebinding) -> Throws `OAuthSecurityError`.
- `WWW-Authenticate` header with unquoted `resource_metadata=https://example.com/oauth/metadata` vs quoted strings -> Both parsed and validated.
- Local MCP server on `http://localhost:3000` -> Loopback permitted, non-loopback private IPs still blocked.
## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run