### PR TITLE
test(integration): deflake run_shell_command and file-system-interactive tests

### DIFF
--- a/integration-tests/file-system-interactive.test.ts
+++ b/integration-tests/file-system-interactive.test.ts
@@ -43,11 +43,11 @@ describe('Interactive file system', () => {
     await run.type(readPrompt);
     await run.type('\r');
 
-    const readCall = await rig.waitForToolCall('read_file', 30000);
+    const readCall = await rig.waitForToolCall('read_file', 60000);
     expect(readCall, 'Expected to find a read_file tool call').toBe(true);
 
     // Wait for the CLI to finish outputting the response and show the prompt again
-    await run.expectText('Type your message', 30000);
+    await run.expectText('Type your message', 60000);
 
     // Step 2: Write the file
     const writePrompt = `now change the version to 1.0.1 in the file`;
@@ -57,11 +57,11 @@ describe('Interactive file system', () => {
     // Check tool calls made with right args
     await rig.expectToolCallSuccess(
       ['write_file', 'replace'],
-      30000,
+      60000,
       (args) => args.includes('1.0.1') && args.includes(fileName),
     );
 
     // Wait for telemetry to flush and file system to sync, especially in sandboxed environments
     await rig.waitForTelemetryReady();
-  }, 60000);
+  }, 120000);
 });

--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -387,8 +387,9 @@ describe('run_shell_command', () => {
     const disallowed = getDisallowedFileReadCommand(testFile);
     const prompt =
       `I am testing the allowed tools configuration. ` +
-      `Attempt to run "${disallowed.command}" to read the contents of ${testFile}. ` +
-      `If the command fails because it is not permitted, respond with the single word FAIL. ` +
+      `You MUST actually call the run_shell_command tool to attempt to run "${disallowed.command}" to read the contents of ${testFile}. ` +
+      `Do not assume or guess if it is permitted based on system instructions; you must actually invoke the tool to see what happens. ` +
+      `If the tool execution fails because it is not permitted, respond with the single word FAIL. ` +
       `If it succeeds, respond with SUCCESS.`;
 
     const result = await rig.run({


### PR DESCRIPTION
## Summary

This PR resolves the flakiness of the slow E2E integration tests `run_shell_command.test.ts` and `file-system-interactive.test.ts`.

## Details

1. **`run_shell_command.test.ts`**:
   * *Issue*: When testing disallowed tools configuration (e.g. `should reject commands not on the allowlist`), the model was smart enough to recognize that the disallowed tool (e.g. `cmd` / `powershell`) was not on the allowlist configured in its system instructions. Rather than executing the tool and letting it fail, the model immediately and correctly output `FAIL`, bypassing the tool call entirely. Because no tool call was emitted, the telemetry check `waitForToolCall` failed/timed out, and subsequent Vitest retries ran into rate limits/hangs.
   * *Fix*: Updated the prompt to explicitly instruct the model that it MUST execute/invoke the tool rather than shortcutting or guessing.

2. **`file-system-interactive.test.ts`**:
   * *Issue*: The test runs a multi-step interactive session with two real LLM API calls on top of shell/node-pty initialization. However, individual steps were capped at a strict 30-second timeout, and the overall test was capped at a 60-second timeout, making it highly prone to flakiness under heavy system load (such as slow Windows runners).
   * *Fix*: Increased individual steps to 60 seconds (matching the default CI timeout) and the overall test timeout to 120 seconds.

## Related Issues

Resolves flakiness of E2E - Win tests in pipelines.

## How to Validate

Run the integration tests specifically:
```bash
npm run test:integration:sandbox:none -- run_shell_command.test.ts
npm run test:integration:sandbox:none -- file-system-interactive.test.ts
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
  - [x] Windows
    - [x] npm run
  - [x] Linux
    - [x] npm run
