### PR TITLE
fix(cli): preserve approved shell commands across confirmation retries

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -9,7 +9,11 @@ import { act } from 'react';
 import { renderHook } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { useSlashCommandProcessor } from './slashCommandProcessor.js';
-import { CommandKind, type SlashCommand } from '../commands/types.js';
+import {
+  CommandKind,
+  type SlashCommand,
+  type CommandContext,
+} from '../commands/types.js';
 import type { LoadedSettings } from '../../config/settings.js';
 import { MessageType } from '../types.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
@@ -20,6 +24,7 @@ import {
   MCPDiscoveryState,
   makeFakeConfig,
   coreEvents,
+  ToolConfirmationOutcome,
   type GeminiClient,
 } from '@google/gemini-cli-core';
 
@@ -812,6 +817,103 @@ describe('useSlashCommandProcessor', () => {
 
       expect(mockAddItem).toHaveBeenCalledWith(
         { type: MessageType.USER, text: '/mcpcmd' },
+        expect.any(Number),
+      );
+    });
+  });
+
+  describe('Shell command confirmation', () => {
+    it('accumulates approvals across multiple confirmation rounds instead of looping forever', async () => {
+      // Simulates a command whose action re-checks the session shell
+      // allowlist from scratch each time it is invoked (as a real
+      // file-based command's ShellProcessor would after a retry), and
+      // requests confirmation for whichever command isn't allowed yet.
+      const action = async (context: CommandContext) => {
+        const allowed = context.session.sessionShellAllowlist;
+        if (!allowed.has('cmd1')) {
+          return {
+            type: 'confirm_shell_commands' as const,
+            commandsToConfirm: ['cmd1'],
+            originalInvocation: { raw: '/multistep' },
+          };
+        }
+        if (!allowed.has('cmd2')) {
+          return {
+            type: 'confirm_shell_commands' as const,
+            commandsToConfirm: ['cmd2'],
+            originalInvocation: { raw: '/multistep' },
+          };
+        }
+        return {
+          type: 'message' as const,
+          messageType: 'info' as const,
+          content: 'both commands confirmed',
+        };
+      };
+
+      const testCommand = createTestCommand({
+        name: 'multistep',
+        action,
+      });
+
+      const result = await setupProcessorHook({
+        builtinCommands: [testCommand],
+      });
+      await waitFor(() => expect(result.current.slashCommands).toHaveLength(1));
+
+      let finalResultPromise: Promise<unknown> = Promise.resolve();
+      act(() => {
+        finalResultPromise = result.current.handleSlashCommand('/multistep');
+      });
+
+      // Round 1: only cmd1 has been discovered so far.
+      await waitFor(() => {
+        expect(result.current.pendingHistoryItems).toHaveLength(1);
+      });
+      let pending = result.current.pendingHistoryItems[0] as unknown as {
+        tools: Array<{
+          confirmationDetails: {
+            rootCommands: string[];
+            onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+          };
+        }>;
+      };
+      expect(pending.tools[0].confirmationDetails.rootCommands).toEqual([
+        'cmd1',
+      ]);
+      await act(async () => {
+        await pending.tools[0].confirmationDetails.onConfirm(
+          ToolConfirmationOutcome.ProceedOnce,
+        );
+      });
+
+      // Round 2: cmd1 is now allowed for this retry, so cmd2 is discovered.
+      await waitFor(() => {
+        expect(result.current.pendingHistoryItems).toHaveLength(1);
+      });
+      pending = result.current.pendingHistoryItems[0] as unknown as {
+        tools: Array<{
+          confirmationDetails: {
+            rootCommands: string[];
+            onConfirm: (outcome: ToolConfirmationOutcome) => Promise<void>;
+          };
+        }>;
+      };
+      expect(pending.tools[0].confirmationDetails.rootCommands).toEqual([
+        'cmd2',
+      ]);
+      await act(async () => {
+        await pending.tools[0].confirmationDetails.onConfirm(
+          ToolConfirmationOutcome.ProceedOnce,
+        );
+      });
+
+      // Both commands were approved across the two rounds, so the retry
+      // should now succeed instead of asking for cmd1 a second time.
+      const finalResult = await finalResultPromise;
+      expect(finalResult).toEqual({ type: 'handled' });
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'both commands confirmed' }),
         expect.any(Number),
       );
     });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -643,8 +643,16 @@ export const useSlashCommandProcessor = (
 
                   return await handleSlashCommand(
                     result.originalInvocation.raw,
-                    // Pass the approved commands as a one-time grant for this execution.
-                    new Set(approvedCommands),
+                    // Accumulate with any commands already granted earlier in
+                    // this same confirmation chain. A retry re-runs the
+                    // command action from scratch, so commands approved in a
+                    // prior round must still be carried forward here rather
+                    // than relied upon via `sessionShellAllowlist`, which may
+                    // not have re-rendered into `commandContext` yet.
+                    new Set([
+                      ...(oneTimeShellAllowlist ?? []),
+                      ...approvedCommands,
+                    ]),
                     undefined,
                     false, // Do not add to history again
                   );


### PR DESCRIPTION
Fixes #29197

## What happened

When a TOML custom command contains multiple `!{...}` shell injections that each need confirmation, the CLI could get stuck asking for permission forever — cycling between commands, and never converging even if the user chose "always allow" for every prompt.

## Root cause

`FileCommandLoader`'s command action re-runs the entire prompt-processing pipeline from scratch on every retry. When `ShellProcessor` throws `ConfirmationRequiredError`, `slashCommandProcessor.ts`'s `confirm_shell_commands` handler recurses into `handleSlashCommand` with a fresh one-time allowlist containing only the commands approved in *that* round:

```ts
return await handleSlashCommand(
  result.originalInvocation.raw,
  // Pass the approved commands as a one-time grant for this execution.
  new Set(approvedCommands),
  undefined,
  false,
);
```

If a second, distinct command still needs confirmation on the retry (e.g. discovered in a later part of the prompt), a second round begins. That round's one-time allowlist only contains the *newly* approved command — the one approved in the first round is dropped, because:

- it isn't in this round's `approvedCommands`, and
- the persisted `sessionShellAllowlist` React state update from the first round (`setSessionShellAllowlist`) may not have been reflected into the `commandContext` this in-flight recursive call closure is using yet, even when the user picked "Always".

So the command originally approved gets asked again, and this can cycle indefinitely.

## Fix

Accumulate approvals across the whole confirmation chain instead of replacing them each round:

```ts
new Set([
  ...(oneTimeShellAllowlist ?? []),
  ...approvedCommands,
]),
```

Now every retry keeps every command approved so far in that chain, regardless of whether the backing React state has re-rendered yet, so the loop always converges once every distinct command has been confirmed at least once.

## Testing

Added a regression test in `packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx` ("Shell command confirmation > accumulates approvals across multiple confirmation rounds instead of looping forever") that simulates a command action which re-checks `context.session.sessionShellAllowlist` from scratch on each invocation and asks for `cmd1` then `cmd2` in turn.

- Confirmed the test **fails** against the pre-fix code: it hangs and times out after 60s because the third round asks for `cmd1` again (reproducing the infinite loop).
- Confirmed the test **passes** with the fix: both confirmations resolve in two rounds.

```
$ npx vitest run src/ui/hooks/slashCommandProcessor.test.tsx
 ✓ src/ui/hooks/slashCommandProcessor.test.tsx (39 tests)
   ✓ useSlashCommandProcessor > Shell command confirmation > accumulates approvals across multiple confirmation rounds instead of looping forever

 Test Files  1 passed (1)
      Tests  39 passed (39)
```

Also ran:
- `npx eslint src/ui/hooks/slashCommandProcessor.ts src/ui/hooks/slashCommandProcessor.test.tsx` — clean
- `npx tsc --noEmit` (packages/cli) — clean
- `npx vitest run src/services/prompt-processors/shellProcessor.test.ts` — 34 tests passed (unaffected)

## AI assistance disclosure

This PR was prepared with the assistance of an AI coding agent (Claude), including root-cause analysis, the fix, and the regression test. All changes were verified by running the project's real lint/typecheck/test commands as shown above.
