### PR TITLE
fix(cli): convert hook timeout from seconds to milliseconds in hooks migration

### DIFF
--- a/packages/cli/src/commands/hooks/migrate.test.ts
+++ b/packages/cli/src/commands/hooks/migrate.test.ts
@@ -118,7 +118,7 @@ describe('migrate command', () => {
               expect.objectContaining({
                 command: 'echo "Before Edit"',
                 type: 'command',
-                timeout: 30,
+                timeout: 30000,
               }),
             ]),
           }),
@@ -274,7 +274,7 @@ describe('migrate command', () => {
     expect(migratedHooks.BeforeTool[0].sequential).toBe(true);
   });
 
-  it('should preserve timeout values', async () => {
+  it('should convert timeout values from seconds to milliseconds', async () => {
     const claudeSettings = {
       hooks: {
         PreToolUse: [
@@ -297,7 +297,7 @@ describe('migrate command', () => {
     await handleMigrateFromClaude();
 
     const migratedHooks = mockSetValue.mock.calls[0][2];
-    expect(migratedHooks.BeforeTool[0].hooks[0].timeout).toBe(60);
+    expect(migratedHooks.BeforeTool[0].hooks[0].timeout).toBe(60000);
   });
 
   it('should merge with existing Gemini hooks', async () => {

--- a/packages/cli/src/commands/hooks/migrate.ts
+++ b/packages/cli/src/commands/hooks/migrate.ts
@@ -93,10 +93,10 @@ function migrateClaudeHook(claudeHook: unknown): unknown {
     migrated['type'] = 'command';
   }
 
-  // Map timeout field (Claude uses seconds, Gemini uses seconds)
+  // Map timeout field (Claude uses seconds, Gemini uses milliseconds)
   // eslint-disable-next-line no-restricted-syntax
   if ('timeout' in hook && typeof hook['timeout'] === 'number') {
-    migrated['timeout'] = hook['timeout'];
+    migrated['timeout'] = hook['timeout'] * 1000;
   }
 
   return migrated;


### PR DESCRIPTION
Fixes #29122.

Claude Code measures hook timeouts in **seconds** (default 60), while Gemini CLI's hook runner interprets the value as **milliseconds** (`DEFAULT_HOOK_TIMEOUT = 60000` in `packages/core/src/hooks/hookRunner.ts`). The migration copied the number verbatim, so a migrated `"timeout": 30` became 30 ms instead of 30 s — the hook would time out almost instantly.

## Changes

- `packages/cli/src/commands/hooks/migrate.ts`: multiply the migrated timeout by 1000 and correct the unit comment
- `packages/cli/src/commands/hooks/migrate.test.ts`: update the two existing assertions that encoded the buggy behavior (`30` → `30000`) and rework the preserve-timeout test to verify the seconds→milliseconds conversion (`60` → `60000`)

## Testing

- `npx vitest run src/commands/hooks/migrate.test.ts` — 17/17 pass
- `npm run typecheck` (cli package) and eslint on the changed files — clean