### PR TITLE
fix(checkpoint): contain legacy raw tag path inside checkpoints directory

### DIFF
--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -710,6 +710,20 @@ describe('Logger', () => {
         await fs.rm(outsidePath, { force: true });
       }
     });
+
+    it('should not reach sibling files that shed the checkpoint prefix (#29191)', async () => {
+      // `../bar/../../logs` normalizes back inside the dir but drops the
+      // `checkpoint-` filename prefix: still refuse it.
+      const siblingPath = path.join(TEST_GEMINI_DIR, 'logs.json');
+      await fs.writeFile(siblingPath, '{}');
+      try {
+        const result = await logger.deleteCheckpoint('../bar/../../logs');
+        expect(result).toBe(false);
+        expect(existsSync(siblingPath)).toBe(true);
+      } finally {
+        await fs.rm(siblingPath, { force: true });
+      }
+    });
   });
 
   describe('checkpointExists', () => {

--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -582,6 +582,24 @@ describe('Logger', () => {
         'Logger not initialized or checkpoint file path not set. Cannot load checkpoint.',
       );
     });
+
+    it('should not read files outside the checkpoints directory (#29191)', async () => {
+      // Same containment as delete: a `../` tag must miss instead of
+      // pulling an outside file into the conversation.
+      const outsidePath = path.join(TEST_GEMINI_DIR, '..', 'outside-read.json');
+      await fs.writeFile(
+        outsidePath,
+        JSON.stringify({
+          history: [{ role: 'user', parts: [{ text: 'pwned' }] }],
+        }),
+      );
+      try {
+        const loaded = await logger.loadCheckpoint('x/../../outside-read');
+        expect(loaded).toEqual({ history: [] });
+      } finally {
+        await fs.rm(outsidePath, { force: true });
+      }
+    });
   });
 
   describe('deleteCheckpoint', () => {
@@ -673,6 +691,24 @@ describe('Logger', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Logger not initialized or checkpoint file path not set. Cannot delete checkpoint.',
       );
+    });
+
+    it('should not delete files outside the checkpoints directory (#29191)', async () => {
+      // A tag carrying `../` must never reach past the checkpoints dir,
+      // even though the legacy fallback resolves the raw tag.
+      const outsidePath = path.join(
+        TEST_GEMINI_DIR,
+        '..',
+        'should-survive.json',
+      );
+      await fs.writeFile(outsidePath, '{}');
+      try {
+        const result = await logger.deleteCheckpoint('x/../../should-survive');
+        expect(result).toBe(false);
+        expect(existsSync(outsidePath)).toBe(true);
+      } finally {
+        await fs.rm(outsidePath, { force: true });
+      }
     });
   });
 

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -297,13 +297,18 @@ export class Logger {
   private _resolveLegacyCheckpointPath(tag: string): string | null {
     // Contain the backward-compatibility fallback: a tag carrying directory
     // components (e.g. `../`) must never resolve outside the checkpoints
-    // directory (#29191).
+    // directory, nor shed its `checkpoint-` filename prefix to reach a
+    // sibling file inside it (#29191).
     if (!this.geminiDir) {
       return null;
     }
     const oldPath = path.join(this.geminiDir, `checkpoint-${tag}.json`);
     const resolvedDir = path.resolve(this.geminiDir) + path.sep;
-    if (!path.resolve(oldPath).startsWith(resolvedDir)) {
+    const resolved = path.resolve(oldPath);
+    if (!resolved.startsWith(resolvedDir)) {
+      return null;
+    }
+    if (!path.basename(resolved).startsWith('checkpoint-')) {
       return null;
     }
     return oldPath;

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -294,6 +294,21 @@ export class Logger {
     return path.join(this.geminiDir, `checkpoint-${encodedTag}.json`);
   }
 
+  private _resolveLegacyCheckpointPath(tag: string): string | null {
+    // Contain the backward-compatibility fallback: a tag carrying directory
+    // components (e.g. `../`) must never resolve outside the checkpoints
+    // directory (#29191).
+    if (!this.geminiDir) {
+      return null;
+    }
+    const oldPath = path.join(this.geminiDir, `checkpoint-${tag}.json`);
+    const resolvedDir = path.resolve(this.geminiDir) + path.sep;
+    if (!path.resolve(oldPath).startsWith(resolvedDir)) {
+      return null;
+    }
+    return oldPath;
+  }
+
   private async _getCheckpointPath(tag: string): Promise<string> {
     // 1. Check for the new encoded path first.
     const newPath = this._checkpointPath(tag);
@@ -309,8 +324,12 @@ export class Logger {
       // It was not found, so we'll check the old path next.
     }
 
-    // 2. Fallback for backward compatibility: check for the old raw path.
-    const oldPath = path.join(this.geminiDir!, `checkpoint-${tag}.json`);
+    // 2. Fallback for backward compatibility: check for the old raw path,
+    // contained to the checkpoints directory.
+    const oldPath = this._resolveLegacyCheckpointPath(tag);
+    if (oldPath === null) {
+      return newPath;
+    }
     try {
       await fs.access(oldPath);
       return oldPath; // Found it, use the old path.
@@ -418,9 +437,10 @@ export class Logger {
       // It's okay if it doesn't exist.
     }
 
-    // 2. Attempt to delete the old raw path for backward compatibility.
-    const oldPath = path.join(this.geminiDir, `checkpoint-${tag}.json`);
-    if (newPath !== oldPath) {
+    // 2. Attempt to delete the old raw path for backward compatibility,
+    // contained to the checkpoints directory.
+    const oldPath = this._resolveLegacyCheckpointPath(tag);
+    if (oldPath !== null && newPath !== oldPath) {
       try {
         await fs.unlink(oldPath);
         deletedSomething = true;


### PR DESCRIPTION
## Summary

`/chat delete <tag>` with a `../` tag deleted files outside the checkpoints directory. The legacy raw-tag fallback resolved the unvalidated tag straight into `path.join`, so traversal tags escaped the dir.

## Details

`deleteCheckpoint` and `_getCheckpointPath` built the backward-compat path from the raw tag while the new encoded path was safe. The fix adds a small `_resolveLegacyCheckpointPath` helper that returns null when the raw path resolves outside the checkpoints dir (same containment idea as #28699 for the a2a-server restore path) — traversal tags now simply miss, flat legacy tags work exactly as before.

## Related Issues

Fixes #29191

## How to Validate

1. `npx vitest run src/core/logger.test.ts` in `packages/core` — 41 passed, including 2 new traversal regressions (delete + load).
2. Manual sandbox check: `deleteCheckpoint('x/../../secret')` against real code now returns false with the outside file intact, while a legit legacy `checkpoint-<tag>.json` still deletes.

- [x] Tests added, all passing
- [x] No breaking change (only traversal tags change behavior: miss instead of escape)
- [x] Validated on macOS; change is pure `node:path` logic, platform-independent