### PR TITLE
fix(cli): protect current session from deletion

### DIFF
--- a/packages/cli/src/utils/sessionUtils.test.ts
+++ b/packages/cli/src/utils/sessionUtils.test.ts
@@ -421,6 +421,56 @@ describe('SessionSelector', () => {
     );
   });
 
+  it('should mark only the session whose filename ends with the current id', async () => {
+    const currentSessionId = randomUUID();
+    const otherSessionId = randomUUID();
+    const chatsDir = path.join(tmpDir, 'chats');
+    await fs.mkdir(chatsDir, { recursive: true });
+
+    const createSession = (sessionId: string) => ({
+      sessionId,
+      projectHash: 'test-hash',
+      startTime: '2024-01-01T10:00:00.000Z',
+      lastUpdated: '2024-01-01T10:30:00.000Z',
+      messages: [
+        {
+          type: 'user',
+          content: 'Test message',
+          id: 'msg1',
+          timestamp: '2024-01-01T10:00:00.000Z',
+        },
+      ],
+    });
+
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}2024-01-01T10-00-${currentSessionId.slice(0, 8)}.json`,
+      ),
+      JSON.stringify(createSession(currentSessionId)),
+    );
+    await fs.writeFile(
+      path.join(
+        chatsDir,
+        `${SESSION_FILE_PREFIX}2024-01-01T10-01-${currentSessionId.slice(0, 8)}-archive.json`,
+      ),
+      JSON.stringify(createSession(otherSessionId)),
+    );
+
+    const sessionSelector = new SessionSelector(storage);
+    const sessions = await sessionSelector.listSessions(currentSessionId);
+
+    expect(sessions).toHaveLength(2);
+    expect(
+      sessions.find((session) => session.id === currentSessionId)
+        ?.isCurrentSession,
+    ).toBe(true);
+    expect(
+      sessions.find((session) => session.id === otherSessionId)
+        ?.isCurrentSession,
+    ).toBe(false);
+  });
+
   it('should throw SessionError with NO_SESSIONS_FOUND when resolving latest with no sessions', async () => {
     // Empty chats directory — no session files
     const chatsDir = path.join(tmpDir, 'chats');

--- a/packages/cli/src/utils/sessionUtils.ts
+++ b/packages/cli/src/utils/sessionUtils.ts
@@ -294,8 +294,10 @@ export const getAllSessionFiles = async (
           const firstUserMessage = content.firstUserMessage
             ? cleanMessage(content.firstUserMessage)
             : extractFirstUserMessage(content.messages);
-          const isCurrentSession = currentSessionId
-            ? file.includes(currentSessionId.slice(0, 8))
+          const shortId = currentSessionId?.slice(0, 8);
+          const isCurrentSession = shortId
+            ? file.endsWith(`-${shortId}.json`) ||
+              file.endsWith(`-${shortId}.jsonl`)
             : false;
 
           let fullContent: string | undefined;
@@ -442,9 +444,9 @@ export class SessionSelector {
   /**
    * Lists all available sessions for the current project.
    */
-  async listSessions(): Promise<SessionInfo[]> {
+  async listSessions(currentSessionId?: string): Promise<SessionInfo[]> {
     const chatsDir = path.join(this.storage.getProjectTempDir(), 'chats');
-    return getSessionFiles(chatsDir);
+    return getSessionFiles(chatsDir, currentSessionId);
   }
 
   /**

--- a/packages/cli/src/utils/sessions.test.ts
+++ b/packages/cli/src/utils/sessions.test.ts
@@ -70,7 +70,7 @@ describe('listSessions', () => {
     await listSessions(mockConfig);
 
     // Assert
-    expect(mockListSessions).toHaveBeenCalledOnce();
+    expect(mockListSessions).toHaveBeenCalledWith('current-session-id');
     expect(mocks.writeToStdout).toHaveBeenCalledWith(
       'No previous sessions found for this project.',
     );
@@ -127,7 +127,7 @@ describe('listSessions', () => {
     await listSessions(mockConfig);
 
     // Assert
-    expect(mockListSessions).toHaveBeenCalledOnce();
+    expect(mockListSessions).toHaveBeenCalledWith('current-session-id');
 
     // Check that the header was displayed
     expect(mocks.writeToStdout).toHaveBeenCalledWith(

--- a/packages/cli/src/utils/sessions.ts
+++ b/packages/cli/src/utils/sessions.ts
@@ -22,7 +22,7 @@ export async function listSessions(config: Config): Promise<void> {
   await generateSummary(config);
 
   const sessionSelector = new SessionSelector(config.storage);
-  const sessions = await sessionSelector.listSessions();
+  const sessions = await sessionSelector.listSessions(config.getSessionId());
 
   if (sessions.length === 0) {
     writeToStdout('No previous sessions found for this project.');
@@ -56,7 +56,7 @@ export async function deleteSession(
   sessionIndex: string,
 ): Promise<void> {
   const sessionSelector = new SessionSelector(config.storage);
-  const sessions = await sessionSelector.listSessions();
+  const sessions = await sessionSelector.listSessions(config.getSessionId());
 
   if (sessions.length === 0) {
     writeToStderr('No sessions found for this project.');


### PR DESCRIPTION
Fixes #29133

## Summary

- Pass the active session ID through the `--list-sessions` and `--delete-session` paths.
- Match the active session only when the filename ends with the expected short-ID suffix, avoiding false positives from unrelated filenames.
- Add regression coverage for active-session detection and verify the CLI command wiring.

This prevents `--delete-session` from deleting the live session and makes `--list-sessions` display the `, current` marker.

## Implementation

`SessionSelector.listSessions()` now accepts the active session ID and forwards it to `getSessionFiles()`. The filename check accepts both supported `.json` and `.jsonl` session formats while requiring the exact suffix. Both CLI session commands pass `config.getSessionId()` into the selector.

## Compatibility

No public command or file format changes. Sessions using either supported filename extension remain discoverable.

## Testing

- `npm ci --ignore-scripts --no-audit --no-fund` — passed.
- `npm run test --workspace=@google/gemini-cli -- src/utils/sessionUtils.test.ts src/utils/sessions.test.ts` — passed: 2 files, 45 tests.
- `npm run typecheck --workspace=@google/gemini-cli` — passed.
- `npx prettier --experimental-cli --check packages/cli/src/utils/sessionUtils.ts packages/cli/src/utils/sessionUtils.test.ts packages/cli/src/utils/sessions.ts packages/cli/src/utils/sessions.test.ts` — passed (Prettier reported the option as ignored by the installed CLI).
- `npx eslint packages/cli/src/utils/sessionUtils.ts packages/cli/src/utils/sessionUtils.test.ts packages/cli/src/utils/sessions.ts packages/cli/src/utils/sessions.test.ts` — passed.
- CLI package build via the test lifecycle — passed.
- `npm run test:ci` — attempted after dependency installation; the initial run failed before the relevant tests because the source archive lacked built workspace package outputs. After building the core package, the second run passed the a2a-server suite but did not produce a reliable final aggregate result in the archive-based environment. The focused affected tests above are the definitive local regression result.

## Limitations

The repository was obtained from the GitHub source archive because Git HTTPS fetches stalled in this environment. The archive extractor reported errors for a small set of long snapshot paths unrelated to this change. The checked source paths and all affected tests were present and verified.
