### PR TITLE
fix(core): enforce MCP policy consistently at runtime

### DIFF
--- a/packages/cli/src/config/mcp/mcpServerEnablement.ts
+++ b/packages/cli/src/config/mcp/mcpServerEnablement.ts
@@ -6,7 +6,11 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { Storage, coreEvents } from '@google/gemini-cli-core';
+import {
+  Storage,
+  coreEvents,
+  normalizeMcpServerName,
+} from '@google/gemini-cli-core';
 
 /**
  * Stored in JSON file - represents persistent enablement state.
@@ -55,7 +59,7 @@ export interface ServerLoadResult {
  * Normalize a server ID to canonical lowercase form.
  */
 export function normalizeServerId(serverId: string): string {
-  return serverId.toLowerCase().trim();
+  return normalizeMcpServerName(serverId);
 }
 
 /**

--- a/packages/cli/src/config/policy-engine.integration.test.ts
+++ b/packages/cli/src/config/policy-engine.integration.test.ts
@@ -141,6 +141,32 @@ describe('Policy Engine Integration Tests', () => {
       ).toBe(PolicyDecision.ASK_USER);
     });
 
+    it('should normalize MCP server names when matching policy rules', async () => {
+      const settings: Settings = {
+        mcp: {
+          allowed: ['  PROBE  '],
+          excluded: ['  BLOCKED  '],
+        },
+      };
+
+      const config = await createPolicyEngineConfig(
+        settings,
+        ApprovalMode.DEFAULT,
+      );
+      const engine = new PolicyEngine(config);
+
+      // Settings matching is case-insensitive and ignores surrounding whitespace.
+      expect(
+        (await engine.check({ name: 'mcp_probe_tool' }, 'probe')).decision,
+      ).toBe(PolicyDecision.ALLOW);
+      expect(
+        (await engine.check({ name: 'mcp_probe_tool' }, undefined)).decision,
+      ).toBe(PolicyDecision.ALLOW);
+      expect(
+        (await engine.check({ name: 'mcp_blocked_tool' }, 'blocked')).decision,
+      ).toBe(PolicyDecision.DENY);
+    });
+
     it('should handle global MCP wildcard (*) in settings', async () => {
       const settings: Settings = {
         mcp: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1021,6 +1021,17 @@ describe('Server Config (config.ts)', () => {
     expect(config.getUserMemory()).toBe('');
   });
 
+  it('preserves an explicitly empty MCP allowlist', () => {
+    const configWithoutAllowlist = new Config(baseParams);
+    const configWithEmptyAllowlist = new Config({
+      ...baseParams,
+      allowedMcpServers: [],
+    });
+
+    expect(configWithoutAllowlist.getAllowedMcpServers()).toBeUndefined();
+    expect(configWithEmptyAllowlist.getAllowedMcpServers()).toEqual([]);
+  });
+
   it('Config constructor should call setGeminiMdFilename with contextFileName if provided', () => {
     const contextFileName = 'CUSTOM_AGENTS.md';
     const paramsWithContextFile: ConfigParameters = {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -754,7 +754,7 @@ export class Config implements McpContext, AgentLoopContext {
   private _toolRegistry!: ToolRegistry;
   private mcpClientManager?: McpClientManager;
   private readonly a2aClientManager?: A2AClientManager;
-  private allowedMcpServers: string[];
+  private allowedMcpServers: string[] | undefined;
   private blockedMcpServers: string[];
   private allowedEnvironmentVariables: string[];
   private blockedEnvironmentVariables: string[];
@@ -1071,7 +1071,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.mcpEnablementCallbacks = params.mcpEnablementCallbacks;
     this.mcpEnabled = params.mcpEnabled ?? true;
     this.extensionsEnabled = params.extensionsEnabled ?? true;
-    this.allowedMcpServers = params.allowedMcpServers ?? [];
+    this.allowedMcpServers = this.mcpEnabled ? params.allowedMcpServers : [];
     this.blockedMcpServers = params.blockedMcpServers ?? [];
     this.allowedEnvironmentVariables = params.allowedEnvironmentVariables ?? [];
     this.blockedEnvironmentVariables = params.blockedEnvironmentVariables ?? [];

--- a/packages/core/src/policy/config.test.ts
+++ b/packages/core/src/policy/config.test.ts
@@ -325,6 +325,26 @@ describe('createPolicyEngineConfig', () => {
     expect(rule2?.source).toBe('Settings (Headless MCP Auto-Allow)');
   });
 
+  it('should not auto-allow configured MCP servers with an explicitly empty allowlist', async () => {
+    const config = await createPolicyEngineConfig(
+      {
+        mcp: { autoAllowInHeadless: true, allowed: [] },
+        mcpServers: {
+          'server-1': new MCPServerConfig('node', []),
+          'server-2': new MCPServerConfig('python', []),
+        },
+      },
+      ApprovalMode.DEFAULT,
+      MOCK_DEFAULT_DIR,
+      false, // non-interactive
+    );
+
+    const autoAllowRules = config.rules?.filter(
+      (rule) => rule.source === 'Settings (Headless MCP Auto-Allow)',
+    );
+    expect(autoAllowRules).toHaveLength(0);
+  });
+
   it('should NOT automatically allow configured MCP servers in interactive mode even if opted-in', async () => {
     const config = await createPolicyEngineConfig(
       {

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -603,10 +603,12 @@ export async function createPolicyEngineConfig(
   // In non-interactive mode, automatically allow all configured MCP servers if opted-in.
   // This ensures that tools provided by these servers are available without
   // requiring explicit entries in settings.mcp.allowed.
+  const hasExplicitEmptyMcpAllowlist = settings.mcp?.allowed?.length === 0;
   if (
     !interactive &&
     settings.mcp?.autoAllowInHeadless &&
-    settings.mcpServers
+    settings.mcpServers &&
+    !hasExplicitEmptyMcpAllowlist
   ) {
     for (const serverName of Object.keys(settings.mcpServers)) {
       // Avoid duplicates if already explicitly allowed, allowed via wildcard, or trusted.

--- a/packages/core/src/policy/policy-engine.ts
+++ b/packages/core/src/policy/policy-engine.ts
@@ -40,6 +40,7 @@ import {
   parseMcpToolName,
   formatMcpToolName,
   isMcpToolName,
+  normalizeMcpServerName,
 } from '../tools/mcp-tool.js';
 import {
   type SandboxManager,
@@ -86,6 +87,18 @@ function isWildcardPattern(name: string): boolean {
   return name === '*' || name.includes('*');
 }
 
+function mcpToolNameMatchesServer(
+  toolName: string,
+  serverName: string,
+): boolean {
+  const normalizedServerName = normalizeMcpServerName(serverName);
+  const serverPrefix = `${MCP_TOOL_PREFIX}${normalizedServerName}_`;
+
+  // Only the server portion is normalized. The tool name remains unchanged
+  // after the separator and is still subject to the rule's normal matching.
+  return toolName.slice(0, serverPrefix.length).toLowerCase() === serverPrefix;
+}
+
 /**
  * Checks if a tool call matches a wildcard pattern.
  * Supports global (*) and the explicit MCP (*mcp_serverName_**) format.
@@ -108,10 +121,14 @@ function matchesWildcard(
     // 1. Must be an MCP tool call (has serverName)
     // 2. Server name must match
     // 3. Tool name must be properly qualified by that server
-    if (serverName === undefined || serverName !== expectedServerName) {
+    if (
+      serverName === undefined ||
+      normalizeMcpServerName(serverName) !==
+        normalizeMcpServerName(expectedServerName)
+    ) {
       return false;
     }
-    return toolName.startsWith(`${MCP_TOOL_PREFIX}${expectedServerName}_`);
+    return mcpToolNameMatchesServer(toolName, expectedServerName);
   }
 
   // Not a recognized wildcard pattern, fallback to exact match just in case
@@ -149,7 +166,13 @@ function ruleMatches(
       if (serverName === undefined) return false;
     } else {
       // Rule requires it to be a specific MCP server
-      if (serverName !== rule.mcpName) return false;
+      if (
+        serverName === undefined ||
+        normalizeMcpServerName(serverName) !==
+          normalizeMcpServerName(rule.mcpName)
+      ) {
+        return false;
+      }
     }
   }
 

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -53,7 +53,7 @@ describe('McpClientManager', () => {
         .mockReturnValue({ setResourcesForServer: vi.fn() }),
       getDebugMode: () => false,
       getWorkspaceContext: () => ({ getDirectories: () => [] }),
-      getAllowedMcpServers: vi.fn().mockReturnValue([]),
+      getAllowedMcpServers: vi.fn().mockReturnValue(undefined),
       getBlockedMcpServers: vi.fn().mockReturnValue([]),
       getExcludedMcpServers: vi.fn().mockReturnValue([]),
       getMcpServerCommand: vi.fn().mockReturnValue(''),
@@ -232,7 +232,7 @@ describe('McpClientManager', () => {
     expect(mockedMcpClient.discoverInto).not.toHaveBeenCalled();
   });
 
-  it('should only start allowed servers if allow list is not empty', async () => {
+  it('should only start servers included in the allowlist', async () => {
     mockConfig.getMcpServers.mockReturnValue({
       'test-server': { command: 'node' },
       'another-server': { command: 'node' },
@@ -242,6 +242,45 @@ describe('McpClientManager', () => {
     await manager.startConfiguredMcpServers();
     expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
     expect(mockedMcpClient.discoverInto).toHaveBeenCalledOnce();
+  });
+
+  it('should normalize server names when checking the allowlist', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      probe: { command: 'node' },
+    });
+    mockConfig.getAllowedMcpServers.mockReturnValue([' PROBE ']);
+
+    const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+    await manager.startConfiguredMcpServers();
+
+    expect(mockedMcpClient.connect).toHaveBeenCalledOnce();
+    expect(mockedMcpClient.discoverInto).toHaveBeenCalledOnce();
+  });
+
+  it('should normalize server names when checking the blocklist', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      probe: { command: 'node' },
+    });
+    mockConfig.getBlockedMcpServers.mockReturnValue([' probe ']);
+
+    const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+    await manager.startConfiguredMcpServers();
+
+    expect(mockedMcpClient.connect).not.toHaveBeenCalled();
+    expect(mockedMcpClient.discoverInto).not.toHaveBeenCalled();
+  });
+
+  it('should not start servers when the allowlist is explicitly empty', async () => {
+    mockConfig.getMcpServers.mockReturnValue({
+      probe: { command: 'node' },
+    });
+    mockConfig.getAllowedMcpServers.mockReturnValue([]);
+
+    const manager = setupManager(new McpClientManager('0.0.1', mockConfig));
+    await manager.startConfiguredMcpServers();
+
+    expect(mockedMcpClient.connect).not.toHaveBeenCalled();
+    expect(mockedMcpClient.discoverInto).not.toHaveBeenCalled();
   });
 
   it('should start servers from extensions', async () => {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -258,20 +258,18 @@ export class McpClientManager {
    * Returns true if blocked, false if allowed.
    */
   private isBlockedBySettings(name: string): boolean {
+    const normalizedName = name.toLowerCase().trim();
+    const isListed = (serverNames: readonly string[]) =>
+      serverNames.some(
+        (serverName) => serverName.toLowerCase().trim() === normalizedName,
+      );
+
     const allowedNames = this.cliConfig.getAllowedMcpServers();
-    if (
-      allowedNames &&
-      allowedNames.length > 0 &&
-      !allowedNames.includes(name)
-    ) {
+    if (allowedNames !== undefined && !isListed(allowedNames)) {
       return true;
     }
     const blockedNames = this.cliConfig.getBlockedMcpServers();
-    if (
-      blockedNames &&
-      blockedNames.length > 0 &&
-      blockedNames.includes(name)
-    ) {
+    if (blockedNames !== undefined && isListed(blockedNames)) {
       return true;
     }
     return false;

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -23,6 +23,7 @@ import { debugLogger } from '../utils/debugLogger.js';
 
 import { createHash } from 'node:crypto';
 import { stableStringify } from '../policy/stable-stringify.js';
+import { normalizeMcpServerName } from './mcp-tool.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type {
   ResourceRegistry,
@@ -258,10 +259,10 @@ export class McpClientManager {
    * Returns true if blocked, false if allowed.
    */
   private isBlockedBySettings(name: string): boolean {
-    const normalizedName = name.toLowerCase().trim();
+    const normalizedName = normalizeMcpServerName(name);
     const isListed = (serverNames: readonly string[]) =>
       serverNames.some(
-        (serverName) => serverName.toLowerCase().trim() === normalizedName,
+        (serverName) => normalizeMcpServerName(serverName) === normalizedName,
       );
 
     const allowedNames = this.cliConfig.getAllowedMcpServers();

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -37,6 +37,17 @@ export const MCP_QUALIFIED_NAME_SEPARATOR = '_';
 export const MCP_TOOL_PREFIX = 'mcp_';
 
 /**
+ * Normalizes an MCP server name for identity comparisons.
+ *
+ * Server names are user-configurable identifiers. Treating case and
+ * surrounding whitespace as significant would make the same server appear
+ * different to the MCP loader and policy engine.
+ */
+export function normalizeMcpServerName(name: string): string {
+  return name.toLowerCase().trim();
+}
+
+/**
  * Returns true if `name` matches the MCP qualified name format: "mcp_server_tool",
  * i.e. starts with the "mcp_" prefix.
  */


### PR DESCRIPTION
## Summary

- Align MCP runtime policy checks with the CLI's case-insensitive, whitespace-trimmed server-name matching.
- Treat an explicitly empty `mcp.allowed` list as fail-closed instead of allowing every configured server.
- Preserve the distinction between an omitted allowlist and an explicit empty allowlist.

## Details

`McpClientManager` previously used exact `includes()` checks and ignored empty policy arrays, so the runtime could disagree with the CLI policy path. This change normalizes server names at the runtime boundary and retains `undefined` for an omitted allowlist while using `[]` when MCP is globally disabled.

## Related Issues

Fixes #29199

## How to Validate

1. Configure a server named `probe` and verify that `allowed: [" PROBE "]` starts it, while `excluded: [" probe "]` and `allowed: []` prevent it from starting.
2. Run `npm test --workspace @google/gemini-cli-core -- src/tools/mcp-client-manager.test.ts` (41 passing).
3. Run `npm test --workspace @google/gemini-cli-core -- src/config/config.test.ts` (237 passing).
4. Run `GEMINI_CLI_TRUST_WORKSPACE=true npm test --workspace @google/gemini-cli -- src/gemini.test.tsx` (43 passing, 1 skipped).
5. Run `npm run typecheck --workspace @google/gemini-cli-core`.

I also ran `npm run preflight`. Its formatting, build, lint, and typecheck stages passed. The core sandbox integration tests cannot run in this container because Bubblewrap is not permitted to mount `/proc` (`Operation not permitted`).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker