### PR TITLE
fix(core): prevent duplicate handleExit execution on spawn failure

### DIFF
--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -816,20 +816,36 @@ export class ShellExecutionService {
 
       child.stdout.on('data', (data) => handleOutput(data, 'stdout'));
       child.stderr.on('data', (data) => handleOutput(data, 'stderr'));
-      child.on('error', (err) => {
-        error = err;
-        handleExit(1, null);
-      });
+      let hasHandledExit = false;
 
-      const abortHandler = async () => {
-        if (child.pid && !exited) {
-          await killProcessGroup({
-            pid: child.pid,
-            escalate: true,
-            isExited: () => exited,
-          });
-        }
-      };
+const safeHandleExit = (code: number | null, signal: NodeJS.Signals | null) => {
+  if (hasHandledExit) {
+    return;
+  }
+  hasHandledExit = true;
+  handleExit(code, signal);
+};
+
+child.on('error', (err) => {
+  error = err;
+  safeHandleExit(1, null);
+});
+
+const abortHandler = async () => {
+  if (child.pid && !exited) {
+    await killProcessGroup({
+      pid: child.pid,
+      escalate: true,
+      isExited: () => exited,
+    });
+  }
+};
+
+abortSignal.addEventListener('abort', abortHandler, { once: true });
+
+child.on('close', (code, signal) => {
+  safeHandleExit(code, signal);
+});
 
       abortSignal.addEventListener('abort', abortHandler, { once: true });
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -816,41 +816,35 @@ export class ShellExecutionService {
 
       child.stdout.on('data', (data) => handleOutput(data, 'stdout'));
       child.stderr.on('data', (data) => handleOutput(data, 'stderr'));
-      let hasHandledExit = false;
+       let hasHandledExit = false;
 
-const safeHandleExit = (code: number | null, signal: NodeJS.Signals | null) => {
-  if (hasHandledExit) {
-    return;
-  }
-  hasHandledExit = true;
-  handleExit(code, signal);
-};
+      const safeHandleExit = (code: number | null, signal: string | null) => {
+        if (hasHandledExit) {
+          return;
+        }
+        hasHandledExit = true;
+        handleExit(code, signal);
+      };
 
-child.on('error', (err) => {
-  error = err;
-  safeHandleExit(1, null);
-});
+      child.on('error', (err) => {
+        error = err;
+        safeHandleExit(1, null);
+      });
 
-const abortHandler = async () => {
-  if (child.pid && !exited) {
-    await killProcessGroup({
-      pid: child.pid,
-      escalate: true,
-      isExited: () => exited,
-    });
-  }
-};
-
-abortSignal.addEventListener('abort', abortHandler, { once: true });
-
-child.on('close', (code, signal) => {
-  safeHandleExit(code, signal);
-});
+      const abortHandler = async () => {
+        if (child.pid && !exited) {
+          await killProcessGroup({
+            pid: child.pid,
+            escalate: true,
+            isExited: () => exited,
+          });
+        }
+      };
 
       abortSignal.addEventListener('abort', abortHandler, { once: true });
 
       child.on('close', (code, signal) => {
-        handleExit(code, signal);
+        safeHandleExit(code, signal);
       });
 
       function cleanup() {


### PR DESCRIPTION
## Summary
Prevents duplicate `handleExit` execution on child process spawn failure by adding a re-entrancy guard flag in `shellExecutionService`.

## Details
When a process spawn fails in Node.js, `child_process` fires both `error` and `close` events in sequence. Previously, both event handlers called `handleExit()` directly without checking if exit handling had already run. This caused exit tasks—such as emitting output events, finalizing history, and running cleanup—to execute twice.

- Introduced a `hasHandledExit` boolean flag within the execution scope.
- Wrapped `handleExit` calls inside a `safeHandleExit` helper function that returns early if exit handling has already executed for the current run.

## Related Issues
Fixes #29057

## How to Validate
1. Run local tests via `npm test`.
2. Trigger a command with an invalid binary or failing spawn path to confirm exit event handling and cleanup run exactly once.

## Pre-Merge Checklist
- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows / PowerShell