### PR TITLE
fix(core): correct exitCode null check in shell sandbox denial heuristic

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1454,6 +1454,40 @@ EOF`;
       // Should be regular exec confirmation, not expansion
       expect(details.type).toBe('exec');
     });
+
+    it('should NOT run sandbox denial detection when exitCode is null without a signal', async () => {
+      const sandboxManager = {
+        parseDenials: vi.fn().mockReturnValue({
+          network: true,
+          filePaths: [],
+        }),
+        prepareCommand: vi.fn(),
+        isKnownSafeCommand: vi.fn(),
+        isDangerousCommand: vi.fn(),
+      } as unknown as SandboxManager;
+      mockSandboxManager = sandboxManager;
+
+      const invocation = shellTool.build({ command: 'echo hi' });
+      const promise = invocation.execute({ abortSignal: mockAbortSignal });
+
+      resolveExecutionPromise({
+        exitCode: null,
+        output: '',
+        executionMethod: 'child_process',
+        signal: null,
+        error: null,
+        aborted: false,
+        pid: 12345,
+        rawOutput: Buffer.from(''),
+      });
+
+      const result = await promise;
+
+      expect(sandboxManager.parseDenials).not.toHaveBeenCalled();
+      expect(result.error?.type).not.toBe(
+        ToolErrorType.SANDBOX_EXPANSION_REQUIRED,
+      );
+    });
   });
 
   describe('getSchema', () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -865,7 +865,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       if (
         !!result.error ||
         !!result.signal ||
-        (result.exitCode !== undefined && result.exitCode !== 0) ||
+        (result.exitCode !== null && result.exitCode !== 0) ||
         result.aborted
       ) {
         const sandboxDenial =


### PR DESCRIPTION
Fixes #29043

## What broke

`ShellToolInvocation`'s "Heuristic Sandbox Denial Detection" block
(`packages/core/src/tools/shell.ts:868`) checked:

```ts
(result.exitCode !== undefined && result.exitCode !== 0) ||
```

but `ExecutionResult.exitCode` is typed `number | null`
(`packages/core/src/services/executionLifecycleService.ts:23`) — it is
never `undefined`. Since `null !== undefined` is `true`, a process
killed by a signal without a captured `signal` string (`exitCode ===
null`) spuriously satisfied this guard and entered the sandbox-denial
heuristic, even though nothing indicates a sandbox denial in that
case. Three other checks in the same function already correctly use
`!== null` (e.g. the two `result.exitCode !== null && result.exitCode
!== 0` sites earlier in the method).

## Fix

Changed the guard to `result.exitCode !== null && result.exitCode !==
0`, matching the sibling checks and the actual type.

## Testing

Added a regression test in
`packages/core/src/tools/shell.test.ts` (`sandbox heuristics`
describe block) that resolves the execution promise with
`exitCode: null, signal: null, error: null, aborted: false` and
asserts `sandboxManager.parseDenials` is **not** called and the result
is not flagged `SANDBOX_EXPANSION_REQUIRED`.

Confirmed the test fails without the fix:

```
$ git checkout HEAD~1 -- packages/core/src/tools/shell.ts
$ npx vitest run src/tools/shell.test.ts -t "should NOT run sandbox denial detection"
 FAIL  src/tools/shell.test.ts > ShellTool > sandbox heuristics > should NOT run sandbox denial detection when exitCode is null without a signal
AssertionError: expected "spy" to not be called at all, but actually been called 1 times
$ git checkout HEAD -- packages/core/src/tools/shell.ts
```

And passes with the fix applied:

```
$ npx vitest run src/tools/shell.test.ts
 ✓ src/tools/shell.test.ts (90 tests | 1 skipped) 488ms
 Test Files  1 passed (1)
      Tests  89 passed | 1 skipped (90)
```

Also ran, both clean:

```
$ npx eslint packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts --max-warnings 0
$ npx tsc --noEmit   # in packages/core
```

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent
(Claude), including drafting the fix, the regression test, and this
PR description. All changes were reviewed and verified locally before
submission.
