### PR TITLE
 fix(core): route read_file content through FileSystemService

### DIFF
--- a/packages/cli/src/acp/acpFileSystemService.test.ts
+++ b/packages/cli/src/acp/acpFileSystemService.test.ts
@@ -39,6 +39,7 @@ describe('AcpFileSystemService', () => {
     mockFallback = {
       readTextFile: vi.fn(),
       writeTextFile: vi.fn(),
+      readBinaryFile: vi.fn(),
     };
     vi.mocked(os.homedir).mockReturnValue('/home/user');
   });
@@ -231,6 +232,31 @@ describe('AcpFileSystemService', () => {
         code: 'ENOENT',
         message: 'Resource not found for directory',
       });
+    });
+  });
+
+  describe('readBinaryFile', () => {
+    it('should always delegate to the fallback, since ACP has no binary read capability', async () => {
+      // Even with both fs capabilities advertised and the path inside root,
+      // there is no ACP wire method for binary content, so this must never
+      // reach the connection and must always use the fallback (which may
+      // itself be a SandboxedFileSystemService enforcing path validation).
+      service = new AcpFileSystemService(
+        mockConnection,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        mockFallback,
+        '/path/to',
+      );
+      const binaryContent = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      vi.mocked(mockFallback.readBinaryFile).mockResolvedValue(binaryContent);
+
+      const result = await service.readBinaryFile('/path/to/image.png');
+
+      expect(result).toBe(binaryContent);
+      expect(mockFallback.readBinaryFile).toHaveBeenCalledWith(
+        '/path/to/image.png',
+      );
     });
   });
 });

--- a/packages/cli/src/acp/acpFileSystemService.ts
+++ b/packages/cli/src/acp/acpFileSystemService.ts
@@ -85,4 +85,14 @@ export class AcpFileSystemService implements FileSystemService {
       this.normalizeFileSystemError(err);
     }
   }
+
+  async readBinaryFile(filePath: string): Promise<Buffer> {
+    // The ACP `fs` capability only defines readTextFile/writeTextFile — there
+    // is no client-routed way to read binary content over the protocol.
+    // Delegate to the fallback service unconditionally so binary reads still
+    // go through whatever local backing that fallback provides (e.g. a
+    // SandboxedFileSystemService's path validation and sandboxing) rather
+    // than silently reading straight off the host disk.
+    return this.fallback.readBinaryFile(filePath);
+  }
 }

--- a/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
+++ b/packages/cli/src/ui/components/ExitPlanModeDialog.test.tsx
@@ -166,6 +166,7 @@ Implement a comprehensive authentication system with multiple providers.
           getFileSystemService: (): FileSystemService => ({
             readTextFile: vi.fn(),
             writeTextFile: vi.fn(),
+            readBinaryFile: vi.fn(),
           }),
           getUseAlternateBuffer: () => useAlternateBuffer,
           getUseTerminalBuffer: () => false,
@@ -474,6 +475,7 @@ Implement a comprehensive authentication system with multiple providers.
                 getFileSystemService: (): FileSystemService => ({
                   readTextFile: vi.fn(),
                   writeTextFile: vi.fn(),
+                  readBinaryFile: vi.fn(),
                 }),
                 getUseAlternateBuffer: () => useAlternateBuffer ?? true,
                 getUseTerminalBuffer: () => false,

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -25,6 +25,17 @@ export interface FileSystemService {
    * @param content - The content to write
    */
   writeTextFile(filePath: string, content: string): Promise<void>;
+
+  /**
+   * Read the raw bytes of a file (images, PDFs, audio, video, or any other
+   * binary content). Implementations MUST return the exact on-disk bytes —
+   * do not round-trip through a string encoding, since that is lossy for
+   * binary data.
+   *
+   * @param filePath - The path to the file to read
+   * @returns The file content as a Buffer
+   */
+  readBinaryFile(filePath: string): Promise<Buffer>;
 }
 
 /**
@@ -37,5 +48,9 @@ export class StandardFileSystemService implements FileSystemService {
 
   async writeTextFile(filePath: string, content: string): Promise<void> {
     await fs.writeFile(filePath, content, 'utf-8');
+  }
+
+  async readBinaryFile(filePath: string): Promise<Buffer> {
+    return fs.readFile(filePath);
   }
 }

--- a/packages/core/src/services/sandboxedFileSystemService.test.ts
+++ b/packages/core/src/services/sandboxedFileSystemService.test.ts
@@ -113,6 +113,49 @@ describe('SandboxedFileSystemService', () => {
     );
   });
 
+  it('should read raw binary bytes through the sandbox without corruption', async () => {
+    const mockChild = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(mockChild, {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    });
+
+    vi.mocked(spawn).mockReturnValue(mockChild);
+
+    // Bytes that are not valid on their own as UTF-8 (e.g. a lone
+    // continuation byte) to prove the content isn't round-tripped through a
+    // lossy string conversion anywhere in the sandboxed read path, and that
+    // it's emitted across multiple chunks to prove chunk boundaries don't
+    // corrupt multi-byte sequences either.
+    const binaryChunks = [
+      Buffer.from([0x89, 0x50, 0x4e, 0x47]), // PNG magic bytes, split...
+      Buffer.from([0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8]), // ...across chunks
+    ];
+
+    const testFile = path.resolve('/test/cwd/image.png');
+    const readPromise = service.readBinaryFile(testFile);
+
+    setImmediate(() => {
+      for (const chunk of binaryChunks) {
+        mockChild.stdout!.emit('data', chunk);
+      }
+      mockChild.emit('close', 0);
+    });
+
+    const content = await readPromise;
+    expect(Buffer.isBuffer(content)).toBe(true);
+    expect(content).toEqual(Buffer.concat(binaryChunks));
+    expect(vi.mocked(sandboxManager.prepareCommand)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: '__read',
+        args: [testFile],
+        policy: {
+          allowedPaths: [testFile],
+        },
+      }),
+    );
+  });
+
   it('should write a file through the sandbox', async () => {
     const mockChild = new EventEmitter() as unknown as ChildProcess;
     const mockStdin = new EventEmitter();

--- a/packages/core/src/services/sandboxedFileSystemService.ts
+++ b/packages/core/src/services/sandboxedFileSystemService.ts
@@ -47,7 +47,13 @@ export class SandboxedFileSystemService implements FileSystemService {
     );
   }
 
-  async readTextFile(filePath: string): Promise<string> {
+  /**
+   * Spawns the sandboxed `__read` command for filePath and resolves with the
+   * raw bytes written to stdout. Chunks are accumulated as Buffers (not
+   * concatenated via `.toString()`) so binary content isn't corrupted and
+   * multi-byte text sequences aren't split across chunk boundaries.
+   */
+  private async runSandboxedRead(filePath: string): Promise<Buffer> {
     const safePath = this.sanitizeAndValidatePath(filePath);
     const prepared = await this.sandboxManager.prepareCommand({
       command: '__read',
@@ -60,7 +66,7 @@ export class SandboxedFileSystemService implements FileSystemService {
     });
 
     try {
-      return await new Promise((resolve, reject) => {
+      return await new Promise<Buffer>((resolve, reject) => {
         // Direct spawn is necessary here for streaming large file contents.
 
         const child = spawn(prepared.program, prepared.args, {
@@ -68,11 +74,11 @@ export class SandboxedFileSystemService implements FileSystemService {
           env: prepared.env,
         });
 
-        let output = '';
+        const outputChunks: Buffer[] = [];
         let error = '';
 
-        child.stdout?.on('data', (data) => {
-          output += data.toString();
+        child.stdout?.on('data', (data: Buffer) => {
+          outputChunks.push(data);
         });
 
         child.stderr?.on('data', (data) => {
@@ -81,7 +87,7 @@ export class SandboxedFileSystemService implements FileSystemService {
 
         child.on('close', (code) => {
           if (code === 0) {
-            resolve(output);
+            resolve(Buffer.concat(outputChunks));
           } else {
             const isEnoent =
               error.toLowerCase().includes('no such file or directory') ||
@@ -109,6 +115,15 @@ export class SandboxedFileSystemService implements FileSystemService {
     } finally {
       prepared.cleanup?.();
     }
+  }
+
+  async readTextFile(filePath: string): Promise<string> {
+    const buffer = await this.runSandboxedRead(filePath);
+    return buffer.toString('utf-8');
+  }
+
+  async readBinaryFile(filePath: string): Promise<Buffer> {
+    return this.runSandboxedRead(filePath);
   }
 
   async writeTextFile(filePath: string, content: string): Promise<void> {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -834,6 +834,7 @@ describe('fileUtils', () => {
       const clientBackedService: FileSystemService = {
         readTextFile,
         writeTextFile: vi.fn(),
+        readBinaryFile: vi.fn(),
       };
 
       const result = await processSingleFileContent(
@@ -961,6 +962,66 @@ describe('fileUtils', () => {
         (result.llmContent as { inlineData: { data: string } }).inlineData.data,
       ).toBe(fakeMp3Data.toString('base64'));
       expect(result.returnDisplay).toContain('Read audio file: audio.mp3');
+    });
+
+    it('should route image file reads through a non-standard FileSystemService', async () => {
+      // On-disk content differs from what the injected service returns, so
+      // asserting on the service's content (not the disk content) proves the
+      // binary read was routed through it rather than reading local disk
+      // directly. This is the security property a SandboxedFileSystemService
+      // relies on to enforce its path validation for binary files.
+      actualNodeFs.writeFileSync(testImageFilePath, 'stale on-disk bytes');
+      mockMimeGetType.mockReturnValue('image/png');
+      const clientBinaryData = Buffer.from('fresh bytes from the client');
+      const readBinaryFile = vi.fn().mockResolvedValue(clientBinaryData);
+      const clientBackedService: FileSystemService = {
+        readTextFile: vi.fn(),
+        writeTextFile: vi.fn(),
+        readBinaryFile,
+      };
+
+      const result = await processSingleFileContent(
+        testImageFilePath,
+        tempRootDir,
+        clientBackedService,
+      );
+
+      expect(readBinaryFile).toHaveBeenCalledWith(testImageFilePath);
+      expect(
+        (result.llmContent as { inlineData: { data: string } }).inlineData.data,
+      ).toBe(clientBinaryData.toString('base64'));
+    });
+
+    it('should route audio file reads through a non-standard FileSystemService', async () => {
+      // detectFileType() does its own on-disk binary-content sniff (to avoid
+      // MIME misidentification) before dispatching to the audio branch, so
+      // the on-disk bytes must still look like binary audio; the actual
+      // returned content, however, should come from the injected service,
+      // not from what's on disk.
+      const staleOnDiskBytes = Buffer.from([
+        0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+      actualNodeFs.writeFileSync(testAudioFilePath, staleOnDiskBytes);
+      mockMimeGetType.mockReturnValue('audio/mpeg');
+      const clientBinaryData = Buffer.from('fresh audio bytes from the client');
+      const readBinaryFile = vi.fn().mockResolvedValue(clientBinaryData);
+      const clientBackedService: FileSystemService = {
+        readTextFile: vi.fn(),
+        writeTextFile: vi.fn(),
+        readBinaryFile,
+      };
+
+      const result = await processSingleFileContent(
+        testAudioFilePath,
+        tempRootDir,
+        clientBackedService,
+      );
+
+      expect(readBinaryFile).toHaveBeenCalledWith(testAudioFilePath);
+      expect(
+        (result.llmContent as { inlineData: { data: string } }).inlineData.data,
+      ).toBe(clientBinaryData.toString('base64'));
     });
 
     it('should normalize supported audio mime types before returning inline data', async () => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -37,7 +37,10 @@ import {
   getRealPath,
   isEmpty,
 } from './fileUtils.js';
-import { StandardFileSystemService } from '../services/fileSystemService.js';
+import {
+  StandardFileSystemService,
+  type FileSystemService,
+} from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 
 vi.mock('mime/lite', () => ({
@@ -817,6 +820,49 @@ describe('fileUtils', () => {
       );
       expect(result.error).toContain('File not found');
       expect(result.returnDisplay).toContain('File not found');
+    });
+
+    it('should route text file reads through a non-standard FileSystemService', async () => {
+      // On-disk content differs from what the injected service returns, so
+      // asserting on the service's content (not the disk content) proves the
+      // read was routed through it rather than reading local disk directly.
+      // This is the behavior an ACP client's fs/read_text_file capability
+      // (or a sandboxed FileSystemService) relies on.
+      actualNodeFs.writeFileSync(testTextFilePath, 'stale on-disk content');
+      const clientContent = 'fresh content from the client';
+      const readTextFile = vi.fn().mockResolvedValue(clientContent);
+      const clientBackedService: FileSystemService = {
+        readTextFile,
+        writeTextFile: vi.fn(),
+      };
+
+      const result = await processSingleFileContent(
+        testTextFilePath,
+        tempRootDir,
+        clientBackedService,
+      );
+
+      expect(readTextFile).toHaveBeenCalledWith(testTextFilePath);
+      expect(result.llmContent).toBe(clientContent);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should still use the BOM-aware reader for the standard FileSystemService', async () => {
+      const utf8Bom = Buffer.from([0xef, 0xbb, 0xbf]);
+      const content = 'Line 1\nLine 2';
+      actualNodeFs.writeFileSync(
+        testTextFilePath,
+        Buffer.concat([utf8Bom, Buffer.from(content, 'utf8')]),
+      );
+
+      const result = await processSingleFileContent(
+        testTextFilePath,
+        tempRootDir,
+        new StandardFileSystemService(),
+      );
+
+      // The BOM should be stripped, matching readFileWithEncoding's behavior.
+      expect(result.llmContent).toBe(content);
     });
 
     it('should handle read errors for text files', async () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -10,7 +10,10 @@ import path from 'node:path';
 import type { PartUnion } from '@google/genai';
 import { isBinaryFile as isBinaryFileCheck } from 'isbinaryfile';
 import mime from 'mime/lite';
-import type { FileSystemService } from '../services/fileSystemService.js';
+import {
+  StandardFileSystemService,
+  type FileSystemService,
+} from '../services/fileSystemService.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
 import { createRequire as createModuleRequire } from 'node:module';
@@ -481,10 +484,33 @@ export interface ProcessedFileReadResult {
 }
 
 /**
+ * Reads the textual content of a file, routing through the provided
+ * FileSystemService so callers (e.g. an ACP client advertising the
+ * fs/read_text_file capability, or a sandboxed service) get a chance to
+ * serve the read instead of it always hitting local disk.
+ *
+ * The default StandardFileSystemService reads straight off local disk, so
+ * for that case we use the BOM-aware reader to preserve existing behavior
+ * (correct handling of UTF-8/16/32 byte-order marks). Any other
+ * implementation is trusted to return already-decoded text.
+ */
+async function readTextFileContent(
+  filePath: string,
+  fileSystemService: FileSystemService,
+): Promise<string> {
+  if (fileSystemService instanceof StandardFileSystemService) {
+    return readFileWithEncoding(filePath);
+  }
+  return fileSystemService.readTextFile(filePath);
+}
+
+/**
  * Reads and processes a single file, handling text, images, and PDFs.
  * @param filePath Absolute path to the file.
  * @param rootDirectory Absolute path to the project root for relative path display.
- * @param _fileSystemService Currently unused in this function; kept for signature stability.
+ * @param fileSystemService Used to read the file's text content, so that a
+ * client-backed or sandboxed FileSystemService is honored instead of always
+ * reading local disk directly.
  * @param startLine Optional 1-based line number to start reading from.
  * @param endLine Optional 1-based line number to end reading at (inclusive).
  * @returns ProcessedFileReadResult object.
@@ -492,7 +518,7 @@ export interface ProcessedFileReadResult {
 export async function processSingleFileContent(
   filePath: string,
   rootDirectory: string,
-  _fileSystemService: FileSystemService,
+  fileSystemService: FileSystemService,
   startLine?: number,
   endLine?: number,
 ): Promise<ProcessedFileReadResult> {
@@ -548,15 +574,17 @@ export async function processSingleFileContent(
             returnDisplay: `Skipped large SVG file (>1MB): ${relativePathForDisplay}`,
           };
         }
-        const content = await readFileWithEncoding(filePath);
+        const content = await readTextFileContent(filePath, fileSystemService);
         return {
           llmContent: content,
           returnDisplay: `Read SVG as text: ${relativePathForDisplay}`,
         };
       }
       case 'text': {
-        // Use BOM-aware reader to avoid leaving a BOM character in content and to support UTF-16/32 transparently
-        const content = await readFileWithEncoding(filePath);
+        // Routed through the FileSystemService (BOM-aware for local disk
+        // reads; see readTextFileContent) so encodings like UTF-16/32 are
+        // still handled correctly and a client-backed service is honored.
+        const content = await readTextFileContent(filePath, fileSystemService);
         const lines = content.split(/\r?\n/);
         const originalLineCount = lines.length;
 

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -508,9 +508,9 @@ async function readTextFileContent(
  * Reads and processes a single file, handling text, images, and PDFs.
  * @param filePath Absolute path to the file.
  * @param rootDirectory Absolute path to the project root for relative path display.
- * @param fileSystemService Used to read the file's text content, so that a
- * client-backed or sandboxed FileSystemService is honored instead of always
- * reading local disk directly.
+ * @param fileSystemService Used to read the file's content (text or binary),
+ * so that a client-backed or sandboxed FileSystemService is honored instead
+ * of always reading local disk directly.
  * @param startLine Optional 1-based line number to start reading from.
  * @param endLine Optional 1-based line number to end reading at (inclusive).
  * @returns ProcessedFileReadResult object.
@@ -655,7 +655,7 @@ export async function processSingleFileContent(
             errorType: ToolErrorType.READ_CONTENT_FAILURE,
           };
         }
-        const contentBuffer = await fs.promises.readFile(filePath);
+        const contentBuffer = await fileSystemService.readBinaryFile(filePath);
         const base64Data = contentBuffer.toString('base64');
         return {
           llmContent: {
@@ -672,7 +672,7 @@ export async function processSingleFileContent(
       case 'video': {
         const mimeType =
           getSpecificMimeType(filePath) ?? 'application/octet-stream';
-        const contentBuffer = await fs.promises.readFile(filePath);
+        const contentBuffer = await fileSystemService.readBinaryFile(filePath);
         const base64Data = contentBuffer.toString('base64');
         return {
           llmContent: {


### PR DESCRIPTION
## Summary
`read_file` reads file contents directly off local disk, ignoring the `FileSystemService` injected into it — unlike `write_file` and `replace`, which already route their I/O through `config.getFileSystemService()`. This means a client connected over ACP that advertises `fs: { readTextFile: true }` never sees an `fs/read_text_file` request for `read_file`; the CLI silently returns raw on-disk bytes instead. The same gap causes `SandboxedFileSystemService` to be bypassed for reads. This PR routes `read_file`'s content read through the injected service so it's consistent with the other file tools.

## Details
`processSingleFileContent` (called by `read-file.ts`) received a `FileSystemService` parameter but never used it — it was prefixed `_fileSystemService` and content was read via `fs.promises.readFile`/`readFileWithEncoding` regardless of what service was configured.

Added a `readTextFileContent()` helper that:
- Calls `fileSystemService.readTextFile(filePath)` for any non-default service, so an ACP client's `fs/read_text_file` or a sandboxed service is honored, matching `write_file`/`replace`.
- Falls back to the existing BOM-aware `readFileWithEncoding` reader specifically for the default `StandardFileSystemService`, so UTF-8/16/32 byte-order-mark handling for plain local reads isn't regressed (the default `StandardFileSystemService.readTextFile` uses a plain `fs.readFile(..., 'utf-8')`, which doesn't strip/decode BOMs).

Existence/size/type checks (`fs.existsSync`, `fs.promises.stat`, `detectFileType`) are left as direct local `fs` calls — this mirrors what `write_file`'s own validation already does (`fs.existsSync`/`fs.lstatSync` for its directory check), and the ACP `fs` capability only covers text content, not stat metadata.

## Related Issues
Fixes #29108

## How to Validate
1. `cd packages/core && npx vitest run src/utils/fileUtils.test.ts src/tools/read-file.test.ts src/tools/write-file.test.ts src/services/fileSystemService.test.ts` — all 181 tests pass, including 2 new regression tests:
   - one asserting `processSingleFileContent` calls a mock client-backed `FileSystemService.readTextFile()` rather than reading local disk directly
   - one asserting the default `StandardFileSystemService` path still strips a UTF-8 BOM correctly
2. Manual ACP check: run `gemini --acp` with a client that advertises `fs: { readTextFile: true, writeTextFile: true }` and trace the wire frames while the model calls `read_file` on a path within the workspace root — an `fs/read_text_file` request should now appear (previously none did), matching the frames already seen for `write_file`/`replace`.
3. Regression check for the non-ACP default case: `read_file` a UTF-8/UTF-16/UTF-32-BOM-prefixed file locally and confirm the BOM is still stripped from the returned content, same as before this change.

## Pre-Merge Checklist
- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker