### PR TITLE
fix(core): use safeLiteralReplace for LLM prompt template placeholders

### DIFF
--- a/packages/core/src/services/sessionSummaryService.test.ts
+++ b/packages/core/src/services/sessionSummaryService.test.ts
@@ -499,6 +499,26 @@ describe('SessionSummaryService', () => {
       expect(summary).toBe('Add dark mode to the app');
     });
 
+    it('should insert conversation text containing $-patterns literally into the prompt', async () => {
+      const dollarMessage = "echo $'\\n' and $$ and $& and $`quote`";
+      const messages: MessageRecord[] = [
+        {
+          id: '1',
+          timestamp: '2025-12-03T00:00:00Z',
+          type: 'user',
+          content: [{ text: dollarMessage }],
+        },
+      ];
+
+      await service.generateSummary({ messages });
+
+      expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+      const callArgs = mockGenerateContent.mock.calls[0][0];
+      const promptText = callArgs.contents[0].parts[0].text;
+
+      expect(promptText).toContain(`User: ${dollarMessage}`);
+    });
+
     it('should handle messages longer than 500 chars', async () => {
       const longMessage = 'a'.repeat(1000);
       const messages: MessageRecord[] = [

--- a/packages/core/src/services/sessionSummaryService.ts
+++ b/packages/core/src/services/sessionSummaryService.ts
@@ -10,7 +10,6 @@ import { partListUnionToString } from '../core/geminiRequest.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { Content } from '@google/genai';
 import { getResponseText } from '../utils/partUtils.js';
-import { safeLiteralReplace } from '../utils/textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const DEFAULT_MAX_MESSAGES = 20;
@@ -105,10 +104,9 @@ export class SessionSummaryService {
         })
         .join('\n\n');
 
-      const prompt = safeLiteralReplace(
-        SUMMARY_PROMPT,
+      const prompt = SUMMARY_PROMPT.replaceAll(
         '{conversation}',
-        conversationText,
+        () => conversationText,
       );
 
       // Create abort controller with timeout

--- a/packages/core/src/services/sessionSummaryService.ts
+++ b/packages/core/src/services/sessionSummaryService.ts
@@ -10,6 +10,7 @@ import { partListUnionToString } from '../core/geminiRequest.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import type { Content } from '@google/genai';
 import { getResponseText } from '../utils/partUtils.js';
+import { safeLiteralReplace } from '../utils/textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const DEFAULT_MAX_MESSAGES = 20;
@@ -104,7 +105,11 @@ export class SessionSummaryService {
         })
         .join('\n\n');
 
-      const prompt = SUMMARY_PROMPT.replace('{conversation}', conversationText);
+      const prompt = safeLiteralReplace(
+        SUMMARY_PROMPT,
+        '{conversation}',
+        conversationText,
+      );
 
       // Create abort controller with timeout
       const abortController = new AbortController();

--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -192,6 +192,32 @@ describe('FixLLMEditWithInstruction', () => {
     );
   });
 
+  it('should not double-interpolate when a value contains a placeholder token', async () => {
+    mockGenerateJson.mockResolvedValue(mockApiResponse);
+    const instructionWithPlaceholder =
+      'Replace {current_content} with the new heading';
+
+    await FixLLMEditWithInstruction(
+      instructionWithPlaceholder,
+      old_string,
+      new_string,
+      error,
+      current_content,
+      mockBaseLlmClient,
+      abortSignal,
+    );
+
+    const generateJsonCall = mockGenerateJson.mock.calls[0][0];
+    const userPromptContent = generateJsonCall.contents[0].parts[0].text;
+
+    expect(userPromptContent).toContain(
+      `<instruction>\n${instructionWithPlaceholder}\n</instruction>`,
+    );
+    expect(userPromptContent).toContain(
+      `<file_content>\n${current_content}\n</file_content>`,
+    );
+  });
+
   it('should return a cached result on subsequent identical calls', async () => {
     mockGenerateJson.mockResolvedValue(mockApiResponse);
     const testPromptId = 'test-prompt-id-caching';

--- a/packages/core/src/utils/llm-edit-fixer.test.ts
+++ b/packages/core/src/utils/llm-edit-fixer.test.ts
@@ -156,6 +156,42 @@ describe('FixLLMEditWithInstruction', () => {
     );
   });
 
+  it('should insert $-pattern values literally without corrupting the prompt', async () => {
+    mockGenerateJson.mockResolvedValue(mockApiResponse);
+    const dollarInstruction = "Replace $& with $$ and $`quote$'";
+    const dollarOldString = "echo $'\\n'";
+    const dollarNewString = 'jQuery $$()';
+    const dollarError = 'not found: $&';
+    const dollarContent = 'body $`before`';
+
+    await FixLLMEditWithInstruction(
+      dollarInstruction,
+      dollarOldString,
+      dollarNewString,
+      dollarError,
+      dollarContent,
+      mockBaseLlmClient,
+      abortSignal,
+    );
+
+    const generateJsonCall = mockGenerateJson.mock.calls[0][0];
+    const userPromptContent = generateJsonCall.contents[0].parts[0].text;
+
+    expect(userPromptContent).toContain(
+      `<instruction>\n${dollarInstruction}\n</instruction>`,
+    );
+    expect(userPromptContent).toContain(
+      `<search>\n${dollarOldString}\n</search>`,
+    );
+    expect(userPromptContent).toContain(
+      `<replace>\n${dollarNewString}\n</replace>`,
+    );
+    expect(userPromptContent).toContain(`<error>\n${dollarError}\n</error>`);
+    expect(userPromptContent).toContain(
+      `<file_content>\n${dollarContent}\n</file_content>`,
+    );
+  });
+
   it('should return a cached result on subsequent identical calls', async () => {
     mockGenerateJson.mockResolvedValue(mockApiResponse);
     const testPromptId = 'test-prompt-id-caching';

--- a/packages/core/src/utils/llm-edit-fixer.ts
+++ b/packages/core/src/utils/llm-edit-fixer.ts
@@ -10,7 +10,6 @@ import { type BaseLlmClient } from '../core/baseLlmClient.js';
 import { LRUCache } from 'mnemonist';
 import { getPromptIdWithFallback } from './promptIdContext.js';
 import { debugLogger } from './debugLogger.js';
-import { safeLiteralReplace } from './textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const MAX_CACHE_SIZE = 50;
@@ -166,18 +165,16 @@ export async function FixLLMEditWithInstruction(
   if (cachedResult) {
     return cachedResult;
   }
-  let userPrompt = safeLiteralReplace(
-    EDIT_USER_PROMPT,
-    '{instruction}',
-    instruction,
-  );
-  userPrompt = safeLiteralReplace(userPrompt, '{old_string}', old_string);
-  userPrompt = safeLiteralReplace(userPrompt, '{new_string}', new_string);
-  userPrompt = safeLiteralReplace(userPrompt, '{error}', error);
-  userPrompt = safeLiteralReplace(
-    userPrompt,
-    '{current_content}',
-    current_content,
+  const replacements: Record<string, string> = {
+    '{instruction}': instruction,
+    '{old_string}': old_string,
+    '{new_string}': new_string,
+    '{error}': error,
+    '{current_content}': current_content,
+  };
+  const userPrompt = EDIT_USER_PROMPT.replace(
+    /\{instruction\}|\{old_string\}|\{new_string\}|\{error\}|\{current_content\}/g,
+    (matched) => replacements[matched],
   );
 
   const contents: Content[] = [

--- a/packages/core/src/utils/llm-edit-fixer.ts
+++ b/packages/core/src/utils/llm-edit-fixer.ts
@@ -10,6 +10,7 @@ import { type BaseLlmClient } from '../core/baseLlmClient.js';
 import { LRUCache } from 'mnemonist';
 import { getPromptIdWithFallback } from './promptIdContext.js';
 import { debugLogger } from './debugLogger.js';
+import { safeLiteralReplace } from './textUtils.js';
 import { LlmRole } from '../telemetry/types.js';
 
 const MAX_CACHE_SIZE = 50;
@@ -165,11 +166,19 @@ export async function FixLLMEditWithInstruction(
   if (cachedResult) {
     return cachedResult;
   }
-  const userPrompt = EDIT_USER_PROMPT.replace('{instruction}', instruction)
-    .replace('{old_string}', old_string)
-    .replace('{new_string}', new_string)
-    .replace('{error}', error)
-    .replace('{current_content}', current_content);
+  let userPrompt = safeLiteralReplace(
+    EDIT_USER_PROMPT,
+    '{instruction}',
+    instruction,
+  );
+  userPrompt = safeLiteralReplace(userPrompt, '{old_string}', old_string);
+  userPrompt = safeLiteralReplace(userPrompt, '{new_string}', new_string);
+  userPrompt = safeLiteralReplace(userPrompt, '{error}', error);
+  userPrompt = safeLiteralReplace(
+    userPrompt,
+    '{current_content}',
+    current_content,
+  );
 
   const contents: Content[] = [
     {

--- a/packages/core/src/utils/summarizer.test.ts
+++ b/packages/core/src/utils/summarizer.test.ts
@@ -184,6 +184,31 @@ Return the summary string which should first contain an overall summarization of
       const contents = calledWith[1];
       expect(contents[0].parts[0].text).toBe(expectedPrompt);
     });
+
+    it('should insert text containing $-patterns literally without corrupting the prompt', async () => {
+      const longText = "echo $'\\n' and $$ and $&".repeat(20).padEnd(2500, '.');
+      const summary = 'This is a summary.';
+      (mockGeminiClient.generateContent as Mock).mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: summary }] } }],
+      });
+
+      await summarizeToolOutput(
+        mockConfigInstance,
+        { model: DEFAULT_GEMINI_MODEL },
+        longText,
+        mockGeminiClient,
+        abortSignal,
+      );
+
+      const calledWith = (mockGeminiClient.generateContent as Mock).mock
+        .calls[0];
+      const contents = calledWith[1];
+      const promptText = contents[0].parts[0].text as string;
+      expect(promptText).toContain(`"${longText}"`);
+      expect(promptText).toContain(
+        'Return the summary string which should first contain an overall summarization',
+      );
+    });
   });
 
   describe('llmSummarizer', () => {

--- a/packages/core/src/utils/summarizer.ts
+++ b/packages/core/src/utils/summarizer.ts
@@ -9,7 +9,6 @@ import type { Content } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import { getResponseText, partToString } from './partUtils.js';
 import { debugLogger } from './debugLogger.js';
-import { safeLiteralReplace } from './textUtils.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import type { Config } from '../config/config.js';
 import { LlmRole } from '../telemetry/llmRole.js';
@@ -85,14 +84,12 @@ export async function summarizeToolOutput(
   if (!textToSummarize || textToSummarize.length < maxOutputTokens) {
     return textToSummarize;
   }
-  const prompt = safeLiteralReplace(
-    safeLiteralReplace(
-      SUMMARIZE_TOOL_OUTPUT_PROMPT,
-      '{maxOutputTokens}',
-      String(maxOutputTokens),
-    ),
-    '{textToSummarize}',
-    textToSummarize,
+  const prompt = SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
+    /\{maxOutputTokens\}|\{textToSummarize\}/g,
+    (matched) =>
+      matched === '{maxOutputTokens}'
+        ? String(maxOutputTokens)
+        : textToSummarize,
   );
 
   const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];

--- a/packages/core/src/utils/summarizer.ts
+++ b/packages/core/src/utils/summarizer.ts
@@ -9,6 +9,7 @@ import type { Content } from '@google/genai';
 import type { GeminiClient } from '../core/client.js';
 import { getResponseText, partToString } from './partUtils.js';
 import { debugLogger } from './debugLogger.js';
+import { safeLiteralReplace } from './textUtils.js';
 import type { ModelConfigKey } from '../services/modelConfigService.js';
 import type { Config } from '../config/config.js';
 import { LlmRole } from '../telemetry/llmRole.js';
@@ -84,10 +85,15 @@ export async function summarizeToolOutput(
   if (!textToSummarize || textToSummarize.length < maxOutputTokens) {
     return textToSummarize;
   }
-  const prompt = SUMMARIZE_TOOL_OUTPUT_PROMPT.replace(
-    '{maxOutputTokens}',
-    String(maxOutputTokens),
-  ).replace('{textToSummarize}', textToSummarize);
+  const prompt = safeLiteralReplace(
+    safeLiteralReplace(
+      SUMMARIZE_TOOL_OUTPUT_PROMPT,
+      '{maxOutputTokens}',
+      String(maxOutputTokens),
+    ),
+    '{textToSummarize}',
+    textToSummarize,
+  );
 
   const contents: Content[] = [{ role: 'user', parts: [{ text: prompt }] }];
   try {


### PR DESCRIPTION
## Related Issue

Fixes #29044

## Problem

Three LLM prompt template files fill `{placeholder}` tokens using
`String.prototype.replace('{placeholder}', userControlledValue)`. In
JavaScript, `$`-sequences in the *replacement* string are special
(ECMA-262 GetSubstitution): `$&` inserts the matched substring, `` $` ``/`$'`
insert the text before/after the match, and `$$` collapses to a literal `$`.

Tool output, source file content, and chat history routinely contain these
sequences (ANSI-C quoting `$'\n'`, jQuery/PHP `$$`, template literals `` $` ``),
so the prompts sent to the summarizer, edit-fixer, and session-summary models
were being silently corrupted — template text got duplicated mid-payload,
`$$` collapsed, or a literal placeholder token got injected into the data.

Affected call sites:
- `packages/core/src/utils/summarizer.ts` (`{maxOutputTokens}`, `{textToSummarize}`)
- `packages/core/src/utils/llm-edit-fixer.ts` (`{instruction}`, `{old_string}`, `{new_string}`, `{error}`, `{current_content}`)
- `packages/core/src/services/sessionSummaryService.ts` (`{conversation}`)

## Fix

The codebase already has `safeLiteralReplace()` in
`packages/core/src/utils/textUtils.ts`, which escapes `$` in the replacement
value before substitution so it's inserted literally. It's already used for
exactly this reason in `packages/core/src/tools/edit.ts`. This PR migrates
the three vulnerable call sites above to use it instead of writing a new
utility, keeping the change minimal and consistent with existing convention.

## Testing

Added a regression test to each of the three existing test files, asserting
that a value containing `$&`, `$$`, `` $` ``, and `$'` patterns is inserted
into the constructed prompt literally.

Confirmed the new tests fail without the fix:
```
$ git checkout HEAD~1 -- packages/core/src/utils/summarizer.ts packages/core/src/utils/llm-edit-fixer.ts packages/core/src/services/sessionSummaryService.ts
$ npx vitest run packages/core/src/utils/summarizer.test.ts packages/core/src/utils/llm-edit-fixer.test.ts packages/core/src/services/sessionSummaryService.test.ts --no-coverage
 Test Files  3 failed (3)
      Tests  3 failed | 49 passed (52)
$ git checkout HEAD -- packages/core/src/utils/summarizer.ts packages/core/src/utils/llm-edit-fixer.ts packages/core/src/services/sessionSummaryService.ts
```

With the fix applied:
```
$ npx vitest run packages/core/src/utils/summarizer.test.ts packages/core/src/utils/llm-edit-fixer.test.ts packages/core/src/services/sessionSummaryService.test.ts --no-coverage
 Test Files  3 passed (3)
      Tests  52 passed (52)
```

Also ran:
```
$ npx eslint packages/core/src/utils/summarizer.ts packages/core/src/utils/llm-edit-fixer.ts packages/core/src/services/sessionSummaryService.ts packages/core/src/utils/summarizer.test.ts packages/core/src/utils/llm-edit-fixer.test.ts packages/core/src/services/sessionSummaryService.test.ts
# clean
$ npx tsc -p packages/core/tsconfig.json --noEmit
# clean
$ npx prettier --check <same files>
# All matched files use Prettier code style!
```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## AI assistance disclosure

This change (analysis, implementation, and tests) was prepared with AI
assistance (Claude Code / Anthropic).
