### PR TITLE
fix(core): validate git args in Windows sandbox to block silent `git diff --output`

### DIFF
--- a/packages/core/src/sandbox/utils/commandSafety.ts
+++ b/packages/core/src/sandbox/utils/commandSafety.ts
@@ -226,35 +226,7 @@ function isSafeToCallWithExec(args: string[]): boolean {
   }
 
   if (cmd === 'git') {
-    if (gitHasConfigOverrideGlobalOption(args)) {
-      return false;
-    }
-
-    const { idx, subcommand } = findGitSubcommand(args, [
-      'status',
-      'log',
-      'diff',
-      'show',
-      'branch',
-    ]);
-    if (!subcommand) {
-      return false;
-    }
-
-    const subcommandArgs = args.slice(idx + 1);
-
-    if (['status', 'log', 'diff', 'show'].includes(subcommand)) {
-      return gitSubcommandArgsAreReadOnly(subcommandArgs);
-    }
-
-    if (subcommand === 'branch') {
-      return (
-        gitSubcommandArgsAreReadOnly(subcommandArgs) &&
-        gitBranchIsReadOnly(subcommandArgs)
-      );
-    }
-
-    return false;
+    return isGitCommandReadOnly(args);
   }
 
   if (cmd === 'sed') {
@@ -409,6 +381,69 @@ function gitBranchIsReadOnly(args: string[]): boolean {
   return sawReadOnlyFlag;
 }
 
+/** The git subcommands treated as candidates for read-only execution. */
+const GIT_READONLY_SUBCOMMANDS = ['status', 'log', 'diff', 'show', 'branch'];
+
+/**
+ * Determines whether a full `git ...` invocation is strictly read-only.
+ *
+ * @param args - The full command and its arguments (including `git`).
+ */
+export function isGitCommandReadOnly(args: string[]): boolean {
+  if (gitHasConfigOverrideGlobalOption(args)) {
+    return false;
+  }
+
+  const { idx, subcommand } = findGitSubcommand(args, GIT_READONLY_SUBCOMMANDS);
+  if (!subcommand) {
+    return false;
+  }
+
+  const subcommandArgs = args.slice(idx + 1);
+
+  if (subcommand === 'branch') {
+    return (
+      gitSubcommandArgsAreReadOnly(subcommandArgs) &&
+      gitBranchIsReadOnly(subcommandArgs)
+    );
+  }
+
+  return gitSubcommandArgsAreReadOnly(subcommandArgs);
+}
+
+/**
+ * Determines whether a `git ...` invocation is dangerous enough to force a
+ * user confirmation even when a policy rule would otherwise allow it.
+ *
+ * Inverse of {@link isGitCommandReadOnly}, but only for recognized
+ * subcommands: an unrecognized git subcommand is "not known safe" rather than
+ * "dangerous", so it returns false and falls through to the normal policy.
+ *
+ * @param args - The full command and its arguments (including `git`).
+ */
+export function isGitCommandDangerous(args: string[]): boolean {
+  if (gitHasConfigOverrideGlobalOption(args)) {
+    return true;
+  }
+
+  const { idx, subcommand } = findGitSubcommand(args, GIT_READONLY_SUBCOMMANDS);
+  if (!subcommand) {
+    // A git command we don't recognize as explicitly safe; leave it to policy.
+    return false;
+  }
+
+  const subcommandArgs = args.slice(idx + 1);
+
+  if (subcommand === 'branch') {
+    return !(
+      gitSubcommandArgsAreReadOnly(subcommandArgs) &&
+      gitBranchIsReadOnly(subcommandArgs)
+    );
+  }
+
+  return !gitSubcommandArgsAreReadOnly(subcommandArgs);
+}
+
 /**
  * Ensures that a `sed` command argument is a valid line-printing instruction
  * (e.g., `10p` or `5,10p`), preventing unsafe script execution in `sed`.
@@ -488,36 +523,7 @@ export function isDangerousCommand(args: string[]): boolean {
   }
 
   if (cmd === 'git') {
-    if (gitHasConfigOverrideGlobalOption(args)) {
-      return true;
-    }
-
-    const { idx, subcommand } = findGitSubcommand(args, [
-      'status',
-      'log',
-      'diff',
-      'show',
-      'branch',
-    ]);
-    if (!subcommand) {
-      // It's a git command we don't recognize as explicitly safe.
-      return false;
-    }
-
-    const subcommandArgs = args.slice(idx + 1);
-
-    if (['status', 'log', 'diff', 'show'].includes(subcommand)) {
-      return !gitSubcommandArgsAreReadOnly(subcommandArgs);
-    }
-
-    if (subcommand === 'branch') {
-      return !(
-        gitSubcommandArgsAreReadOnly(subcommandArgs) &&
-        gitBranchIsReadOnly(subcommandArgs)
-      );
-    }
-
-    return false;
+    return isGitCommandDangerous(args);
   }
 
   if (cmd === 'base64') {

--- a/packages/core/src/sandbox/windows/commandSafety.test.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.test.ts
@@ -25,6 +25,29 @@ describe('Windows commandSafety', () => {
       expect(isKnownSafeCommand(['unknown'])).toBe(false);
       expect(isKnownSafeCommand(['npm', 'install'])).toBe(false);
     });
+
+    it('should treat read-only git commands as safe', () => {
+      expect(isKnownSafeCommand(['git', 'status'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'diff'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'log', '--oneline'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'show', 'HEAD'])).toBe(true);
+      expect(isKnownSafeCommand(['git', 'branch', '--list'])).toBe(true);
+    });
+
+    it('should NOT treat write-capable git commands as safe', () => {
+      expect(
+        isKnownSafeCommand(['git', 'diff', '--output=C:\\Users\\me\\x.txt']),
+      ).toBe(false);
+      expect(isKnownSafeCommand(['git', 'diff', '--output', 'x.txt'])).toBe(
+        false,
+      );
+      expect(isKnownSafeCommand(['git', 'diff', '--ext-diff'])).toBe(false);
+      expect(isKnownSafeCommand(['git', 'show', '--textconv'])).toBe(false);
+      expect(isKnownSafeCommand(['git', '-c', 'core.pager=calc', 'diff'])).toBe(
+        false,
+      );
+      expect(isKnownSafeCommand(['git', 'branch', '-D', 'main'])).toBe(false);
+    });
   });
 
   describe('isDangerousCommand', () => {
@@ -45,6 +68,25 @@ describe('Windows commandSafety', () => {
     it('should not flag safe commands as dangerous', () => {
       expect(isDangerousCommand(['dir'])).toBe(false);
       expect(isDangerousCommand(['echo', 'hello'])).toBe(false);
+    });
+
+    it('should flag write-capable git commands as dangerous', () => {
+      expect(
+        isDangerousCommand(['git', 'diff', '--output=C:\\Users\\me\\x.txt']),
+      ).toBe(true);
+      expect(isDangerousCommand(['git', 'diff', '--output', 'x.txt'])).toBe(
+        true,
+      );
+      expect(isDangerousCommand(['git', '-c', 'core.pager=calc', 'diff'])).toBe(
+        true,
+      );
+      expect(isDangerousCommand(['git', 'branch', '-D', 'main'])).toBe(true);
+    });
+
+    it('should not flag read-only git commands as dangerous', () => {
+      expect(isDangerousCommand(['git', 'diff'])).toBe(false);
+      expect(isDangerousCommand(['git', 'status'])).toBe(false);
+      expect(isDangerousCommand(['git', 'log', '--oneline'])).toBe(false);
     });
   });
 });

--- a/packages/core/src/sandbox/windows/commandSafety.ts
+++ b/packages/core/src/sandbox/windows/commandSafety.ts
@@ -10,6 +10,10 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../../utils/shell-utils.js';
+import {
+  isGitCommandDangerous,
+  isGitCommandReadOnly,
+} from '../utils/commandSafety.js';
 
 /**
  * Determines if a command is strictly approved for execution on Windows.
@@ -103,12 +107,10 @@ export function isKnownSafeCommand(args: string[]): boolean {
     return true;
   }
 
-  // We allow git on Windows if it's read-only, using the same logic as POSIX
+  // Allow git only if it's strictly read-only, using the same sub-command and
+  // argument validation as POSIX.
   if (cmd === 'git') {
-    // For simplicity in this branch, we'll allow standard git read operations
-    // In a full implementation, we'd port the sub-command validation too.
-    const sub = args[1]?.toLowerCase();
-    return ['status', 'log', 'diff', 'show', 'branch'].includes(sub);
+    return isGitCommandReadOnly(args);
   }
 
   return false;
@@ -146,5 +148,13 @@ export function isDangerousCommand(args: string[]): boolean {
     'new-item',
   ]);
 
-  return dangerous.has(cmd);
+  if (dangerous.has(cmd)) {
+    return true;
+  }
+
+  if (cmd === 'git') {
+    return isGitCommandDangerous(args);
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Summary

On Windows, any `git status | log | diff | show | branch` is treated as read-only and runs **without a confirmation prompt**, regardless of its arguments. So `git diff --output=<path>` runs silently in the default (non-YOLO) mode.

That flag opens the target file and truncates it before writing any diff — an arbitrary file overwrite with no prompt (overwrite a config, profile, or any important file).

POSIX already validates these args. The Windows branch only checks the sub-command name and skips the flags — it even says so:

> `// In a full implementation, we'd port the sub-command validation too.`

Fixes #29189

## Fix

Reuse the POSIX validation instead of a second, weaker check:

- Extract `isGitCommandReadOnly` / `isGitCommandDangerous` as shared helpers in `sandbox/utils/commandSafety.ts` (pure refactor, POSIX behavior unchanged).
- Windows `isKnownSafeCommand` / `isDangerousCommand` now delegate to them.

Now `--output` (both forms), `--ext-diff`, `--textconv`, `--exec`, `-c` config overrides, and `git branch -D` all require confirmation. Plain `git diff` / `status` / `log` stay silent as before.

## Testing

- Added Windows regression tests for the cases above.
- POSIX suite unchanged and passing; `tsc --noEmit` clean.
- Verified end-to-end through `PolicyEngine` on Windows: write-capable git →
  `ASK_USER`, read-only git → `ALLOW`.

## Related report

Reported to the Google AI VRP:
https://issuetracker.google.com/issues/550750284 - Security Control Bypass in Gemini CLI via git diff --output Flag Injection Leading to Unprompted Arbitrary File Overwrite


I used AI assistance on this, but didn't submit it blindly — I read through the sandbox/policy code, confirmed the root cause, built and reproduced both the vulnerable and fixed behavior locally, and reviewed the diff. Please still verify on your end. Thanks.
