### PR TITLE
fix(cli): isolate temporary directory for macOS Seatbelt sandbox

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -137,6 +137,10 @@ describe('sandbox', () => {
     vi.mocked(os.tmpdir).mockReturnValue('/tmp');
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+    vi.mocked(fs.mkdtempSync).mockImplementation(
+      (prefix) => `${prefix}test-tmp`,
+    );
+    vi.mocked(fs.rmSync).mockImplementation(() => {});
     vi.mocked(execSync).mockReturnValue(Buffer.from(''));
   });
 
@@ -180,6 +184,121 @@ describe('sandbox', () => {
         ]),
         expect.objectContaining({ stdio: 'inherit' }),
       );
+    });
+
+    it('should isolate temporary directory for macOS seatbelt (sandbox-exec)', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      vi.mocked(os.tmpdir).mockReturnValue('/var/folders/test/T');
+      vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+      vi.mocked(fs.mkdtempSync).mockReturnValue(
+        '/var/folders/test/T/gemini-sandbox-tmp-123456',
+      );
+
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const onSpy = vi.spyOn(process, 'on');
+      const offSpy = vi.spyOn(process, 'off');
+
+      const promise = start_sandbox(config, [], undefined, ['arg1']);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      await expect(promise).resolves.toBe(0);
+
+      // Verify that an isolated temporary directory was created
+      expect(fs.mkdtempSync).toHaveBeenCalledWith(
+        expect.stringContaining(
+          path.join('/var/folders/test/T', 'gemini-sandbox-'),
+        ),
+      );
+
+      const spawnCalls = vi.mocked(spawn).mock.calls;
+      const spawnArgs = spawnCalls[0]?.[1] as string[];
+
+      // Verify that TMP_DIR argument passed to seatbelt is the isolated temp directory, NOT host tmpdir
+      expect(spawnArgs).toContain(
+        'TMP_DIR=/var/folders/test/T/gemini-sandbox-tmp-123456',
+      );
+      expect(spawnArgs).not.toContain('TMP_DIR=/var/folders/test/T');
+
+      // Verify that TMPDIR environment variable is set in the sandboxed shell execution
+      const shCommand = spawnArgs[spawnArgs.indexOf('sh') + 2];
+      expect(shCommand).toContain('TMPDIR=');
+      expect(shCommand).toContain(
+        '/var/folders/test/T/gemini-sandbox-tmp-123456',
+      );
+
+      // Verify cleanup of the isolated temporary directory
+      expect(fs.rmSync).toHaveBeenCalledWith(
+        '/var/folders/test/T/gemini-sandbox-tmp-123456',
+        expect.objectContaining({ recursive: true, force: true }),
+      );
+
+      // Verify that exit and signal cleanup hooks are registered and unregistered
+      expect(onSpy).toHaveBeenCalledWith('exit', expect.any(Function));
+      expect(onSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(onSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+      expect(offSpy).toHaveBeenCalledWith('exit', expect.any(Function));
+      expect(offSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(offSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+      onSpy.mockRestore();
+      offSpy.mockRestore();
+    });
+
+    it('should safely swallow errors if fs.rmSync fails during cleanup', async () => {
+      vi.mocked(os.platform).mockReturnValue('darwin');
+      vi.mocked(os.tmpdir).mockReturnValue('/var/folders/test/T');
+      vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+      vi.mocked(fs.mkdtempSync).mockReturnValue(
+        '/var/folders/test/T/gemini-sandbox-tmp-error',
+      );
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error('EPERM: operation not permitted');
+      });
+
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'sandbox-exec',
+        image: 'some-image',
+      });
+
+      interface MockProcess extends EventEmitter {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      }
+      const mockSpawnProcess = new EventEmitter() as MockProcess;
+      mockSpawnProcess.stdout = new EventEmitter();
+      mockSpawnProcess.stderr = new EventEmitter();
+      vi.mocked(spawn).mockReturnValue(
+        mockSpawnProcess as unknown as ReturnType<typeof spawn>,
+      );
+
+      const promise = start_sandbox(config, [], undefined, ['arg1']);
+
+      setTimeout(() => {
+        mockSpawnProcess.emit('close', 0);
+      }, 10);
+
+      // Even if fs.rmSync throws, start_sandbox should resolve successfully and not crash
+      await expect(promise).resolves.toBe(0);
+      expect(fs.rmSync).toHaveBeenCalled();
     });
 
     it('should resolve custom seatbelt profile from user home directory', async () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -176,13 +176,14 @@ export async function start_sandbox(
         const createdTmpDir = fs.mkdtempSync(
           path.join(hostTmpDir, 'gemini-sandbox-'),
         );
-        sandboxTmpDir = fs.realpathSync(createdTmpDir);
+        const resolvedTmpDir = fs.realpathSync(createdTmpDir);
+        sandboxTmpDir = resolvedTmpDir;
 
         const args = [
           '-D',
           `TARGET_DIR=${fs.realpathSync(process.cwd())}`,
           '-D',
-          `TMP_DIR=${sandboxTmpDir}`,
+          `TMP_DIR=${resolvedTmpDir}`,
           '-D',
           `HOME_DIR=${fs.realpathSync(homedir())}`,
           '-D',
@@ -243,9 +244,9 @@ export async function start_sandbox(
           '-c',
           [
             `SANDBOX=sandbox-exec`,
-            'TMPDIR=' + quote([sandboxTmpDir]),
-            'TMP=' + quote([sandboxTmpDir]),
-            'TEMP=' + quote([sandboxTmpDir]),
+            'TMPDIR=' + quote([resolvedTmpDir]),
+            'TMP=' + quote([resolvedTmpDir]),
+            'TEMP=' + quote([resolvedTmpDir]),
             'NODE_OPTIONS=' + quote([nodeOptions]),
             ...finalArgv.map((arg) => quote([arg])),
           ].join(' '),
@@ -255,9 +256,9 @@ export async function start_sandbox(
         let proxyProcess: ChildProcess | undefined = undefined;
         let sandboxProcess: ChildProcess | undefined = undefined;
         const sandboxEnv = { ...process.env };
-        sandboxEnv['TMPDIR'] = sandboxTmpDir;
-        sandboxEnv['TMP'] = sandboxTmpDir;
-        sandboxEnv['TEMP'] = sandboxTmpDir;
+        sandboxEnv['TMPDIR'] = resolvedTmpDir;
+        sandboxEnv['TMP'] = resolvedTmpDir;
+        sandboxEnv['TEMP'] = resolvedTmpDir;
         if (proxyCommand) {
           const proxy =
             process.env['HTTPS_PROXY'] ||

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -58,15 +58,30 @@ export async function start_sandbox(
 
   let stopProxy: (() => void) | undefined = undefined;
   let tempProfileFile: string | null = null;
+  let sandboxTmpDir: string | null = null;
 
   const cleanup = () => {
-    if (tempProfileFile && fs.existsSync(tempProfileFile)) {
+    if (sandboxTmpDir) {
+      const dirToDelete = sandboxTmpDir;
+      sandboxTmpDir = null;
       try {
-        fs.unlinkSync(tempProfileFile);
+        if (fs.existsSync(dirToDelete)) {
+          fs.rmSync(dirToDelete, { recursive: true, force: true });
+        }
       } catch {
         // ignore
       }
+    }
+    if (tempProfileFile) {
+      const fileToDelete = tempProfileFile;
       tempProfileFile = null;
+      try {
+        if (fs.existsSync(fileToDelete)) {
+          fs.unlinkSync(fileToDelete);
+        }
+      } catch {
+        // ignore
+      }
     }
     if (stopProxy) {
       try {
@@ -157,11 +172,17 @@ export async function start_sandbox(
           ...nodeArgs,
         ].join(' ');
 
+        const hostTmpDir = fs.realpathSync(os.tmpdir());
+        const createdTmpDir = fs.mkdtempSync(
+          path.join(hostTmpDir, 'gemini-sandbox-'),
+        );
+        sandboxTmpDir = fs.realpathSync(createdTmpDir);
+
         const args = [
           '-D',
           `TARGET_DIR=${fs.realpathSync(process.cwd())}`,
           '-D',
-          `TMP_DIR=${fs.realpathSync(os.tmpdir())}`,
+          `TMP_DIR=${sandboxTmpDir}`,
           '-D',
           `HOME_DIR=${fs.realpathSync(homedir())}`,
           '-D',
@@ -222,6 +243,9 @@ export async function start_sandbox(
           '-c',
           [
             `SANDBOX=sandbox-exec`,
+            'TMPDIR=' + quote([sandboxTmpDir]),
+            'TMP=' + quote([sandboxTmpDir]),
+            'TEMP=' + quote([sandboxTmpDir]),
             'NODE_OPTIONS=' + quote([nodeOptions]),
             ...finalArgv.map((arg) => quote([arg])),
           ].join(' '),
@@ -231,6 +255,9 @@ export async function start_sandbox(
         let proxyProcess: ChildProcess | undefined = undefined;
         let sandboxProcess: ChildProcess | undefined = undefined;
         const sandboxEnv = { ...process.env };
+        sandboxEnv['TMPDIR'] = sandboxTmpDir;
+        sandboxEnv['TMP'] = sandboxTmpDir;
+        sandboxEnv['TEMP'] = sandboxTmpDir;
         if (proxyCommand) {
           const proxy =
             process.env['HTTPS_PROXY'] ||
@@ -288,6 +315,7 @@ export async function start_sandbox(
         process.stdin.pause();
         sandboxProcess = spawn(config.command, args, {
           stdio: 'inherit',
+          env: sandboxEnv,
         });
         return await new Promise((resolve, reject) => {
           sandboxProcess?.on('error', (err) => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -173,10 +173,9 @@ export async function start_sandbox(
         ].join(' ');
 
         const hostTmpDir = fs.realpathSync(os.tmpdir());
-        const createdTmpDir = fs.mkdtempSync(
+        const resolvedTmpDir = fs.mkdtempSync(
           path.join(hostTmpDir, 'gemini-sandbox-'),
         );
-        const resolvedTmpDir = fs.realpathSync(createdTmpDir);
         sandboxTmpDir = resolvedTmpDir;
 
         const args = [


### PR DESCRIPTION
## Summary

When launching macOS Seatbelt sandboxing (`sandbox-exec`), Gemini CLI previously passed the host user's temporary directory (`os.tmpdir()`) directly to the Seatbelt profile parameter `TMP_DIR`. 

Because the Seatbelt profile permits writes to `TMP_DIR`, sandboxed processes shared and wrote to the host temporary directory namespace, which includes tool metadata and cache files such as `xcrun_db`.

This change provisions a dedicated, unique session temporary directory for the sandboxed process lifecycle. The isolated path is supplied as `TMP_DIR` to the Seatbelt profile, exported as `TMPDIR`, `TMP`, and `TEMP` in the execution environment, and automatically cleaned up upon session termination. This ensures temporary file access remains strictly confined to the sandboxed process scope without affecting host temporary resources.

## Details

- **Session Temporary Directory Allocation**: Provision a unique temporary directory via `fs.mkdtempSync` within the host temporary root prior to spawning `sandbox-exec`.
    - **Seatbelt Parameter Binding**: Parameterize `TMP_DIR` with the resolved isolated session path, ensuring `(allow file-write* (subpath (param "TMP_DIR")))` only applies within the designated session directory.
    - **Environment Parameter Propagation**: Export `TMPDIR`, `TMP`, and `TEMP` in both the shell invocation arguments and process environment passed to `sandbox-exec` to ensure child processes route temporary file operations to the isolated path.
    - **Lifecycle Cleanup**: Ensure the dedicated directory is recursively removed when the sandboxed process exits or terminates. Cleanup is wrapped in robust `try...catch` blocks and bound to process exit and termination signals (`SIGINT`, `SIGTERM`) to avoid leaving orphaned temporary directories upon unexpected termination.
    - **Test Coverage**: Added unit tests verifying session directory isolation, parameter passing, environment propagation, cleanup resilience against filesystem removal errors, and signal hook registration during `start_sandbox` on macOS.

## Related Issues

## How to Validate

 Run the dedicated Vitest suite in sandbox.test.ts:

    npm test -w @google/gemini-cli -- src/utils/sandbox.test.ts

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ x] Validated on required platforms/methods:
  - [ x] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ x] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
