### PR TITLE
fix(vscode-ide-companion): resolve stop() with an MCP stream open

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.test.ts
+++ b/packages/vscode-ide-companion/src/ide-server.test.ts
@@ -535,4 +535,82 @@ describe('IDEServer HTTP endpoints', () => {
     // but it's not a host error, which is what we are testing.
     expect(response.statusCode).toBe(400);
   });
+  it('should resolve stop() while an MCP stream is open', async () => {
+    // The bug: stop() awaited server.close(), whose callback fires only once
+    // every established connection has drained. The MCP transport holds a
+    // long-lived streaming response on GET /mcp, so nothing drained and
+    // extension deactivate blocked behind stop() forever.
+    //
+    // An idle socket does not reproduce it: close() destroys those. The
+    // connection has to be one the server is actively holding open, which
+    // means a real session and a real stream.
+    const initialize = await request(
+      port,
+      {
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          Host: `localhost:${port}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          Authorization: 'Bearer test-auth-token',
+        },
+      },
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'stop-test', version: '1.0.0' },
+        },
+      }),
+    );
+    const sessionId = initialize.headers['mcp-session-id'] as string;
+    expect(sessionId).toBeTruthy();
+
+    // Held open by the server for the lifetime of the session.
+    const stream = http.request({
+      hostname: '127.0.0.1',
+      port,
+      path: '/mcp',
+      method: 'GET',
+      headers: {
+        Host: `localhost:${port}`,
+        Accept: 'text/event-stream',
+        Authorization: 'Bearer test-auth-token',
+        'mcp-session-id': sessionId,
+      },
+    });
+    const streamOpen = new Promise<void>((resolve, reject) => {
+      stream.once('response', (res) => {
+        expect(res.statusCode).toBe(200);
+        res.resume();
+        resolve();
+      });
+      stream.once('error', reject);
+    });
+    stream.end();
+    await streamOpen;
+
+    try {
+      await expect(
+        Promise.race([
+          ideServer.stop().then(() => 'stopped' as const),
+          new Promise<'timed out'>((resolve) =>
+            setTimeout(() => resolve('timed out'), 3000),
+          ),
+        ]),
+      ).resolves.toBe('stopped');
+
+      // stop() must close the transport, not just stop listening. The
+      // transport's onclose handler is what clears the keep-alive interval
+      // and drops the session, so this log line is the observable proof that
+      // the interval is not still pinging a server that is gone.
+      expect(mockLog).toHaveBeenCalledWith(`Session closed: ${sessionId}`);
+    } finally {
+      stream.destroy();
+    }
+  });
 });

--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -127,6 +127,12 @@ export class IDEServer {
   private authToken: string | undefined;
   private transports: { [sessionId: string]: StreamableHTTPServerTransport } =
     {};
+  // Every live keep-alive interval, including those for transports that have
+  // not finished initializing and so are not in `transports` yet. `onclose`
+  // removes an entry; `stop()` clears whatever is left. Without this, a
+  // transport that never completes its handshake keeps a 60s timer running
+  // against a server that is already gone.
+  private keepAliveIntervals: Set<NodeJS.Timeout> = new Set();
   private openFilesManager: OpenFilesManager | undefined;
   diffManager: DiffManager;
 
@@ -242,12 +248,19 @@ export class IDEServer {
                     `Session ${sessionId} missed ${missedPings} pings. Closing connection and cleaning up interval.`,
                   );
                   clearInterval(keepAlive);
+                  this.keepAliveIntervals.delete(keepAlive);
+                  // The log above has always claimed this closes the
+                  // connection. Until now it only stopped the pings, leaving
+                  // the transport in `transports` and its socket open.
+                  void transport.close();
                 }
               });
           }, 60000); // 60 sec
+          this.keepAliveIntervals.add(keepAlive);
 
           transport.onclose = () => {
             clearInterval(keepAlive);
+            this.keepAliveIntervals.delete(keepAlive);
             if (transport.sessionId) {
               this.log(`Session closed: ${transport.sessionId}`);
               sessionsWithInitialNotification.delete(transport.sessionId);
@@ -404,8 +417,25 @@ export class IDEServer {
   }
 
   async stop(): Promise<void> {
+    // Order matters. `server.close()` stops new connections but its callback
+    // waits for established ones to drain, and an MCP transport holds a
+    // long-lived streaming response on `GET /mcp`. Closing the transports
+    // first lets that drain happen; `closeAllConnections()` below releases
+    // anything still holding a socket. Without both, the callback never fires
+    // and extension deactivate blocks behind this promise.
+    for (const interval of this.keepAliveIntervals) {
+      clearInterval(interval);
+    }
+    this.keepAliveIntervals.clear();
+
+    await Promise.allSettled(
+      Object.values(this.transports).map((transport) => transport.close()),
+    );
+    this.transports = {};
+
     if (this.server) {
       await new Promise<void>((resolve, reject) => {
+        this.server!.closeAllConnections();
         this.server!.close((err?: Error) => {
           if (err) {
             this.log(`Error shutting down IDE server: ${err.message}`);


### PR DESCRIPTION
Fixes #28785.

`IdeServer.stop()` awaits `this.server.close()`. That callback fires only once every established connection has drained, and the MCP transport holds a long-lived streaming response on `GET /mcp`, so nothing drains. `stop()` never resolves and extension deactivate blocks behind it. VS Code then reports the extension as unresponsive on shutdown.

## What changed

`stop()` now clears the keep-alive intervals, closes the open transports, and calls `closeAllConnections()` alongside `close()`. Closing the transports is what lets the stream drain; `closeAllConnections()` releases anything still holding a socket.

Keep-alive intervals are tracked in a `Set` that is written immediately after `setInterval` returns, not in `onsessioninitialized`. A transport whose handshake never completes is in neither `transports` nor any session map, so an interval registered at initialization time would leave that timer running against a server that is already gone.

The `missedPings >= 3` branch has always logged `Closing connection and cleaning up interval`, but only cleared the interval. It now closes the transport too, which is what the message says and what drops the session.

## What I did not change

The `missedPings = 0` reset on success. The issue I filed lists it, and on reflection consecutive-miss counting is a reasonable reading of "missed pings" rather than a bug. Changing the threshold semantics is a policy call, it is what took the previous attempt at this out of scope, and the leak it was worried about is closed by `stop()` clearing every interval regardless.

## On the test, and what it does not prove

The raw mechanism does reproduce on this Node. A plain server holding one streaming response, then `close()`:

```
stream open; calling server.close()
close callback NEVER fired -> bug reproduces on node v24.10.0
```

The added test opens a real session, holds a real `GET /mcp` stream, and asserts `stop()` resolves. Being straight about it: that assertion alone passes with or without this change in the vitest harness, so on its own it is a regression guard, not a reproduction.

What makes it fail-first is the second assertion, that `stop()` logs `Session closed: <id>`. That only happens if `stop()` actually closes the transport, and `onclose` is what clears the keep-alive interval and drops the session. Reverting `stop()` to its previous body and keeping the test fails on exactly that line. An idle socket does not reproduce anything either, since `close()` destroys those, which is why the test does the full handshake.

## Gates

`npm run lint` and `npm run typecheck` clean. `vitest run src/` in `packages/vscode-ide-companion`: 41 passed, 1 skipped.

Two files, no API changes.