### PR TITLE
fix(core): normalize line endings in diff context snippets

### DIFF
--- a/packages/core/src/tools/diff-utils.test.ts
+++ b/packages/core/src/tools/diff-utils.test.ts
@@ -74,4 +74,13 @@ describe('getDiffContextSnippet', () => {
       '...\n9\nchanged\n11\n...',
     );
   });
+
+  it('should keep line indexes consistent for standalone CR line endings', () => {
+    const original = ['1', '2', '3', '4'].join('\r');
+    const modified = ['1', 'changed', '3', '4'].join('\r');
+
+    expect(getDiffContextSnippet(original, modified, 1)).toBe(
+      '1\nchanged\n3\n...',
+    );
+  });
 });

--- a/packages/core/src/tools/diff-utils.test.ts
+++ b/packages/core/src/tools/diff-utils.test.ts
@@ -63,4 +63,15 @@ describe('getDiffContextSnippet', () => {
 
     expect(snippet).toBe('...\n4\n6\n...');
   });
+
+  it('should ignore CRLF differences when finding changed lines', () => {
+    const original = Array.from({ length: 20 }, (_, i) => `${i + 1}`).join(
+      '\r\n',
+    );
+    const modified = original.replace('10\r\n', 'changed\r\n');
+
+    expect(getDiffContextSnippet(original, modified, 1)).toBe(
+      '...\n9\nchanged\n11\n...',
+    );
+  });
 });

--- a/packages/core/src/tools/diff-utils.ts
+++ b/packages/core/src/tools/diff-utils.ts
@@ -23,7 +23,7 @@ export function getDiffContextSnippet(
   const normalizedOriginal = originalContent.replace(/\r\n?/g, '\n');
   const normalizedNew = newContent.replace(/\r\n?/g, '\n');
   const changes = Diff.diffLines(normalizedOriginal, normalizedNew);
-  const newLines = newContent.split(/\r?\n/);
+  const newLines = normalizedNew.split('\n');
   const ranges: Array<{ start: number; end: number }> = [];
   let newLineIdx = 0;
 

--- a/packages/core/src/tools/diff-utils.ts
+++ b/packages/core/src/tools/diff-utils.ts
@@ -18,7 +18,11 @@ export function getDiffContextSnippet(
     return newContent;
   }
 
-  const changes = Diff.diffLines(originalContent, newContent);
+  // Compare logical lines so that changing only the line-ending style does not
+  // turn every line into a diff (for example, when an edit restores CRLF).
+  const normalizedOriginal = originalContent.replace(/\r\n?/g, '\n');
+  const normalizedNew = newContent.replace(/\r\n?/g, '\n');
+  const changes = Diff.diffLines(normalizedOriginal, normalizedNew);
   const newLines = newContent.split(/\r?\n/);
   const ranges: Array<{ start: number; end: number }> = [];
   let newLineIdx = 0;


### PR DESCRIPTION
## Summary

- Normalize CRLF and CR line endings before computing diff context snippets.
- Add a regression test covering a CRLF file with one changed line.

Fixes #29130

## Testing

- `npm run test:ci`
- `npm run typecheck --workspace @google/gemini-cli-core`
- `npm exec prettier -- --check packages/core/src/tools/diff-utils.ts packages/core/src/tools/diff-utils.test.ts`
- `npm exec eslint packages/core/src/tools/diff-utils.ts packages/core/src/tools/diff-utils.test.ts`
- `git diff --check`

