### PR TITLE
fix(extensions): only strip trailing .git suffix

### DIFF
--- a/packages/cli/src/config/extensions/github.test.ts
+++ b/packages/cli/src/config/extensions/github.test.ts
@@ -133,6 +133,9 @@ describe('github.ts', () => {
     it.each([
       ['https://github.com/owner/repo', 'owner', 'repo'],
       ['https://github.com/owner/repo.git', 'owner', 'repo'],
+      ['https://github.com/owner/blog.github.io', 'owner', 'blog.github.io'],
+      ['owner/my.git.repo', 'owner', 'my.git.repo'],
+      ['owner/repo.GIT', 'owner', 'repo'],
       ['git@github.com:owner/repo.git', 'owner', 'repo'],
       ['owner/repo', 'owner', 'repo'],
     ])('should parse %s to %s/%s', (url, owner, repo) => {

--- a/packages/cli/src/config/extensions/github.ts
+++ b/packages/cli/src/config/extensions/github.ts
@@ -125,7 +125,7 @@ export function tryParseGithubUrl(source: string): GithubRepoInfo | null {
     );
   }
   const owner = parts[0];
-  const repo = parts[1].replace('.git', '');
+  const repo = parts[1].replace(/\.git$/i, '');
 
   return {
     owner,


### PR DESCRIPTION
## Summary

Fix GitHub extension repository parsing so `.git` is removed only when it is a trailing suffix. Repository names containing `.git` internally, such as `blog.github.io`, now remain intact.

## Details

- Anchor `.git` removal to the end of the repository name and match it case-insensitively.
- Add regression coverage for internal `.git` substrings and uppercase `.GIT` suffixes.

## Related Issues

Fixes #29037

## How to Validate

Run:

```bash
npm test -w @google/gemini-cli -- src/config/extensions/github.test.ts --coverage.enabled=false --maxWorkers=1
```

Expected: all 37 tests pass, including cases for `blog.github.io`, `my.git.repo`, and `repo.GIT`.

Additional validation completed:

- `npm run build`
- `npm run typecheck`
- ESLint and Prettier checks on the two changed files

Note: the repository-wide preflight reached the lint stage on Windows but could not execute the existing `yamllint` pipeline because it uses POSIX shell quoting under `cmd.exe`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (not required; no documentation change)
- [x] Added/updated tests
- [x] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [x] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
