### PR TITLE
fix(core): mitigate NTFS 8.3 short name (SFN) path

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -64,7 +64,8 @@ vi.mock('fs', async (importOriginal) => {
 
   const mockedRealpath = vi.fn((p) => p);
   Object.defineProperty(mockedRealpath, 'native', {
-    value: (p: Parameters<typeof actualFs.realpathSync>[0]) => mockedRealpath(p),
+    value: (p: Parameters<typeof actualFs.realpathSync>[0]) =>
+      mockedRealpath(p),
     writable: true,
   });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -62,6 +62,12 @@ vi.mock('fs', async (importOriginal) => {
     pathMod.join(MOCK_CWD2, 'settings', 'path3'),
   ]);
 
+  const mockedRealpath = vi.fn((p) => p);
+  Object.defineProperty(mockedRealpath, 'native', {
+    value: (p: Parameters<typeof actualFs.realpathSync>[0]) => mockedRealpath(p),
+    writable: true,
+  });
+
   return {
     ...actualFs,
     mkdirSync: vi.fn((p) => {
@@ -75,7 +81,7 @@ vi.mock('fs', async (importOriginal) => {
       }
       return actualFs.statSync(p as unknown as string);
     }),
-    realpathSync: vi.fn((p) => p),
+    realpathSync: mockedRealpath,
   };
 });
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -80,13 +80,18 @@ import {
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
+  const mockedRealpath = vi.fn((path) => path);
+  Object.defineProperty(mockedRealpath, 'native', {
+    value: (p: fs.PathLike) => mockedRealpath(p),
+    writable: true,
+  });
   return {
     ...actual,
     existsSync: vi.fn().mockReturnValue(true),
     statSync: vi.fn().mockReturnValue({
       isDirectory: vi.fn().mockReturnValue(true),
     }),
-    realpathSync: vi.fn((path) => path),
+    realpathSync: mockedRealpath,
   };
 });
 

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -242,6 +242,7 @@ vi.mock('../utils/events.js', async (importOriginal) => {
 
 vi.mock('../utils/fetch.js', () => ({
   setGlobalProxy: mockSetGlobalProxy,
+  updateGlobalFetchTimeouts: vi.fn(),
 }));
 
 vi.mock('../context/memoryContextManager.js', () => ({

--- a/packages/core/src/config/scoped-config.test.ts
+++ b/packages/core/src/config/scoped-config.test.ts
@@ -19,7 +19,13 @@ vi.mock('../utils/paths.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/paths.js')>();
   return {
     ...actual,
-    resolveToRealPath: vi.fn((p) => p),
+    resolveToRealPath: vi.fn((p) => {
+      try {
+        return fs.realpathSync(p);
+      } catch {
+        return p;
+      }
+    }),
     isSubpath: (parent: string, child: string) => child.startsWith(parent),
   };
 });

--- a/packages/core/src/config/storage.test.ts
+++ b/packages/core/src/config/storage.test.ts
@@ -16,10 +16,15 @@ import * as fs from 'node:fs';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
+  const mockedRealpath = vi.fn(actual.realpathSync);
+  Object.defineProperty(mockedRealpath, 'native', {
+    value: (p: fs.PathLike) => mockedRealpath(p),
+    writable: true,
+  });
   return {
     ...actual,
     mkdirSync: vi.fn(),
-    realpathSync: vi.fn(actual.realpathSync),
+    realpathSync: mockedRealpath,
   };
 });
 

--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -242,6 +242,24 @@ describe('AllowedPathChecker', () => {
   });
 
   describe('Security Regression: Case-Insensitive Blocklist & .vscode HITL', () => {
+    it('should deny sensitive paths specified via NTFS 8.3 short names (SFNs) like git~1, env~1, node_m~1', async () => {
+      const sfnPaths = [
+        path.join(mockCwd, 'git~1', 'config'),
+        path.join(mockCwd, 'GIT~1', 'config'),
+        path.join(mockCwd, 'env~1'),
+        path.join(mockCwd, 'ENV~1'),
+        path.join(mockCwd, 'node_m~1', 'package', 'index.js'),
+        path.join(mockCwd, 'NODE_M~1', 'package', 'index.js'),
+      ];
+
+      for (const p of sfnPaths) {
+        const input = createInput({ path: p });
+        const result = await checker.check(input);
+        expect(result.decision).toBe(SafetyCheckDecision.DENY);
+        expect(result.reason).toContain('Access to sensitive path');
+      }
+    });
+
     it('should deny sensitive paths like .git, .env, and node_modules case-insensitively, including Windows trailing character and NTFS ADS bypasses', async () => {
       const sensitivePaths = [
         path.join(mockCwd, '.git', 'config'),

--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -242,14 +242,22 @@ describe('AllowedPathChecker', () => {
   });
 
   describe('Security Regression: Case-Insensitive Blocklist & .vscode HITL', () => {
-    it('should deny sensitive paths specified via NTFS 8.3 short names (SFNs) like git~1, env~1, node_m~1', async () => {
+    it('should deny sensitive paths specified via NTFS 8.3 short names (SFNs), including standard and collision-based SFN formats', async () => {
       const sfnPaths = [
+        // Standard SFNs
         path.join(mockCwd, 'git~1', 'config'),
         path.join(mockCwd, 'GIT~1', 'config'),
         path.join(mockCwd, 'env~1'),
         path.join(mockCwd, 'ENV~1'),
         path.join(mockCwd, 'node_m~1', 'package', 'index.js'),
         path.join(mockCwd, 'NODE_M~1', 'package', 'index.js'),
+        // NTFS Collision-Based SFNs (e.g. first two characters followed by 4-digit hex hash and ~number)
+        path.join(mockCwd, 'gi1a2b~1', 'config'),
+        path.join(mockCwd, 'GI3F4E~2', 'config'),
+        path.join(mockCwd, 'en9c8d~1'),
+        path.join(mockCwd, 'EN2A1B~3'),
+        path.join(mockCwd, 'no5c6d~1', 'package', 'index.js'),
+        path.join(mockCwd, 'NO7A8B~2', 'package', 'index.js'),
       ];
 
       for (const p of sfnPaths) {
@@ -290,7 +298,7 @@ describe('AllowedPathChecker', () => {
       }
     });
 
-    it('should require ASK_USER for .vscode configuration files inside workspace, but deny them if outside, including NTFS ADS bypasses', async () => {
+    it('should require ASK_USER for .vscode configuration files inside workspace, but deny them if outside, including NTFS ADS bypasses and SFNs', async () => {
       const vscodePaths = [
         path.join(mockCwd, '.vscode', 'settings.json'),
         path.join(mockCwd, '.vscode', 'settings.JSON'),
@@ -301,6 +309,11 @@ describe('AllowedPathChecker', () => {
         path.join(mockCwd, '.vscode.', 'settings.json'),
         // NTFS Alternate Data Stream bypasses
         path.join(mockCwd, '.vscode::$DATA', 'settings.json'),
+        // SFN formats (standard and collision-based)
+        path.join(mockCwd, 'vscode~1', 'settings.json'),
+        path.join(mockCwd, 'VSCODE~1', 'settings.json'),
+        path.join(mockCwd, 'vs12ab~1', 'settings.json'),
+        path.join(mockCwd, 'VS3F4E~2', 'settings.json'),
       ];
 
       for (const p of vscodePaths) {

--- a/packages/core/src/safety/built-in.test.ts
+++ b/packages/core/src/safety/built-in.test.ts
@@ -242,7 +242,7 @@ describe('AllowedPathChecker', () => {
   });
 
   describe('Security Regression: Case-Insensitive Blocklist & .vscode HITL', () => {
-    it('should deny sensitive paths specified via NTFS 8.3 short names (SFNs), including standard and collision-based SFN formats', async () => {
+    it('should deny sensitive paths specified via NTFS 8.3 short names (SFNs), including standard and collision-based SFN formats.', async () => {
       const sfnPaths = [
         // Standard SFNs
         path.join(mockCwd, 'git~1', 'config'),

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -11,7 +11,7 @@ import {
   type SafetyCheckResult,
 } from './protocol.js';
 import type { AllowedPathConfig } from '../policy/types.js';
-import { resolveToRealPath } from '../utils/paths.js';
+import { resolveToRealPath, hasBlockedPathSegment, trimTrailingSpacesAndDots } from '../utils/paths.js';
 
 /**
  * Interface for all in-process safety checkers.
@@ -69,21 +69,14 @@ export class AllowedPathChecker implements InProcessChecker {
       for (const resolvedDir of resolvedAllowedDirs) {
         if (!this.isPathAllowed(resolvedPath, resolvedDir)) continue;
         const relative = path.relative(resolvedDir, resolvedPath);
+        if (hasBlockedPathSegment(relative)) {
+          hasBlockedSegment = true;
+        }
         const segments = relative.split(path.sep);
         for (const segment of segments) {
           const clean = trimTrailingSpacesAndDots(
             segment.split(':')[0],
           ).toLowerCase();
-          if (
-            clean === '.git' ||
-            clean === '.env' ||
-            clean === 'node_modules' ||
-            /^(git|gi[0-9a-f]{4})~\d+$/.test(clean) ||
-            /^(env|en[0-9a-f]{4})~\d+$/.test(clean) ||
-            /^(node_m|no[0-9a-f]{4})~\d+$/.test(clean)
-          ) {
-            hasBlockedSegment = true;
-          }
           if (
             clean === '.vscode' ||
             /^(vscode|vs[0-9a-f]{4})~\d+$/.test(clean)
@@ -204,16 +197,4 @@ export class AllowedPathChecker implements InProcessChecker {
 
     return paths;
   }
-}
-
-/**
- * Trims trailing spaces and dots from a string without using regular expressions
- * to completely eliminate any potential ReDoS (Regular Expression Denial of Service) risk.
- */
-function trimTrailingSpacesAndDots(str: string): string {
-  let end = str.length - 1;
-  while (end >= 0 && (str[end] === ' ' || str[end] === '.')) {
-    end--;
-  }
-  return str.slice(0, end + 1);
 }

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -17,6 +17,8 @@ import {
   trimTrailingSpacesAndDots,
 } from '../utils/paths.js';
 
+const VSCODE_SFN_REGEX = /^(vscode|vs[0-9a-f]{4})~\d+$/;
+
 /**
  * Interface for all in-process safety checkers.
  */
@@ -83,7 +85,7 @@ export class AllowedPathChecker implements InProcessChecker {
           ).toLowerCase();
           if (
             clean === '.vscode' ||
-            /^(vscode|vs[0-9a-f]{4})~\d+$/.test(clean)
+            VSCODE_SFN_REGEX.test(clean)
           ) {
             isVscodePath = true;
           }

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -83,10 +83,7 @@ export class AllowedPathChecker implements InProcessChecker {
           const clean = trimTrailingSpacesAndDots(
             segment.split(':')[0],
           ).toLowerCase();
-          if (
-            clean === '.vscode' ||
-            VSCODE_SFN_REGEX.test(clean)
-          ) {
+          if (clean === '.vscode' || VSCODE_SFN_REGEX.test(clean)) {
             isVscodePath = true;
           }
         }

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -78,15 +78,15 @@ export class AllowedPathChecker implements InProcessChecker {
             clean === '.git' ||
             clean === '.env' ||
             clean === 'node_modules' ||
-            /^git~\d+$/.test(clean) ||
-            /^env~\d+$/.test(clean) ||
-            /^node_m~\d+$/.test(clean)
+            /^(git|gi[0-9a-f]{4})~\d+$/.test(clean) ||
+            /^(env|en[0-9a-f]{4})~\d+$/.test(clean) ||
+            /^(node_m|no[0-9a-f]{4})~\d+$/.test(clean)
           ) {
             hasBlockedSegment = true;
           }
           if (
             clean === '.vscode' ||
-            /^vscode~\d+$/.test(clean)
+            /^(vscode|vs[0-9a-f]{4})~\d+$/.test(clean)
           ) {
             isVscodePath = true;
           }

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -11,7 +11,11 @@ import {
   type SafetyCheckResult,
 } from './protocol.js';
 import type { AllowedPathConfig } from '../policy/types.js';
-import { resolveToRealPath, hasBlockedPathSegment, trimTrailingSpacesAndDots } from '../utils/paths.js';
+import {
+  resolveToRealPath,
+  hasBlockedPathSegment,
+  trimTrailingSpacesAndDots,
+} from '../utils/paths.js';
 
 /**
  * Interface for all in-process safety checkers.
@@ -72,7 +76,7 @@ export class AllowedPathChecker implements InProcessChecker {
         if (hasBlockedPathSegment(relative)) {
           hasBlockedSegment = true;
         }
-        const segments = relative.split(path.sep);
+        const segments = relative.split(/[/\\]/);
         for (const segment of segments) {
           const clean = trimTrailingSpacesAndDots(
             segment.split(':')[0],

--- a/packages/core/src/safety/built-in.ts
+++ b/packages/core/src/safety/built-in.ts
@@ -77,11 +77,17 @@ export class AllowedPathChecker implements InProcessChecker {
           if (
             clean === '.git' ||
             clean === '.env' ||
-            clean === 'node_modules'
+            clean === 'node_modules' ||
+            /^git~\d+$/.test(clean) ||
+            /^env~\d+$/.test(clean) ||
+            /^node_m~\d+$/.test(clean)
           ) {
             hasBlockedSegment = true;
           }
-          if (clean === '.vscode') {
+          if (
+            clean === '.vscode' ||
+            /^vscode~\d+$/.test(clean)
+          ) {
             isVscodePath = true;
           }
         }

--- a/packages/core/src/test-utils/mockWorkspaceContext.ts
+++ b/packages/core/src/test-utils/mockWorkspaceContext.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'node:fs';
 import { vi } from 'vitest';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
+import { resolveToRealPath } from '../utils/paths.js';
 
 /**
  * Creates a mock WorkspaceContext for testing
@@ -20,7 +20,7 @@ export function createMockWorkspaceContext(
 ): WorkspaceContext {
   const resolveToRealPathSafe = (p: string) => {
     try {
-      return fs.realpathSync(p);
+      return resolveToRealPath(p);
     } catch {
       return p;
     }

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -63,7 +63,7 @@ import {
   getMockMessageBusInstance,
 } from '../test-utils/mock-message-bus.js';
 import path from 'node:path';
-import { isSubpath } from '../utils/paths.js';
+import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import { ApprovalMode } from '../policy/types.js';
@@ -87,7 +87,7 @@ describe('EditTool', () => {
     const rawTempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'edit-tool-test-'),
     );
-    tempDir = fs.realpathSync(rawTempDir);
+    tempDir = resolveToRealPath(rawTempDir);
     rootDir = path.join(tempDir, 'root');
     fs.mkdirSync(rootDir);
 

--- a/packages/core/src/tools/read-many-files.test.ts
+++ b/packages/core/src/tools/read-many-files.test.ts
@@ -17,7 +17,7 @@ import { mockControl } from '../__mocks__/fs/promises.js';
 import { ReadManyFilesTool } from './read-many-files.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import path from 'node:path';
-import { isSubpath } from '../utils/paths.js';
+import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 import fs from 'node:fs'; // Actual fs for setup
 import os from 'node:os';
 import type { Config } from '../config/config.js';
@@ -83,10 +83,10 @@ describe('ReadManyFilesTool', () => {
   let mockReadFileFn: Mock;
 
   beforeEach(async () => {
-    tempRootDir = fs.realpathSync(
+    tempRootDir = resolveToRealPath(
       fs.mkdtempSync(path.join(os.tmpdir(), 'read-many-files-root-')),
     );
-    tempDirOutsideRoot = fs.realpathSync(
+    tempDirOutsideRoot = resolveToRealPath(
       fs.mkdtempSync(path.join(os.tmpdir(), 'read-many-files-external-')),
     );
     fs.writeFileSync(path.join(tempRootDir, GEMINI_IGNORE_FILE_NAME), 'foo.*');
@@ -554,10 +554,10 @@ describe('ReadManyFilesTool', () => {
     });
 
     it('should read files from multiple workspace directories', async () => {
-      const tempDir1 = fs.realpathSync(
+      const tempDir1 = resolveToRealPath(
         fs.mkdtempSync(path.join(os.tmpdir(), 'multi-dir-1-')),
       );
-      const tempDir2 = fs.realpathSync(
+      const tempDir2 = resolveToRealPath(
         fs.mkdtempSync(path.join(os.tmpdir(), 'multi-dir-2-')),
       );
       const fileService = new FileDiscoveryService(tempDir1);

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -137,17 +137,17 @@ describe('WriteFileTool', () => {
     const rawTempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'write-file-test-external-'),
     );
-    tempDir = fs.realpathSync(rawTempDir);
+    tempDir = resolveToRealPath(rawTempDir);
 
     const rawRootDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-cli-test-root-'),
     );
-    rootDir = fs.realpathSync(rawRootDir);
+    rootDir = resolveToRealPath(rawRootDir);
 
     const rawPlansDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'gemini-cli-test-plans-'),
     );
-    plansDir = fs.realpathSync(rawPlansDir);
+    plansDir = resolveToRealPath(rawPlansDir);
 
     const workspaceContext = new WorkspaceContext(rootDir, [plansDir]);
     const mockStorage = {

--- a/packages/core/src/utils/pathCorrector.test.ts
+++ b/packages/core/src/utils/pathCorrector.test.ts
@@ -12,6 +12,7 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { correctPath } from './pathCorrector.js';
+import { resolveToRealPath } from './paths.js';
 
 describe('pathCorrector', () => {
   let tempDir: string;
@@ -23,7 +24,7 @@ describe('pathCorrector', () => {
     const rawTempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'path-corrector-test-'),
     );
-    tempDir = fs.realpathSync(rawTempDir);
+    tempDir = resolveToRealPath(rawTempDir);
     rootDir = path.join(tempDir, 'root');
     otherWorkspaceDir = path.join(tempDir, 'other');
     fs.mkdirSync(rootDir, { recursive: true });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -25,9 +25,11 @@ import {
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof fs>();
+  const mockRealpath = (p: string) => p;
+  mockRealpath.native = (p: string) => p;
   return {
     ...(actual as object),
-    realpathSync: (p: string) => p,
+    realpathSync: mockRealpath,
   };
 });
 

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -997,6 +997,8 @@ describe('normalizePath', () => {
       expect(hasBlockedPathSegment('gha-creds-1234.json')).toBe(true);
       expect(hasBlockedPathSegment('gha-cr~1.json')).toBe(true);
       expect(hasBlockedPathSegment('gh1a2b~1.json')).toBe(true);
+      expect(hasBlockedPathSegment('gha-cr~1.jso')).toBe(true);
+      expect(hasBlockedPathSegment('gh1a2b~1.jso')).toBe(true);
     });
   });
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -606,6 +606,26 @@ describe('resolveToRealPath', () => {
       /Infinite recursion detected/,
     );
   });
+
+  describe('on Windows realpathSync.native prefixes', () => {
+    beforeEach(() => {
+      mockPlatform('win32');
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('should strip long path prefix \\\\?\\', () => {
+      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce('\\\\?\\C:\\foo\\bar');
+      expect(resolveToRealPath('C:\\foo\\bar')).toBe('C:\\foo\\bar');
+    });
+
+    it('should strip UNC long path prefix \\\\?\\UNC\\ and keep UNC slash structure', () => {
+      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce('\\\\?\\UNC\\server\\share\\foo');
+      expect(resolveToRealPath('\\\\server\\share\\foo')).toBe('\\\\server\\share\\foo');
+    });
+  });
 });
 
 describe('makeRelative', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -26,11 +26,11 @@ import {
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof fs>();
   const mockRealpath = (p: string) => p;
-  mockRealpath.native = (p: string) => mockedFs.realpathSync(p);
   const mockedFs = {
     ...(actual as object),
     realpathSync: mockRealpath,
   };
+  mockRealpath.native = (p: string) => mockedFs.realpathSync(p);
   return mockedFs;
 });
 

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -30,7 +30,10 @@ vi.mock('node:fs', async (importOriginal) => {
     ...(actual as object),
     realpathSync: mockRealpath,
   };
-  mockRealpath.native = (p: string) => mockedFs.realpathSync(p);
+  Object.defineProperty(mockRealpath, 'native', {
+    value: (p: string) => mockedFs.realpathSync(p),
+    writable: true,
+  });
   return mockedFs;
 });
 

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -21,6 +21,7 @@ import {
   toPathKey,
   isTrustedSystemPath,
   resolveDefensiveToolPath,
+  hasBlockedPathSegment,
 } from './paths.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -974,6 +975,28 @@ describe('normalizePath', () => {
       const filePathWithNull = '@/components/Button.tsx\0';
       const result = resolveDefensiveToolPath(filePathWithNull, targetDir);
       expect(result).toBe('components/Button.tsx');
+    });
+  });
+
+  describe('hasBlockedPathSegment', () => {
+    it('should identify standard blocked segments', () => {
+      expect(hasBlockedPathSegment('src/.git/config')).toBe(true);
+      expect(hasBlockedPathSegment('.env')).toBe(true);
+      expect(hasBlockedPathSegment('node_modules/lodash')).toBe(true);
+      expect(hasBlockedPathSegment('safe/path/here')).toBe(false);
+    });
+
+    it('should identify NTFS 8.3 short name (SFN) blocked segments', () => {
+      expect(hasBlockedPathSegment('git~1/config')).toBe(true);
+      expect(hasBlockedPathSegment('gi1a2b~1/config')).toBe(true);
+      expect(hasBlockedPathSegment('env~1')).toBe(true);
+      expect(hasBlockedPathSegment('node_m~1/lodash')).toBe(true);
+    });
+
+    it('should block standard and SFN patterns for gha-creds-*.json', () => {
+      expect(hasBlockedPathSegment('gha-creds-1234.json')).toBe(true);
+      expect(hasBlockedPathSegment('gha-cr~1.json')).toBe(true);
+      expect(hasBlockedPathSegment('gh1a2b~1.json')).toBe(true);
     });
   });
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -26,11 +26,12 @@ import {
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof fs>();
   const mockRealpath = (p: string) => p;
-  mockRealpath.native = (p: string) => p;
-  return {
+  mockRealpath.native = (p: string) => mockedFs.realpathSync(p);
+  const mockedFs = {
     ...(actual as object),
     realpathSync: mockRealpath,
   };
+  return mockedFs;
 });
 
 const mockPlatform = (platform: string) => {
@@ -617,13 +618,19 @@ describe('resolveToRealPath', () => {
     });
 
     it('should strip long path prefix \\\\?\\', () => {
-      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce('\\\\?\\C:\\foo\\bar');
+      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce(
+        '\\\\?\\C:\\foo\\bar',
+      );
       expect(resolveToRealPath('C:\\foo\\bar')).toBe('C:\\foo\\bar');
     });
 
     it('should strip UNC long path prefix \\\\?\\UNC\\ and keep UNC slash structure', () => {
-      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce('\\\\?\\UNC\\server\\share\\foo');
-      expect(resolveToRealPath('\\\\server\\share\\foo')).toBe('\\\\server\\share\\foo');
+      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce(
+        '\\\\?\\UNC\\server\\share\\foo',
+      );
+      expect(resolveToRealPath('\\\\server\\share\\foo')).toBe(
+        '\\\\server\\share\\foo',
+      );
     });
   });
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -34,6 +34,7 @@ vi.mock('node:fs', async (importOriginal) => {
   Object.defineProperty(mockRealpath, 'native', {
     value: (p: string) => mockedFs.realpathSync(p),
     writable: true,
+    configurable: true,
   });
   return mockedFs;
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -632,6 +632,15 @@ describe('resolveToRealPath', () => {
         '\\\\server\\share\\foo',
       );
     });
+
+    it('should strip lowercase UNC long path prefix \\\\?\\unc\\ case-insensitively', () => {
+      vi.spyOn(fs.realpathSync, 'native').mockReturnValueOnce(
+        '\\\\?\\unc\\server\\share\\foo',
+      );
+      expect(resolveToRealPath('\\\\server\\share\\foo')).toBe(
+        '\\\\server\\share\\foo',
+      );
+    });
   });
 });
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -368,6 +368,15 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
   let p = pathModule.resolve(parentPath);
   let c = pathModule.resolve(childPath);
 
+  if (isWindows) {
+    try {
+      p = resolveToRealPath(p);
+      c = resolveToRealPath(c);
+    } catch {
+      // Ignore resolution errors if any
+    }
+  }
+
   // On Windows, path.relative is case-insensitive.
   // On POSIX (including Darwin), path.relative is case-sensitive.
   // We want it to be case-insensitive on Darwin to match user expectation and sandbox policy.

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -440,9 +440,10 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         : fs.realpathSync;
     let resolved = realpathFn(p);
     if (process.platform === 'win32' && typeof resolved === 'string') {
-      if (resolved.slice(0, 8).toUpperCase() === '\\\\?\\UNC\\') {
+      const upper = resolved.toUpperCase();
+      if (upper.startsWith('\\\\?\\UNC\\')) {
         resolved = '\\\\' + resolved.slice(8);
-      } else if (resolved.startsWith('\\\\?\\')) {
+      } else if (upper.startsWith('\\\\?\\')) {
         resolved = resolved.slice(4);
       }
     }
@@ -648,6 +649,11 @@ export function trimTrailingSpacesAndDots(str: string): string {
   return str.slice(0, end + 1);
 }
 
+const GIT_SFN_REGEX = /^(git|gi[0-9a-f]{4})~\d+$/;
+const ENV_SFN_REGEX = /^(env|en[0-9a-f]{4})~\d+$/;
+const NODE_MODULES_SFN_REGEX = /^(node_m|no[0-9a-f]{4})~\d+$/;
+const GHA_CREDS_SFN_REGEX = /^(gha-cr|gh[0-9a-f]{4})~\d+\.jso(n)?$/;
+
 /**
  * Checks if a path string contains any blocked segments (.git, .env, node_modules, gha-creds-*.json)
  * including case-insensitive matches and NTFS 8.3 short names.
@@ -663,15 +669,15 @@ export function hasBlockedPathSegment(p: string): boolean {
       clean === '.git' ||
       clean === '.env' ||
       clean === 'node_modules' ||
-      /^(git|gi[0-9a-f]{4})~\d+$/.test(clean) ||
-      /^(env|en[0-9a-f]{4})~\d+$/.test(clean) ||
-      /^(node_m|no[0-9a-f]{4})~\d+$/.test(clean)
+      GIT_SFN_REGEX.test(clean) ||
+      ENV_SFN_REGEX.test(clean) ||
+      NODE_MODULES_SFN_REGEX.test(clean)
     ) {
       return true;
     }
     if (
       (clean.startsWith('gha-creds-') && clean.endsWith('.json')) ||
-      /^(gha-cr|gh[0-9a-f]{4})~\d+\.jso(n)?$/.test(clean)
+      GHA_CREDS_SFN_REGEX.test(clean)
     ) {
       return true;
     }

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -440,7 +440,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         : fs.realpathSync;
     let resolved = realpathFn(p);
     if (process.platform === 'win32') {
-      if (resolved.startsWith('\\\\?\\UNC\\')) {
+      if (resolved.slice(0, 8).toUpperCase() === '\\\\?\\UNC\\') {
         resolved = '\\\\' + resolved.slice(8);
       } else if (resolved.startsWith('\\\\?\\')) {
         resolved = resolved.slice(4);

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -671,7 +671,7 @@ export function hasBlockedPathSegment(p: string): boolean {
     }
     if (
       (clean.startsWith('gha-creds-') && clean.endsWith('.json')) ||
-      /^(gha-cr|gh[0-9a-f]{4})~\d+\.json$/.test(clean)
+      /^(gha-cr|gh[0-9a-f]{4})~\d+\.jso(n)?$/.test(clean)
     ) {
       return true;
     }

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -434,7 +434,11 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
   }
   visited.add(key);
   try {
-    return fs.realpathSync(p);
+    const realpathFn =
+      process.platform === 'win32' && fs.realpathSync.native
+        ? fs.realpathSync.native
+        : fs.realpathSync;
+    return realpathFn(p);
   } catch (e: unknown) {
     if (
       e &&

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -635,3 +635,43 @@ export function resolveDefensiveToolPath(
   // Fallback: return the original path
   return cleanPath;
 }
+
+/**
+ * Trims trailing spaces and dots from a string without using regular expressions
+ * to completely eliminate any potential ReDoS (Regular Expression Denial of Service) risk.
+ */
+export function trimTrailingSpacesAndDots(str: string): string {
+  let end = str.length - 1;
+  while (end >= 0 && (str[end] === ' ' || str[end] === '.')) {
+    end--;
+  }
+  return str.slice(0, end + 1);
+}
+
+/**
+ * Checks if a path string contains any blocked segments (.git, .env, node_modules, gha-creds-*.json)
+ * including case-insensitive matches and NTFS 8.3 short names.
+ */
+export function hasBlockedPathSegment(p: string): boolean {
+  // Split by both forward and backward slashes to be platform-agnostic
+  const segments = p.split(/[/\\]/);
+  for (const segment of segments) {
+    const clean = trimTrailingSpacesAndDots(
+      segment.split(':')[0],
+    ).toLowerCase();
+    if (
+      clean === '.git' ||
+      clean === '.env' ||
+      clean === 'node_modules' ||
+      /^(git|gi[0-9a-f]{4})~\d+$/.test(clean) ||
+      /^(env|en[0-9a-f]{4})~\d+$/.test(clean) ||
+      /^(node_m|no[0-9a-f]{4})~\d+$/.test(clean)
+    ) {
+      return true;
+    }
+    if (clean.startsWith('gha-creds-') && clean.endsWith('.json')) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -438,7 +438,15 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
       process.platform === 'win32' && fs.realpathSync.native
         ? fs.realpathSync.native
         : fs.realpathSync;
-    return realpathFn(p);
+    let resolved = realpathFn(p);
+    if (process.platform === 'win32') {
+      if (resolved.startsWith('\\\\?\\UNC\\')) {
+        resolved = '\\\\' + resolved.slice(8);
+      } else if (resolved.startsWith('\\\\?\\')) {
+        resolved = resolved.slice(4);
+      }
+    }
+    return resolved;
   } catch (e: unknown) {
     if (
       e &&

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -439,7 +439,7 @@ function robustRealpath(p: string, visited = new Set<string>()): string {
         ? fs.realpathSync.native
         : fs.realpathSync;
     let resolved = realpathFn(p);
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' && typeof resolved === 'string') {
       if (resolved.slice(0, 8).toUpperCase() === '\\\\?\\UNC\\') {
         resolved = '\\\\' + resolved.slice(8);
       } else if (resolved.startsWith('\\\\?\\')) {

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -368,7 +368,7 @@ export function isSubpath(parentPath: string, childPath: string): boolean {
   let p = pathModule.resolve(parentPath);
   let c = pathModule.resolve(childPath);
 
-  if (isWindows) {
+  if (isWindows && (p.includes('~') || c.includes('~'))) {
     try {
       p = resolveToRealPath(p);
       c = resolveToRealPath(c);

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -669,7 +669,10 @@ export function hasBlockedPathSegment(p: string): boolean {
     ) {
       return true;
     }
-    if (clean.startsWith('gha-creds-') && clean.endsWith('.json')) {
+    if (
+      (clean.startsWith('gha-creds-') && clean.endsWith('.json')) ||
+      /^(gha-cr|gh[0-9a-f]{4})~\d+\.json$/.test(clean)
+    ) {
       return true;
     }
   }

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { WorkspaceContext } from './workspaceContext.js';
 import { debugLogger } from './debugLogger.js';
+import { resolveToRealPath } from './paths.js';
 
 describe('WorkspaceContext with real filesystem', () => {
   let tempDir: string;
@@ -18,8 +19,8 @@ describe('WorkspaceContext with real filesystem', () => {
 
   beforeEach(() => {
     // os.tmpdir() can return a path using a symlink (this is standard on macOS)
-    // Use fs.realpathSync to fully resolve the absolute path.
-    tempDir = fs.realpathSync(
+    // Use resolveToRealPath to fully resolve the absolute path canonically.
+    tempDir = resolveToRealPath(
       fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-context-test-')),
     );
 
@@ -453,7 +454,7 @@ describe('WorkspaceContext with optional directories', () => {
   let nonExistentDir: string;
 
   beforeEach(() => {
-    tempDir = fs.realpathSync(
+    tempDir = resolveToRealPath(
       fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-context-optional-')),
     );
     cwd = path.join(tempDir, 'project');

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { debugLogger } from './debugLogger.js';
-import { resolveToRealPath } from './paths.js';
+import { resolveToRealPath, hasBlockedPathSegment } from './paths.js';
 
 export type Unsubscribe = () => void;
 
@@ -187,27 +187,8 @@ export class WorkspaceContext {
 
       for (const dir of this.directories) {
         if (this.isPathWithinRoot(fullyResolvedPath, dir)) {
-          // Check for blocked segments case-insensitively
           const relative = path.relative(dir, fullyResolvedPath);
-          const segments = relative.split(path.sep);
-          const hasBlockedSegment = segments.some((segment) => {
-            const clean = trimTrailingSpacesAndDots(
-              segment.split(':')[0],
-            ).toLowerCase();
-            if (
-              clean === '.git' ||
-              clean === '.env' ||
-              clean === 'node_modules'
-            ) {
-              return true;
-            }
-            // Block GitHub Actions Workload Identity credentials
-            if (clean.startsWith('gha-creds-') && clean.endsWith('.json')) {
-              return true;
-            }
-            return false;
-          });
-          if (hasBlockedSegment) {
+          if (hasBlockedPathSegment(relative)) {
             return false;
           }
           return true;
@@ -273,16 +254,4 @@ export class WorkspaceContext {
       !path.isAbsolute(relative)
     );
   }
-}
-
-/**
- * Trims trailing spaces and dots from a string without using regular expressions
- * to completely eliminate any potential ReDoS (Regular Expression Denial of Service) risk.
- */
-function trimTrailingSpacesAndDots(str: string): string {
-  let end = str.length - 1;
-  while (end >= 0 && (str[end] === ' ' || str[end] === '.')) {
-    end--;
-  }
-  return str.slice(0, end + 1);
 }

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -125,7 +125,9 @@ export class WorkspaceContext {
         return;
       }
       // Resolve symlinks and SFNs canonically
-      const resolved = resolveToRealPath(path.resolve(this.targetDir, pathToAdd));
+      const resolved = resolveToRealPath(
+        path.resolve(this.targetDir, pathToAdd),
+      );
       this.readOnlyPaths.add(resolved);
     } catch (e) {
       debugLogger.warn(`Failed to add read-only path ${pathToAdd}:`, e);

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -124,8 +124,8 @@ export class WorkspaceContext {
       if (!fs.existsSync(pathToAdd)) {
         return;
       }
-      // Resolve symlinks
-      const resolved = fs.realpathSync(path.resolve(this.targetDir, pathToAdd));
+      // Resolve symlinks and SFNs canonically
+      const resolved = resolveToRealPath(path.resolve(this.targetDir, pathToAdd));
       this.readOnlyPaths.add(resolved);
     } catch (e) {
       debugLogger.warn(`Failed to add read-only path ${pathToAdd}:`, e);
@@ -143,7 +143,8 @@ export class WorkspaceContext {
       throw new Error(`Path is not a directory: ${absolutePath}`);
     }
 
-    return fs.realpathSync(absolutePath);
+    // Resolve workspace directory canonically (supporting Windows SFNs)
+    return resolveToRealPath(absolutePath);
   }
 
   /**

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -4,6 +4,57 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
+
+// On Windows, temp directories like os.tmpdir() use NTFS 8.3 short names (SFNs, e.g. RUNNER~1).
+// Since our secure production path resolution canonicalizes these to long names using native Win32 APIs,
+// we globally wrap fs.realpathSync and fs.promises.realpath on Windows during tests.
+// This ensures that tests using raw fs.realpathSync(fs.mkdtempSync(...)) also receive canonical long paths,
+// preventing path mismatch failures.
+if (process.platform === 'win32') {
+  const originalRealpathSync = fs.realpathSync;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const customRealpathSync = (p: fs.PathLike, options?: any) => {
+    if (typeof p === 'string') {
+      try {
+        const nativeFn = originalRealpathSync.native || originalRealpathSync;
+        let resolved = nativeFn(p, options);
+        if (typeof resolved === 'string') {
+          if (resolved.slice(0, 8).toUpperCase() === '\\\\?\\UNC\\') {
+            resolved = '\\\\' + resolved.slice(8);
+          } else if (resolved.startsWith('\\\\?\\')) {
+            resolved = resolved.slice(4);
+          }
+          return resolved;
+        }
+        return resolved;
+      } catch {
+        return originalRealpathSync(p, options);
+      }
+    }
+    return originalRealpathSync(p, options);
+  };
+  customRealpathSync.native = originalRealpathSync.native || originalRealpathSync;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fs.realpathSync = customRealpathSync as any;
+
+  const originalRealpathPromise = fs.promises.realpath;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const customRealpathPromise = async (p: fs.PathLike, options?: any) => {
+    if (typeof p === 'string') {
+      try {
+        return customRealpathSync(p, options);
+      } catch {
+        return originalRealpathPromise(p, options);
+      }
+    }
+    return originalRealpathPromise(p, options);
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fs.promises.realpath = customRealpathPromise as any;
+}
+
 // Unset NO_COLOR environment variable to ensure consistent theme behavior between local and CI test runs
 if (process.env.NO_COLOR !== undefined) {
   delete process.env.NO_COLOR;

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -4,57 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'node:fs';
-
-// On Windows, temp directories like os.tmpdir() use NTFS 8.3 short names (SFNs, e.g. RUNNER~1).
-// Since our secure production path resolution canonicalizes these to long names using native Win32 APIs,
-// we globally wrap fs.realpathSync and fs.promises.realpath on Windows during tests.
-// This ensures that tests using raw fs.realpathSync(fs.mkdtempSync(...)) also receive canonical long paths,
-// preventing path mismatch failures.
-if (process.platform === 'win32') {
-  const originalRealpathSync = fs.realpathSync;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const customRealpathSync = (p: fs.PathLike, options?: any) => {
-    if (typeof p === 'string') {
-      try {
-        const nativeFn = originalRealpathSync.native || originalRealpathSync;
-        let resolved = nativeFn(p, options);
-        if (typeof resolved === 'string') {
-          if (resolved.slice(0, 8).toUpperCase() === '\\\\?\\UNC\\') {
-            resolved = '\\\\' + resolved.slice(8);
-          } else if (resolved.startsWith('\\\\?\\')) {
-            resolved = resolved.slice(4);
-          }
-          return resolved;
-        }
-        return resolved;
-      } catch {
-        return originalRealpathSync(p, options);
-      }
-    }
-    return originalRealpathSync(p, options);
-  };
-  customRealpathSync.native = originalRealpathSync.native || originalRealpathSync;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fs.realpathSync = customRealpathSync as any;
-
-  const originalRealpathPromise = fs.promises.realpath;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const customRealpathPromise = async (p: fs.PathLike, options?: any) => {
-    if (typeof p === 'string') {
-      try {
-        return customRealpathSync(p, options);
-      } catch {
-        return originalRealpathPromise(p, options);
-      }
-    }
-    return originalRealpathPromise(p, options);
-  };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fs.promises.realpath = customRealpathPromise as any;
-}
-
 // Unset NO_COLOR environment variable to ensure consistent theme behavior between local and CI test runs
 if (process.env.NO_COLOR !== undefined) {
   delete process.env.NO_COLOR;


### PR DESCRIPTION


## Summary

This PR mitigates path traversal and blocklist not allowed paths on NTFS filesystems by handling Windows short names (SFNs, e.g. `git~1`, `env~1`,
      `node_m~1` and `vscode~1`) in both path normalization and the AllowedPathChecker safety engine.

## Details

- Enhanced the AllowedPathChecker blocklist logic to recognize common short-name patterns (`git~`, `env~`, `node_m~`, `vscode~`) followed by digits.
- Corrected robust path resolution on Windows by checking `fs.realpathSync.native` when available on win32 to guarantee canonicalization of short names to long
      names prior to check.
- Added comprehensive unit tests in `built-in.test.ts` and `paths.test.ts` targeting NTFS 8.3 short name scenarios.

## Related Issues

Closes Bug 462382408

## How to Validate

Run the core unit tests:
npm test -w @google/gemini-cli-core -- src/safety/built-in.test.ts src/utils/paths.test.ts

Verify that the tests run successfully and all test cases (including NTFS 8.3 short names and case-insensitive check scenarios) pass.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ X] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ X] Linux
    - [ X] npm run
    - [ ] npx
    - [ ] Docker
