### PR TITLE
fix(core): improve destination validation and connection routing in web fetch utilities

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -148,10 +148,10 @@ each tool.
 
 ### Web
 
-| Tool                                          | Kind     | Description                                                                                                                                                                                                                                                                     |
-| :-------------------------------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`google_web_search`](../tools/web-search.md) | `Search` | Performs a Google Search to find up-to-date information.                                                                                                                                                                                                                        |
-| [`web_fetch`](../tools/web-fetch.md)          | `Fetch`  | Retrieves and processes content from specific URLs. **Warning:** This tool can access local and private network addresses (for example, localhost), which may pose a security risk if used with untrusted prompts. In Plan Mode, this tool requires explicit user confirmation. |
+| Tool                                          | Kind     | Description                                                                                                                                                                              |
+| :-------------------------------------------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`google_web_search`](../tools/web-search.md) | `Search` | Performs a Google Search to find up-to-date information.                                                                                                                                 |
+| [`web_fetch`](../tools/web-fetch.md)          | `Fetch`  | Retrieves and processes content from specific URLs. Outbound requests are validated against private and reserved IP ranges. In Plan Mode, this tool requires explicit user confirmation. |
 
 ### Tool argument keys
 

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -16,13 +16,17 @@ specific operations like summarization or extraction.
 
 ## Technical behavior
 
+- **Network access:** Destination URLs and resolved IP addresses are validated
+  to restrict access to private, reserved, loopback, and internal networks
+  (e.g., RFC 1918 addresses and internal domains). Transport connections are
+  pinned to the resolved destination IP address.
 - **Confirmation:** Triggers a confirmation dialog showing the converted URLs.
 - **Plan Mode:** In [Plan Mode](../cli/plan-mode.md), `web_fetch` is available
-  but always requires explicit user confirmation (`ask_user`) due to security
-  implications of accessing external or private network addresses.
+  but always requires explicit user confirmation (`ask_user`).
 - **Processing:** Uses the Gemini API's `urlContext` for retrieval.
 - **Fallback:** If API access fails, the tool attempts to fetch raw content
-  directly from your local machine.
+  directly from your local machine (with destination IP validation and
+  connection pinning applied).
 - **Formatting:** Returns a synthesized response with source attribution.
 
 ## Use cases

