### PR TITLE
fix(core): avoid tildeifying sibling home paths

### DIFF
--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -69,6 +69,10 @@ describe('tildeifyPath', () => {
         '/Users/albert/Documents/app',
       );
     });
+
+    it('should not replace a relative path', () => {
+      expect(tildeifyPath('Documents/app')).toBe('Documents/app');
+    });
   });
 
   describe('on Windows', () => {
@@ -91,6 +95,10 @@ describe('tildeifyPath', () => {
       expect(tildeifyPath('C:\\Users\\Albert\\Documents\\app')).toBe(
         'C:\\Users\\Albert\\Documents\\app',
       );
+    });
+
+    it('should not replace a relative path', () => {
+      expect(tildeifyPath('Documents\\app')).toBe('Documents\\app');
     });
   });
 });

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -69,6 +69,13 @@ describe('tildeifyPath', () => {
       expect(tildeifyPath('/Users/al/Documents/app/')).toBe('~/Documents/app/');
     });
 
+    it('should normalize duplicate slashes and relative segments', () => {
+      expect(tildeifyPath('/Users//al/Documents/app')).toBe('~/Documents/app');
+      expect(tildeifyPath('/Users/al/../al/Documents/./app')).toBe(
+        '~/Documents/app',
+      );
+    });
+
     it('should not replace a sibling directory with the same prefix', () => {
       expect(tildeifyPath('/Users/albert/Documents/app')).toBe(
         '/Users/albert/Documents/app',
@@ -100,6 +107,15 @@ describe('tildeifyPath', () => {
       vi.stubEnv('GEMINI_CLI_HOME', 'C:\\Users\\Al\\');
       expect(tildeifyPath('C:/Users/Al/Documents/app/')).toBe(
         '~/Documents/app/',
+      );
+    });
+
+    it('should normalize duplicate separators and relative segments', () => {
+      expect(tildeifyPath('C:\\Users\\\\Al\\Documents\\.\\app')).toBe(
+        '~\\Documents\\app',
+      );
+      expect(tildeifyPath('C:/Users/Al/Documents/../Documents/app')).toBe(
+        '~/Documents/app',
       );
     });
 

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -64,6 +64,11 @@ describe('tildeifyPath', () => {
       expect(tildeifyPath('/Users/al/Documents/app')).toBe('~/Documents/app');
     });
 
+    it('should preserve a descendant trailing slash when home has one', () => {
+      vi.stubEnv('GEMINI_CLI_HOME', '/Users/al/');
+      expect(tildeifyPath('/Users/al/Documents/app/')).toBe('~/Documents/app/');
+    });
+
     it('should not replace a sibling directory with the same prefix', () => {
       expect(tildeifyPath('/Users/albert/Documents/app')).toBe(
         '/Users/albert/Documents/app',
@@ -89,6 +94,13 @@ describe('tildeifyPath', () => {
 
     it('should replace the home directory prefix with forward slashes', () => {
       expect(tildeifyPath('C:/Users/Al/Documents/app')).toBe('~/Documents/app');
+    });
+
+    it('should preserve forward slashes when home has a trailing slash', () => {
+      vi.stubEnv('GEMINI_CLI_HOME', 'C:\\Users\\Al\\');
+      expect(tildeifyPath('C:/Users/Al/Documents/app/')).toBe(
+        '~/Documents/app/',
+      );
     });
 
     it('should not replace a sibling directory with the same prefix', () => {

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -22,6 +22,7 @@ import {
   isTrustedSystemPath,
   resolveDefensiveToolPath,
   stripExtendedLengthPrefix,
+  tildeifyPath,
 } from './paths.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -42,6 +43,57 @@ const mockPlatform = (platform: string) => {
     }),
   );
 };
+
+describe('tildeifyPath', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  describe('on POSIX', () => {
+    beforeEach(() => {
+      mockPlatform('linux');
+      vi.stubEnv('GEMINI_CLI_HOME', '/Users/al');
+    });
+
+    it('should replace the exact home directory with a tilde', () => {
+      expect(tildeifyPath('/Users/al')).toBe('~');
+    });
+
+    it('should replace the home directory prefix for a descendant', () => {
+      expect(tildeifyPath('/Users/al/Documents/app')).toBe('~/Documents/app');
+    });
+
+    it('should not replace a sibling directory with the same prefix', () => {
+      expect(tildeifyPath('/Users/albert/Documents/app')).toBe(
+        '/Users/albert/Documents/app',
+      );
+    });
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => {
+      mockPlatform('win32');
+      vi.stubEnv('GEMINI_CLI_HOME', 'C:\\Users\\Al');
+    });
+
+    it('should replace the home directory prefix with native separators', () => {
+      expect(tildeifyPath('C:\\Users\\Al\\Documents\\app')).toBe(
+        '~\\Documents\\app',
+      );
+    });
+
+    it('should replace the home directory prefix with forward slashes', () => {
+      expect(tildeifyPath('C:/Users/Al/Documents/app')).toBe('~/Documents/app');
+    });
+
+    it('should not replace a sibling directory with the same prefix', () => {
+      expect(tildeifyPath('C:\\Users\\Albert\\Documents\\app')).toBe(
+        'C:\\Users\\Albert\\Documents\\app',
+      );
+    });
+  });
+});
 
 describe('escapePath', () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -36,15 +36,33 @@ export function tmpdir(): string {
 
 /**
  * Replaces the home directory with a tilde.
- * @param path - The path to tildeify.
+ * @param filePath - The path to tildeify.
  * @returns The tildeified path.
  */
-export function tildeifyPath(path: string): string {
+export function tildeifyPath(filePath: string): string {
   const homeDir = homedir();
-  if (path.startsWith(homeDir)) {
-    return path.replace(homeDir, '~');
+  const pathModule = process.platform === 'win32' ? path.win32 : path.posix;
+  const relativePath = pathModule.relative(homeDir, filePath);
+  const isWithinHome =
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${pathModule.sep}`) &&
+      !pathModule.isAbsolute(relativePath));
+
+  if (!isWithinHome) {
+    return filePath;
   }
-  return path;
+
+  if (relativePath === '') {
+    return '~';
+  }
+
+  const originalSuffix = filePath.slice(homeDir.length);
+  if (originalSuffix.startsWith('/') || originalSuffix.startsWith('\\')) {
+    return `~${originalSuffix}`;
+  }
+
+  return `~${pathModule.sep}${relativePath}`;
 }
 
 /**

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -40,8 +40,12 @@ export function tmpdir(): string {
  * @returns The tildeified path.
  */
 export function tildeifyPath(filePath: string): string {
-  const homeDir = homedir();
   const pathModule = process.platform === 'win32' ? path.win32 : path.posix;
+  if (!pathModule.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  const homeDir = homedir();
   const relativePath = pathModule.relative(homeDir, filePath);
   const isWithinHome =
     relativePath === '' ||

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -69,12 +69,16 @@ export function tildeifyPath(filePath: string): string {
     return '~';
   }
 
-  const originalSuffix = filePath.slice(homeDir.length);
-  if (originalSuffix.startsWith('/') || originalSuffix.startsWith('\\')) {
-    return `~${originalSuffix}`;
-  }
+  const separator =
+    process.platform === 'win32' && !filePath.includes('/') ? '\\' : '/';
+  const formattedRelativePath =
+    process.platform === 'win32'
+      ? relativePath.replaceAll(pathModule.sep, separator)
+      : relativePath;
+  const trailingSeparator =
+    filePath.endsWith('/') || filePath.endsWith('\\') ? separator : '';
 
-  return `~${pathModule.sep}${relativePath}`;
+  return `~${separator}${formattedRelativePath}${trailingSeparator}`;
 }
 
 /**

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -45,7 +45,15 @@ export function tildeifyPath(filePath: string): string {
     return filePath;
   }
 
-  const homeDir = homedir();
+  let homeDir = homedir();
+  const homeRoot = pathModule.parse(homeDir).root;
+  while (
+    homeDir.length > homeRoot.length &&
+    (homeDir.endsWith('/') || homeDir.endsWith('\\'))
+  ) {
+    homeDir = homeDir.slice(0, -1);
+  }
+
   const relativePath = pathModule.relative(homeDir, filePath);
   const isWithinHome =
     relativePath === '' ||


### PR DESCRIPTION
## Summary

Prevent `tildeifyPath` from treating sibling directories whose names share the home-directory prefix as paths inside the current user's home.

## Details

- Use the platform-specific `path.relative` implementation to enforce directory-segment containment.
- Leave relative paths unchanged instead of resolving them against the current working directory.
- Normalize trailing home separators and construct output from path.relative, preserving input separator style and trailing slash even with duplicate separators or . and .. segments.
- Cover exact-home, descendant, sibling-prefix, and relative-path cases on POSIX and Windows, including forward-slash Windows paths.

## Related Issues

Fixes #29175

## How to Validate

```sh
npm run build
npm run typecheck
npx eslint packages/core/src/utils/paths.ts packages/core/src/utils/paths.test.ts
npx prettier --check packages/core/src/utils/paths.ts packages/core/src/utils/paths.test.ts
npm test -w @google/gemini-cli-core -- src/utils/paths.test.ts
```

Local Windows results:

- Full repository build passed.
- Full repository typecheck passed.
- ESLint and Prettier checks passed for the changed files.
- Focused path utility suite passed: 141 passed, 27 skipped (168 total).
- A full `npm run preflight` run completed clean/install, formatting, build, ESLint, actionlint, and ShellCheck. It then stopped in the repository's Windows lint launcher because `cmd.exe` parses the POSIX `git ls-files | grep ... | xargs yamllint` pipeline; this is a tooling portability failure rather than a failure in the changed code.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (not required for this behavior-only fix)
- [x] Added/updated tests
- [x] Noted breaking changes (none)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker