### PR TITLE
fix(extensions): back up the extension dir before update so rollback restores it

### DIFF
--- a/packages/cli/src/config/extensions/update.test.ts
+++ b/packages/cli/src/config/extensions/update.test.ts
@@ -295,7 +295,16 @@ describe('Extension Update Logic', () => {
         ),
       ).rejects.toThrow('Updated extension not found after installation');
 
-      expect(copyExtension).toHaveBeenCalledWith(
+      // Order matters. A backup taken after the install has already mutated
+      // the extension directory is exactly as empty as no backup at all, so
+      // an unordered pair of assertions would not catch a regression.
+      expect(copyExtension).toHaveBeenNthCalledWith(
+        1,
+        mockExtension.path,
+        '/tmp/mock-dir',
+      );
+      expect(copyExtension).toHaveBeenNthCalledWith(
+        2,
         '/tmp/mock-dir',
         mockExtension.path,
       );
@@ -306,6 +315,27 @@ describe('Extension Update Logic', () => {
           state: ExtensionUpdateState.ERROR,
         },
       });
+      expect(fs.promises.rm).toHaveBeenCalled();
+    });
+
+    it('should not restore from the temp dir if the backup itself failed', async () => {
+      vi.mocked(copyExtension).mockRejectedValueOnce(
+        new Error('Backup failed'),
+      );
+
+      await expect(
+        updateExtension(
+          mockExtension,
+          mockExtensionManager,
+          ExtensionUpdateState.UPDATE_AVAILABLE,
+          mockDispatch,
+        ),
+      ).rejects.toThrow('Backup failed');
+
+      // The extension directory is still intact at this point. Copying a
+      // partial temp dir over it would be the corruption the rollback exists
+      // to prevent, so the only call must be the failed backup attempt.
+      expect(copyExtension).toHaveBeenCalledTimes(1);
       expect(fs.promises.rm).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/config/extensions/update.ts
+++ b/packages/cli/src/config/extensions/update.ts
@@ -100,7 +100,16 @@ export async function updateExtension(
   const originalVersion = extension.version;
 
   const tempDir = await ExtensionStorage.createTmpDir();
+  // Tracks whether tempDir actually holds a copy of the current installation.
+  // The rollback below must not restore from tempDir unless it does, or a
+  // failed backup would overwrite an intact extension with a partial copy.
+  let backedUp = false;
   try {
+    // Back up the current installation before anything mutates it. Without
+    // this, tempDir stays empty and the rollback in the catch block restores
+    // nothing.
+    await copyExtension(extension.path, tempDir);
+    backedUp = true;
     const previousExtensionConfig = await extensionManager.loadExtensionConfig(
       extension.path,
     );
@@ -142,7 +151,9 @@ export async function updateExtension(
       type: 'SET_STATE',
       payload: { name: extension.name, state: ExtensionUpdateState.ERROR },
     });
-    await copyExtension(tempDir, extension.path);
+    if (backedUp) {
+      await copyExtension(tempDir, extension.path);
+    }
     throw e;
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`updateExtension` never backed up the extension before updating it. It created a temp dir, and on failure copied that temp dir back over `extension.path`. Nothing ever copied the extension into the temp dir, so the temp dir was always empty and the rollback restored nothing. A failed update left the half-updated installation in place.

## Details

`packages/cli/src/config/extensions/update.ts`. Two changes.

1. Copy the current installation into the temp dir before anything mutates it.
2. Track whether that backup succeeded, and only restore from the temp dir when it did. Without the flag, a backup that failed partway would let the catch block copy a partial temp dir over an extension that was still intact, which is the corruption the rollback exists to prevent.

The test change isn't garnish. There was already a rollback test at `update.test.ts:278` and it passed against this bug, so the fix can regress silently without it. Its whole rollback assertion was:

```ts
expect(copyExtension).toHaveBeenCalledWith('/tmp/mock-dir', mockExtension.path);
```

`copyExtension` is mocked as a bare `vi.fn()` and `createTmpDir` is stubbed to the string `'/tmp/mock-dir'`. So it asserted that the restore call was made with the expected arguments. That is equally true when the temp dir is empty. It checked the call, not the effect.

The asymmetry was the tell: there was an assertion for the restore direction and none for the backup direction, and the missing call was exactly the unasserted one. This PR asserts both in order. Order matters, because a backup taken after the install has already mutated the directory is as empty as no backup at all, and an unordered pair wouldn't catch that. A second test covers the new guard.

## Related Issues

Fixes #29033

## How to Validate

```
npx vitest run src/config/extensions/update.test.ts   # from packages/cli
```

15 passed here. For the negative control, revert `update.ts` alone and re-run: both new tests fail, the other 13 still pass.

## Pre-Merge Checklist

- [x] Added/updated tests (if needed)
- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)

Validated on Windows via `npm run` only. I couldn't run the full `npm run preflight`: `npm ci` fails on this machine building the native `tree-sitter-bash` dependency, so I installed with `--ignore-scripts` and ran the single test file plus `prettier --check` on both changed files. Worth a CI run on the other platforms.