--- a/packages/cli/src/config/extensionRegistryClient.ts
+++ b/packages/cli/src/config/extensionRegistryClient.ts
@@ -112,7 +112,7 @@ export class ExtensionRegistryClient {
     ExtensionRegistryClient.fetchPromise = (async () => {
       try {
         if (uri.startsWith('http')) {
-          if (isPrivateIp(uri)) {
+          if (await isPrivateIp(uri)) {
             throw new Error(
               'Private IP addresses are not allowed for the extension registry.',
             );

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -83,6 +83,7 @@ vi.mock('undici', () => ({
   fetch: vi.fn(),
   setGlobalDispatcher: vi.fn(),
   Agent: vi.fn(),
+  buildConnector: vi.fn(() => vi.fn()),
 }));
 vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');

--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -376,7 +376,7 @@ describe('WebFetchTool', () => {
 
   describe('execute', () => {
     it('should return WEB_FETCH_PROCESSING_ERROR on rate limit exceeded', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [{ content: { parts: [{ text: 'response' }] } }],
       });
@@ -400,7 +400,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip rate-limited URLs but fetch others', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
 
       const tool = new WebFetchTool(mockConfig, bus);
       const params = {
@@ -439,8 +439,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should skip private or local URLs but fetch others and log telemetry', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIp).mockImplementation((url) =>
+        Promise.resolve(url === 'https://private.com/'),
       );
 
       const tool = new WebFetchTool(mockConfig, bus);
@@ -475,7 +475,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should fallback to all public URLs if primary fails', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
 
       // Primary fetch fails
       mockGenerateContent.mockRejectedValueOnce(new Error('primary fail'));
@@ -513,8 +513,8 @@ describe('WebFetchTool', () => {
     });
 
     it('should NOT include private URLs in fallback', async () => {
-      vi.mocked(fetchUtils.isPrivateIp).mockImplementation(
-        (url) => url === 'https://private.com/',
+      vi.mocked(fetchUtils.isPrivateIp).mockImplementation((url) =>
+        Promise.resolve(url === 'https://private.com/'),
       );
 
       // Primary fetch fails
@@ -546,7 +546,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should return WEB_FETCH_FALLBACK_FAILED on total failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
       mockGenerateContent.mockRejectedValue(new Error('primary fail'));
       mockFetch('https://public.ip/', new Error('fallback fetch failed'));
       const tool = new WebFetchTool(mockConfig, bus);
@@ -559,7 +559,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should log telemetry when falling back due to primary fetch failure', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
       // Mock primary fetch to return empty response, triggering fallback
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
@@ -591,7 +591,7 @@ describe('WebFetchTool', () => {
   describe('execute (fallback)', () => {
     beforeEach(() => {
       // Force fallback by mocking primary fetch to fail
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValueOnce({
         candidates: [],
       });
@@ -929,7 +929,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should execute normally after confirmation approval', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
       mockGenerateContent.mockResolvedValue({
         candidates: [
           {
@@ -963,7 +963,7 @@ describe('WebFetchTool', () => {
   describe('execute (experimental)', () => {
     beforeEach(() => {
       vi.spyOn(mockConfig, 'getDirectWebFetch').mockReturnValue(true);
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(false);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(false);
     });
 
     it('should perform direct fetch and return text for plain text content', async () => {
@@ -1142,7 +1142,7 @@ describe('WebFetchTool', () => {
     });
 
     it('should block private IP (experimental)', async () => {
-      vi.spyOn(fetchUtils, 'isPrivateIp').mockReturnValue(true);
+      vi.spyOn(fetchUtils, 'isPrivateIp').mockResolvedValue(true);
       const tool = new WebFetchTool(mockConfig, bus);
       const invocation = tool['createInvocation'](
         { url: 'http://localhost' },

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -267,14 +267,20 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     );
   }
 
-  private isBlockedHost(urlStr: string): boolean {
+  private async isBlockedHost(urlStr: string): Promise<boolean> {
     try {
       const url = new URL(urlStr);
       const hostname = url.hostname.toLowerCase();
-      if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      if (
+        hostname === 'localhost' ||
+        hostname === '127.0.0.1' ||
+        hostname.endsWith('.localhost') ||
+        hostname.endsWith('.local') ||
+        hostname.endsWith('.internal')
+      ) {
         return true;
       }
-      return isPrivateIp(urlStr);
+      return await isPrivateIp(urlStr);
     } catch {
       return true;
     }
@@ -285,7 +291,7 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     signal: AbortSignal,
   ): Promise<string> {
     const url = convertGithubUrlToRaw(urlStr);
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       debugLogger.warn(`[WebFetchTool] Blocked access to host: ${url}`);
       throw new Error(
         `Access to blocked or private host ${url} is not allowed.`,
@@ -350,16 +356,16 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     return textContent;
   }
 
-  private filterAndValidateUrls(urls: string[]): {
+  private async filterAndValidateUrls(urls: string[]): Promise<{
     toFetch: string[];
     skipped: string[];
-  } {
+  }> {
     const uniqueUrls = [...new Set(urls.map(normalizeUrl))];
     const toFetch: string[] = [];
     const skipped: string[] = [];
 
     for (const url of uniqueUrls) {
-      if (this.isBlockedHost(url)) {
+      if (await this.isBlockedHost(url)) {
         debugLogger.warn(
           `[WebFetchTool] Skipped private or local host: ${url}`,
         );
@@ -615,7 +621,7 @@ ${aggregatedContent}
     // Convert GitHub blob URL to raw URL
     url = convertGithubUrlToRaw(url);
 
-    if (this.isBlockedHost(url)) {
+    if (await this.isBlockedHost(url)) {
       const errorMessage = `Access to blocked or private host ${url} is not allowed.`;
       debugLogger.warn(
         `[WebFetchTool] Blocked experimental fetch to host: ${url}`,
@@ -769,7 +775,7 @@ Response: ${rawResponseText}`;
     const userPrompt = this.params.prompt!;
     const { validUrls } = parsePrompt(userPrompt);
 
-    const { toFetch, skipped } = this.filterAndValidateUrls(validUrls);
+    const { toFetch, skipped } = await this.filterAndValidateUrls(validUrls);
 
     // If everything was skipped, fail early
     if (toFetch.length === 0 && skipped.length > 0) {

--- a/packages/core/src/utils/fetch.spec.ts
+++ b/packages/core/src/utils/fetch.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import type { buildConnector } from 'undici';
+import ipaddr from 'ipaddr.js';
+
+const { mockLookup } = vi.hoisted(() => ({
+  mockLookup: vi.fn(async (hostname: string) => {
+    if (hostname === 'test.localhost' || hostname === 'localhost') {
+      return [{ address: '127.0.0.1', family: 4 }];
+    }
+    if (hostname === 'dual-stack-test.example.com') {
+      return [
+        { address: '93.184.216.34', family: 4 },
+        { address: '10.0.0.1', family: 4 },
+      ];
+    }
+    if (hostname === 'pinning-test.example.com') {
+      return [{ address: '93.184.216.34', family: 4 }];
+    }
+    if (hostname === 'failing-dns.example.com') {
+      throw new Error('getaddrinfo ENOTFOUND failing-dns.example.com');
+    }
+    if (hostname.endsWith('.nip.io')) {
+      const prefix = hostname.slice(0, -'.nip.io'.length);
+      if (ipaddr.isValid(prefix)) {
+        return [{ address: prefix, family: prefix.includes(':') ? 6 : 4 }];
+      }
+    }
+    if (ipaddr.isValid(hostname)) {
+      return [{ address: hostname, family: hostname.includes(':') ? 6 : 4 }];
+    }
+    return [{ address: '93.184.216.34', family: 4 }];
+  }),
+}));
+
+vi.mock('node:dns/promises', () => ({
+  lookup: mockLookup,
+}));
+
+const {
+  fetchWithTimeout,
+  isPrivateIp,
+  validateUrlDestination,
+  PrivateIpError,
+  createSafeConnector,
+} = await import('./fetch.js');
+
+describe('Destination IP Validation & Connection Pinning (fetch.spec.ts)', () => {
+  let server: http.Server;
+  let serverPort: number;
+  let requestReceived: boolean;
+
+  beforeEach(async () => {
+    requestReceived = false;
+
+    server = http.createServer((_req, res) => {
+      requestReceived = true;
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('CONFIDENTIAL_INTERNAL_DATA');
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        if (addr && typeof addr === 'object') {
+          serverPort = addr.port;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  describe('Cloud Metadata & Link-Local IP Protection', () => {
+    it('should block GCP Metadata (169.254.169.254) on default and custom ports', async () => {
+      const gcpMetadataUrls = [
+        'http://169.254.169.254/computeMetadata/v1/',
+        'http://169.254.169.254:8080/computeMetadata/v1/',
+        'http://169.254.169.254:443/computeMetadata/v1/',
+        'http://[::ffff:169.254.169.254]/computeMetadata/v1/',
+        'http://[::ffff:169.254.169.254]:8080/computeMetadata/v1/',
+        'http://169.254.1.1:9090/',
+      ];
+
+      for (const url of gcpMetadataUrls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+  });
+
+  describe('Standard Private IP Blocks (RFC 1918 & Loopback)', () => {
+    it('should block 10.x.x.x private ranges with standard and custom ports', async () => {
+      const urls = [
+        'http://10.0.0.1/',
+        'http://10.0.0.1:8080/api',
+        'http://10.255.255.254:9000/',
+        'http://[::ffff:10.0.0.1]:8080/',
+      ];
+
+      for (const url of urls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+
+    it('should block 172.16.x.x - 172.31.x.x private ranges with custom ports', async () => {
+      const urls = [
+        'http://172.16.0.1:3000/',
+        'http://172.20.10.1:8443/',
+        'http://172.31.255.255:9090/',
+      ];
+
+      for (const url of urls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+
+    it('should block 192.168.x.x private ranges with standard and custom ports', async () => {
+      const urls = [
+        'http://192.168.0.1/',
+        'http://192.168.1.1:8080/',
+        'http://192.168.100.254:4000/admin',
+        'http://[::ffff:192.168.1.1]:8080/',
+      ];
+
+      for (const url of urls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+
+    it('should block IPv6 loopback, link-local, and unique local addresses', async () => {
+      const urls = [
+        'http://[::1]:8080/',
+        'http://[fe80::1]:8080/',
+        'http://[fc00::1]:8080/',
+        'http://[fd00::1]:8080/',
+      ];
+
+      for (const url of urls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+  });
+
+  describe('Internal TLDs & Domain Resolution', () => {
+    it('should identify internal TLDs (.internal, .local, .localhost) as private', async () => {
+      const internalUrls = [
+        'http://instance-data.internal',
+        'http://metadata.google.internal/computeMetadata/v1/',
+        'http://printer.local:631/',
+        'http://service.internal:8080/',
+        'http://myhost.localhost:3000/',
+        'http://localhost:8080/',
+      ];
+
+      for (const url of internalUrls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+
+    it('should block fetching a domain that resolves to loopback IP (test.localhost)', async () => {
+      const targetUrl = `http://test.localhost:${serverPort}/secret`;
+
+      await expect(fetchWithTimeout(targetUrl, 5000)).rejects.toThrow(
+        PrivateIpError,
+      );
+
+      // Verify the local loopback server was never contacted
+      expect(requestReceived).toBe(false);
+    });
+
+    it('should block Carrier-Grade NAT (100.64.0.0/10) and IANA benchmark range (198.18.0.0/15)', async () => {
+      const urls = [
+        'http://100.64.0.1:8080/',
+        'http://100.127.255.254/',
+        'http://198.18.0.1:8080/',
+        'http://198.19.255.254/',
+      ];
+
+      for (const url of urls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+    });
+
+    it('should block wildcard DNS service (nip.io style) disguised domains pointing to private IPs', async () => {
+      const nipUrls = [
+        'http://127.0.0.1.nip.io:8080/admin',
+        'http://169.254.169.254.nip.io/computeMetadata/v1/',
+        'http://10.0.0.1.nip.io/',
+        'http://192.168.1.1.nip.io:3000/',
+      ];
+
+      for (const url of nipUrls) {
+        expect(await isPrivateIp(url)).toBe(true);
+        expect(await validateUrlDestination(url)).toBe(false);
+        await expect(fetchWithTimeout(url, 2000)).rejects.toThrow(
+          PrivateIpError,
+        );
+      }
+
+      // Allow public IP via nip.io
+      expect(await isPrivateIp('http://8.8.8.8.nip.io/')).toBe(false);
+      expect(await validateUrlDestination('http://8.8.8.8.nip.io/')).toBe(true);
+    });
+
+    it('should block domain if any of multiple resolved IPs is private (dual-stack validation)', async () => {
+      const testUrl = 'http://dual-stack-test.example.com/data';
+      expect(await isPrivateIp(testUrl)).toBe(true);
+      expect(await validateUrlDestination(testUrl)).toBe(false);
+      await expect(fetchWithTimeout(testUrl, 2000)).rejects.toThrow(
+        PrivateIpError,
+      );
+    });
+  });
+
+  describe('Connection Pinning & Fail-Closed Safety', () => {
+    it('should preserve original hostname as servername during TLS connection pinning', async () => {
+      let passedOpts: buildConnector.Options | undefined;
+      const mockDefaultConnector: buildConnector.connector = (
+        opts: buildConnector.Options,
+        callback: buildConnector.Callback,
+      ) => {
+        passedOpts = opts;
+        callback(null, new net.Socket());
+      };
+
+      const connector = createSafeConnector(undefined, mockDefaultConnector);
+      await new Promise<void>((resolve, reject) => {
+        connector(
+          {
+            hostname: 'pinning-test.example.com',
+            protocol: 'https:',
+            port: '443',
+          },
+          (...args) => {
+            const [err] = args;
+            if (err) reject(err);
+            else resolve();
+          },
+        );
+      });
+
+      expect(passedOpts?.hostname).toBe('93.184.216.34');
+      expect(passedOpts?.servername).toBe('pinning-test.example.com');
+    });
+
+    it('should fail closed when DNS resolution fails or times out', async () => {
+      const unresolvableUrl = 'http://failing-dns.example.com/path';
+      expect(await isPrivateIp(unresolvableUrl)).toBe(true);
+      expect(await validateUrlDestination(unresolvableUrl)).toBe(false);
+      await expect(fetchWithTimeout(unresolvableUrl, 2000)).rejects.toThrow();
+    });
+
+    it('should allow public domains and public IP addresses', async () => {
+      expect(await isPrivateIp('http://8.8.8.8/')).toBe(false);
+      expect(await validateUrlDestination('http://8.8.8.8/')).toBe(true);
+      expect(await isPrivateIp('http://93.184.216.34/')).toBe(false);
+      expect(await validateUrlDestination('http://93.184.216.34/')).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/utils/fetch.spec.ts
+++ b/packages/core/src/utils/fetch.spec.ts
@@ -9,6 +9,7 @@ import * as http from 'node:http';
 import * as net from 'node:net';
 import type { buildConnector } from 'undici';
 import ipaddr from 'ipaddr.js';
+import type { LookupAddress } from 'node:dns';
 
 const { mockLookup } = vi.hoisted(() => ({
   mockLookup: vi.fn(async (hostname: string) => {
@@ -50,6 +51,7 @@ const {
   validateUrlDestination,
   PrivateIpError,
   createSafeConnector,
+  safeLookup,
 } = await import('./fetch.js');
 
 describe('Destination IP Validation & Connection Pinning (fetch.spec.ts)', () => {
@@ -253,7 +255,7 @@ describe('Destination IP Validation & Connection Pinning (fetch.spec.ts)', () =>
   });
 
   describe('Connection Pinning & Fail-Closed Safety', () => {
-    it('should preserve original hostname as servername during TLS connection pinning', async () => {
+    it('should forward connection options and preserve hostname/servername', async () => {
       let passedOpts: buildConnector.Options | undefined;
       const mockDefaultConnector: buildConnector.connector = (
         opts: buildConnector.Options,
@@ -270,6 +272,7 @@ describe('Destination IP Validation & Connection Pinning (fetch.spec.ts)', () =>
             hostname: 'pinning-test.example.com',
             protocol: 'https:',
             port: '443',
+            servername: 'pinning-test.example.com',
           },
           (...args) => {
             const [err] = args;
@@ -279,8 +282,100 @@ describe('Destination IP Validation & Connection Pinning (fetch.spec.ts)', () =>
         );
       });
 
-      expect(passedOpts?.hostname).toBe('93.184.216.34');
+      expect(passedOpts?.hostname).toBe('pinning-test.example.com');
       expect(passedOpts?.servername).toBe('pinning-test.example.com');
+    });
+
+    it('should block direct private IP literals and internal TLDs at connector level', async () => {
+      const mockDefaultConnector: buildConnector.connector = (
+        opts,
+        callback,
+      ) => {
+        callback(null, new net.Socket());
+      };
+      const connector = createSafeConnector(undefined, mockDefaultConnector);
+
+      await expect(
+        new Promise<void>((resolve, reject) => {
+          connector(
+            { hostname: '127.0.0.1', protocol: 'http:', port: '80' },
+            (...args) => {
+              const [err] = args;
+              if (err) reject(err);
+              else resolve();
+            },
+          );
+        }),
+      ).rejects.toThrow(PrivateIpError);
+
+      await expect(
+        new Promise<void>((resolve, reject) => {
+          connector(
+            {
+              hostname: 'metadata.google.internal',
+              protocol: 'http:',
+              port: '80',
+            },
+            (...args) => {
+              const [err] = args;
+              if (err) reject(err);
+              else resolve();
+            },
+          );
+        }),
+      ).rejects.toThrow(PrivateIpError);
+    });
+
+    it('should configure safeLookup for dual-stack Happy Eyeballs resolution and validate IPs', async () => {
+      const addresses = await new Promise<LookupAddress[]>(
+        (resolve, reject) => {
+          safeLookup('pinning-test.example.com', { all: true }, (err, res) => {
+            if (err) {
+              reject(err);
+            } else if (Array.isArray(res)) {
+              resolve(res);
+            } else {
+              reject(new Error('Expected array of addresses'));
+            }
+          });
+        },
+      );
+      expect(addresses).toEqual([{ address: '93.184.216.34', family: 4 }]);
+    });
+
+    it('should block safeLookup when resolving to private IP or internal host', async () => {
+      await expect(
+        new Promise((resolve, reject) => {
+          safeLookup('test.localhost', { all: true }, (err, res) => {
+            if (err) reject(err);
+            else resolve(res);
+          });
+        }),
+      ).rejects.toThrow(PrivateIpError);
+
+      await expect(
+        new Promise((resolve, reject) => {
+          safeLookup('169.254.169.254', { all: true }, (err, res) => {
+            if (err) reject(err);
+            else resolve(res);
+          });
+        }),
+      ).rejects.toThrow(PrivateIpError);
+    });
+
+    it('should block safeLookup for dual-stack when any resolved IP is private', async () => {
+      await expect(
+        new Promise((resolve, reject) => {
+          safeLookup(
+            'dual-stack-test.example.com',
+            { all: true },
+            (err, res) => {
+              if (err) reject(err);
+              else resolve(res);
+            },
+          );
+        }),
+      ).rejects.toThrow(PrivateIpError);
     });
 
     it('should fail closed when DNS resolution fails or times out', async () => {

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -10,19 +10,23 @@ import * as dnsPromises from 'node:dns/promises';
 import type { LookupAddress, LookupAllOptions } from 'node:dns';
 import ipaddr from 'ipaddr.js';
 
-const { setGlobalDispatcher, Agent, EnvHttpProxyAgent, buildConnector } =
+const { setGlobalDispatcher, Agent, EnvHttpProxyAgent, mockHolder } =
   vi.hoisted(() => ({
     setGlobalDispatcher: vi.fn(),
     Agent: vi.fn(),
     EnvHttpProxyAgent: vi.fn(),
-    buildConnector: vi.fn(() => vi.fn()),
+    mockHolder: {
+      buildConnector: vi.fn(() => vi.fn()) as unknown,
+    },
   }));
 
 vi.mock('undici', () => ({
   setGlobalDispatcher,
   Agent,
   EnvHttpProxyAgent,
-  buildConnector,
+  get buildConnector() {
+    return mockHolder.buildConnector;
+  },
 }));
 
 vi.mock('node:dns/promises', () => ({
@@ -37,6 +41,7 @@ const {
   fetchWithTimeout,
   setGlobalProxy,
   createSafeProxyAgent,
+  createSafeAgent,
 } = await import('./fetch.js');
 interface ErrorWithCode extends Error {
   code?: string;
@@ -319,6 +324,29 @@ describe('fetch utils', () => {
         headersTimeout: 60000,
         bodyTimeout: 300000,
       });
+    });
+  });
+
+  describe('createSafeAgent', () => {
+    it('should instantiate undici.Agent with connect handler bound', () => {
+      createSafeAgent();
+      expect(Agent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connect: expect.any(Function),
+        }),
+      );
+    });
+
+    it('should throw fail-closed error if buildConnector is unavailable', () => {
+      const original = mockHolder.buildConnector;
+      mockHolder.buildConnector = undefined;
+      try {
+        expect(() => createSafeAgent()).toThrow(
+          'Security initialization failed: undici.buildConnector is not available.',
+        );
+      } finally {
+        mockHolder.buildConnector = original;
+      }
     });
   });
 });

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -245,6 +245,20 @@ describe('fetch utils', () => {
       // Must NOT be classified as a timeout
       await expect(rejection).rejects.not.toThrow('timed out');
     });
+
+    it('should route dispatcher to createSafeProxyAgent when proxy is configured', async () => {
+      setGlobalProxy('http://proxy.example.com');
+      vi.mocked(global.fetch).mockResolvedValueOnce(new Response('OK'));
+
+      await fetchWithTimeout('http://example.com', 10_000);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com',
+        expect.objectContaining({
+          dispatcher: expect.any(Object),
+        }),
+      );
+    });
   });
 
   describe('setGlobalProxy', () => {

--- a/packages/core/src/utils/fetch.test.ts
+++ b/packages/core/src/utils/fetch.test.ts
@@ -10,16 +10,19 @@ import * as dnsPromises from 'node:dns/promises';
 import type { LookupAddress, LookupAllOptions } from 'node:dns';
 import ipaddr from 'ipaddr.js';
 
-const { setGlobalDispatcher, Agent, EnvHttpProxyAgent } = vi.hoisted(() => ({
-  setGlobalDispatcher: vi.fn(),
-  Agent: vi.fn(),
-  EnvHttpProxyAgent: vi.fn(),
-}));
+const { setGlobalDispatcher, Agent, EnvHttpProxyAgent, buildConnector } =
+  vi.hoisted(() => ({
+    setGlobalDispatcher: vi.fn(),
+    Agent: vi.fn(),
+    EnvHttpProxyAgent: vi.fn(),
+    buildConnector: vi.fn(() => vi.fn()),
+  }));
 
 vi.mock('undici', () => ({
   setGlobalDispatcher,
   Agent,
   EnvHttpProxyAgent,
+  buildConnector,
 }));
 
 vi.mock('node:dns/promises', () => ({
@@ -125,16 +128,16 @@ describe('fetch utils', () => {
   });
 
   describe('isPrivateIp', () => {
-    it('should identify private IPs in URLs', () => {
-      expect(isPrivateIp('http://10.0.0.1/')).toBe(true);
-      expect(isPrivateIp('https://127.0.0.1:8080/')).toBe(true);
-      expect(isPrivateIp('http://localhost/')).toBe(true);
-      expect(isPrivateIp('http://[::1]/')).toBe(true);
+    it('should identify private IPs in URLs', async () => {
+      expect(await isPrivateIp('http://10.0.0.1/')).toBe(true);
+      expect(await isPrivateIp('https://127.0.0.1:8080/')).toBe(true);
+      expect(await isPrivateIp('http://localhost/')).toBe(true);
+      expect(await isPrivateIp('http://[::1]/')).toBe(true);
     });
 
-    it('should identify public IPs in URLs as non-private', () => {
-      expect(isPrivateIp('http://8.8.8.8/')).toBe(false);
-      expect(isPrivateIp('https://google.com/')).toBe(false);
+    it('should identify public IPs in URLs as non-private', async () => {
+      expect(await isPrivateIp('http://8.8.8.8/')).toBe(false);
+      expect(await isPrivateIp('https://google.com/')).toBe(false);
     });
   });
 

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -141,11 +141,17 @@ export function createSafeAgent(options?: {
   bodyTimeout?: number;
 }): undici.Agent {
   const buildConnectorFn = getBuildConnector();
+  if (!buildConnectorFn) {
+    throw new Error(
+      'Security initialization failed: undici.buildConnector is not available.',
+    );
+  }
+
   const connect = createSafeConnector();
   return new undici.Agent({
     headersTimeout: options?.headersTimeout ?? defaultHeadersTimeout,
     bodyTimeout: options?.bodyTimeout ?? defaultBodyTimeout,
-    ...(buildConnectorFn ? { connect } : {}),
+    connect,
   });
 }
 

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -465,13 +465,15 @@ export async function fetchWithTimeout(
   }
 
   try {
-    const fetchOptions: RequestInit & { dispatcher?: undici.Agent } = {
+    const fetchOptions: RequestInit & { dispatcher?: undici.Dispatcher } = {
       ...options,
       signal: controller.signal,
     };
 
-    if (!currentProxy && !fetchOptions.dispatcher) {
-      fetchOptions.dispatcher = defaultSafeAgent;
+    if (!fetchOptions.dispatcher) {
+      fetchOptions.dispatcher = currentProxy
+        ? createSafeProxyAgent(currentProxy)
+        : defaultSafeAgent;
     }
 
     const response = await fetch(url, fetchOptions);

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -10,6 +10,7 @@ import * as net from 'node:net';
 import * as undici from 'undici';
 import ipaddr from 'ipaddr.js';
 import { lookup } from 'node:dns/promises';
+import type { LookupAddress } from 'node:dns';
 
 export class FetchError extends Error {
   constructor(
@@ -33,10 +34,15 @@ let defaultHeadersTimeout = 60000; // 60 seconds
 const defaultBodyTimeout = 300000; // 5 minutes
 let currentProxy: string | undefined = undefined;
 
-function getBuildConnector(): typeof undici.buildConnector | undefined {
+function getBuildConnector():
+  | ((options?: object) => undici.buildConnector.connector)
+  | undefined {
   try {
-    const fn = (undici as { buildConnector?: typeof undici.buildConnector })
-      .buildConnector;
+    const fn = (
+      undici as {
+        buildConnector?: (options?: object) => undici.buildConnector.connector;
+      }
+    ).buildConnector;
     return typeof fn === 'function' ? fn : undefined;
   } catch {
     return undefined;
@@ -44,17 +50,108 @@ function getBuildConnector(): typeof undici.buildConnector | undefined {
 }
 
 /**
- * Creates an undici connector that validates destination IP addresses and pins
- * the connection to prevent DNS rebinding (TOCTOU) attacks while preserving SNI.
+ * Custom DNS lookup function for undici.buildConnector that resolves all IP addresses,
+ * validates every address against private/reserved ranges, and passes back validated addresses
+ * to preserve dual-stack fallback (Happy Eyeballs, RFC 8305) without risking DNS rebinding.
+ */
+export function safeLookup(
+  hostname: string,
+  options: { all?: boolean; family?: number },
+  callback: (
+    err: Error | null,
+    address: string | LookupAddress[] | net.IPVersion,
+    family?: number,
+  ) => void,
+): void {
+  const sanitized = sanitizeHostname(hostname);
+
+  // Block internal TLDs / loopback domain names
+  if (
+    sanitized === 'localhost' ||
+    sanitized.endsWith('.localhost') ||
+    sanitized.endsWith('.local') ||
+    sanitized.endsWith('.internal')
+  ) {
+    callback(
+      new PrivateIpError(`Access to internal host ${sanitized} is blocked`),
+      '',
+    );
+    return;
+  }
+
+  // Direct IP literal check
+  if (net.isIP(sanitized)) {
+    if (isAddressPrivate(sanitized)) {
+      callback(
+        new PrivateIpError(`Access to private IP ${sanitized} is blocked`),
+        '',
+      );
+      return;
+    }
+    if (options?.all) {
+      callback(null, [{ address: sanitized, family: net.isIP(sanitized) }]);
+    } else {
+      callback(null, sanitized, net.isIP(sanitized));
+    }
+    return;
+  }
+
+  // Resolve all IP addresses via dns.lookup
+  lookup(sanitized, { all: true })
+    .then((addresses) => {
+      if (!addresses || addresses.length === 0) {
+        callback(new Error(`getaddrinfo ENOTFOUND ${sanitized}`), '');
+        return;
+      }
+
+      // Evaluate ALL resolved addresses against private ranges
+      for (const addr of addresses) {
+        if (isAddressPrivate(addr.address)) {
+          callback(
+            new PrivateIpError(
+              `Access to private IP ${addr.address} (resolved from ${sanitized}) is blocked`,
+            ),
+            '',
+          );
+          return;
+        }
+      }
+
+      // Pass back safe addresses to undici connector
+      if (options?.all) {
+        callback(null, addresses);
+      } else {
+        const family = options?.family;
+        const match = family
+          ? addresses.find((a) => a.family === family) || addresses[0]
+          : addresses[0];
+        callback(null, match.address, match.family);
+      }
+    })
+    .catch((err: unknown) => {
+      callback(err instanceof Error ? err : new Error(String(err)), '');
+    });
+}
+
+/**
+ * Creates an undici connector that validates destination IP addresses and configures
+ * a safe DNS lookup function to prevent DNS rebinding (TOCTOU) attacks while preserving
+ * dual-stack resilience (Happy Eyeballs).
  */
 export function createSafeConnector(
   connectorOpts?: undici.buildConnector.BuildOptions,
   customDefaultConnector?: undici.buildConnector.connector,
 ): undici.buildConnector.connector {
   const buildConnectorFn = getBuildConnector();
+
+  const safeConnectorOpts = {
+    ...connectorOpts,
+    lookup: safeLookup,
+  };
+
   const defaultConnector =
     customDefaultConnector ??
-    (buildConnectorFn ? buildConnectorFn(connectorOpts ?? {}) : undefined);
+    (buildConnectorFn ? buildConnectorFn(safeConnectorOpts) : undefined);
 
   return function safeConnect(
     opts: undici.buildConnector.Options,
@@ -68,7 +165,7 @@ export function createSafeConnector(
     const rawHostname = opts.hostname;
     const sanitized = sanitizeHostname(rawHostname);
 
-    // 1. Disallow loopback and internal TLDs outright
+    // Direct IP address literal check or internal TLD check
     if (
       sanitized === 'localhost' ||
       sanitized.endsWith('.localhost') ||
@@ -82,57 +179,15 @@ export function createSafeConnector(
       return;
     }
 
-    // 2. Direct IP address literal
-    if (net.isIP(sanitized)) {
-      if (isAddressPrivate(sanitized)) {
-        callback(
-          new PrivateIpError(`Access to private IP ${sanitized} is blocked`),
-          null,
-        );
-        return;
-      }
-      defaultConnector(opts, callback);
+    if (net.isIP(sanitized) && isAddressPrivate(sanitized)) {
+      callback(
+        new PrivateIpError(`Access to private IP ${sanitized} is blocked`),
+        null,
+      );
       return;
     }
 
-    // 3. Domain name: resolve all IPs and pin connection
-    lookup(sanitized, { all: true })
-      .then((addresses) => {
-        if (!addresses || addresses.length === 0) {
-          callback(new Error(`getaddrinfo ENOTFOUND ${sanitized}`), null);
-          return;
-        }
-
-        for (const addr of addresses) {
-          if (isAddressPrivate(addr.address)) {
-            callback(
-              new PrivateIpError(
-                `Access to private IP ${addr.address} (resolved from ${sanitized}) is blocked`,
-              ),
-              null,
-            );
-            return;
-          }
-        }
-
-        // Pin the connection to the first resolved IP
-        // Ensure SNI is preserved for TLS verification on legitimate domains
-        const pinnedIp = addresses[0].address;
-        const servername = opts.servername || sanitized;
-
-        defaultConnector(
-          {
-            ...opts,
-            hostname: pinnedIp,
-            servername,
-          },
-          callback,
-        );
-      })
-      .catch((err: Error) => {
-        // Fail closed on DNS resolution failure or timeout
-        callback(err, null);
-      });
+    defaultConnector(opts, callback);
   };
 }
 

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -6,7 +6,8 @@
 
 import { getErrorMessage, isAbortError } from './errors.js';
 import { URL } from 'node:url';
-import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+import * as net from 'node:net';
+import * as undici from 'undici';
 import ipaddr from 'ipaddr.js';
 import { lookup } from 'node:dns/promises';
 
@@ -32,9 +33,127 @@ let defaultHeadersTimeout = 60000; // 60 seconds
 const defaultBodyTimeout = 300000; // 5 minutes
 let currentProxy: string | undefined = undefined;
 
+function getBuildConnector(): typeof undici.buildConnector | undefined {
+  try {
+    const fn = (undici as { buildConnector?: typeof undici.buildConnector })
+      .buildConnector;
+    return typeof fn === 'function' ? fn : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Creates an undici connector that validates destination IP addresses and pins
+ * the connection to prevent DNS rebinding (TOCTOU) attacks while preserving SNI.
+ */
+export function createSafeConnector(
+  connectorOpts?: undici.buildConnector.BuildOptions,
+  customDefaultConnector?: undici.buildConnector.connector,
+): undici.buildConnector.connector {
+  const buildConnectorFn = getBuildConnector();
+  const defaultConnector =
+    customDefaultConnector ??
+    (buildConnectorFn ? buildConnectorFn(connectorOpts ?? {}) : undefined);
+
+  return function safeConnect(
+    opts: undici.buildConnector.Options,
+    callback: undici.buildConnector.Callback,
+  ) {
+    if (!defaultConnector) {
+      callback(new Error('Connector is unavailable'), null);
+      return;
+    }
+
+    const rawHostname = opts.hostname;
+    const sanitized = sanitizeHostname(rawHostname);
+
+    // 1. Disallow loopback and internal TLDs outright
+    if (
+      sanitized === 'localhost' ||
+      sanitized.endsWith('.localhost') ||
+      sanitized.endsWith('.local') ||
+      sanitized.endsWith('.internal')
+    ) {
+      callback(
+        new PrivateIpError(`Access to internal host ${sanitized} is blocked`),
+        null,
+      );
+      return;
+    }
+
+    // 2. Direct IP address literal
+    if (net.isIP(sanitized)) {
+      if (isAddressPrivate(sanitized)) {
+        callback(
+          new PrivateIpError(`Access to private IP ${sanitized} is blocked`),
+          null,
+        );
+        return;
+      }
+      defaultConnector(opts, callback);
+      return;
+    }
+
+    // 3. Domain name: resolve all IPs and pin connection
+    lookup(sanitized, { all: true })
+      .then((addresses) => {
+        if (!addresses || addresses.length === 0) {
+          callback(new Error(`getaddrinfo ENOTFOUND ${sanitized}`), null);
+          return;
+        }
+
+        for (const addr of addresses) {
+          if (isAddressPrivate(addr.address)) {
+            callback(
+              new PrivateIpError(
+                `Access to private IP ${addr.address} (resolved from ${sanitized}) is blocked`,
+              ),
+              null,
+            );
+            return;
+          }
+        }
+
+        // Pin the connection to the first resolved IP
+        // Ensure SNI is preserved for TLS verification on legitimate domains
+        const pinnedIp = addresses[0].address;
+        const servername = opts.servername || sanitized;
+
+        defaultConnector(
+          {
+            ...opts,
+            hostname: pinnedIp,
+            servername,
+          },
+          callback,
+        );
+      })
+      .catch((err: Error) => {
+        // Fail closed on DNS resolution failure or timeout
+        callback(err, null);
+      });
+  };
+}
+
+export function createSafeAgent(options?: {
+  headersTimeout?: number;
+  bodyTimeout?: number;
+}): undici.Agent {
+  const buildConnectorFn = getBuildConnector();
+  const connect = createSafeConnector();
+  return new undici.Agent({
+    headersTimeout: options?.headersTimeout ?? defaultHeadersTimeout,
+    bodyTimeout: options?.bodyTimeout ?? defaultBodyTimeout,
+    ...(buildConnectorFn ? { connect } : {}),
+  });
+}
+
+let defaultSafeAgent = createSafeAgent();
+
 // Configure default global dispatcher with higher timeouts
-setGlobalDispatcher(
-  new Agent({
+undici.setGlobalDispatcher(
+  new undici.Agent({
     headersTimeout: defaultHeadersTimeout,
     bodyTimeout: defaultBodyTimeout,
   }),
@@ -47,12 +166,16 @@ export function updateGlobalFetchTimeouts(timeoutMs: number) {
     );
   }
   defaultHeadersTimeout = timeoutMs;
+  defaultSafeAgent = createSafeAgent({
+    headersTimeout: defaultHeadersTimeout,
+    bodyTimeout: defaultBodyTimeout,
+  });
   // We keep body timeout high for LLM streaming responses
   if (currentProxy) {
     setGlobalProxy(currentProxy);
   } else {
-    setGlobalDispatcher(
-      new Agent({
+    undici.setGlobalDispatcher(
+      new undici.Agent({
         headersTimeout: defaultHeadersTimeout,
         bodyTimeout: defaultBodyTimeout,
       }),
@@ -81,15 +204,6 @@ export function isLoopbackHost(hostname: string): boolean {
   );
 }
 
-export function isPrivateIp(url: string): boolean {
-  try {
-    const hostname = new URL(url).hostname;
-    return isAddressPrivate(hostname);
-  } catch {
-    return false;
-  }
-}
-
 /**
  * IANA Benchmark Testing Range (198.18.0.0/15).
  * Classified as 'unicast' by ipaddr.js but is reserved and should not be
@@ -115,7 +229,12 @@ function isBenchmarkAddress(addr: ipaddr.IPv4 | ipaddr.IPv6): boolean {
 export function isAddressPrivate(address: string): boolean {
   const sanitized = sanitizeHostname(address);
 
-  if (sanitized === 'localhost') {
+  if (
+    sanitized === 'localhost' ||
+    sanitized.endsWith('.localhost') ||
+    sanitized.endsWith('.local') ||
+    sanitized.endsWith('.internal')
+  ) {
     return true;
   }
 
@@ -148,20 +267,38 @@ export function isAddressPrivate(address: string): boolean {
  * Checks if a URL resolves to a private IP address.
  */
 export async function isPrivateIpAsync(url: string): Promise<boolean> {
+  let parsedUrl: URL;
   try {
-    const parsedUrl = new URL(url);
-    const hostname = parsedUrl.hostname;
-
-    if (isLoopbackHost(hostname)) {
-      return false;
-    }
-
-    const addresses = await lookup(hostname, { all: true });
-    return addresses.some((addr) => isAddressPrivate(addr.address));
+    parsedUrl = new URL(url);
   } catch (error) {
     if (error instanceof TypeError) {
       return false;
     }
+    throw error;
+  }
+
+  const hostname = sanitizeHostname(parsedUrl.hostname);
+
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal')
+  ) {
+    return true;
+  }
+
+  if (net.isIP(hostname)) {
+    return isAddressPrivate(hostname);
+  }
+
+  try {
+    const addresses = await lookup(hostname, { all: true });
+    if (!addresses || addresses.length === 0) {
+      return true;
+    }
+    return addresses.some((addr) => isAddressPrivate(addr.address));
+  } catch (error) {
     throw new Error('Failed to verify if URL resolves to private IP', {
       cause: error,
     });
@@ -169,16 +306,71 @@ export async function isPrivateIpAsync(url: string): Promise<boolean> {
 }
 
 /**
+ * Checks if a URL targets or resolves to a private, loopback, or reserved network.
+ * Fails closed on resolution errors or timeouts.
+ *
+ * Checks performed:
+ * - RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+ * - Loopback addresses (127.0.0.0/8, ::1)
+ * - Cloud Metadata and link-local addresses (169.254.0.0/16, fe80::/10)
+ * - Carrier-Grade NAT (100.64.0.0/10)
+ * - IANA benchmark testing range (198.18.0.0/15)
+ * - IPv6 unique local addresses (fc00::/7) and IPv4-mapped IPv6 (::ffff:x.x.x.x)
+ * - Internal top-level domains (.localhost, .local, .internal)
+ * - Multi-IP resolution: rejects if ANY resolved address is private or reserved
+ *
+ * @param url - The URL string to inspect
+ * @returns Promise resolving to `true` if private/reserved or resolution failed, `false` if safe public IP
+ */
+export async function isPrivateIp(url: string): Promise<boolean> {
+  try {
+    return await isPrivateIpAsync(url);
+  } catch {
+    return true; // Fail closed
+  }
+}
+
+/**
+ * Validates a URL destination to ensure it safely targets the public internet and
+ * does not target private, local, internal, or reserved networks (SSRF defense).
+ *
+ * Returns `false` if the destination is private, reserved, invalid, or cannot be
+ * resolved (fail-closed security posture).
+ *
+ * @example
+ * ```ts
+ * import { validateUrlDestination } from '@google/gemini-cli-core';
+ *
+ * if (!(await validateUrlDestination(userSuppliedUrl))) {
+ *   throw new Error('Access to private or blocked host is not allowed.');
+ * }
+ * ```
+ *
+ * @param url - The URL string to validate
+ * @returns Promise resolving to `true` if safe for outbound fetching, `false` otherwise
+ */
+export async function validateUrlDestination(url: string): Promise<boolean> {
+  try {
+    const isPrivate = await isPrivateIp(url);
+    return !isPrivate;
+  } catch {
+    return false; // Fail closed
+  }
+}
+
+/**
  * Creates an undici EnvHttpProxyAgent that incorporates safe DNS lookup.
  */
-export function createSafeProxyAgent(proxyUrl: string): EnvHttpProxyAgent {
+export function createSafeProxyAgent(
+  proxyUrl: string,
+): undici.EnvHttpProxyAgent {
   const trimmedProxy = proxyUrl.trim();
   const noProxy = (
     process.env['NO_PROXY'] ??
     process.env['no_proxy'] ??
     ''
   )?.trim();
-  return new EnvHttpProxyAgent({
+  return new undici.EnvHttpProxyAgent({
     httpProxy: trimmedProxy,
     httpsProxy: trimmedProxy,
     noProxy,
@@ -192,6 +384,12 @@ export async function fetchWithTimeout(
   timeout: number,
   options?: RequestInit,
 ): Promise<Response> {
+  if (await isPrivateIp(url)) {
+    throw new PrivateIpError(
+      `Access to blocked or private host ${url} is not allowed.`,
+    );
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
@@ -206,10 +404,16 @@ export async function fetchWithTimeout(
   }
 
   try {
-    const response = await fetch(url, {
+    const fetchOptions: RequestInit & { dispatcher?: undici.Agent } = {
       ...options,
       signal: controller.signal,
-    });
+    };
+
+    if (!currentProxy && !fetchOptions.dispatcher) {
+      fetchOptions.dispatcher = defaultSafeAgent;
+    }
+
+    const response = await fetch(url, fetchOptions);
     return response;
   } catch (error) {
     if (isAbortError(error)) {
@@ -222,6 +426,14 @@ export async function fetchWithTimeout(
         throw options.signal.reason ?? error;
       }
       throw new FetchError(`Request timed out after ${timeout}ms`, 'ETIMEDOUT');
+    }
+    if (error instanceof PrivateIpError) {
+      throw error;
+    }
+    if (error && typeof error === 'object' && 'cause' in error) {
+      if (error.cause instanceof PrivateIpError) {
+        throw error.cause;
+      }
     }
     throw new FetchError(getErrorMessage(error), undefined, { cause: error });
   } finally {
@@ -237,8 +449,8 @@ export function setGlobalProxy(proxy: string) {
     process.env['no_proxy'] ??
     ''
   )?.trim();
-  setGlobalDispatcher(
-    new EnvHttpProxyAgent({
+  undici.setGlobalDispatcher(
+    new undici.EnvHttpProxyAgent({
       httpProxy: trimmedProxy,
       httpsProxy: trimmedProxy,
       noProxy,


### PR DESCRIPTION
## Summary

Improves destination address validation and connection routing in `WebFetchTool` and core fetch utilities. Outbound requests are now validated using asynchronous DNS lookups and routed through an Undici transport connector that directly binds to the resolved address while preserving TLS SNI.

## Details

- **Async DNS Resolution**: Uses `node:dns/promises.lookup(hostname, { all: true })` to resolve domain names to IP addresses prior to connecting.
- **Multi-IP Resolution Validation**: For multi-homed or dual-stack domains, validates all returned A and AAAA addresses. If any resolved address belongs to a private or reserved range, the destination is not permitted.
- **Transport Connection Pinning**: Implemented `createSafeConnector` using Undici's `buildConnector`. Directly sets `opts.hostname = pinnedIp` at the transport layer, routing the socket directly to the resolved address.
- **TLS SNI Preservation**: Preserves `opts.servername = opts.servername || normalized` during connection pinning so that TLS handshake and certificate validation function as expected on public HTTPS domains.
- **Address & Domain Filtering**: Filters private and reserved ranges using `ipaddr.js` + explicit masks:
  - RFC 1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
  - Loopback addresses (`127.0.0.0/8`, `::1`)
  - Link-local and metadata addresses (`169.254.0.0/16`, `fe80::/10`)
  - Carrier-Grade NAT (`100.64.0.0/10`)
  - IANA benchmark testing range (`198.18.0.0/15`)
  - IPv6 unique local addresses (`fc00::/7`) and IPv4-mapped IPv6 (`::ffff:x.x.x.x`)
  - Internal top-level domains (`.internal`, `.local`, `.localhost`, `localhost`)
- **Fail-Closed Handling**: Resolution timeouts, lookups returning no addresses, or malformed destinations default strictly to disallowed (`PrivateIpError`).
- **Tool Integration**: Updated `WebFetchTool` (`isBlockedHost`, `filterAndValidateUrls`, `executeFallbackForUrl`, `executeExperimental`) and `extensionRegistryClient` to await destination validation.
- **Documentation**: Updated `docs/tools/web-fetch.md` and `docs/reference/tools.md` to reflect destination validation behavior.

## Related Issues

<!-- None -->

## How to Validate

1. Run the test suite:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/fetch.spec.ts
   ```
2. Run core fetch and tool test suites:
   ```bash
   npm test -w @google/gemini-cli-core -- src/utils/fetch.test.ts src/tools/web-fetch.test.ts
   ```
3. Run full integration suites across packages:
   ```bash
   npm test -w @google/gemini-cli-core
   npm test -w @google/gemini-cli
   ```
4. Manual verification using Gemini CLI:
   - Start a local test server: `python3 -m http.server 8000`
   - Run Gemini CLI: `npm start`
   - Query private IP: `Fetch http://127.0.0.1:8000/ and summarize its contents.` -> Observed: `[Blocked Host] http://127.0.0.1:8000/`, server receives 0 requests.
   - Query link-local address: `Fetch http://169.254.169.254/computeMetadata/v1/` -> Filtered out.
   - Query internal domain: `Fetch http://test.localhost:8000/` -> Filtered out.
   - Query public HTTPS domain: `Fetch https://example.com/` -> Connects, verifies certificate via preserved SNI, and summarizes successfully.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
