### PR TITLE
fix(cli): prevent concurrent extension install races

### DIFF
--- a/packages/cli/src/config/extension-manager.test.ts
+++ b/packages/cli/src/config/extension-manager.test.ts
@@ -11,7 +11,11 @@ import * as path from 'node:path';
 import { ExtensionManager } from './extension-manager.js';
 import { createTestMergedSettings, type MergedSettings } from './settings.js';
 import { createExtension } from '../test-utils/createExtension.js';
-import { EXTENSIONS_DIRECTORY_NAME } from './extensions/variables.js';
+import {
+  EXTENSIONS_DIRECTORY_NAME,
+  INSTALL_METADATA_FILENAME,
+} from './extensions/variables.js';
+import { ExtensionStorage } from './extensions/storage.js';
 import { themeManager } from '../ui/themes/theme-manager.js';
 import {
   TrustLevel,
@@ -223,6 +227,339 @@ describe('ExtensionManager', () => {
       expect(names).toEqual(['ext1', 'ext2']);
 
       fs.rmSync(externalDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('concurrent installation locking', () => {
+    function createLocalSource(
+      prefix: string,
+      name: string,
+      version: string,
+      marker: string,
+    ): string {
+      const sourceDir = fs.mkdtempSync(path.join(tempHomeDir, prefix));
+      fs.writeFileSync(
+        path.join(sourceDir, 'gemini-extension.json'),
+        JSON.stringify({ name, version }),
+      );
+      fs.writeFileSync(path.join(sourceDir, marker), marker);
+      return sourceDir;
+    }
+
+    function createManager(
+      integrityManager: typeof mockIntegrityManager = mockIntegrityManager,
+    ): ExtensionManager {
+      return new ExtensionManager({
+        settings: createTestMergedSettings(),
+        workspaceDir: tempWorkspaceDir,
+        requestConsent: vi.fn().mockResolvedValue(true),
+        requestSetting: null,
+        integrityManager,
+      });
+    }
+
+    function createStoreBarrier() {
+      let notifyStoreStarted!: () => void;
+      const storeStarted = new Promise<void>((resolve) => {
+        notifyStoreStarted = resolve;
+      });
+      let releaseStore!: () => void;
+      const storeCanFinish = new Promise<void>((resolve) => {
+        releaseStore = resolve;
+      });
+      const integrityManager = {
+        verify: vi.fn().mockResolvedValue(IntegrityDataStatus.VERIFIED),
+        store: vi.fn().mockImplementation(async () => {
+          notifyStoreStarted();
+          await storeCanFinish;
+        }),
+      };
+
+      return { integrityManager, storeStarted, releaseStore };
+    }
+
+    it('allows only one concurrent install to write the destination', async () => {
+      const winnerSource = createLocalSource(
+        'winner-source-',
+        'shared-name',
+        '1.0.0',
+        'winner-only.txt',
+      );
+      const loserSource = createLocalSource(
+        'loser-source-',
+        'shared-name',
+        '2.0.0',
+        'loser-only.txt',
+      );
+      const { integrityManager, storeStarted, releaseStore } =
+        createStoreBarrier();
+      const winnerManager = createManager(integrityManager);
+      const loserManager = createManager({
+        verify: vi.fn().mockResolvedValue(IntegrityDataStatus.VERIFIED),
+        store: vi.fn().mockResolvedValue(undefined),
+      });
+      await Promise.all([
+        winnerManager.loadExtensions(),
+        loserManager.loadExtensions(),
+      ]);
+
+      const winnerInstall = winnerManager.installOrUpdateExtension({
+        type: 'local',
+        source: winnerSource,
+      });
+      await storeStarted;
+
+      await expect(
+        loserManager.installOrUpdateExtension({
+          type: 'local',
+          source: loserSource,
+        }),
+      ).rejects.toThrow(
+        'Extension "shared-name" is currently being installed or updated by another process.',
+      );
+
+      releaseStore();
+      const installed = await winnerInstall;
+      const destinationPath = path.join(userExtensionsDir, 'shared-name');
+      const metadata = JSON.parse(
+        fs.readFileSync(
+          path.join(destinationPath, INSTALL_METADATA_FILENAME),
+          'utf8',
+        ),
+      ) as { source: string };
+
+      expect(installed.version).toBe('1.0.0');
+      expect(metadata.source).toBe(winnerSource);
+      expect(fs.existsSync(path.join(destinationPath, 'winner-only.txt'))).toBe(
+        true,
+      );
+      expect(fs.existsSync(path.join(destinationPath, 'loser-only.txt'))).toBe(
+        false,
+      );
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'shared-name.lock',
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not expose installation locks to extension discovery', async () => {
+      const source = createLocalSource(
+        'discovery-source-',
+        'discoverable',
+        '1.0.0',
+        'content.txt',
+      );
+      const { integrityManager, storeStarted, releaseStore } =
+        createStoreBarrier();
+      const installingManager = createManager(integrityManager);
+      await installingManager.loadExtensions();
+
+      const install = installingManager.installOrUpdateExtension({
+        type: 'local',
+        source,
+      });
+      await storeStarted;
+
+      const settings = {
+        security: {
+          folderTrust: { enabled: false },
+          allowedExtensions: [source.replace(/\\/g, '\\\\')],
+        },
+        experimental: { extensionConfig: false },
+        admin: { extensions: { enabled: true }, mcp: { enabled: true } },
+        hooksConfig: { enabled: true },
+      } as unknown as MergedSettings;
+      const loadingManager = new ExtensionManager({
+        settings,
+        workspaceDir: tempWorkspaceDir,
+        requestConsent: vi.fn().mockResolvedValue(true),
+        requestSetting: null,
+      });
+
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'discoverable.lock',
+          ),
+        ),
+      ).toBe(true);
+      await expect(loadingManager.loadExtensions()).resolves.toHaveLength(1);
+
+      releaseStore();
+      await install;
+    });
+
+    it('prevents concurrent updates from replacing each other', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'update-target',
+        version: '1.0.0',
+      });
+      const winnerSource = createLocalSource(
+        'winner-update-',
+        'update-target',
+        '2.0.0',
+        'winner-update.txt',
+      );
+      const loserSource = createLocalSource(
+        'loser-update-',
+        'update-target',
+        '3.0.0',
+        'loser-update.txt',
+      );
+      const { integrityManager, storeStarted, releaseStore } =
+        createStoreBarrier();
+      const winnerManager = createManager(integrityManager);
+      const loserManager = createManager();
+      await Promise.all([
+        winnerManager.loadExtensions(),
+        loserManager.loadExtensions(),
+      ]);
+      const previousConfig = { name: 'update-target', version: '1.0.0' };
+
+      const winnerUpdate = winnerManager.installOrUpdateExtension(
+        { type: 'local', source: winnerSource },
+        previousConfig,
+      );
+      await storeStarted;
+
+      await expect(
+        loserManager.installOrUpdateExtension(
+          { type: 'local', source: loserSource },
+          previousConfig,
+        ),
+      ).rejects.toThrow(/currently being installed or updated/);
+
+      releaseStore();
+      await winnerUpdate;
+      const destinationPath = path.join(userExtensionsDir, 'update-target');
+      expect(
+        fs.existsSync(path.join(destinationPath, 'winner-update.txt')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(destinationPath, 'loser-update.txt')),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'update-target.lock',
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it('locks both names while renaming an extension', async () => {
+      createExtension({
+        extensionsDir: userExtensionsDir,
+        name: 'old-name',
+        version: '1.0.0',
+      });
+      const renamedSource = createLocalSource(
+        'renamed-source-',
+        'new-name',
+        '2.0.0',
+        'renamed.txt',
+      );
+      const competingSource = createLocalSource(
+        'competing-source-',
+        'new-name',
+        '1.0.0',
+        'competing.txt',
+      );
+      const { integrityManager, storeStarted, releaseStore } =
+        createStoreBarrier();
+      const updateManager = createManager(integrityManager);
+      const installManager = createManager();
+      await Promise.all([
+        updateManager.loadExtensions(),
+        installManager.loadExtensions(),
+      ]);
+
+      const renameUpdate = updateManager.installOrUpdateExtension(
+        { type: 'local', source: renamedSource },
+        { name: 'old-name', version: '1.0.0' },
+      );
+      await storeStarted;
+
+      await expect(
+        installManager.installOrUpdateExtension({
+          type: 'local',
+          source: competingSource,
+        }),
+      ).rejects.toThrow(/currently being installed or updated/);
+
+      releaseStore();
+      await renameUpdate;
+      expect(fs.existsSync(path.join(userExtensionsDir, 'old-name'))).toBe(
+        false,
+      );
+      expect(
+        fs.existsSync(path.join(userExtensionsDir, 'new-name', 'renamed.txt')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(userExtensionsDir, 'new-name', 'competing.txt'),
+        ),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'old-name.lock',
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'new-name.lock',
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it('releases the lock when installation fails', async () => {
+      const source = createLocalSource(
+        'failing-source-',
+        'failing-install',
+        '1.0.0',
+        'content.txt',
+      );
+      const integrityManager = {
+        verify: vi.fn().mockResolvedValue(IntegrityDataStatus.VERIFIED),
+        store: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('integrity storage failed'))
+          .mockResolvedValue(undefined),
+      };
+      const manager = createManager(integrityManager);
+      await manager.loadExtensions();
+
+      await expect(
+        manager.installOrUpdateExtension({ type: 'local', source }),
+      ).rejects.toThrow('integrity storage failed');
+
+      const destinationPath = path.join(userExtensionsDir, 'failing-install');
+      expect(
+        fs.existsSync(
+          path.join(
+            ExtensionStorage.getUserExtensionsLockDir(),
+            'failing-install.lock',
+          ),
+        ),
+      ).toBe(false);
+
+      fs.rmSync(destinationPath, { recursive: true, force: true });
+      await expect(
+        manager.installOrUpdateExtension({ type: 'local', source }),
+      ).resolves.toMatchObject({ name: 'failing-install' });
     });
   });
 

--- a/packages/cli/src/config/extension-manager.ts
+++ b/packages/cli/src/config/extension-manager.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { stat } from 'node:fs/promises';
 import chalk from 'chalk';
+import { lock } from 'proper-lockfile';
 import { ExtensionEnablementManager } from './extensions/extensionEnablement.js';
 import { type MergedSettings, SettingScope } from './settings.js';
 import { createHash, randomUUID } from 'node:crypto';
@@ -243,6 +244,7 @@ export class ExtensionManager extends ExtensionLoader {
       }
 
       let tempDir: string | undefined;
+      let releaseExtensionLocks: ReleaseExtensionLock | undefined;
 
       if (
         installMetadata.type === 'git' ||
@@ -354,6 +356,10 @@ Would you like to attempt to install via "git clone" instead?`,
         const destinationPath = new ExtensionStorage(
           newExtensionName,
         ).getExtensionDir();
+        releaseExtensionLocks = await acquireExtensionLocks(
+          isUpdate ? [previousName, newExtensionName] : [newExtensionName],
+          newExtensionName,
+        );
 
         if (
           (!isUpdate || newExtensionName !== previousName) &&
@@ -496,6 +502,7 @@ Would you like to attempt to install via "git clone" instead?`,
           );
         }
       } finally {
+        await releaseExtensionLocks?.();
         if (tempDir) {
           await fs.promises.rm(tempDir, { recursive: true, force: true });
         }
@@ -1235,6 +1242,65 @@ Would you like to attempt to install via "git clone" instead?`,
     }
     await this.maybeStartExtension(extension);
   }
+}
+
+type ReleaseExtensionLock = () => Promise<void>;
+
+async function releaseExtensionLocks(
+  releases: ReleaseExtensionLock[],
+): Promise<void> {
+  for (const release of releases.reverse()) {
+    try {
+      await release();
+    } catch (error) {
+      debugLogger.error(
+        'Failed to release extension installation lock:',
+        error,
+      );
+    }
+  }
+}
+
+async function acquireExtensionLocks(
+  extensionNames: string[],
+  requestedExtensionName: string,
+): Promise<ReleaseExtensionLock> {
+  const releases: ReleaseExtensionLock[] = [];
+  // A stable order prevents rename operations from deadlocking each other.
+  const uniqueNames = [...new Set(extensionNames)].sort();
+  const locksDir = ExtensionStorage.getUserExtensionsLockDir();
+
+  try {
+    await fs.promises.mkdir(locksDir, { recursive: true });
+    for (const extensionName of uniqueNames) {
+      const extensionPath = new ExtensionStorage(
+        extensionName,
+      ).getExtensionDir();
+      releases.push(
+        await lock(extensionPath, {
+          realpath: false,
+          // Keep lock directories outside the extensions directory because the
+          // loader treats every entry there as a potential extension.
+          lockfilePath: path.join(locksDir, `${extensionName}.lock`),
+        }),
+      );
+    }
+  } catch (error) {
+    await releaseExtensionLocks(releases);
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ELOCKED'
+    ) {
+      throw new Error(
+        `Extension "${requestedExtensionName}" is currently being installed or updated by another process. Please try again.`,
+      );
+    }
+    throw error;
+  }
+
+  return async () => releaseExtensionLocks(releases);
 }
 
 function filterMcpConfig(original: MCPServerConfig): MCPServerConfig {

--- a/packages/cli/src/config/extensions/extensionUpdates.test.ts
+++ b/packages/cli/src/config/extensions/extensionUpdates.test.ts
@@ -42,6 +42,10 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
+vi.mock('proper-lockfile', () => ({
+  lock: vi.fn().mockResolvedValue(vi.fn().mockResolvedValue(undefined)),
+}));
+
 vi.mock('@google/gemini-cli-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@google/gemini-cli-core')>();
@@ -119,6 +123,9 @@ vi.mock('./storage.js', () => ({
     }
     static getUserExtensionsDir() {
       return '/mock/extensions';
+    }
+    static getUserExtensionsLockDir() {
+      return '/mock/extension-locks';
     }
     static createTmpDir() {
       return Promise.resolve('/mock/tmp');

--- a/packages/cli/src/config/extensions/storage.ts
+++ b/packages/cli/src/config/extensions/storage.ts
@@ -39,6 +39,10 @@ export class ExtensionStorage {
     return new Storage(homedir()).getExtensionsDir();
   }
 
+  static getUserExtensionsLockDir(): string {
+    return path.join(new Storage(homedir()).getGeminiDir(), 'extension-locks');
+  }
+
   static async createTmpDir(): Promise<string> {
     return fs.promises.mkdtemp(path.join(os.tmpdir(), 'gemini-extension'));
   }


### PR DESCRIPTION
## Summary

Prevent two Gemini CLI processes from installing or updating the same extension at the same time.

Without coordination, both processes can pass the destination check and then interleave file copies and metadata writes. This change uses the existing `proper-lockfile` dependency to give one process exclusive access to each affected extension name.

## Details

- Acquire the lock after source preparation and consent, but before checking or modifying the destination.
- Lock both the old and new names during a rename, using a stable order to avoid deadlocks.
- Keep lock artifacts in `~/.gemini/extension-locks` so extension discovery never treats them as installed extensions.
- Release every acquired lock in the existing cleanup path, including failed installs.
- Add deterministic coverage for competing installs, updates, renames, failed installs, and extension discovery while a lock is active.

## Related Issues

Fixes #29036

## How to Validate

```sh
npm test -w @google/gemini-cli -- src/config/extension-manager.test.ts src/config/extensions/extensionUpdates.test.ts src/config/extensions/update.test.ts src/commands/extensions/update.test.ts
npm run typecheck -w @google/gemini-cli
npx eslint packages/cli/src/config/extension-manager.ts packages/cli/src/config/extension-manager.test.ts packages/cli/src/config/extensions/storage.ts packages/cli/src/config/extensions/extensionUpdates.test.ts --max-warnings 0
```

The focused test run passes 46 tests across four files.

## Pre-Merge Checklist

- [x] Documentation changes are not needed for this internal concurrency fix
- [x] Added regression tests
- [x] No breaking changes
- [x] Validated with npm on macOS
