### PR TITLE
fix(cli): correct SubagentStop event key in hooks migration

### DIFF
--- a/packages/cli/src/commands/hooks/migrate.test.ts
+++ b/packages/cli/src/commands/hooks/migrate.test.ts
@@ -178,7 +178,7 @@ describe('migrate command', () => {
         PostToolUse: [{ hooks: [{ type: 'command', command: 'echo 2' }] }],
         UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'echo 3' }] }],
         Stop: [{ hooks: [{ type: 'command', command: 'echo 4' }] }],
-        SubAgentStop: [{ hooks: [{ type: 'command', command: 'echo 5' }] }],
+        SubagentStop: [{ hooks: [{ type: 'command', command: 'echo 5' }] }],
         SessionStart: [{ hooks: [{ type: 'command', command: 'echo 6' }] }],
         SessionEnd: [{ hooks: [{ type: 'command', command: 'echo 7' }] }],
         PreCompact: [{ hooks: [{ type: 'command', command: 'echo 8' }] }],

--- a/packages/cli/src/commands/hooks/migrate.ts
+++ b/packages/cli/src/commands/hooks/migrate.ts
@@ -24,7 +24,7 @@ const EVENT_MAPPING: Record<string, string> = {
   PostToolUse: 'AfterTool',
   UserPromptSubmit: 'BeforeAgent',
   Stop: 'AfterAgent',
-  SubAgentStop: 'AfterAgent', // Gemini doesn't have sub-agents, map to AfterAgent
+  SubagentStop: 'AfterAgent', // Gemini doesn't have sub-agents, map to AfterAgent
   SessionStart: 'SessionStart',
   SessionEnd: 'SessionEnd',
   PreCompact: 'PreCompress',


### PR DESCRIPTION
Fixes #29123.

Claude Code spells the sub-agent stop event `SubagentStop` (lowercase `a`), but `EVENT_MAPPING` in `migrate.ts` keyed it as `SubAgentStop`. The key never matches a real Claude `settings.json`, so a `SubagentStop` hook is silently dropped during `gemini hooks migrate` instead of being mapped to `AfterAgent`.

## Changes

- `packages/cli/src/commands/hooks/migrate.ts`: correct the mapping key to `SubagentStop`
- `packages/cli/src/commands/hooks/migrate.test.ts`: update the event-mapping test to use the event name Claude Code actually emits

## Testing

- `npx vitest run src/commands/hooks/migrate.test.ts` — 17/17 pass
- `npm run typecheck` (cli package) and eslint on the changed files — clean