### PR TITLE
fix(core): enforce RFC 9207 issuer identification in MCP OAuth flow

### DIFF
--- a/docs/tools/mcp-server.md
+++ b/docs/tools/mcp-server.md
@@ -322,6 +322,57 @@ This feature will not work in:
 - Remote SSH sessions without X11 forwarding
 - Containerized environments without browser support
 
+#### Authorization server requirements (RFC 9207)
+
+<!-- prettier-ignore -->
+> [!IMPORTANT]
+> To protect against OAuth Identity Provider (IdP) mix-up attacks, Gemini CLI
+> validates the `iss` (issuer) parameter per
+> [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207). When an expected issuer is
+> discovered or configured, authorization servers **must** return the `iss`
+> parameter in the callback redirect matching the issuer URL. Responses missing
+> `iss` or with mismatched issuers are rejected with HTTP 400.
+
+##### Expected authorization callback example
+
+When the authorization server redirects the user back to Gemini CLI, the
+redirect URI must include the `iss` parameter:
+
+```http
+HTTP/1.1 302 Found
+Location: http://localhost:<port>/oauth/callback?code=AUTH_CODE&state=STATE&iss=https%3A%2F%2Fauth.example.com
+```
+
+- **Valid response (accepted):** `iss` matches the configured or discovered
+  issuer (`https://auth.example.com`).
+- **Missing `iss` (rejected):**
+  `http://localhost:<port>/oauth/callback?code=AUTH_CODE&state=STATE` (fails
+  with HTTP 400: `Missing issuer parameter in response`).
+- **Mismatched `iss` (rejected):** `iss` points to a different domain or
+  includes userinfo (fails with HTTP 400: `Issuer mismatch`).
+
+##### Configuration example with explicit issuer
+
+If your remote MCP server uses an authorization server with a known issuer URL:
+
+```json
+{
+  "mcpServers": {
+    "secureRemoteServer": {
+      "url": "https://mcp.example.com/sse",
+      "oauth": {
+        "enabled": true,
+        "issuer": "https://auth.example.com",
+        "authorizationUrl": "https://auth.example.com/oauth/authorize",
+        "tokenUrl": "https://auth.example.com/oauth/token",
+        "clientId": "gemini-cli-client",
+        "scopes": ["mcp:read", "mcp:write"]
+      }
+    }
+  }
+}
+```
+
 #### Managing OAuth authentication
 
 Use the `/mcp auth` command to manage OAuth authentication:
@@ -345,6 +396,8 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`clientSecret`** (string): OAuth client secret (optional for public clients)
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered
   if omitted)
