### PR TITLE
fix(a2a-server): mount express.json before a2a sdk routes

### DIFF
--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -1262,5 +1262,20 @@ describe('E2E Tests', () => {
       listenSpy.mockRestore();
       exitSpy.mockRestore();
     });
+
+    it('should parse json body for A2A SDK routes', async () => {
+      const app = await createApp();
+      const res = await request(app)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'message/send',
+          params: { message: { role: 'user', parts: [{ text: 'test' }] } },
+        });
+
+      expect(res.status).not.toBe(400);
+    });
   });
 });

--- a/packages/a2a-server/src/http/app.test.ts
+++ b/packages/a2a-server/src/http/app.test.ts
@@ -1264,7 +1264,6 @@ describe('E2E Tests', () => {
     });
 
     it('should parse json body for A2A SDK routes', async () => {
-      const app = await createApp();
       const res = await request(app)
         .post('/')
         .set('Content-Type', 'application/json')

--- a/packages/a2a-server/src/http/app.ts
+++ b/packages/a2a-server/src/http/app.ts
@@ -276,10 +276,10 @@ export async function createApp() {
     expressApp.use((req, res, next) => {
       requestStorage.run({ req }, next);
     });
+    expressApp.use(express.json());
 
     const appBuilder = new A2AExpressApp(requestHandler, customUserBuilder);
     expressApp = appBuilder.setupRoutes(expressApp, '');
-    expressApp.use(express.json());
 
     expressApp.post('/tasks', async (req, res) => {
       try {


### PR DESCRIPTION
Fixes #29073

### Description
In `packages/a2a-server/src/http/app.ts`, `express.json()` was mounted after `appBuilder.setupRoutes(expressApp, '')`. As a result, A2A SDK routes (such as `POST /`) received `req.body` as undefined, breaking JSON-RPC parsing.

### Changes
- Mounted `expressApp.use(express.json())` prior to `appBuilder.setupRoutes` in `createApp()`.
- Added unit test in `packages/a2a-server/src/http/app.test.ts` to verify JSON-RPC body parsing on SDK routes.