### PR TITLE
fix(core): forward abortSignal to retryWithBackoff in BaseLlmClient

### DIFF
--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -575,6 +575,28 @@ describe('BaseLlmClient', () => {
       );
     });
 
+    it('should forward the caller-provided abortSignal to retryWithBackoff so the overall retry loop honors it', async () => {
+      const mockResponse = createMockResponse('This is the content.');
+      mockGenerateContent.mockResolvedValue(mockResponse);
+
+      const options = {
+        modelConfigKey: { model: 'test-model' },
+        contents: [{ role: 'user', parts: [{ text: 'Give me content.' }] }],
+        abortSignal: abortController.signal,
+        promptId: 'content-prompt-id',
+        role: LlmRole.UTILITY_TOOL,
+      };
+
+      await client.generateContent(options);
+
+      expect(retryWithBackoff).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          signal: options.abortSignal,
+        }),
+      );
+    });
+
     it('should validate content using shouldRetryOnContent function', async () => {
       const mockResponse = createMockResponse('Some valid content.');
       mockGenerateContent.mockResolvedValue(mockResponse);

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -357,6 +357,7 @@ export class BaseLlmClient {
         shouldRetryOnContent,
         maxAttempts:
           availabilityMaxAttempts ?? maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+        signal: abortSignal,
         getAvailabilityContext,
         onPersistent429: this.config.isInteractive()
           ? (authType, error) =>


### PR DESCRIPTION
Relates to #29065

## What

`BaseLlmClient.generateContent` / `generateJson` (the client used by
`SessionSummaryService`, chat compression, the classifier, prompt
completion, etc.) accept an `abortSignal` and thread it into each
individual API call, but never pass it as the `signal` option of
`retryWithBackoff`. As a result, a caller-side timeout only aborts the
in-flight HTTP request — the retry loop itself is not bounded by it and
keeps waiting out its full exponential-backoff schedule and issuing
further attempts regardless of the timeout having already fired.

`geminiChat.ts` and `web-fetch.ts` already pass `signal` to
`retryWithBackoff` for this exact reason; `BaseLlmClient` was the
outlier.

## Relationship to #29065

#29065 reports that session summary generation hardcodes
`gemini-3.1-flash-lite` (via the `summarizer-default` model config in
`defaultModelConfigs.ts`) instead of using the user's configured/active
model, which causes every summary attempt to fail outright on
custom/proxy endpoints that don't serve that model. **This PR does not
fix that.** The hardcoded-model issue is the actual root cause reported
in #29065 and needs a separate fix (making `summarizer-default`, and
likely the other `UTILITY_*` configs with the same pattern, derive from
the user's configured model).

What this PR does fix is a related but secondary symptom visible in the
same issue's logs: because `BaseLlmClient` never forwarded `abortSignal`
into `retryWithBackoff`, `SessionSummaryService`'s own 5s timeout
couldn't stop the retry loop, which otherwise runs ~65s
(5s/10s/20s/30s backoff across 5 attempts) printing "Attempt N failed...
Retrying with backoff" stack traces the whole time. With this fix, a
timed-out or unreachable summary model now fails fast and quietly
(`SessionSummaryService` already handles `AbortError` by logging at
debug level and returning `null`) instead of spamming the terminal for
over a minute past its own timeout budget.

In short: after this change, users on custom endpoints will still see
every session summary attempt fail (since it still targets a hardcoded
model their endpoint may not serve), but they'll see it fail in ~5s
with no retry spam instead of ~65s with a wall of stack traces. This
PR should not auto-close #29065 — leaving it open until the
model-hardcoding is addressed.

## Change

One line: pass `signal: abortSignal` into the `retryWithBackoff` call
inside `BaseLlmClient._generateWithRetry`.

## Test plan

Added a regression test in `packages/core/src/core/baseLlmClient.test.ts`
asserting that `generateContent` forwards its `abortSignal` to
`retryWithBackoff` as the `signal` option.

Confirmed the test fails without the fix (reverted the one-line change
locally and re-ran):

```
$ npx vitest run packages/core/src/core/baseLlmClient.test.ts -t "forward the caller-provided abortSignal"
 FAIL  packages/core/src/core/baseLlmClient.test.ts > BaseLlmClient > generateContent > should forward the caller-provided abortSignal to retryWithBackoff so the overall retry loop honors it
AssertionError: expected "spy" to be called with arguments: [ Any<Function>, ObjectContaining{…} ]
  1st spy call:
  [
-   Any<Function>,
-   ObjectContaining { "signal": AbortSignal {...} },
+   [Function apiCall],
+   { "authType": "gemini-api-key", "maxAttempts": 5, ... }  // no `signal` key
  ]
```

With the fix applied:

```
$ npx vitest run packages/core/src/core/baseLlmClient.test.ts packages/core/src/services/sessionSummaryService.test.ts
 ✓ packages/core/src/services/sessionSummaryService.test.ts (33 tests) 40ms
 ✓ packages/core/src/core/baseLlmClient.test.ts (30 tests) 43ms

 Test Files  2 passed (2)
      Tests  63 passed (63)
```

Also ran:

- `npx eslint packages/core/src/core/baseLlmClient.ts packages/core/src/core/baseLlmClient.test.ts` — clean.
- `npx tsc -p packages/core/tsconfig.json --noEmit` — clean.

## AI assistance disclosure

This change (investigation, fix, and test) was authored with the
assistance of an AI coding agent (Claude Code) and reviewed by me
before submission.
