### PR TITLE
fix(core): decode BOM-encoded content correctly in isEmpty

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -216,6 +216,41 @@ describe('fileUtils', () => {
       const testFile = path.join(tempRootDir, 'ghost.txt');
       expect(await isEmpty(testFile)).toBe(true);
     });
+
+    it('should return true for a UTF-16 LE file containing only whitespace', async () => {
+      const testFile = path.join(tempRootDir, 'utf16le-whitespace.txt');
+      actualNodeFs.writeFileSync(
+        testFile,
+        Buffer.concat([
+          Buffer.from([0xff, 0xfe]),
+          Buffer.from(' \n\t', 'utf16le'),
+        ]),
+      );
+      expect(await isEmpty(testFile)).toBe(true);
+    });
+
+    it('should return false for a UTF-16 LE file containing content', async () => {
+      const testFile = path.join(tempRootDir, 'utf16le-content.txt');
+      actualNodeFs.writeFileSync(
+        testFile,
+        Buffer.concat([
+          Buffer.from([0xff, 0xfe]),
+          Buffer.from('hello', 'utf16le'),
+        ]),
+      );
+      expect(await isEmpty(testFile)).toBe(false);
+    });
+
+    it('should return true for a UTF-16 BE file containing only whitespace', async () => {
+      const testFile = path.join(tempRootDir, 'utf16be-whitespace.txt');
+      const whitespace = Buffer.from(' \n\t', 'utf16le');
+      whitespace.swap16(); // convert to UTF-16 BE
+      actualNodeFs.writeFileSync(
+        testFile,
+        Buffer.concat([Buffer.from([0xfe, 0xff]), whitespace]),
+      );
+      expect(await isEmpty(testFile)).toBe(true);
+    });
   });
 
   describe('fileExists', () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -161,22 +161,11 @@ function decodeUTF32(buf: Buffer, littleEndian: boolean): string {
 }
 
 /**
- * Read a file as text, honoring BOM encodings (UTF‑8/16/32) and stripping the BOM.
- * Falls back to utf8 when no BOM is present.
+ * Decode a buffer whose BOM has already been detected, stripping the BOM and
+ * decoding according to its encoding.
  */
-export async function readFileWithEncoding(filePath: string): Promise<string> {
-  // Read the file once; detect BOM and decode from the single buffer.
-  const full = await fs.promises.readFile(filePath);
-  if (full.length === 0) return '';
-
-  const bom = detectBOM(full);
-  if (!bom) {
-    // No BOM → treat as UTF‑8
-    return full.toString('utf8');
-  }
-
-  // Strip BOM and decode per encoding
-  const content = full.subarray(bom.bomLength);
+function decodeBOMContent(buffer: Buffer, bom: BOMInfo): string {
+  const content = buffer.subarray(bom.bomLength);
   switch (bom.encoding) {
     case 'utf8':
       return content.toString('utf8');
@@ -192,6 +181,24 @@ export async function readFileWithEncoding(filePath: string): Promise<string> {
       // Defensive fallback; should be unreachable
       return content.toString('utf8');
   }
+}
+
+/**
+ * Read a file as text, honoring BOM encodings (UTF‑8/16/32) and stripping the BOM.
+ * Falls back to utf8 when no BOM is present.
+ */
+export async function readFileWithEncoding(filePath: string): Promise<string> {
+  // Read the file once; detect BOM and decode from the single buffer.
+  const full = await fs.promises.readFile(filePath);
+  if (full.length === 0) return '';
+
+  const bom = detectBOM(full);
+  if (!bom) {
+    // No BOM → treat as UTF‑8
+    return full.toString('utf8');
+  }
+
+  return decodeBOMContent(full, bom);
 }
 
 /**
@@ -375,7 +382,7 @@ export async function isEmpty(filePath: string): Promise<boolean> {
 
       const bom = detectBOM(buffer);
       const content = bom
-        ? buffer.subarray(bom.bomLength).toString('utf8')
+        ? decodeBOMContent(buffer, bom)
         : buffer.toString('utf8');
 
       return content.trim().length === 0;


### PR DESCRIPTION
## Description

`isEmpty()` detected the file's BOM but always decoded the sampled bytes as UTF-8 (`buffer.subarray(bom.bomLength).toString('utf8')`). Whitespace-only plan files encoded as UTF-16/UTF-32 therefore decoded to NUL characters, and `trim()` classified them as non-empty, so `validatePlanContent()` accepted them.

## Related Issues

Fixes #29142

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/google-gemini/gemini-cli/blob/main/CONTRIBUTING.md)
- [x] My changes are covered by tests
- [x] I have run the linter and tests pass