### PR TITLE
fix(core): enforce fail-closed workspace trust and filter mcpServers in restricted mode

### DIFF
--- a/packages/a2a-server/src/config/config.test.ts
+++ b/packages/a2a-server/src/config/config.test.ts
@@ -305,7 +305,7 @@ describe('loadConfig', () => {
         adminPolicyPaths: ['/path/to/admin/policy'],
       };
 
-      await loadConfig(settings, mockExtensionLoader, taskId);
+      await loadConfig(settings, mockExtensionLoader, taskId, true);
 
       expect(createPolicyEngineConfig).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/a2a-server/src/config/config.ts
+++ b/packages/a2a-server/src/config/config.ts
@@ -287,8 +287,16 @@ export async function loadConfig(
       ? ApprovalMode.YOLO
       : ApprovalMode.DEFAULT;
 
+  let safeMcpServers = settings.mcpServers;
+  if (!trusted && safeMcpServers) {
+    logger.warn(
+      '[Configuration] Untrusted workspace detected. Stripping repository mcpServers definitions to prevent unintended command execution.',
+    );
+    safeMcpServers = undefined;
+  }
+
   const policySettings: PolicySettings = {
-    mcpServers: settings.mcpServers,
+    mcpServers: safeMcpServers,
     tools: {
       core: settings.tools?.core,
       exclude: settings.tools?.exclude,
@@ -322,7 +330,7 @@ export async function loadConfig(
     showMemoryUsage: settings.showMemoryUsage || false,
     approvalMode,
     policyEngineConfig,
-    mcpServers: settings.mcpServers,
+    mcpServers: safeMcpServers,
     cwd: workspaceDir,
     telemetry: {
       enabled: settings.telemetry?.enabled,

--- a/packages/a2a-server/src/config/workspace_trust.test.ts
+++ b/packages/a2a-server/src/config/workspace_trust.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  Config,
+  checkPathTrust,
+  SimpleExtensionLoader,
+} from '@google/gemini-cli-core';
+import * as core from '@google/gemini-cli-core';
+import { loadConfig } from './config.js';
+import type { Settings } from './settings.js';
+
+describe('Workspace Trust Evaluation', () => {
+  let tempWorkspaceDir: string;
+
+  beforeEach(() => {
+    tempWorkspaceDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-trust-eval-'),
+    );
+    const geminiDir = path.join(tempWorkspaceDir, '.gemini');
+    fs.mkdirSync(geminiDir, { recursive: true });
+
+    vi.stubEnv('GEMINI_API_KEY', 'dummy-key-for-eval');
+    vi.spyOn(Config.prototype, 'initialize').mockResolvedValue(undefined);
+    vi.spyOn(Config.prototype, 'waitForMcpInit').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    fs.rmSync(tempWorkspaceDir, { recursive: true, force: true });
+  });
+
+  it('resolves untrusted environment signals in checkPathTrust', () => {
+    vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+    vi.stubEnv('GEMINI_CLI_TRUST_WORKSPACE', '');
+
+    const result = checkPathTrust({
+      path: tempWorkspaceDir,
+      isFolderTrustEnabled: true,
+    });
+
+    expect(result).toEqual({ isTrusted: false, source: 'env' });
+
+    vi.stubEnv('GEMINI_FOLDER_TRUST', '');
+    vi.stubEnv('GEMINI_RESTRICTED_MODE', 'true');
+
+    const restrictedResult = checkPathTrust({
+      path: tempWorkspaceDir,
+      isFolderTrustEnabled: true,
+    });
+
+    expect(restrictedResult).toEqual({ isTrusted: false, source: 'env' });
+  });
+
+  it('evaluates to false in Config.isTrustedFolder when untrusted signals are present or undefined', () => {
+    vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+
+    const untrustedConfig = new Config({
+      sessionId: 'test-session',
+      clientName: 'test-client',
+      model: 'gemini-pro',
+      targetDir: tempWorkspaceDir,
+      cwd: tempWorkspaceDir,
+      debugMode: false,
+      question: '',
+      folderTrust: false,
+      trustedFolder: undefined,
+    });
+
+    expect(untrustedConfig.isTrustedFolder()).toBe(false);
+
+    vi.unstubAllEnvs();
+
+    const fallbackConfig = new Config({
+      sessionId: 'test-session',
+      clientName: 'test-client',
+      model: 'gemini-pro',
+      targetDir: tempWorkspaceDir,
+      cwd: tempWorkspaceDir,
+      debugMode: false,
+      question: '',
+      folderTrust: true,
+      trustedFolder: undefined,
+    });
+
+    expect(fallbackConfig.isTrustedFolder()).toBe(false);
+  });
+
+  it('assigns undefined to mcpServers in configParams and policySettings when trusted is false', async () => {
+    const policySpy = vi.spyOn(core, 'createPolicyEngineConfig');
+    const settings: Settings = {
+      mcpServers: {
+        'test-tool': {
+          command: 'node',
+          args: ['-e', 'process.exit(0)'],
+        },
+      },
+    };
+
+    const config = await loadConfig(
+      settings,
+      new SimpleExtensionLoader([]),
+      'test-untrusted-task',
+      false,
+      tempWorkspaceDir,
+    );
+
+    expect(config.getMcpServers()).toBeUndefined();
+    expect(policySpy.mock.calls[0][0].mcpServers).toBeUndefined();
+  });
+
+  it('retains mcpServers in configParams and policySettings when trusted is true', async () => {
+    const policySpy = vi.spyOn(core, 'createPolicyEngineConfig');
+    const settings: Settings = {
+      mcpServers: {
+        'test-tool': {
+          command: 'node',
+          args: ['-e', 'process.exit(0)'],
+        },
+      },
+    };
+
+    const config = await loadConfig(
+      settings,
+      new SimpleExtensionLoader([]),
+      'test-trusted-task',
+      true,
+      tempWorkspaceDir,
+    );
+
+    expect(config.getMcpServers()).toEqual(settings.mcpServers);
+    expect(policySpy.mock.calls[0][0].mcpServers).toEqual(settings.mcpServers);
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -3160,6 +3160,14 @@ export class Config implements McpContext, AgentLoopContext {
    * 'false' for untrusted.
    */
   isTrustedFolder(): boolean {
+    if (
+      process.env['GEMINI_RESTRICTED_MODE'] === 'true' ||
+      process.env['GEMINI_FOLDER_TRUST'] === 'false' ||
+      process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'false'
+    ) {
+      return false;
+    }
+
     if (this.trustedFolder !== undefined) {
       return this.trustedFolder;
     }

--- a/packages/core/src/utils/trust.test.ts
+++ b/packages/core/src/utils/trust.test.ts
@@ -49,6 +49,7 @@ describe('Trust Utility (Core)', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     fs.rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -148,6 +149,24 @@ describe('Trust Utility (Core)', () => {
         isFolderTrustEnabled: false,
       });
       expect(result).toEqual({ isTrusted: true, source: undefined });
+    });
+
+    it('should return untrusted from environment when GEMINI_FOLDER_TRUST is false', () => {
+      vi.stubEnv('GEMINI_FOLDER_TRUST', 'false');
+      const result = checkPathTrust({
+        path: '/any',
+        isFolderTrustEnabled: false,
+      });
+      expect(result).toEqual({ isTrusted: false, source: 'env' });
+    });
+
+    it('should return untrusted from environment when GEMINI_RESTRICTED_MODE is true', () => {
+      vi.stubEnv('GEMINI_RESTRICTED_MODE', 'true');
+      const result = checkPathTrust({
+        path: '/any',
+        isFolderTrustEnabled: false,
+      });
+      expect(result).toEqual({ isTrusted: false, source: 'env' });
     });
 
     it('should return IDE trust if available', () => {

--- a/packages/core/src/utils/trust.ts
+++ b/packages/core/src/utils/trust.ts
@@ -44,11 +44,15 @@ export function isTrustLevel(value: unknown): value is TrustLevel {
  * IDE context, and local configuration file.
  */
 export function checkPathTrust(options: TrustOptions): TrustResult {
+  if (
+    process.env['GEMINI_RESTRICTED_MODE'] === 'true' ||
+    process.env['GEMINI_FOLDER_TRUST'] === 'false' ||
+    process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'false'
+  ) {
+    return { isTrusted: false, source: 'env' };
+  }
   if (process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'true') {
     return { isTrusted: true, source: 'env' };
-  }
-  if (process.env['GEMINI_CLI_TRUST_WORKSPACE'] === 'false') {
-    return { isTrusted: false, source: 'env' };
   }
 
   if (!options.isFolderTrustEnabled) {


### PR DESCRIPTION
## Summary

Enforce fail-closed workspace trust resolution and filter out repository-defined `mcpServers` in `@google/gemini-cli-a2a-server` when running in untrusted or restricted environments. This prevents unintended process execution during server startup and ensures that environment trust signals take precedence over configuration fallbacks.

## Details

- **Environment Signal Precedence in `checkPathTrust` (`packages/core/src/utils/trust.ts`):**
  Evaluates `GEMINI_RESTRICTED_MODE`, `GEMINI_FOLDER_TRUST`, and `GEMINI_CLI_TRUST_WORKSPACE` prior to evaluating local options (`options.isFolderTrustEnabled`), immediately returning `{ isTrusted: false, source: 'env' }` when an untrusted signal is present. This prevents permissive fallback resolution when restricted mode is active.
- **Fail-Closed Fallback in `Config.isTrustedFolder()` (`packages/core/src/config/config.ts`):**
  Evaluates untrusted environment variables early to return `false` before checking store context or fallbacks, ensuring downstream components that query `isTrustedFolder()` accurately reflect the untrusted state.
- **Child Process Configuration Filtering (`packages/a2a-server/src/config/config.ts`):**
  In `loadConfig()`, checks the authoritative `trusted` argument. When `!trusted`, strips repository-scoped `mcpServers` definitions (`safeMcpServers = undefined`) before assigning them to `policySettings` and `configParams`.
- **Unit Test Coverage:**
  - Added comprehensive test suite `packages/a2a-server/src/config/workspace_trust.test.ts` validating signal resolution, fail-closed behavior, and MCP configuration filtering under untrusted conditions.
  - Added unit test cases to `packages/core/src/utils/trust.test.ts` for `GEMINI_FOLDER_TRUST` and `GEMINI_RESTRICTED_MODE`.
  - Aligned existing test in `packages/a2a-server/src/config/config.test.ts` to assert MCP definition mapping with `trusted = true`.

## Related Issues


## How to Validate

1. Run targeted unit tests across affected workspaces:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/trust.test.ts
   npm test -w @google/gemini-cli-a2a-server -- src/config/workspace_trust.test.ts
   npm test -w @google/gemini-cli-a2a-server -- src/config/config.test.ts
   ```
2. Verify lint, formatting, and types:
   ```bash
   npm run lint
   npm run typecheck
   npm run format
   ```
## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker