### PR TITLE
fix(core): handle skill precedence and active state case-insensitively

### DIFF
--- a/packages/core/src/skills/skillManager.test.ts
+++ b/packages/core/src/skills/skillManager.test.ts
@@ -165,6 +165,69 @@ description: project-desc
     expect(service.getSkills()[0].description).toBe('user-desc');
   });
 
+  it('should respect precedence case-insensitively', async () => {
+    const userDir = path.join(testRootDir, 'user');
+    const projectDir = path.join(testRootDir, 'workspace');
+    await fs.mkdir(path.join(userDir, 'skill'), { recursive: true });
+    await fs.mkdir(path.join(projectDir, 'skill'), { recursive: true });
+
+    await fs.writeFile(
+      path.join(userDir, 'skill', 'SKILL.md'),
+      `---
+name: my-skill
+description: user-desc
+---
+`,
+    );
+    await fs.writeFile(
+      path.join(projectDir, 'skill', 'SKILL.md'),
+      `---
+name: My-Skill
+description: project-desc
+---
+`,
+    );
+
+    const mockExtension: GeminiCLIExtension = {
+      name: 'test-ext',
+      version: '1.0.0',
+      isActive: true,
+      path: '/ext',
+      contextFiles: [],
+      id: 'ext-id',
+      skills: [
+        {
+          name: 'MY-SKILL',
+          description: 'ext-desc',
+          location: '/ext/skills/SKILL.md',
+          body: 'body',
+        },
+      ],
+    };
+
+    vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(userDir);
+    vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+      '/non-existent-user-agent',
+    );
+    const storage = new Storage('/dummy');
+    vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(projectDir);
+    vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+      '/non-existent-project-agent',
+    );
+
+    const service = new SkillManager();
+    // @ts-expect-error accessing private method for testing
+    vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+    await service.discoverSkills(storage, [mockExtension], true);
+
+    const skills = service.getSkills();
+    expect(skills).toHaveLength(1);
+    expect(skills[0].description).toBe('project-desc');
+
+    const skillFetched = service.getSkill('my-skill');
+    expect(skillFetched?.description).toBe('project-desc');
+  });
+
   it('should discover built-in skills', async () => {
     const service = new SkillManager();
     const mockBuiltinSkill: SkillDefinition = {
@@ -332,6 +395,16 @@ description: project-desc
     expect(service.isSkillActive('skill-2')).toBe(false);
   });
 
+  it('should activate and check active skills case-insensitively', () => {
+    const service = new SkillManager();
+    service.activateSkill('Skill-One');
+
+    expect(service.isSkillActive('skill-one')).toBe(true);
+    expect(service.isSkillActive('Skill-One')).toBe(true);
+    expect(service.isSkillActive('SKILL-ONE')).toBe(true);
+    expect(service.isSkillActive('skill-two')).toBe(false);
+  });
+
   describe('Conflict Detection', () => {
     it('should emit UI warning when a non-built-in skill is overridden', async () => {
       const emitFeedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
@@ -448,6 +521,64 @@ description: project-desc
       expect(debugWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           `Skill "${skillName}" from "${userSkillPath}" is overriding the built-in skill.`,
+        ),
+      );
+    });
+
+    it('should detect skill conflicts case-insensitively', async () => {
+      const emitFeedbackSpy = vi.spyOn(coreEvents, 'emitFeedback');
+      const userDir = path.join(testRootDir, 'user');
+      const projectDir = path.join(testRootDir, 'workspace');
+      await fs.mkdir(userDir, { recursive: true });
+      await fs.mkdir(projectDir, { recursive: true });
+
+      const userSkillPath = path.join(userDir, 'SKILL.md');
+      const projectSkillPath = path.join(projectDir, 'SKILL.md');
+
+      vi.mocked(loadSkillsFromDir).mockImplementation(async (dir) => {
+        if (dir === userDir) {
+          return [
+            {
+              name: 'Conflicting-Skill',
+              description: 'user-desc',
+              location: userSkillPath,
+              body: '',
+            },
+          ];
+        }
+        if (dir === projectDir) {
+          return [
+            {
+              name: 'conflicting-skill',
+              description: 'project-desc',
+              location: projectSkillPath,
+              body: '',
+            },
+          ];
+        }
+        return [];
+      });
+
+      vi.spyOn(Storage, 'getUserSkillsDir').mockReturnValue(userDir);
+      vi.spyOn(Storage, 'getUserAgentSkillsDir').mockReturnValue(
+        '/non-existent-user-agent',
+      );
+      const storage = new Storage('/dummy');
+      vi.spyOn(storage, 'getProjectSkillsDir').mockReturnValue(projectDir);
+      vi.spyOn(storage, 'getProjectAgentSkillsDir').mockReturnValue(
+        '/non-existent-project-agent',
+      );
+
+      const service = new SkillManager();
+      // @ts-expect-error accessing private method for testing
+      vi.spyOn(service, 'discoverBuiltinSkills').mockResolvedValue(undefined);
+
+      await service.discoverSkills(storage, [], true);
+
+      expect(emitFeedbackSpy).toHaveBeenCalledWith(
+        'warning',
+        expect.stringContaining(
+          `Skill conflict detected: "conflicting-skill" from "${projectSkillPath}" is overriding the same skill from "${userSkillPath}".`,
         ),
       );
     });

--- a/packages/core/src/skills/skillManager.ts
+++ b/packages/core/src/skills/skillManager.ts
@@ -123,11 +123,12 @@ export class SkillManager {
 
   private addSkillsWithPrecedence(newSkills: SkillDefinition[]): void {
     const skillMap = new Map<string, SkillDefinition>(
-      this.skills.map((s) => [s.name, s]),
+      this.skills.map((s) => [s.name.toLowerCase(), s]),
     );
 
     for (const newSkill of newSkills) {
-      const existingSkill = skillMap.get(newSkill.name);
+      const key = newSkill.name.toLowerCase();
+      const existingSkill = skillMap.get(key);
       if (existingSkill && existingSkill.location !== newSkill.location) {
         if (existingSkill.isBuiltin) {
           debugLogger.warn(
@@ -140,7 +141,7 @@ export class SkillManager {
           );
         }
       }
-      skillMap.set(newSkill.name, newSkill);
+      skillMap.set(key, newSkill);
     }
 
     this.skills = Array.from(skillMap.values());
@@ -201,13 +202,13 @@ export class SkillManager {
    * Activates a skill by name.
    */
   activateSkill(name: string): void {
-    this.activeSkillNames.add(name);
+    this.activeSkillNames.add(name.toLowerCase());
   }
 
   /**
    * Checks if a skill is active.
    */
   isSkillActive(name: string): boolean {
-    return this.activeSkillNames.has(name);
+    return this.activeSkillNames.has(name.toLowerCase());
   }
 }


### PR DESCRIPTION
## Summary

Fixes a case-sensitivity mismatch in `SkillManager` where skill precedence overrides (e.g., workspace skills overriding built-in or extension skills) and active skill tracking failed when skill names differed in letter casing.

## Details

- **Case-Insensitive Precedence Map:** In `SkillManager.addSkillsWithPrecedence`, keyed and queried the deduplication map using `skill.name.toLowerCase()`. This ensures higher-precedence skills (workspace > user > extension > built-in) properly override lower-precedence skills even if their casing differs (e.g., `git-commit` vs `Git-Commit`).
- **Normalized Active State Tracking:** In `activateSkill` and `isSkillActive`, normalized skill names with `.toLowerCase()` before adding to / checking in `activeSkillNames`.
- **Unit Tests:** Added test cases in `skillManager.test.ts` to verify case-insensitive precedence overriding, active state tracking, and conflict warning emission.


## Related Issues

Closes #29150

## How to Validate

1. Run the `SkillManager` unit tests:
   ```bash
   npx vitest run packages/core/src/skills/skillManager.test.ts

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