+- **`issuer`** (string): Authorization server issuer URL (auto-discovered if
+  omitted; validated per RFC 9207)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
 - **`redirectUri`** (string): Custom redirect URI (defaults to an OS-assigned

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -239,7 +239,7 @@ describe('MCPOAuthProvider', () => {
         // Simulate OAuth callback
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -421,7 +421,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -505,7 +505,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -603,7 +603,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -713,7 +713,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -845,7 +845,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -965,7 +965,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1004,7 +1004,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1081,7 +1081,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1184,7 +1184,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1236,7 +1236,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1284,7 +1284,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1328,7 +1328,7 @@ describe('MCPOAuthProvider', () => {
         // Simulate OAuth callback
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1370,7 +1370,7 @@ describe('MCPOAuthProvider', () => {
       vi.mocked(http.createServer).mockImplementation((handler) => {
         setTimeout(() => {
           const req = {
-            url: '/oauth/callback?code=code&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=code&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           } as http.IncomingMessage;
           const res = {
             writeHead: vi.fn(),
@@ -1798,7 +1798,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1848,7 +1848,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1905,7 +1905,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -1959,7 +1959,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw&iss=https://auth.example.com',
           };
           const mockRes = {
             writeHead: vi.fn(),

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -397,8 +397,15 @@ export class MCPOAuthProvider {
     const preferredPort = getPortFromUrl(config.redirectUri);
 
     // Start callback server first to allocate port
-    // This ensures we only create one server and eliminates race conditions
-    const callbackServer = startCallbackServer(pkceParams.state, preferredPort);
+    // Pass config.issuer for RFC 9207 Authorization Server Issuer Identification / Mix-Up defense
+    debugLogger.debug(
+      `Starting callback server for "${serverName}" (expected issuer: ${config.issuer || 'none'})...`,
+    );
+    const callbackServer = startCallbackServer(
+      pkceParams.state,
+      preferredPort,
+      config.issuer,
+    );
 
     // Wait for server to start and get the allocated port
     // We need this port for client registration and auth URL building

--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -20,6 +20,7 @@ import {
   startCallbackServer,
   exchangeCodeForToken,
   refreshAccessToken,
+  areIssuersEqual,
   REDIRECT_PATH,
 } from './oauth-flow.js';
 
@@ -83,6 +84,62 @@ describe('oauth-flow', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  describe('areIssuersEqual', () => {
+    it('should return true for identical issuer strings', () => {
+      expect(
+        areIssuersEqual(
+          'https://github.com/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(true);
+    });
+
+    it('should return true when one issuer has a trailing slash', () => {
+      expect(
+        areIssuersEqual(
+          'https://github.com/login/oauth/',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(true);
+      expect(
+        areIssuersEqual(
+          'https://github.com/login/oauth',
+          'https://github.com/login/oauth/',
+        ),
+      ).toBe(true);
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com/',
+          'https://auth.example.com',
+        ),
+      ).toBe(true);
+    });
+
+    it('should return false for different domains', () => {
+      expect(
+        areIssuersEqual(
+          'https://attacker.example.com',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(false);
+    });
+
+    it('should return false for different paths', () => {
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com/realm-a',
+          'https://auth.example.com/realm-b',
+        ),
+      ).toBe(false);
+    });
+
+    it('should handle non-URL strings gracefully', () => {
+      expect(areIssuersEqual('custom-issuer', 'custom-issuer')).toBe(true);
+      expect(areIssuersEqual('custom-issuer/', 'custom-issuer')).toBe(true);
+      expect(areIssuersEqual('custom-issuer-a', 'custom-issuer-b')).toBe(false);
+    });
   });
 
   describe('generatePKCEParams', () => {
@@ -377,6 +434,62 @@ describe('oauth-flow', () => {
       expect(response.state).toBe('my-state');
     });
 
+    it('should resolve response with code, state, and matching iss on valid callback', async () => {
+      const server = startCallbackServer(
+        'my-state',
+        undefined,
+        'https://github.com/login/oauth',
+      );
+      const port = await server.port;
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=auth-code-123&state=my-state&iss=https://github.com/login/oauth`,
+      );
+      expect(res.status).toBe(200);
+
+      const response = await server.response;
+      expect(response.code).toBe('auth-code-123');
+      expect(response.state).toBe('my-state');
+      expect(response.iss).toBe('https://github.com/login/oauth');
+    });
+
+    it('should accept callback when issuer matches with trailing slash normalization', async () => {
+      const server = startCallbackServer(
+        'my-state',
+        undefined,
+        'https://github.com/login/oauth/',
+      );
+      const port = await server.port;
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=auth-code-123&state=my-state&iss=https://github.com/login/oauth`,
+      );
+      expect(res.status).toBe(200);
+
+      const response = await server.response;
+      expect(response.code).toBe('auth-code-123');
+      expect(response.state).toBe('my-state');
+    });
+
+    it('should allow callback when iss parameter is omitted for legacy authorization servers', async () => {
+      const server = startCallbackServer(
+        'my-state',
+        undefined,
+        'https://legacy-idp.example.com',
+      );
+      const port = await server.port;
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=legacy-code&state=my-state`,
+      );
+      expect(res.status).toBe(200);
+
+      const response = await server.response;
+      expect(response.code).toBe('legacy-code');
+      expect(response.state).toBe('my-state');
+      expect(response.iss).toBeUndefined();
+    });
+
     it('should reject on state mismatch', async () => {
       const server = startCallbackServer('expected-state');
       const port = await server.port;
@@ -396,6 +509,31 @@ describe('oauth-flow', () => {
 
       const error = await responseResult;
       expect(error.message).toContain('State mismatch - possible CSRF attack');
+    });
+
+    it('should reject callback when issuer (iss) does not match expected authorization server', async () => {
+      const server = startCallbackServer(
+        'expected-state',
+        undefined,
+        'https://github.com/login/oauth',
+      );
+      const port = await server.port;
+
+      const responseResult = server.response.then(
+        () => new Error('Expected rejection'),
+        (e: Error) => e,
+      );
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=abc&state=expected-state&iss=https://attacker-idp.example.com`,
+      ).catch(() => {});
+
+      if (res) {
+        expect(res.status).toBe(400);
+      }
+
+      const error = await responseResult;
+      expect(error.message).toContain('Issuer mismatch');
     });
 
     it('should reject on OAuth error in callback', async () => {

--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -555,12 +555,37 @@ describe('oauth-flow', () => {
       expect(response.state).toBe('my-state');
     });
 
-    it('should allow callback when iss parameter is omitted for legacy authorization servers', async () => {
+    it('should reject callback when expectedIssuer is configured but iss parameter is omitted (downgrade prevention)', async () => {
       const server = startCallbackServer(
         'my-state',
         undefined,
-        'https://legacy-idp.example.com',
+        'https://secure-idp.example.com',
       );
+      const port = await server.port;
+
+      const responseResult = server.response.then(
+        () => new Error('Expected rejection'),
+        (e: Error) => e,
+      );
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=auth-code-123&state=my-state`,
+      ).catch(() => {});
+
+      if (res) {
+        expect(res.status).toBe(400);
+      }
+
+      const error = await responseResult;
+      expect(error.message).toContain(
+        'Missing "iss" parameter in authorization response per RFC 9207',
+      );
+      // Ensure sensitive internal issuer details are not exposed in the error message
+      expect(error.message).not.toContain('https://secure-idp.example.com');
+    });
+
+    it('should allow callback when no expectedIssuer is configured and iss parameter is omitted', async () => {
+      const server = startCallbackServer('my-state', undefined, undefined);
       const port = await server.port;
 
       const res = await realFetch(
@@ -572,6 +597,21 @@ describe('oauth-flow', () => {
       expect(response.code).toBe('legacy-code');
       expect(response.state).toBe('my-state');
       expect(response.iss).toBeUndefined();
+    });
+
+    it('should allow callback when no expectedIssuer is configured and iss parameter is present', async () => {
+      const server = startCallbackServer('my-state', undefined, undefined);
+      const port = await server.port;
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=code-456&state=my-state&iss=https://idp.example.com`,
+      );
+      expect(res.status).toBe(200);
+
+      const response = await server.response;
+      expect(response.code).toBe('code-456');
+      expect(response.state).toBe('my-state');
+      expect(response.iss).toBe('https://idp.example.com');
     });
 
     it('should reject on state mismatch', async () => {
@@ -618,6 +658,8 @@ describe('oauth-flow', () => {
 
       const error = await responseResult;
       expect(error.message).toContain('Issuer mismatch');
+      expect(error.message).not.toContain('https://attacker-idp.example.com');
+      expect(error.message).not.toContain('https://github.com/login/oauth');
     });
 
     it('should reject callback when issuer contains userinfo spoofing attempt', async () => {
@@ -643,6 +685,8 @@ describe('oauth-flow', () => {
 
       const error = await responseResult;
       expect(error.message).toContain('Issuer mismatch');
+      expect(error.message).not.toContain('https://attacker.com');
+      expect(error.message).not.toContain('https://github.com/login/oauth');
     });
 
     it('should reject on OAuth error in callback', async () => {

--- a/packages/core/src/utils/oauth-flow.test.ts
+++ b/packages/core/src/utils/oauth-flow.test.ts
@@ -135,6 +135,90 @@ describe('oauth-flow', () => {
       ).toBe(false);
     });
 
+    it('should reject issuers containing userinfo to prevent mix-up attacks (RFC 9207 bypass)', () => {
+      expect(
+        areIssuersEqual(
+          'https://github.com/login/oauth',
+          'https://attacker.com@github.com/login/oauth',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://attacker.com@github.com/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://github.com@attacker.com/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://user:password@github.com/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://attacker.com@github.com/login/oauth',
+          'https://attacker.com@github.com/login/oauth',
+        ),
+      ).toBe(false);
+    });
+
+    it('should distinguish issuers with different query parameters to prevent multi-tenant mix-up', () => {
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com?tenant=tenant1',
+          'https://auth.example.com?tenant=tenant2',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com?tenant=tenant1',
+          'https://auth.example.com',
+        ),
+      ).toBe(false);
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com/oauth/?tenant=tenant1',
+          'https://auth.example.com/oauth?tenant=tenant1',
+        ),
+      ).toBe(true);
+    });
+
+    it('should distinguish issuers with different hash fragments', () => {
+      expect(
+        areIssuersEqual(
+          'https://auth.example.com#env1',
+          'https://auth.example.com#env2',
+        ),
+      ).toBe(false);
+    });
+
+    it('should normalize host casing and default ports', () => {
+      expect(
+        areIssuersEqual(
+          'HTTPS://GITHUB.COM/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(true);
+      expect(
+        areIssuersEqual(
+          'https://github.com:443/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(true);
+      expect(
+        areIssuersEqual(
+          'https://github.com:8443/login/oauth',
+          'https://github.com/login/oauth',
+        ),
+      ).toBe(false);
+    });
+
     it('should handle non-URL strings gracefully', () => {
       expect(areIssuersEqual('custom-issuer', 'custom-issuer')).toBe(true);
       expect(areIssuersEqual('custom-issuer/', 'custom-issuer')).toBe(true);
@@ -526,6 +610,31 @@ describe('oauth-flow', () => {
 
       const res = await realFetch(
         `http://localhost:${port}${REDIRECT_PATH}?code=abc&state=expected-state&iss=https://attacker-idp.example.com`,
+      ).catch(() => {});
+
+      if (res) {
+        expect(res.status).toBe(400);
+      }
+
+      const error = await responseResult;
+      expect(error.message).toContain('Issuer mismatch');
+    });
+
+    it('should reject callback when issuer contains userinfo spoofing attempt', async () => {
+      const server = startCallbackServer(
+        'expected-state',
+        undefined,
+        'https://github.com/login/oauth',
+      );
+      const port = await server.port;
+
+      const responseResult = server.response.then(
+        () => new Error('Expected rejection'),
+        (e: Error) => e,
+      );
+
+      const res = await realFetch(
+        `http://localhost:${port}${REDIRECT_PATH}?code=abc&state=expected-state&iss=https://attacker.com@github.com/login/oauth`,
       ).catch(() => {});
 
       if (res) {

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -55,6 +55,7 @@ export interface PKCEParams {
 export interface OAuthAuthorizationResponse {
   code: string;
   state: string;
+  iss?: string;
 }
 
 /**
@@ -136,16 +137,36 @@ export function generatePKCEParams(): PKCEParams {
 }
 
 /**
+ * Compares two OAuth issuer URLs per RFC 8414 / RFC 9207.
+ * Normalizes trailing slashes and origins to ensure consistent matching.
+ */
+export function areIssuersEqual(issuerA: string, issuerB: string): boolean {
+  if (issuerA === issuerB) return true;
+  const normalize = (iss: string): string => {
+    try {
+      const u = new URL(iss);
+      const normalizedPath = u.pathname.replace(/\/+$/, '');
+      return `${u.protocol}//${u.host}${normalizedPath}`;
+    } catch {
+      return iss.replace(/\/+$/, '');
+    }
+  };
+  return normalize(issuerA) === normalize(issuerB);
+}
+
+/**
  * Start a local HTTP server to handle OAuth callback.
  * The server will listen on the specified port (or port 0 for OS assignment).
  *
  * @param expectedState The state parameter to validate
  * @param port Optional preferred port to listen on
+ * @param expectedIssuer Optional expected authorization server issuer for RFC 9207 validation
  * @returns Object containing the port (available immediately) and a promise for the auth response
  */
 export function startCallbackServer(
   expectedState: string,
   port?: number,
+  expectedIssuer?: string,
 ): {
   port: Promise<number>;
   response: Promise<OAuthAuthorizationResponse>;
@@ -177,8 +198,10 @@ export function startCallbackServer(
             const code = url.searchParams.get('code');
             const state = url.searchParams.get('state');
             const error = url.searchParams.get('error');
+            const iss = url.searchParams.get('iss') || undefined;
 
             if (error) {
+              debugLogger.warn(`OAuth callback received error: ${error}`);
               res.writeHead(HTTP_OK, { 'Content-Type': 'text/html' });
               res.end(`
               <html>
@@ -196,17 +219,60 @@ export function startCallbackServer(
             }
 
             if (!code || !state) {
+              debugLogger.warn(
+                'OAuth callback rejected: Missing code or state parameter.',
+              );
               res.writeHead(400);
               res.end('Missing code or state parameter');
               return;
             }
 
             if (state !== expectedState) {
+              debugLogger.error(
+                `OAuth callback state mismatch: received state "${state}", expected "${expectedState}". Possible CSRF attack.`,
+              );
               res.writeHead(400);
               res.end('Invalid state parameter');
               server.close();
               reject(new Error('State mismatch - possible CSRF attack'));
               return;
+            }
+
+            // RFC 9207 Authorization Server Issuer Identification check
+            if (expectedIssuer && iss) {
+              if (!areIssuersEqual(iss, expectedIssuer)) {
+                debugLogger.error(
+                  `OAuth callback issuer mismatch: received "${iss}", expected "${expectedIssuer}". Possible IdP mix-up attack (RFC 9207).`,
+                );
+                res.writeHead(400, { 'Content-Type': 'text/html' });
+                res.end(`
+                <html>
+                  <body>
+                    <h1>Authentication Failed</h1>
+                    <p>Error: Issuer mismatch - possible OAuth mix-up attack.</p>
+                    <p>You can close this window.</p>
+                  </body>
+                </html>
+              `);
+                server.close();
+                reject(
+                  new Error(
+                    `Issuer mismatch: received "${iss}", expected "${expectedIssuer}" - possible OAuth mix-up attack`,
+                  ),
+                );
+                return;
+              }
+              debugLogger.debug(
+                `✓ OAuth callback issuer validated successfully: "${iss}"`,
+              );
+            } else if (expectedIssuer && !iss) {
+              debugLogger.debug(
+                `OAuth callback omitted "iss" parameter; expected "${expectedIssuer}". Proceeding for backwards compatibility with legacy authorization servers.`,
+              );
+            } else if (iss) {
+              debugLogger.debug(
+                `OAuth callback received issuer: "${iss}" (no expected issuer was specified).`,
+              );
             }
 
             // Send success response to browser
@@ -222,7 +288,7 @@ export function startCallbackServer(
           `);
 
             server.close();
-            resolve({ code, state });
+            resolve({ code, state, iss });
           } catch (error) {
             server.close();
             reject(error);

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -138,20 +138,46 @@ export function generatePKCEParams(): PKCEParams {
 
 /**
  * Compares two OAuth issuer URLs per RFC 8414 / RFC 9207.
- * Normalizes trailing slashes and origins to ensure consistent matching.
+ * Normalizes trailing slashes and origins to ensure consistent matching,
+ * while rejecting userinfo (preventing OAuth mix-up attacks) and preserving
+ * query parameters and fragments.
  */
 export function areIssuersEqual(issuerA: string, issuerB: string): boolean {
-  if (issuerA === issuerB) return true;
-  const normalize = (iss: string): string => {
+  if (issuerA === issuerB && !issuerA.includes('@')) return true;
+
+  const normalize = (iss: string): string | null => {
     try {
       const u = new URL(iss);
+
+      // RFC 8414 & RFC 9207: Valid OAuth issuers MUST NOT contain userinfo.
+      // Discarding or accepting userinfo can enable URL confusion / mix-up attacks
+      // (e.g., https://attacker.com@github.com/login/oauth).
+      if (u.username || u.password) {
+        return null;
+      }
+
+      // Normalize trailing slashes on pathname (e.g., "/oauth/" -> "/oauth")
       const normalizedPath = u.pathname.replace(/\/+$/, '');
-      return `${u.protocol}//${u.host}${normalizedPath}`;
+
+      // Reconstruct canonical URL:
+      // - u.protocol and u.host handle lowercasing and default port removal (:443)
+      // - normalizedPath handles trailing slash equivalence
+      // - u.search and u.hash are preserved so different tenants/queries never collide
+      return `${u.protocol}//${u.host}${normalizedPath}${u.search}${u.hash}`;
     } catch {
+      // Fallback for non-standard / relative strings
       return iss.replace(/\/+$/, '');
     }
   };
-  return normalize(issuerA) === normalize(issuerB);
+
+  const normA = normalize(issuerA);
+  const normB = normalize(issuerB);
+
+  if (normA === null || normB === null) {
+    return false;
+  }
+
+  return normA === normB;
 }
 
 /**

--- a/packages/core/src/utils/oauth-flow.ts
+++ b/packages/core/src/utils/oauth-flow.ts
@@ -265,10 +265,34 @@ export function startCallbackServer(
             }
 
             // RFC 9207 Authorization Server Issuer Identification check
-            if (expectedIssuer && iss) {
+            if (expectedIssuer) {
+              // Fail-closed: if an issuer was expected, the response MUST include it
+              if (!iss) {
+                debugLogger.error(
+                  'OAuth callback rejected: Missing required "iss" parameter when an expected issuer is configured. Possible IdP mix-up attack (RFC 9207).',
+                );
+                res.writeHead(400, { 'Content-Type': 'text/html' });
+                res.end(`
+                <html>
+                  <body>
+                    <h1>Authentication Failed</h1>
+                    <p>Error: Missing issuer parameter in response.</p>
+                    <p>You can close this window.</p>
+                  </body>
+                </html>
+              `);
+                server.close();
+                reject(
+                  new Error(
+                    'Missing "iss" parameter in authorization response per RFC 9207',
+                  ),
+                );
+                return;
+              }
+
               if (!areIssuersEqual(iss, expectedIssuer)) {
                 debugLogger.error(
-                  `OAuth callback issuer mismatch: received "${iss}", expected "${expectedIssuer}". Possible IdP mix-up attack (RFC 9207).`,
+                  'OAuth callback rejected: Issuer mismatch between authorization response and expected authorization server. Possible IdP mix-up attack (RFC 9207).',
                 );
                 res.writeHead(400, { 'Content-Type': 'text/html' });
                 res.end(`
@@ -283,21 +307,17 @@ export function startCallbackServer(
                 server.close();
                 reject(
                   new Error(
-                    `Issuer mismatch: received "${iss}", expected "${expectedIssuer}" - possible OAuth mix-up attack`,
+                    'Issuer mismatch in authorization response - possible OAuth mix-up attack',
                   ),
                 );
                 return;
               }
               debugLogger.debug(
-                `✓ OAuth callback issuer validated successfully: "${iss}"`,
-              );
-            } else if (expectedIssuer && !iss) {
-              debugLogger.debug(
-                `OAuth callback omitted "iss" parameter; expected "${expectedIssuer}". Proceeding for backwards compatibility with legacy authorization servers.`,
+                '✓ OAuth callback issuer validated successfully.',
               );
             } else if (iss) {
               debugLogger.debug(
-                `OAuth callback received issuer: "${iss}" (no expected issuer was specified).`,
+                'OAuth callback received "iss" parameter (no expected issuer was configured).',
               );
             }
 


### PR DESCRIPTION
## Summary
Implements RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) validation in Gemini CLI's MCP OAuth flow to ensure response origin consistency and prevent unintended token routing.

## Details
- Extended `OAuthAuthorizationResponse` to include the optional `iss?: string` parameter.
- Implemented `areIssuersEqual(issuerA, issuerB)` helper in `oauth-flow.ts` to normalize trailing slashes and origin paths per RFC 8414/9207 while rejecting `userinfo` and preserving queries/fragments.
- Updated `startCallbackServer` to accept `expectedIssuer?: string` and enforce fail-closed RFC 9207 validation (rejecting missing `iss` or mismatched issuers with HTTP 400).
- Formatted error messages and redacted debug logs to avoid reflecting unvalidated callback parameters or exposing internal issuer URLs.
- Connected `config.issuer` from MCP discovery to `startCallbackServer` in `MCPOAuthProvider.authenticate`.
- Updated documentation in `docs/tools/mcp-server.md` with RFC 9207 authorization server requirements.

## Compatibility Note for MCP Developers
- Remote MCP servers using OAuth must ensure their Authorization Server supports RFC 9207 by returning the `iss` parameter in the callback redirect (`/oauth/callback?code=...&state=...&iss=https://<issuer>`).
- If an expected issuer is configured or discovered for the MCP server, callback responses missing `iss` will be rejected.

## Related Issues

## How to Validate
1.  Run targeted OAuth flow unit tests:
       ```bash
       npm test -w @google/gemini-cli-core -- src/utils/oauth-flow.test.ts src/mcp/oauth-provider.test.ts src/mcp/oauth-utils.test.ts
       ```

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ x] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ x] Linux
    - [ x] npm run
    - [ ] npx
    - [ ] Docker
