### PR TITLE
fix(core): flush final SSE event on EOF without trailing blank line

### DIFF
--- a/packages/core/src/code_assist/server.test.ts
+++ b/packages/core/src/code_assist/server.test.ts
@@ -503,6 +503,41 @@ describe('CodeAssistServer', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should yield the final buffered event when the stream ends without a trailing blank line (EOF flush)', async () => {
+    const { server, mockRequest } = createTestServer();
+
+    const { Readable } = await import('node:stream');
+    const mockStream = new Readable({
+      read() {},
+    });
+
+    mockRequest.mockResolvedValue({ data: mockStream });
+
+    const stream = await server.requestStreamingPost('testStream', {});
+
+    const firstEvent = {
+      candidates: [{ content: { parts: [{ text: 'first' }] } }],
+    };
+    const finalEvent = {
+      candidates: [{ content: { parts: [{ text: 'final' }] } }],
+    };
+
+    setTimeout(() => {
+      mockStream.push('data: ' + JSON.stringify(firstEvent) + '\n\n');
+      mockStream.push('data: ' + JSON.stringify(finalEvent) + '\n');
+      mockStream.push(null);
+    }, 0);
+
+    const results = [];
+    for await (const res of stream) {
+      results.push(res);
+    }
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(firstEvent);
+    expect(results[1]).toEqual(finalEvent);
+  });
+
   it('should call the onboardUser endpoint', async () => {
     const { server } = createTestServer();
 

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -495,29 +495,34 @@ export class CodeAssistServer implements ContentGenerator {
       });
 
       let bufferedLines: string[] = [];
+      const flushBufferedLines = function* (): Generator<T> {
+        if (bufferedLines.length === 0) {
+          return; // no data to yield
+        }
+        const chunk = bufferedLines.join('\n');
+        try {
+          yield JSON.parse(chunk);
+        } catch {
+          if (server.config) {
+            logInvalidChunk(
+              server.config,
+              // Don't include the chunk content in the log for security/privacy reasons.
+              new InvalidChunkEvent('Malformed JSON chunk'),
+            );
+          }
+        }
+        bufferedLines = []; // Reset the buffer after yielding
+      };
+
       for await (const line of rl) {
         if (line.startsWith('data: ')) {
           bufferedLines.push(line.slice(6).trim());
         } else if (line === '') {
-          if (bufferedLines.length === 0) {
-            continue; // no data to yield
-          }
-          const chunk = bufferedLines.join('\n');
-          try {
-            yield JSON.parse(chunk);
-          } catch {
-            if (server.config) {
-              logInvalidChunk(
-                server.config,
-                // Don't include the chunk content in the log for security/privacy reasons.
-                new InvalidChunkEvent('Malformed JSON chunk'),
-              );
-            }
-          }
-          bufferedLines = []; // Reset the buffer after yielding
+          yield* flushBufferedLines();
         }
         // Ignore other lines like comments or id fields
       }
+      yield* flushBufferedLines();
     })(this);
   }
 

--- a/packages/core/src/code_assist/server.ts
+++ b/packages/core/src/code_assist/server.ts
@@ -495,13 +495,15 @@ export class CodeAssistServer implements ContentGenerator {
       });
 
       let bufferedLines: string[] = [];
-      const flushBufferedLines = function* (): Generator<T> {
+      const flushBufferedLines = (): T | undefined => {
         if (bufferedLines.length === 0) {
-          return; // no data to yield
+          return undefined;
         }
         const chunk = bufferedLines.join('\n');
+        bufferedLines = [];
         try {
-          yield JSON.parse(chunk);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          return JSON.parse(chunk) as T;
         } catch {
           if (server.config) {
             logInvalidChunk(
@@ -511,18 +513,24 @@ export class CodeAssistServer implements ContentGenerator {
             );
           }
         }
-        bufferedLines = []; // Reset the buffer after yielding
+        return undefined;
       };
 
       for await (const line of rl) {
         if (line.startsWith('data: ')) {
           bufferedLines.push(line.slice(6).trim());
         } else if (line === '') {
-          yield* flushBufferedLines();
+          const chunk = flushBufferedLines();
+          if (chunk !== undefined) {
+            yield chunk;
+          }
         }
         // Ignore other lines like comments or id fields
       }
-      yield* flushBufferedLines();
+      const finalChunk = flushBufferedLines();
+      if (finalChunk !== undefined) {
+        yield finalChunk;
+      }
     })(this);
   }
 


### PR DESCRIPTION
## Summary

The SSE parser in `CodeAssistServer.requestStreamingPost()` silently dropped the final buffered event when a stream ended without a trailing blank line (e.g. a truncated connection or non-conformant proxy). This often lost `finishReason`/usage metadata with no error or log.

## Details

Per the SSE spec, a pending event must be dispatched at EOF too, not just on blank lines. Extracted the parse/yield logic into `flushBufferedLines()` and call it once more after the read loop exits, so nothing pending is lost. No change for streams that already end normally.

## Related Issues

Fixes #29059

## How to Validate

1. `cd packages/core`
2. `npx vitest run src/code_assist/server.test.ts -t "EOF flush"` — new regression test passes (fails on `main`, only 1 of 2 events yielded)
3. `npx vitest run src/code_assist/server.test.ts` — all 38 tests pass
4. `npm run preflight` from repo root — full suite green, no regressions:
   - `packages/core`: 408 test files passed, 1 skipped (409); 7865 tests passed, 50 skipped (7915)
   - `packages/sdk`: 5 files passed, 29 tests passed, 6 skipped
   - `packages/vscode-ide-companion`: 3 files passed, 40 tests passed, 1 skipped

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker