### PR TITLE
fix(checkpoint): degrade non-array history instead of crashing resume

### DIFF
--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -567,6 +567,25 @@ describe('Logger', () => {
       );
     });
 
+    it.each([
+      ['null', null],
+      ['number', 123],
+    ])(
+      'should return an empty history if history is %s instead of an array (#29194)',
+      async (_label: string, badHistory: unknown) => {
+        const taggedFilePath = path.join(
+          TEST_GEMINI_DIR,
+          'checkpoint-wrong-shape.json',
+        );
+        await fs.writeFile(
+          taggedFilePath,
+          JSON.stringify({ history: badHistory }),
+        );
+        const loadedCheckpoint = await logger.loadCheckpoint('wrong-shape');
+        expect(loadedCheckpoint).toEqual({ history: [] });
+      },
+    );
+
     it('should return an empty history if logger is not initialized', async () => {
       const uninitializedLogger = new Logger(
         testSessionId,

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -367,8 +367,13 @@ export class Logger {
         parsedContent !== null &&
         'history' in parsedContent
       ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        return parsedContent as Checkpoint;
+        const history: unknown = parsedContent.history;
+        // A valid-JSON file with a non-array history (crash mid-save, full
+        // disk, hand edit) must degrade like any other corrupt file (#29194).
+        if (Array.isArray(history)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          return parsedContent as Checkpoint;
+        }
       }
 
       debugLogger.warn(


### PR DESCRIPTION
## Summary

A checkpoint file with valid JSON but a non-array `history` crashed `/resume resume` with a raw `TypeError`. `loadCheckpoint` now verifies the shape and degrades to an empty checkpoint, like it already does for unparseable files.

## Details

The object branch of `loadCheckpoint` only checked that the `history` key exists, then handed the raw value to resume — where `null.length` / `number.slice` threw. Corrupt shapes like these come from a crash mid-save, a full disk, or a hand edit. The fix checks `Array.isArray` before returning parsed content; anything else falls through to the existing corrupt-file warning + empty checkpoint. Valid checkpoints (including extra fields like `authType`) are untouched.

## Related Issues

Fixes #29194

## How to Validate

1. `npx vitest run src/core/logger.test.ts` in `packages/core` — 41 passed, including 2 new wrong-shape regressions (null/number history).
2. `npm run preflight`-relevant gates on touched files: ESLint zero warnings, Prettier clean.

- [x] Tests added, all passing
- [x] No breaking change (only corrupt files change behavior: clean miss instead of throw)
- [x] Validated on macOS; pure Node `fs`/`path` logic, platform-independent