### PR TITLE
fix(core): enhance workspace path boundary checks and symlink resolution in command safety and file discovery

### DIFF
--- a/packages/core/src/policy/policy-engine.test.ts
+++ b/packages/core/src/policy/policy-engine.test.ts
@@ -1479,7 +1479,10 @@ describe('PolicyEngine', () => {
         },
       ];
 
-      engine = new PolicyEngine({ rules });
+      engine = new PolicyEngine({
+        rules,
+        sandboxManager: new NoopSandboxManager({ workspace: '/safe/path' }),
+      });
 
       // Compound command. The decomposition will call check() for "echo hello"
       // which should match our specific high-priority rule IF dir_path is preserved.
@@ -1487,6 +1490,55 @@ describe('PolicyEngine', () => {
         {
           name: 'run_shell_command',
           args: { command: 'echo hello && pwd', dir_path: '/safe/path' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ALLOW);
+    });
+
+    it('should force ASK_USER when dir_path escapes workspace boundary even if rule allows it', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({
+        rules,
+        sandboxManager: new NoopSandboxManager({ workspace: '/safe/path' }),
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'pwd', dir_path: '/outside/path' },
+        },
+        undefined,
+      );
+
+      expect(result.decision).toBe(PolicyDecision.ASK_USER);
+    });
+
+    it('should preserve ALLOW in YOLO mode even when dir_path escapes workspace boundary', async () => {
+      const rules: PolicyRule[] = [
+        {
+          toolName: 'run_shell_command',
+          decision: PolicyDecision.ALLOW,
+        },
+      ];
+
+      engine = new PolicyEngine({
+        rules,
+        approvalMode: ApprovalMode.YOLO,
+        sandboxManager: new NoopSandboxManager({ workspace: '/safe/path' }),
+      });
+
+      const result = await engine.check(
+        {
+          name: 'run_shell_command',
+          args: { command: 'pwd', dir_path: '/outside/path' },
         },
         undefined,
       );

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -351,6 +351,7 @@ export class PolicyEngine {
   private async applyShellHeuristics(
     command: string,
     decision: PolicyDecision,
+    dir_path?: string,
   ): Promise<PolicyDecision> {
     if (decision === PolicyDecision.DENY) {
       return PolicyDecision.DENY;
@@ -360,6 +361,14 @@ export class PolicyEngine {
       const parsedObjArgs = shellParse(command);
       const parsedArgs = parsedObjArgs.map(extractStringFromParseEntry);
 
+      const workspace =
+        typeof this.sandboxManager.getWorkspace === 'function'
+          ? this.sandboxManager.getWorkspace()
+          : process.cwd();
+      const effectiveCwd = dir_path
+        ? path.resolve(workspace, dir_path)
+        : workspace;
+
       if (containsGitCommand(parsedArgs) && !this.isTrustedFolder()) {
         debugLogger.debug(
           `[PolicyEngine.check] Git command evaluated in untrusted workspace. Forcing ASK_USER: ${command}`,
@@ -367,7 +376,7 @@ export class PolicyEngine {
         return PolicyDecision.ASK_USER;
       }
 
-      if (this.sandboxManager.isDangerousCommand(parsedArgs)) {
+      if (this.sandboxManager.isDangerousCommand(parsedArgs, effectiveCwd)) {
         if (this.approvalMode === ApprovalMode.YOLO) {
           debugLogger.debug(
             `[PolicyEngine.check] Command evaluated as dangerous, but YOLO mode is active. Preserving decision: ${command}`,
@@ -382,9 +391,16 @@ export class PolicyEngine {
       }
 
       if (
-        this.sandboxManager.isKnownSafeCommand(parsedArgs) &&
+        this.sandboxManager.isKnownSafeCommand(parsedArgs, effectiveCwd) &&
         decision === PolicyDecision.ASK_USER
       ) {
+        if (effectiveCwd !== workspace && !isSubpath(workspace, effectiveCwd)) {
+          debugLogger.debug(
+            `[PolicyEngine.check] dir_path evaluated outside workspace. Preserving ASK_USER: ${command}`,
+          );
+          return PolicyDecision.ASK_USER;
+        }
+
         if (containsGitCommand(parsedArgs) && !this.isTrustedFolder()) {
           debugLogger.debug(
             `[PolicyEngine.check] Known safe Git command evaluated in untrusted workspace. Preserving ASK_USER: ${command}`,
@@ -667,7 +683,11 @@ export class PolicyEngine {
           !('commandPrefix' in rule) &&
           !rule.argsPattern
         ) {
-          ruleDecision = await this.applyShellHeuristics(command, ruleDecision);
+          ruleDecision = await this.applyShellHeuristics(
+            command,
+            ruleDecision,
+            shellDirPath,
+          );
         }
 
         if (isShellCommand && toolName) {
@@ -713,6 +733,7 @@ export class PolicyEngine {
           heuristicDecision = await this.applyShellHeuristics(
             command,
             heuristicDecision,
+            shellDirPath,
           );
         }
 

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -369,6 +369,17 @@ export class PolicyEngine {
         ? path.resolve(workspace, dir_path)
         : workspace;
 
+      if (
+        effectiveCwd !== workspace &&
+        !isSubpath(workspace, effectiveCwd) &&
+        this.approvalMode !== ApprovalMode.YOLO
+      ) {
+        debugLogger.debug(
+          `[PolicyEngine.check] Command working directory is outside workspace, forcing ASK_USER: ${command}`,
+        );
+        return PolicyDecision.ASK_USER;
+      }
+
       if (containsGitCommand(parsedArgs) && !this.isTrustedFolder()) {
         debugLogger.debug(
           `[PolicyEngine.check] Git command evaluated in untrusted workspace. Forcing ASK_USER: ${command}`,

--- a/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
+++ b/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
@@ -160,12 +160,14 @@ export class LinuxSandboxManager implements SandboxManager {
     this.governanceFilesInitialized = true;
   }
 
-  isKnownSafeCommand(args: string[]): boolean {
-    return isKnownSafeCommand(args);
+  isKnownSafeCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isKnownSafeCommand(args, effectiveCwd, this.options.workspace);
   }
 
-  isDangerousCommand(args: string[]): boolean {
-    return isDangerousCommand(args);
+  isDangerousCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isDangerousCommand(args, effectiveCwd, this.options.workspace);
   }
 
   parseDenials(result: ShellExecutionResult): ParsedSandboxDenial | undefined {

--- a/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
+++ b/packages/core/src/sandbox/macos/MacOsSandboxManager.ts
@@ -48,17 +48,14 @@ export class MacOsSandboxManager implements SandboxManager {
 
   constructor(private readonly options: GlobalSandboxOptions) {}
 
-  isKnownSafeCommand(args: string[]): boolean {
-    const toolName = args[0];
-    const approvedTools = this.options.modeConfig?.approvedTools ?? [];
-    if (toolName && approvedTools.includes(toolName)) {
-      return true;
-    }
-    return isKnownSafeCommand(args);
+  isKnownSafeCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isKnownSafeCommand(args, effectiveCwd, this.options.workspace);
   }
 
-  isDangerousCommand(args: string[]): boolean {
-    return isDangerousCommand(args);
+  isDangerousCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isDangerousCommand(args, effectiveCwd, this.options.workspace);
   }
 
   parseDenials(result: ShellExecutionResult): ParsedSandboxDenial | undefined {

--- a/packages/core/src/sandbox/utils/commandSafety.test.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.test.ts
@@ -280,6 +280,16 @@ describe('commandSafety', () => {
         ),
       ).toBe(false);
     });
+
+    it('should reject file-reading commands with options containing relative paths escaping workspace', () => {
+      expect(
+        isKnownSafeCommand(
+          ['cat', '--output=subdir/../../outside/file'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+    });
   });
 
   describe('ln command safety in isDangerousCommand', () => {

--- a/packages/core/src/sandbox/utils/commandSafety.test.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import {
   isStrictlyApproved,
   isKnownSafeCommand,
@@ -124,6 +127,135 @@ describe('commandSafety', () => {
       expect(await isStrictlyApproved('/tmp/malicious/rg', ['pattern'])).toBe(
         false,
       );
+    });
+  });
+
+  describe('workspace path boundary validation in isKnownSafeCommand', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'gemini-cli-test-safety-'),
+    );
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const outsideDir = path.join(tempDir, 'outside');
+
+    beforeEach(() => {
+      fs.mkdirSync(workspaceDir, { recursive: true });
+      fs.mkdirSync(outsideDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(workspaceDir, 'in_workspace.txt'),
+        'in workspace',
+      );
+      fs.writeFileSync(path.join(outsideDir, 'outside.txt'), 'outside content');
+    });
+
+    it('should consider ls or cat safe with in-workspace arguments', () => {
+      expect(
+        isKnownSafeCommand(
+          ['ls', 'in_workspace.txt'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(true);
+      expect(
+        isKnownSafeCommand(
+          ['cat', 'in_workspace.txt'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(true);
+    });
+
+    it('should reject ls or cat when argument traverses outside workspace', () => {
+      expect(
+        isKnownSafeCommand(
+          ['ls', '../outside/outside.txt'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['cat', path.join(outsideDir, 'outside.txt')],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+    });
+
+    it('should reject safe commands accessing a symlink pointing outside workspace', () => {
+      const symlinkPath = path.join(workspaceDir, 'my_link');
+      if (!fs.existsSync(symlinkPath)) {
+        fs.symlinkSync(outsideDir, symlinkPath);
+      }
+
+      expect(
+        isKnownSafeCommand(['ls', 'my_link'], workspaceDir, workspaceDir),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['cat', 'my_link/outside.txt'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+    });
+
+    it('should reject commands with unresolved shell variable expansions in paths', () => {
+      expect(
+        isKnownSafeCommand(['ls', '${d}'], workspaceDir, workspaceDir),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(['cat', '$SECRET_PATH'], workspaceDir, workspaceDir),
+      ).toBe(false);
+    });
+
+    it('should reject commands with user-specific tilde expansions', () => {
+      expect(
+        isKnownSafeCommand(['ls', '~root/secret'], workspaceDir, workspaceDir),
+      ).toBe(false);
+    });
+
+    it('should reject commands when effectiveCwd is outside workspace', () => {
+      expect(isKnownSafeCommand(['ls'], outsideDir, workspaceDir)).toBe(false);
+      expect(isKnownSafeCommand(['pwd'], outsideDir, workspaceDir)).toBe(false);
+    });
+
+    it('should reject grep or rg with file options pointing outside workspace', () => {
+      const outsideFile = path.join(outsideDir, 'outside.txt');
+      expect(
+        isKnownSafeCommand(
+          ['grep', '--file', outsideFile, 'pattern'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['grep', `-f${outsideFile}`, 'pattern'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['/usr/bin/rg', '--file', outsideFile, 'pattern'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('ln command safety in isDangerousCommand', () => {
+    it('should flag ln with symbolic flags as dangerous', () => {
+      expect(isDangerousCommand(['ln', '-s', 'target', 'link'])).toBe(true);
+      expect(isDangerousCommand(['ln', '-sf', 'target', 'link'])).toBe(true);
+      expect(isDangerousCommand(['ln', '--symbolic', 'target', 'link'])).toBe(
+        true,
+      );
+    });
+
+    it('should not flag hard link ln without symbolic flag as dangerous', () => {
+      expect(isDangerousCommand(['ln', 'target', 'link'])).toBe(false);
     });
   });
 });

--- a/packages/core/src/sandbox/utils/commandSafety.test.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.test.ts
@@ -243,6 +243,43 @@ describe('commandSafety', () => {
         ),
       ).toBe(false);
     });
+
+    it('should reject cd with switches escaping workspace and bare cd escaping', () => {
+      expect(
+        isKnownSafeCommand(
+          ['cd', '-P', '../outside'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['cd', '-L', '../outside'],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(isKnownSafeCommand(['cd'], workspaceDir, workspaceDir)).toBe(
+        false,
+      );
+    });
+
+    it('should reject find commands with paths escaping workspace even with options', () => {
+      expect(
+        isKnownSafeCommand(
+          ['find', '-L', outsideDir],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['find', '.', '-type', 'f', outsideDir],
+          workspaceDir,
+          workspaceDir,
+        ),
+      ).toBe(false);
+    });
   });
 
   describe('ln command safety in isDangerousCommand', () => {

--- a/packages/core/src/sandbox/utils/commandSafety.test.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.test.ts
@@ -290,6 +290,43 @@ describe('commandSafety', () => {
         ),
       ).toBe(false);
     });
+
+    it('should reject file-reading commands and grep/rg when an argument starting with hyphen is an existing file escaping workspace', () => {
+      const hyphenSymlinkName = '-escapedFile';
+      const hyphenSymlinkPath = path.join(workspaceDir, hyphenSymlinkName);
+      const outsideFile = path.join(outsideDir, 'outside.txt');
+      fs.symlinkSync(outsideFile, hyphenSymlinkPath);
+
+      try {
+        expect(
+          isKnownSafeCommand(
+            ['cat', hyphenSymlinkName],
+            workspaceDir,
+            workspaceDir,
+          ),
+        ).toBe(false);
+
+        expect(
+          isKnownSafeCommand(
+            ['grep', 'foo', hyphenSymlinkName],
+            workspaceDir,
+            workspaceDir,
+          ),
+        ).toBe(false);
+
+        expect(
+          isKnownSafeCommand(
+            ['/usr/bin/rg', 'foo', hyphenSymlinkName],
+            workspaceDir,
+            workspaceDir,
+          ),
+        ).toBe(false);
+      } finally {
+        if (fs.existsSync(hyphenSymlinkPath)) {
+          fs.unlinkSync(hyphenSymlinkPath);
+        }
+      }
+    });
   });
 
   describe('ln command safety in isDangerousCommand', () => {

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -341,17 +341,9 @@ function isSafeToCallWithExec(
             if (arg.includes('=')) {
               const val = arg.slice(arg.indexOf('=') + 1);
               if (
-                val.startsWith('/') ||
-                val.startsWith('~') ||
-                val.startsWith('.') ||
-                val.includes('$') ||
-                val.includes('`')
+                isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
               ) {
-                if (
-                  isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
-                ) {
-                  return false;
-                }
+                return false;
               }
             }
             continue;

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -127,7 +127,11 @@ function isPathEscapingWorkspace(
 
   // Check if target or any parent directory resolves through a symlink to outside the workspace
   let curr = target;
-  while (curr && curr !== workspaceRoot && curr !== path.dirname(curr)) {
+  while (
+    curr &&
+    isSubpath(workspaceRoot, curr) &&
+    curr !== path.dirname(curr)
+  ) {
     try {
       const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
       if (stat?.isSymbolicLink()) {

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -349,8 +349,19 @@ function isSafeToCallWithExec(
               ) {
                 return false;
               }
+              continue;
             }
-            continue;
+
+            try {
+              const stat = fs.lstatSync(path.resolve(effectiveCwd, arg), {
+                throwIfNoEntry: false,
+              });
+              if (!stat) {
+                continue;
+              }
+            } catch {
+              continue;
+            }
           }
         }
         if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
@@ -397,8 +408,19 @@ function isSafeToCallWithExec(
               ) {
                 return false;
               }
+              continue;
             }
-            continue;
+
+            try {
+              const stat = fs.lstatSync(path.resolve(effectiveCwd, arg), {
+                throwIfNoEntry: false,
+              });
+              if (!stat) {
+                continue;
+              }
+            } catch {
+              continue;
+            }
           }
         }
         if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
@@ -507,8 +529,19 @@ function isSafeToCallWithExec(
             ) {
               return false;
             }
+            continue;
           }
-          continue;
+
+          try {
+            const stat = fs.lstatSync(path.resolve(effectiveCwd, arg), {
+              throwIfNoEntry: false,
+            });
+            if (!stat) {
+              continue;
+            }
+          } catch {
+            continue;
+          }
         }
       }
       if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -3,6 +3,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { parse as shellParse } from 'shell-quote';
 import {
@@ -11,6 +13,7 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
+import { isWithinRoot } from '../../utils/fileUtils.js';
 import { isTrustedSystemPath, resolveToRealPath } from '../../utils/paths.js';
 
 function isRipgrepCommand(cmd: string): boolean {
@@ -44,6 +47,8 @@ export async function isStrictlyApproved(
   command: string,
   args: string[],
   approvedTools?: string[],
+  cwd?: string,
+  workspaceRoot?: string,
 ): Promise<boolean> {
   const tools = approvedTools ?? [];
 
@@ -58,7 +63,10 @@ export async function isStrictlyApproved(
   if (pipelineCommands.length === 0) {
     // For simple commands, we check the root command.
     // If it's explicitly approved OR it's a known safe POSIX command, we allow it.
-    return tools.includes(command) || isKnownSafeCommand([command, ...args]);
+    return (
+      tools.includes(command) ||
+      isKnownSafeCommand([command, ...args], cwd, workspaceRoot)
+    );
   }
 
   // Check every segment of the pipeline
@@ -71,8 +79,67 @@ export async function isStrictlyApproved(
 
     const root = parsedArgs[0];
     // The segment is approved if the root tool is in the allowlist OR if the whole segment is safe.
-    return tools.includes(root) || isKnownSafeCommand(parsedArgs);
+    return (
+      tools.includes(root) || isKnownSafeCommand(parsedArgs, cwd, workspaceRoot)
+    );
   });
+}
+
+/**
+ * Checks whether an argument provided to a file-reading command points outside the workspace
+ * or resolves via symbolic link to a target outside the workspace.
+ */
+function isPathEscapingWorkspace(
+  arg: string,
+  workspaceRoot: string,
+  cwd: string,
+): boolean {
+  if (!arg || typeof arg !== 'string') return false;
+
+  // Unresolved shell variables or backticks cannot be statically verified
+  if (arg.includes('$') || arg.includes('`')) {
+    return true;
+  }
+
+  let target: string;
+  if (arg === '~' || arg.startsWith('~/') || arg.startsWith('~\\')) {
+    const homeDir = os.homedir();
+    target = path.resolve(homeDir, arg.slice(2));
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  } else if (arg.startsWith('~')) {
+    return true;
+  } else if (path.isAbsolute(arg)) {
+    target = path.resolve(arg);
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  } else {
+    target = path.resolve(cwd, arg);
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  }
+
+  // Check if target or any parent directory resolves through a symlink to outside the workspace
+  let curr = target;
+  while (curr && curr !== workspaceRoot && curr !== path.dirname(curr)) {
+    try {
+      const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
+      if (stat?.isSymbolicLink()) {
+        const real = fs.realpathSync(curr);
+        if (!isWithinRoot(real, workspaceRoot)) {
+          return true;
+        }
+      }
+    } catch {
+      // ignore
+    }
+    curr = path.dirname(curr);
+  }
+
+  return false;
 }
 
 /**
@@ -86,9 +153,15 @@ export async function isStrictlyApproved(
  * (like subshells or redirection) are used.
  *
  * @param args - The command and its arguments (e.g., ['ls', '-la'])
+ * @param cwd - Optional working directory for resolving relative paths
+ * @param workspaceRoot - Optional workspace root directory
  * @returns true if the command is considered safe, false otherwise.
  */
-export function isKnownSafeCommand(args: string[]): boolean {
+export function isKnownSafeCommand(
+  args: string[],
+  cwd?: string,
+  workspaceRoot?: string,
+): boolean {
   if (!args || args.length === 0) {
     return false;
   }
@@ -96,7 +169,7 @@ export function isKnownSafeCommand(args: string[]): boolean {
   // Normalize zsh to bash
   const normalizedArgs = args.map((a) => (a === 'zsh' ? 'bash' : a));
 
-  if (isSafeToCallWithExec(normalizedArgs)) {
+  if (isSafeToCallWithExec(normalizedArgs, cwd, workspaceRoot)) {
     return true;
   }
 
@@ -125,7 +198,7 @@ export function isKnownSafeCommand(args: string[]): boolean {
         const parsed = shellParse(trimmed).map(extractStringFromParseEntry);
         if (parsed.length === 0) return true;
 
-        return isSafeToCallWithExec(parsed);
+        return isSafeToCallWithExec(parsed, cwd, workspaceRoot);
       });
     } catch {
       return false;
@@ -139,14 +212,46 @@ export function isKnownSafeCommand(args: string[]): boolean {
  * Core validation logic that checks a single command and its arguments
  * against an allowlist of known safe operations. It performs deep validation
  * for specific tools like `base64`, `find`, `rg`, `git`, and `sed` to ensure
- * unsafe flags (like `--output`, `-exec`, or mutating options) are not used.
+ * unsafe flags (like `--output`, `-exec`, or mutating options) are not used,
+ * and ensures all path arguments remain strictly within the workspace.
  *
  * @param args - The command and its arguments.
+ * @param cwd - Optional working directory for relative path resolution.
+ * @param workspaceRoot - Optional workspace boundary.
  * @returns true if the command is strictly read-only and safe.
  */
-function isSafeToCallWithExec(args: string[]): boolean {
+function isSafeToCallWithExec(
+  args: string[],
+  cwd?: string,
+  workspaceRoot?: string,
+): boolean {
   if (!args || args.length === 0) return false;
   const cmd = args[0];
+
+  let effectiveWorkspace = workspaceRoot
+    ? path.resolve(workspaceRoot)
+    : cwd
+      ? path.resolve(cwd)
+      : process.cwd();
+  try {
+    effectiveWorkspace = resolveToRealPath(effectiveWorkspace);
+  } catch {
+    // Keep resolved path on failure
+  }
+
+  let effectiveCwd = cwd ? path.resolve(cwd) : effectiveWorkspace;
+  try {
+    effectiveCwd = resolveToRealPath(effectiveCwd);
+  } catch {
+    // Keep resolved path on failure
+  }
+
+  if (
+    effectiveCwd !== effectiveWorkspace &&
+    !isWithinRoot(effectiveCwd, effectiveWorkspace)
+  ) {
+    return false;
+  }
 
   const safeCommands = new Set([
     '__read',
@@ -180,19 +285,146 @@ function isSafeToCallWithExec(args: string[]): boolean {
   ]);
 
   if (safeCommands.has(cmd)) {
+    if (cmd === 'cd') {
+      if (args[1]) {
+        if (
+          isPathEscapingWorkspace(args[1], effectiveWorkspace, effectiveCwd)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    const fileReadingCommands = new Set([
+      'cat',
+      'head',
+      'tail',
+      'tac',
+      'nl',
+      'stat',
+      'wc',
+      'cut',
+      'paste',
+      'rev',
+      'uniq',
+      'numfmt',
+      'ls',
+      '__read',
+    ]);
+
+    if (fileReadingCommands.has(cmd)) {
+      let passedDoubleDash = false;
+      for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        if (!passedDoubleDash) {
+          if (arg === '--') {
+            passedDoubleDash = true;
+            continue;
+          }
+          if (arg === '-') {
+            continue;
+          }
+          if (arg.startsWith('-')) {
+            if (arg.includes('=')) {
+              const val = arg.slice(arg.indexOf('=') + 1);
+              if (
+                val.startsWith('/') ||
+                val.startsWith('~') ||
+                val.startsWith('.') ||
+                val.includes('$') ||
+                val.includes('`')
+              ) {
+                if (
+                  isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
+                ) {
+                  return false;
+                }
+              }
+            }
+            continue;
+          }
+        }
+        if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    if (cmd === 'grep') {
+      let passedDoubleDash = false;
+      for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        if (!passedDoubleDash) {
+          if (arg === '--') {
+            passedDoubleDash = true;
+            continue;
+          }
+          if (arg === '-') {
+            continue;
+          }
+          if (arg.startsWith('-f') || arg.startsWith('--file')) {
+            let fileArg: string | undefined;
+            if (arg.startsWith('--file=')) {
+              fileArg = arg.slice(7);
+            } else if (arg === '--file') {
+              fileArg = args[++i];
+            } else {
+              fileArg = arg.length > 2 ? arg.slice(2) : args[++i];
+            }
+            if (
+              fileArg &&
+              isPathEscapingWorkspace(fileArg, effectiveWorkspace, effectiveCwd)
+            ) {
+              return false;
+            }
+            continue;
+          }
+          if (arg.startsWith('-')) {
+            if (arg.includes('=')) {
+              const val = arg.slice(arg.indexOf('=') + 1);
+              if (
+                isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
+              ) {
+                return false;
+              }
+            }
+            continue;
+          }
+        }
+        if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     return true;
   }
 
   if (cmd === 'base64') {
     const unsafeOptions = new Set(['-o', '--output']);
-    return !args
-      .slice(1)
-      .some(
-        (arg) =>
-          unsafeOptions.has(arg) ||
-          arg.startsWith('--output=') ||
-          (arg.startsWith('-o') && arg !== '-o'),
-      );
+    if (
+      args
+        .slice(1)
+        .some(
+          (arg) =>
+            unsafeOptions.has(arg) ||
+            arg.startsWith('--output=') ||
+            (arg.startsWith('-o') && arg !== '-o'),
+        )
+    ) {
+      return false;
+    }
+    for (let i = 1; i < args.length; i++) {
+      const arg = args[i];
+      if (arg.startsWith('-')) continue;
+      if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   if (cmd === 'find') {
@@ -207,7 +439,17 @@ function isSafeToCallWithExec(args: string[]): boolean {
       '-fprint0',
       '-fprintf',
     ]);
-    return !args.some((arg) => unsafeOptions.has(arg));
+    if (args.some((arg) => unsafeOptions.has(arg))) {
+      return false;
+    }
+    for (let i = 1; i < args.length; i++) {
+      const arg = args[i];
+      if (arg.startsWith('-')) break;
+      if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   if (isRipgrepCommand(cmd)) {
@@ -216,13 +458,57 @@ function isSafeToCallWithExec(args: string[]): boolean {
     const unsafeWithArgs = new Set(['--pre', '--hostname-bin']);
     const unsafeWithoutArgs = new Set(['--search-zip', '-z']);
 
-    return !args.some((arg) => {
-      if (unsafeWithoutArgs.has(arg)) return true;
+    for (let i = 1; i < args.length; i++) {
+      const arg = args[i];
+      if (unsafeWithoutArgs.has(arg)) return false;
       for (const opt of unsafeWithArgs) {
-        if (arg === opt || arg.startsWith(opt + '=')) return true;
+        if (arg === opt || arg.startsWith(opt + '=')) return false;
       }
-      return false;
-    });
+    }
+
+    let passedDoubleDash = false;
+    for (let i = 1; i < args.length; i++) {
+      const arg = args[i];
+      if (!passedDoubleDash) {
+        if (arg === '--') {
+          passedDoubleDash = true;
+          continue;
+        }
+        if (arg.startsWith('-f') || arg.startsWith('--file')) {
+          let fileArg: string | undefined;
+          if (arg.startsWith('--file=')) {
+            fileArg = arg.slice(7);
+          } else if (arg === '--file') {
+            fileArg = args[++i];
+          } else {
+            fileArg = arg.length > 2 ? arg.slice(2) : args[++i];
+          }
+          if (
+            fileArg &&
+            isPathEscapingWorkspace(fileArg, effectiveWorkspace, effectiveCwd)
+          ) {
+            return false;
+          }
+          continue;
+        }
+        if (arg.startsWith('-')) {
+          if (arg.includes('=')) {
+            const val = arg.slice(arg.indexOf('=') + 1);
+            if (
+              isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
+            ) {
+              return false;
+            }
+          }
+          continue;
+        }
+      }
+      if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   if (cmd === 'git') {
@@ -260,6 +546,13 @@ function isSafeToCallWithExec(args: string[]): boolean {
   if (cmd === 'sed') {
     // Special-case sed -n {N|M,N}p
     if (args.length <= 4 && args[1] === '-n' && isValidSedNArg(args[2])) {
+      if (args[3]) {
+        if (
+          isPathEscapingWorkspace(args[3], effectiveWorkspace, effectiveCwd)
+        ) {
+          return false;
+        }
+      }
       return true;
     }
     return false;
@@ -444,12 +737,28 @@ function isValidSedNArg(arg: string | undefined): boolean {
  * @param args - The command and its arguments.
  * @returns true if the command is identified as dangerous, false otherwise.
  */
-export function isDangerousCommand(args: string[]): boolean {
+export function isDangerousCommand(
+  args: string[],
+  _cwd?: string,
+  _workspaceRoot?: string,
+): boolean {
   if (!args || args.length === 0) {
     return false;
   }
 
   const cmd = args[0];
+
+  if (cmd === 'ln') {
+    const isSymbolic = args.some(
+      (arg) =>
+        arg === '-s' ||
+        arg === '--symbolic' ||
+        (arg.startsWith('-') && !arg.startsWith('--') && arg.includes('s')),
+    );
+    if (isSymbolic) {
+      return true;
+    }
+  }
 
   if (cmd === 'rm') {
     return args[1] === '-f' || args[1] === '-rf' || args[1] === '-fr';

--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -13,8 +13,11 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
-import { isWithinRoot } from '../../utils/fileUtils.js';
-import { isTrustedSystemPath, resolveToRealPath } from '../../utils/paths.js';
+import {
+  isSubpath,
+  isTrustedSystemPath,
+  resolveToRealPath,
+} from '../../utils/paths.js';
 
 function isRipgrepCommand(cmd: string): boolean {
   const cmdBasename = path.basename(cmd);
@@ -105,19 +108,19 @@ function isPathEscapingWorkspace(
   if (arg === '~' || arg.startsWith('~/') || arg.startsWith('~\\')) {
     const homeDir = os.homedir();
     target = path.resolve(homeDir, arg.slice(2));
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   } else if (arg.startsWith('~')) {
     return true;
   } else if (path.isAbsolute(arg)) {
     target = path.resolve(arg);
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   } else {
     target = path.resolve(cwd, arg);
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   }
@@ -129,7 +132,7 @@ function isPathEscapingWorkspace(
       const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
       if (stat?.isSymbolicLink()) {
         const real = fs.realpathSync(curr);
-        if (!isWithinRoot(real, workspaceRoot)) {
+        if (!isSubpath(workspaceRoot, real)) {
           return true;
         }
       }
@@ -248,7 +251,7 @@ function isSafeToCallWithExec(
 
   if (
     effectiveCwd !== effectiveWorkspace &&
-    !isWithinRoot(effectiveCwd, effectiveWorkspace)
+    !isSubpath(effectiveWorkspace, effectiveCwd)
   ) {
     return false;
   }
@@ -286,10 +289,19 @@ function isSafeToCallWithExec(
 
   if (safeCommands.has(cmd)) {
     if (cmd === 'cd') {
-      if (args[1]) {
-        if (
-          isPathEscapingWorkspace(args[1], effectiveWorkspace, effectiveCwd)
-        ) {
+      let hasPath = false;
+      for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        if (arg.startsWith('-')) {
+          continue;
+        }
+        hasPath = true;
+        if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+          return false;
+        }
+      }
+      if (!hasPath) {
+        if (isPathEscapingWorkspace('~', effectiveWorkspace, effectiveCwd)) {
           return false;
         }
       }
@@ -444,7 +456,7 @@ function isSafeToCallWithExec(
     }
     for (let i = 1; i < args.length; i++) {
       const arg = args[i];
-      if (arg.startsWith('-')) break;
+      if (arg.startsWith('-')) continue;
       if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
         return false;
       }

--- a/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
+++ b/packages/core/src/sandbox/windows/WindowsSandboxManager.ts
@@ -71,17 +71,14 @@ export class WindowsSandboxManager implements SandboxManager {
     this.helperPath = path.resolve(__dirname, WindowsSandboxManager.HELPER_EXE);
   }
 
-  isKnownSafeCommand(args: string[]): boolean {
-    const toolName = args[0]?.toLowerCase();
-    const approvedTools = this.options.modeConfig?.approvedTools ?? [];
-    if (toolName && approvedTools.some((t) => t.toLowerCase() === toolName)) {
-      return true;
-    }
-    return isKnownSafeCommand(args);
+  isKnownSafeCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isKnownSafeCommand(args, effectiveCwd, this.options.workspace);
   }
 
-  isDangerousCommand(args: string[]): boolean {
-    return isDangerousCommand(args);
+  isDangerousCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.options.workspace;
+    return isDangerousCommand(args, effectiveCwd, this.options.workspace);
   }
 
   parseDenials(result: ShellExecutionResult): ParsedSandboxDenial | undefined {
@@ -355,6 +352,8 @@ export class WindowsSandboxManager implements SandboxManager {
           command,
           args,
           this.options.modeConfig?.approvedTools,
+          req.cwd,
+          this.options.workspace,
         )
       : false;
 

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -42,11 +42,31 @@ describe('Windows commandSafety', () => {
       ).toBe(false);
       expect(
         isKnownSafeCommand(
+          ['findstr', '/F:subdir\\..\\..\\outside\\win.ini', 'foo'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
           ['dir', '/Windows/win.ini'],
           'C:\\workspace',
           'C:\\workspace',
         ),
       ).toBe(false);
+    });
+
+    it('should reject cd with switches escaping workspace and bare cd escaping', () => {
+      expect(
+        isKnownSafeCommand(
+          ['cd', '-Path', '..\\outside'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
+      expect(isKnownSafeCommand(['cd'], 'C:\\workspace', 'C:\\workspace')).toBe(
+        false,
+      );
     });
 
     it('should allow file-reading commands with valid switches', () => {

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -25,6 +25,35 @@ describe('Windows commandSafety', () => {
       expect(isKnownSafeCommand(['unknown'])).toBe(false);
       expect(isKnownSafeCommand(['npm', 'install'])).toBe(false);
     });
+
+    it('should reject safe commands when effectiveCwd is outside workspace', () => {
+      expect(isKnownSafeCommand(['dir'], 'C:\\Windows', 'C:\\workspace')).toBe(
+        false,
+      );
+    });
+
+    it('should reject file-reading commands with options pointing outside workspace', () => {
+      expect(
+        isKnownSafeCommand(
+          ['findstr', '/F:C:\\Windows\\win.ini', 'foo'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['dir', '/Windows/win.ini'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
+    });
+
+    it('should allow file-reading commands with valid switches', () => {
+      expect(
+        isKnownSafeCommand(['dir', '/B'], 'C:\\workspace', 'C:\\workspace'),
+      ).toBe(true);
+    });
   });
 
   describe('isDangerousCommand', () => {

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -94,6 +94,16 @@ describe('Windows commandSafety', () => {
       expect(
         isKnownSafeCommand(['dir', '/B'], 'C:\\workspace', 'C:\\workspace'),
       ).toBe(true);
+      expect(
+        isKnownSafeCommand(['findstr', '/s'], 'C:\\workspace', 'C:\\workspace'),
+      ).toBe(true);
+      expect(
+        isKnownSafeCommand(
+          ['sort', '-nonExistentFlag'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(true);
     });
   });
 

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -78,6 +78,13 @@ describe('Windows commandSafety', () => {
           'C:\\workspace',
         ),
       ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['cd', '/windows'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
       expect(isKnownSafeCommand(['cd'], 'C:\\workspace', 'C:\\workspace')).toBe(
         false,
       );

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -54,6 +54,20 @@ describe('Windows commandSafety', () => {
           'C:\\workspace',
         ),
       ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['dir', '/windows'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
+      expect(
+        isKnownSafeCommand(
+          ['sort', 'C:\\Windows\\win.ini'],
+          'C:\\workspace',
+          'C:\\workspace',
+        ),
+      ).toBe(false);
     });
 
     it('should reject cd with switches escaping workspace and bare cd escaping', () => {

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -3,6 +3,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { parse as shellParse } from 'shell-quote';
 import {
   extractStringFromParseEntry,
@@ -10,6 +13,8 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
+import { isWithinRoot } from '../../utils/fileUtils.js';
+import { resolveToRealPath } from '../../utils/paths.js';
 
 /**
  * Determines if a command is strictly approved for execution on Windows.
@@ -19,12 +24,16 @@ import {
  * @param command - The full command string to execute.
  * @param args - The arguments for the command.
  * @param approvedTools - A list of explicitly approved tool names (e.g., ['npm', 'git']).
+ * @param cwd - Optional working directory
+ * @param workspaceRoot - Optional workspace root directory
  * @returns true if the command is strictly approved, false otherwise.
  */
 export async function isStrictlyApproved(
   command: string,
   args: string[],
   approvedTools?: string[],
+  cwd?: string,
+  workspaceRoot?: string,
 ): Promise<boolean> {
   const tools = approvedTools ?? [];
 
@@ -37,7 +46,10 @@ export async function isStrictlyApproved(
 
   // Fallback for simple commands or parsing failures
   if (pipelineCommands.length === 0) {
-    return tools.includes(command) || isKnownSafeCommand([command, ...args]);
+    return (
+      tools.includes(command) ||
+      isKnownSafeCommand([command, ...args], cwd, workspaceRoot)
+    );
   }
 
   // Check every segment of the pipeline
@@ -55,19 +67,107 @@ export async function isStrictlyApproved(
     // The segment is approved if the root tool is in the allowlist OR if the whole segment is safe.
     return (
       tools.some((t) => t.toLowerCase() === root) ||
-      isKnownSafeCommand(parsedArgs)
+      isKnownSafeCommand(parsedArgs, cwd, workspaceRoot)
     );
   });
+}
+
+function isPathEscapingWorkspace(
+  arg: string,
+  workspaceRoot: string,
+  cwd: string,
+): boolean {
+  if (!arg || typeof arg !== 'string') return false;
+
+  if (arg.includes('$') || arg.includes('`') || arg.includes('%')) {
+    return true;
+  }
+
+  let target: string;
+  if (arg === '~' || arg.startsWith('~/') || arg.startsWith('~\\')) {
+    const homeDir = os.homedir();
+    target = path.win32.resolve(homeDir, arg.slice(2));
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  } else if (arg.startsWith('~')) {
+    return true;
+  } else if (path.win32.isAbsolute(arg) || path.isAbsolute(arg)) {
+    target = path.win32.resolve(arg);
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  } else {
+    target = path.win32.resolve(cwd, arg);
+    if (!isWithinRoot(target, workspaceRoot)) {
+      return true;
+    }
+  }
+
+  let curr = target;
+  while (curr && curr !== workspaceRoot && curr !== path.win32.dirname(curr)) {
+    try {
+      const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
+      if (stat?.isSymbolicLink()) {
+        const real = fs.realpathSync(curr);
+        if (!isWithinRoot(real, workspaceRoot)) {
+          return true;
+        }
+      }
+    } catch {
+      // ignore
+    }
+    curr = path.win32.dirname(curr);
+  }
+
+  return false;
 }
 
 /**
  * Checks if a Windows command is known to be safe (read-only).
  */
-export function isKnownSafeCommand(args: string[]): boolean {
+export function isKnownSafeCommand(
+  args: string[],
+  cwd?: string,
+  workspaceRoot?: string,
+): boolean {
   if (!args || args.length === 0) return false;
   let cmd = args[0].toLowerCase();
   if (cmd.endsWith('.exe')) {
     cmd = cmd.slice(0, -4);
+  }
+
+  let effectiveWorkspace = workspaceRoot
+    ? path.win32.isAbsolute(workspaceRoot)
+      ? path.win32.resolve(workspaceRoot)
+      : path.resolve(workspaceRoot)
+    : cwd
+      ? path.win32.isAbsolute(cwd)
+        ? path.win32.resolve(cwd)
+        : path.resolve(cwd)
+      : process.cwd();
+  try {
+    effectiveWorkspace = resolveToRealPath(effectiveWorkspace);
+  } catch {
+    // Keep resolved path on failure
+  }
+
+  let effectiveCwd = cwd
+    ? path.win32.isAbsolute(cwd)
+      ? path.win32.resolve(cwd)
+      : path.resolve(cwd)
+    : effectiveWorkspace;
+  try {
+    effectiveCwd = resolveToRealPath(effectiveCwd);
+  } catch {
+    // Keep resolved path on failure
+  }
+
+  if (
+    effectiveCwd !== effectiveWorkspace &&
+    !isWithinRoot(effectiveCwd, effectiveWorkspace)
+  ) {
+    return false;
   }
 
   // Native Windows/PowerShell safe commands
@@ -100,6 +200,72 @@ export function isKnownSafeCommand(args: string[]): boolean {
   ]);
 
   if (safeCommands.has(cmd)) {
+    if (cmd === 'cd') {
+      if (args[1]) {
+        if (
+          isPathEscapingWorkspace(args[1], effectiveWorkspace, effectiveCwd)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    const fileReadingCommands = new Set([
+      'dir',
+      'type',
+      'attrib',
+      'more',
+      'findstr',
+      'get-childitem',
+      'get-content',
+      'select-string',
+      '__read',
+    ]);
+
+    if (fileReadingCommands.has(cmd)) {
+      let passedDoubleDash = false;
+      for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        if (!passedDoubleDash) {
+          if (arg === '--') {
+            passedDoubleDash = true;
+            continue;
+          }
+          const isSwitch =
+            arg.startsWith('-') ||
+            (arg.startsWith('/') && /^\/[a-zA-Z0-9?]+(?::.*)?$/.test(arg));
+          if (isSwitch) {
+            const sepIdx =
+              arg.indexOf('=') !== -1 ? arg.indexOf('=') : arg.indexOf(':');
+            if (sepIdx !== -1) {
+              const val = arg.slice(sepIdx + 1);
+              if (
+                val.startsWith('/') ||
+                val.startsWith('\\') ||
+                val.startsWith('~') ||
+                val.startsWith('.') ||
+                val.includes('$') ||
+                val.includes('%') ||
+                /^[a-zA-Z]:/.test(val)
+              ) {
+                if (
+                  isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
+                ) {
+                  return false;
+                }
+              }
+            }
+            continue;
+          }
+        }
+        if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     return true;
   }
 
@@ -117,7 +283,11 @@ export function isKnownSafeCommand(args: string[]): boolean {
 /**
  * Checks if a Windows command is explicitly dangerous.
  */
-export function isDangerousCommand(args: string[]): boolean {
+export function isDangerousCommand(
+  args: string[],
+  _cwd?: string,
+  _workspaceRoot?: string,
+): boolean {
   if (!args || args.length === 0) return false;
   let cmd = args[0].toLowerCase();
   if (cmd.endsWith('.exe')) {

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -104,7 +104,11 @@ function isPathEscapingWorkspace(
   }
 
   let curr = target;
-  while (curr && curr !== workspaceRoot && curr !== path.win32.dirname(curr)) {
+  while (
+    curr &&
+    isSubpath(workspaceRoot, curr) &&
+    curr !== path.win32.dirname(curr)
+  ) {
     try {
       const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
       if (stat?.isSymbolicLink()) {
@@ -232,6 +236,7 @@ export function isKnownSafeCommand(
       'get-content',
       'select-string',
       '__read',
+      'sort',
     ]);
 
     if (fileReadingCommands.has(cmd)) {
@@ -245,7 +250,7 @@ export function isKnownSafeCommand(
           }
           const isSwitch =
             arg.startsWith('-') ||
-            (arg.startsWith('/') && /^\/[a-zA-Z0-9?]+(?::.*)?$/.test(arg));
+            (arg.startsWith('/') && /^\/[a-zA-Z0-9?]{1,4}(?::.*)?$/.test(arg));
           if (isSwitch) {
             const sepIdx =
               arg.indexOf('=') !== -1 ? arg.indexOf('=') : arg.indexOf(':');

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -13,8 +13,7 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
-import { isWithinRoot } from '../../utils/fileUtils.js';
-import { resolveToRealPath } from '../../utils/paths.js';
+import { isSubpath, resolveToRealPath } from '../../utils/paths.js';
 
 /**
  * Determines if a command is strictly approved for execution on Windows.
@@ -87,19 +86,19 @@ function isPathEscapingWorkspace(
   if (arg === '~' || arg.startsWith('~/') || arg.startsWith('~\\')) {
     const homeDir = os.homedir();
     target = path.win32.resolve(homeDir, arg.slice(2));
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   } else if (arg.startsWith('~')) {
     return true;
   } else if (path.win32.isAbsolute(arg) || path.isAbsolute(arg)) {
     target = path.win32.resolve(arg);
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   } else {
     target = path.win32.resolve(cwd, arg);
-    if (!isWithinRoot(target, workspaceRoot)) {
+    if (!isSubpath(workspaceRoot, target)) {
       return true;
     }
   }
@@ -110,7 +109,7 @@ function isPathEscapingWorkspace(
       const stat = fs.lstatSync(curr, { throwIfNoEntry: false });
       if (stat?.isSymbolicLink()) {
         const real = fs.realpathSync(curr);
-        if (!isWithinRoot(real, workspaceRoot)) {
+        if (!isSubpath(workspaceRoot, real)) {
           return true;
         }
       }
@@ -165,7 +164,7 @@ export function isKnownSafeCommand(
 
   if (
     effectiveCwd !== effectiveWorkspace &&
-    !isWithinRoot(effectiveCwd, effectiveWorkspace)
+    !isSubpath(effectiveWorkspace, effectiveCwd)
   ) {
     return false;
   }
@@ -201,10 +200,22 @@ export function isKnownSafeCommand(
 
   if (safeCommands.has(cmd)) {
     if (cmd === 'cd') {
-      if (args[1]) {
-        if (
-          isPathEscapingWorkspace(args[1], effectiveWorkspace, effectiveCwd)
-        ) {
+      let hasPath = false;
+      for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        const isSwitch =
+          arg.startsWith('-') ||
+          (arg.startsWith('/') && /^\/[a-zA-Z0-9?]+(?::.*)?$/.test(arg));
+        if (isSwitch) {
+          continue;
+        }
+        hasPath = true;
+        if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {
+          return false;
+        }
+      }
+      if (!hasPath) {
+        if (isPathEscapingWorkspace('~', effectiveWorkspace, effectiveCwd)) {
           return false;
         }
       }
@@ -241,19 +252,9 @@ export function isKnownSafeCommand(
             if (sepIdx !== -1) {
               const val = arg.slice(sepIdx + 1);
               if (
-                val.startsWith('/') ||
-                val.startsWith('\\') ||
-                val.startsWith('~') ||
-                val.startsWith('.') ||
-                val.includes('$') ||
-                val.includes('%') ||
-                /^[a-zA-Z]:/.test(val)
+                isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
               ) {
-                if (
-                  isPathEscapingWorkspace(val, effectiveWorkspace, effectiveCwd)
-                ) {
-                  return false;
-                }
+                return false;
               }
             }
             continue;

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -261,8 +261,26 @@ export function isKnownSafeCommand(
               ) {
                 return false;
               }
+              continue;
             }
-            continue;
+
+            if (arg.startsWith('-')) {
+              try {
+                const stat = fs.lstatSync(
+                  path.win32.resolve(effectiveCwd, arg),
+                  {
+                    throwIfNoEntry: false,
+                  },
+                );
+                if (!stat) {
+                  continue;
+                }
+              } catch {
+                continue;
+              }
+            } else {
+              continue;
+            }
           }
         }
         if (isPathEscapingWorkspace(arg, effectiveWorkspace, effectiveCwd)) {

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -209,7 +209,7 @@ export function isKnownSafeCommand(
         const arg = args[i];
         const isSwitch =
           arg.startsWith('-') ||
-          (arg.startsWith('/') && /^\/[a-zA-Z0-9?]+(?::.*)?$/.test(arg));
+          (arg.startsWith('/') && /^\/[a-zA-Z0-9?]{1,4}(?::.*)?$/.test(arg));
         if (isSwitch) {
           continue;
         }

--- a/packages/core/src/services/fileDiscoveryService.symlink.test.ts
+++ b/packages/core/src/services/fileDiscoveryService.symlink.test.ts
@@ -164,4 +164,22 @@ describe('FileDiscoveryService - Symlink Ignore Handling', () => {
     // it should dynamically detect that the target is a directory and match 'ignored_dir/'
     expect(service.shouldIgnoreFile('link_to_dir')).toBe(true);
   });
+
+  it('should ignore symlinks pointing outside the project root (Scenario G)', async () => {
+    // Create an external directory outside projectRoot
+    const outsideDir = path.join(testRootDir, 'outside');
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(
+      path.join(outsideDir, 'external.txt'),
+      'outside content',
+    );
+
+    const linkPath = path.join(projectRoot, 'my_link');
+    await fs.symlink(outsideDir, linkPath);
+
+    const service = new FileDiscoveryService(projectRoot);
+    expect(service.shouldIgnoreFile('my_link')).toBe(true);
+    expect(service.shouldIgnoreDirectory('my_link')).toBe(true);
+    expect(service.filterFiles(['my_link'])).toEqual([]);
+  });
 });

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -17,6 +17,7 @@ import { GEMINI_IGNORE_FILE_NAME } from '../config/constants.js';
 import { isNodeError } from '../utils/errors.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { resolveToRealPath } from '../utils/paths.js';
+import { isWithinRoot } from '../utils/fileUtils.js';
 import fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -276,6 +277,10 @@ export class FileDiscoveryService {
 
       if (isSymlink) {
         const realPath = resolveToRealPath(absolutePath);
+        const realProjectRoot = resolveToRealPath(this.projectRoot);
+        if (!isWithinRoot(realPath, realProjectRoot)) {
+          return true;
+        }
         let targetIsDir = isDirectory;
         try {
           targetIsDir = fs.statSync(realPath).isDirectory();

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -16,8 +16,7 @@ import { isGitRepository } from '../utils/gitUtils.js';
 import { GEMINI_IGNORE_FILE_NAME } from '../config/constants.js';
 import { isNodeError } from '../utils/errors.js';
 import { debugLogger } from '../utils/debugLogger.js';
-import { resolveToRealPath } from '../utils/paths.js';
-import { isWithinRoot } from '../utils/fileUtils.js';
+import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 import fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -278,7 +277,7 @@ export class FileDiscoveryService {
       if (isSymlink) {
         const realPath = resolveToRealPath(absolutePath);
         const realProjectRoot = resolveToRealPath(this.projectRoot);
-        if (!isWithinRoot(realPath, realProjectRoot)) {
+        if (!isSubpath(realProjectRoot, realPath)) {
           return true;
         }
         let targetIsDir = isDirectory;

--- a/packages/core/src/services/fileDiscoveryService.ts
+++ b/packages/core/src/services/fileDiscoveryService.ts
@@ -44,6 +44,18 @@ export class FileDiscoveryService {
     customIgnoreFilePaths: [],
   };
   private projectRoot: string;
+  private _realProjectRoot?: string;
+
+  private get realProjectRoot(): string {
+    if (!this._realProjectRoot) {
+      try {
+        this._realProjectRoot = resolveToRealPath(this.projectRoot);
+      } catch {
+        this._realProjectRoot = this.projectRoot;
+      }
+    }
+    return this._realProjectRoot;
+  }
 
   constructor(projectRoot: string, options?: FilterFilesOptions) {
     this.projectRoot = path.resolve(projectRoot);
@@ -276,8 +288,7 @@ export class FileDiscoveryService {
 
       if (isSymlink) {
         const realPath = resolveToRealPath(absolutePath);
-        const realProjectRoot = resolveToRealPath(this.projectRoot);
-        if (!isSubpath(realProjectRoot, realPath)) {
+        if (!isSubpath(this.realProjectRoot, realPath)) {
           return true;
         }
         let targetIsDir = isDirectory;

--- a/packages/core/src/services/sandboxManager.ts
+++ b/packages/core/src/services/sandboxManager.ts
@@ -168,12 +168,12 @@ export interface SandboxManager {
   /**
    * Checks if a command with its arguments is known to be safe for this sandbox.
    */
-  isKnownSafeCommand(args: string[]): boolean;
+  isKnownSafeCommand(args: string[], cwd?: string): boolean;
 
   /**
    * Checks if a command with its arguments is explicitly known to be dangerous for this sandbox.
    */
-  isDangerousCommand(args: string[]): boolean;
+  isDangerousCommand(args: string[], cwd?: string): boolean;
 
   /**
    * Parses the output of a command to detect sandbox denials.
@@ -307,16 +307,18 @@ export class NoopSandboxManager implements SandboxManager {
     };
   }
 
-  isKnownSafeCommand(args: string[]): boolean {
+  isKnownSafeCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.getWorkspace();
     return os.platform() === 'win32'
-      ? isWindowsSafeCommand(args)
-      : isMacSafeCommand(args);
+      ? isWindowsSafeCommand(args, effectiveCwd, this.getWorkspace())
+      : isMacSafeCommand(args, effectiveCwd, this.getWorkspace());
   }
 
-  isDangerousCommand(args: string[]): boolean {
+  isDangerousCommand(args: string[], cwd?: string): boolean {
+    const effectiveCwd = cwd ?? this.getWorkspace();
     return os.platform() === 'win32'
-      ? isWindowsDangerousCommand(args)
-      : isMacDangerousCommand(args);
+      ? isWindowsDangerousCommand(args, effectiveCwd, this.getWorkspace())
+      : isMacDangerousCommand(args, effectiveCwd, this.getWorkspace());
   }
 
   parseDenials(): undefined {
@@ -342,11 +344,11 @@ export class LocalSandboxManager implements SandboxManager {
     throw new Error('Tool sandboxing is not yet implemented.');
   }
 
-  isKnownSafeCommand(_args: string[]): boolean {
+  isKnownSafeCommand(_args: string[], _cwd?: string): boolean {
     return false;
   }
 
-  isDangerousCommand(_args: string[]): boolean {
+  isDangerousCommand(_args: string[], _cwd?: string): boolean {
     return false;
   }
 

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -229,6 +229,14 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
       for (const relativePath of filteredPaths) {
         const fullPath = path.resolve(this.config.getTargetDir(), relativePath);
 
+        const validationError = this.config.validatePathAccess(
+          fullPath,
+          'read',
+        );
+        if (validationError) {
+          continue;
+        }
+
         if (this.shouldIgnore(path.basename(fullPath), this.params.ignore)) {
           continue;
         }


### PR DESCRIPTION

## Summary

Enhances workspace boundary enforcement and symbolic link resolution across command safety heuristics, file discovery services, and directory listing tools on POSIX and Windows systems.

## Details

- **POSIX Command Safety**: Added workspace boundary checking (`isPathEscapingWorkspace`) to `isKnownSafeCommand` and `isSafeToCallWithExec` in `@google/gemini-cli-core` (`packages/core/src/sandbox/utils/commandSafety.ts`). Inspects target file and directory arguments for file-reading utilities (such as `cat`, `head`, `tail`, `ls`, `grep`, `find`, `sed`, etc.) to ensure arguments do not traverse outside the workspace root or dereference through symbolic links to external targets. Unresolved shell variables and user directory expansions (`~`) that cannot be validated statically are treated as non-safe.
- **Symbolic Link Command Handling**: Updated `isDangerousCommand` in `commandSafety.ts` to identify `ln` invocations that specify symbolic link flags (`-s`, `--symbolic`) so that confirmation is required before creating new symbolic links.
- **Windows Command Safety**: Added matching workspace boundary and symlink validation in Windows command safety heuristics (`packages/core/src/sandbox/windows/commandSafety.ts`) for utilities like `dir`, `type`, `attrib`, `more`, `findstr`, `get-childitem`, and `get-content`.
- **Sandbox Manager Interface & Policy Integration**: Updated `SandboxManager` interface and implementations (`LocalSandboxManager`, `LinuxSandboxManager`, `MacOsSandboxManager`, `WindowsSandboxManager`) to accept and propagate the current working directory (`cwd`) alongside workspace root, ensuring that `PolicyEngine.applyShellHeuristics` passes the effective directory context to safety evaluators.
- **File Discovery Service**: Updated `FileDiscoveryService` (`packages/core/src/services/fileDiscoveryService.ts`) to verify symbolic link targets with `isWithinRoot` and ignore links pointing outside the project root.
- **Directory Listing (`ls`) Tool**: Added `validatePathAccess` checks when resolving directory entries in `packages/core/src/tools/ls.ts` to ensure entries outside the workspace boundary are excluded.
- **Unit Test Coverage**: Added comprehensive test cases in `packages/core/src/sandbox/utils/commandSafety.test.ts`, `packages/core/src/services/fileDiscoveryService.symlink.test.ts`, and verified against `ls.test.ts` and `policy-engine.test.ts`.

## Related Issues

Fixes b/439919800

## How to Validate

1. Run targeted unit tests for command safety, symlinks, and policy evaluation:
   ```bash
   npm test --workspace @google/gemini-cli-core -- src/sandbox/utils/commandSafety.test.ts src/services/fileDiscoveryService.symlink.test.ts src/tools/ls.test.ts src/policy/policy-engine.test.ts
   ```
2. Run full linting, formatting, and typecheck:
   ```bash
   npm run lint:ci && npm run typecheck
   ```
3. Run the core test suite:
   ```bash
   npm test --workspace @google/gemini-cli-core
   ```

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker
