### PR TITLE
feat(cli): add [Skill] tag to slash command autocomplete suggestions and help

### DIFF
--- a/packages/cli/src/ui/components/Help.tsx
+++ b/packages/cli/src/ui/components/Help.tsx
@@ -80,6 +80,9 @@ export const Help: React.FC<Help> = ({ commands }) => (
             {command.kind === CommandKind.MCP_PROMPT && (
               <Text color={theme.text.secondary}> [MCP]</Text>
             )}
+            {command.kind === CommandKind.SKILL && (
+              <Text color={theme.text.secondary}> [Skill]</Text>
+            )}
             {command.description &&
               ' - ' + sanitizeForDisplay(command.description, 100)}
           </Text>
@@ -108,6 +111,9 @@ export const Help: React.FC<Help> = ({ commands }) => (
     <Text color={theme.text.primary}>
       <Text color={theme.text.secondary}>[MCP]</Text> - Model Context Protocol
       command (from external servers)
+    </Text>
+    <Text color={theme.text.primary}>
+      <Text color={theme.text.secondary}>[Skill]</Text> - Agent Skill
     </Text>
 
     <Box height={1} />

--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -122,6 +122,29 @@ describe('SuggestionsDisplay', () => {
     expect(lastFrame()).toMatchSnapshot();
   });
 
+  it('renders Skill tag for skills', async () => {
+    const skillSuggestions = [
+      {
+        label: 'Skill Tool',
+        value: 'skill-tool',
+        commandKind: CommandKind.SKILL,
+      },
+    ];
+
+    const { lastFrame } = await render(
+      <SuggestionsDisplay
+        suggestions={skillSuggestions}
+        activeIndex={0}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput=""
+        mode="reverse"
+      />,
+    );
+    expect(lastFrame()).toMatchSnapshot();
+  });
+
   it('renders command section separators for slash mode', async () => {
     const groupedSuggestions = [
       {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -68,6 +68,7 @@ export function SuggestionsDisplay({
   const COMMAND_KIND_SUFFIX: Partial<Record<CommandKind, string>> = {
     [CommandKind.MCP_PROMPT]: ' [MCP]',
     [CommandKind.AGENT]: ' [Agent]',
+    [CommandKind.SKILL]: ' [Skill]',
   };
 
   const getFullLabel = (s: Suggestion) =>

--- a/packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap
@@ -27,6 +27,11 @@ exports[`SuggestionsDisplay > renders MCP tag for MCP prompts 1`] = `
 "
 `;
 
+exports[`SuggestionsDisplay > renders Skill tag for skills 1`] = `
+" skill-tool [Skill]                                                            
+"
+`;
+
 exports[`SuggestionsDisplay > renders loading state 1`] = `
 " Loading suggestions...
 "


### PR DESCRIPTION
## Summary

Adds a `[Skill]` tag to skill-backed slash commands in the `/` autocomplete menu and `/help` command, mirroring the existing `[MCP]` and `[Agent]` visual treatment. Makes it immediately obvious which entries in the menu are user-installed skills vs. built-in commands or MCP prompts.

**Before:**

    my-skill                      Activate the my-skill skill
    help                          For help on gemini-cli

**After:**

    my-skill [Skill]              Activate the my-skill skill
    help                          For help on gemini-cli

## Context

Issue #21165 asks for manual skill activation via `/skill-name` and discoverability in the command completion menu. While `SkillCommandLoader` converts displayable skills into executable slash commands, skills lacked the `[Skill]` visual badge in `SuggestionsDisplay` and `/help`, making them visually indistinguishable from built-in commands.

## Changes

- `packages/cli/src/ui/components/SuggestionsDisplay.tsx`: Added `[CommandKind.SKILL]: ' [Skill]'` to `COMMAND_KIND_SUFFIX`.
- `packages/cli/src/ui/components/Help.tsx`: Added `[Skill]` badge to skill commands and added `[Skill] - Agent Skill` to the help footer legend.
- `packages/cli/src/ui/components/SuggestionsDisplay.test.tsx`: Added unit test verifying `[Skill]` tag rendering for `CommandKind.SKILL`.
- `packages/cli/src/ui/components/__snapshots__/SuggestionsDisplay.test.tsx.snap`: Updated snapshot.

## Related Issues

Closes #21165
