### PR TITLE
fix(vscode-ide-companion): track all activate() Disposables in subscriptions

### DIFF
--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -22,55 +22,74 @@ vi.mock('@google/gemini-cli-core/src/ide/detect-ide.js', async () => {
   };
 });
 
-vi.mock('vscode', () => ({
-  window: {
-    createOutputChannel: vi.fn(() => ({
-      appendLine: vi.fn(),
-    })),
-    showInformationMessage: vi.fn(),
-    createTerminal: vi.fn(() => ({
-      show: vi.fn(),
-      sendText: vi.fn(),
-    })),
-    onDidChangeActiveTextEditor: vi.fn(),
-    activeTextEditor: undefined,
-    tabGroups: {
-      all: [],
-      close: vi.fn(),
-    },
-    showTextDocument: vi.fn(),
-    showWorkspaceFolderPick: vi.fn(),
-  },
-  workspace: {
-    workspaceFolders: [],
-    onDidCloseTextDocument: vi.fn(),
-    registerTextDocumentContentProvider: vi.fn(),
-    onDidChangeWorkspaceFolders: vi.fn(),
-    onDidGrantWorkspaceTrust: vi.fn(),
-    getConfiguration: vi.fn(() => ({
-      get: vi.fn(),
-    })),
-  },
-  commands: {
-    registerCommand: vi.fn(),
-    executeCommand: vi.fn(),
-  },
-  Uri: {
-    joinPath: vi.fn(),
-  },
-  ExtensionMode: {
-    Development: 1,
-    Production: 2,
-  },
-  EventEmitter: vi.fn(() => ({
-    event: vi.fn(),
-    fire: vi.fn(),
+vi.mock('vscode', () => {
+  const createDisposable = (id: string) => ({
     dispose: vi.fn(),
-  })),
-  extensions: {
-    getExtension: vi.fn(),
-  },
-}));
+    id,
+  });
+
+  return {
+    window: {
+      createOutputChannel: vi.fn(() => ({
+        appendLine: vi.fn(),
+      })),
+      showInformationMessage: vi.fn(),
+      createTerminal: vi.fn(() => ({
+        show: vi.fn(),
+        sendText: vi.fn(),
+      })),
+      onDidChangeActiveTextEditor: vi.fn(() =>
+        createDisposable('onDidChangeActiveTextEditor'),
+      ),
+      activeTextEditor: undefined,
+      tabGroups: {
+        all: [],
+        close: vi.fn(),
+      },
+      showTextDocument: vi.fn(),
+      showWorkspaceFolderPick: vi.fn(),
+    },
+    workspace: {
+      workspaceFolders: [],
+      onDidCloseTextDocument: vi.fn(() =>
+        createDisposable('onDidCloseTextDocument'),
+      ),
+      registerTextDocumentContentProvider: vi.fn(() =>
+        createDisposable('registerTextDocumentContentProvider'),
+      ),
+      onDidChangeWorkspaceFolders: vi.fn(() =>
+        createDisposable('onDidChangeWorkspaceFolders'),
+      ),
+      onDidGrantWorkspaceTrust: vi.fn(() =>
+        createDisposable('onDidGrantWorkspaceTrust'),
+      ),
+      getConfiguration: vi.fn(() => ({
+        get: vi.fn(),
+      })),
+    },
+    commands: {
+      registerCommand: vi.fn((command: string) =>
+        createDisposable(`registerCommand:${command}`),
+      ),
+      executeCommand: vi.fn(),
+    },
+    Uri: {
+      joinPath: vi.fn(),
+    },
+    ExtensionMode: {
+      Development: 1,
+      Production: 2,
+    },
+    EventEmitter: vi.fn(() => ({
+      event: vi.fn(),
+      fire: vi.fn(),
+      dispose: vi.fn(),
+    })),
+    extensions: {
+      getExtension: vi.fn(),
+    },
+  };
+});
 
 describe('activate', () => {
   let context: vscode.ExtensionContext;
@@ -129,6 +148,23 @@ describe('activate', () => {
   it('should register a handler for onDidGrantWorkspaceTrust', async () => {
     await activate(context);
     expect(vscode.workspace.onDidGrantWorkspaceTrust).toHaveBeenCalled();
+  });
+
+  it('should track gemini.diff.accept and onDidChangeWorkspaceFolders in context.subscriptions', async () => {
+    await activate(context);
+
+    const subscriptionIds = context.subscriptions.map(
+      (disposable) => (disposable as { id?: string }).id,
+    );
+
+    expect(subscriptionIds).toEqual(
+      expect.arrayContaining([
+        'registerCommand:gemini.diff.accept',
+        'registerCommand:gemini.diff.cancel',
+        'onDidChangeWorkspaceFolders',
+        'onDidGrantWorkspaceTrust',
+      ]),
+    );
   });
 
   it('should launch the Gemini CLI when the user clicks the button', async () => {

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
       DIFF_SCHEME,
       diffContentProvider,
     ),
-    (vscode.commands.registerCommand(
+    vscode.commands.registerCommand(
       'gemini.diff.accept',
       (uri?: vscode.Uri) => {
         const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -152,7 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
           diffManager.cancelDiff(docUri);
         }
       },
-    )),
+    ),
   );
 
   ideServer = new IDEServer(log, diffManager);
@@ -174,14 +174,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
-    (vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
     }),
     vscode.workspace.onDidGrantWorkspaceTrust(() => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       ideServer.syncEnvVars();
-    })),
+    }),
     vscode.commands.registerCommand('gemini-cli.runGeminiCLI', async () => {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {


### PR DESCRIPTION
## Summary
- Fixes a comma-operator bug in `activate()` where wrapping two registrations in parentheses meant only the last Disposable of each pair was pushed to `context.subscriptions`.
- Ensures `gemini.diff.accept` and `onDidChangeWorkspaceFolders` are disposed on deactivation (avoids "command already exists" on reload and stale workspace-folder listeners).
- Adds a regression test that asserts those Disposables are present in `context.subscriptions` (existing `toHaveBeenCalled()` checks could not catch this).

Fixes #27790

## Test plan
- [x] `npm run test --workspace=gemini-cli-vscode-ide-companion -- src/extension.test.ts` (12 passed)
- [x] Confirmed the new test fails when the comma-operator parentheses are restored
- [ ] Reload the companion extension in VS Code and verify `gemini.diff.accept` does not throw "already exists"
- [ ] Change workspace folders and confirm env sync still works after reload


Made with [Cursor](https://cursor.com)