### PR TITLE
fix(extensions): strip only a trailing .git suffix when parsing GitHub repo names

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -140,6 +140,19 @@ describe('github.ts', () => {
     });
 
     it.each([
+      ['https://github.com/owner/blog.github.io', 'owner', 'blog.github.io'],
+      ['https://github.com/owner/my.git.repo.git', 'owner', 'my.git.repo'],
+      ['https://github.com/owner/repo.GIT', 'owner', 'repo'],
+      ['owner/blog.github.io', 'owner', 'blog.github.io'],
+      ['owner/my.git.repo.git', 'owner', 'my.git.repo'],
+    ])(
+      'should only strip a trailing .git suffix from %s',
+      (url, owner, repo) => {
+        expect(tryParseGithubUrl(url)).toEqual({ owner, repo });
+      },
+    );
+
+    it.each([
       'https://gitlab.com/owner/repo',
       'https://my-git-host.com/owner/group/repo',
       'git@gitlab.com:some-group/some-project/some-repo.git',

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -125,7 +125,7 @@ export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
     );
   }
   const owner = parts[0];
-  const repo = parts[1].replace('.git', '');
+  const repo = parts[1].replace(/\.git$/i, '');
 
   return {
     owner,


### PR DESCRIPTION
## TLDR

`tryParseGithubUrl` used `String.prototype.replace('.git', '')`, which strips the **first occurrence** of `.git` anywhere in the repo name — not just a trailing suffix. Repos like `blog.github.io` were parsed as `hub.io`, producing wrong API URLs (`/repos/owner/hub.io/releases/latest` → 404) and corrupting the extension id used for dedup in settings/state.

This anchors the strip to the end of the name: `.replace(/\.git$/i, '')`.

## Testing

- Added unit tests covering:
  - `https://github.com/owner/blog.github.io` → `blog.github.io` (previously mangled to `hub.io`)
  - `https://github.com/owner/my.git.repo.git` → `my.git.repo`
  - `https://github.com/owner/repo.GIT` → `repo` (case-insensitive suffix)
  - bare `owner/repo` forms of the above
- All existing tests pass: 39/39 in `github.test.ts`

## Checklist

- [x] Verified the fix locally — lint, prettier, typecheck and unit tests all pass.
