### PR TITLE
fix(security): strip shell wrappers carrying extra flags

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -412,6 +412,11 @@ describe('stripShellWrapper', () => {
     );
   });
 
+  it('should not backtrack on long flag runs without -Command (#29203)', () => {
+    const input = `powershell ${'-A '.repeat(30)}tail`;
+    expect(stripShellWrapper(input)).toEqual(input.trim());
+  });
+
   it('should not strip anything if no wrapper is present', () => {
     expect(stripShellWrapper('ls -l')).toEqual('ls -l');
   });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -389,6 +389,29 @@ describe('stripShellWrapper', () => {
     ).toEqual('Get-ChildItem');
   });
 
+  it('should strip posix wrappers carrying extra flags (#29202)', () => {
+    expect(stripShellWrapper('bash -x -c "rm -rf /"')).toEqual('rm -rf /');
+    expect(stripShellWrapper('bash -xc "rm -rf /"')).toEqual('rm -rf /');
+    expect(stripShellWrapper('bash --noprofile -c "rm -rf /"')).toEqual(
+      'rm -rf /',
+    );
+    expect(stripShellWrapper('sh -e -c "rm -rf /"')).toEqual('rm -rf /');
+  });
+
+  it('should strip powershell wrappers carrying extra flags (#29202)', () => {
+    expect(
+      stripShellWrapper(
+        'powershell -NoProfile -ExecutionPolicy Bypass -Command "Remove-Item"',
+      ),
+    ).toEqual('Remove-Item');
+  });
+
+  it('should not strip a script-file invocation that merely contains -c (#29202)', () => {
+    expect(stripShellWrapper('bash somescript.sh -c x')).toEqual(
+      'bash somescript.sh -c x',
+    );
+  });
+
   it('should not strip anything if no wrapper is present', () => {
     expect(stripShellWrapper('ls -l')).toEqual('ls -l');
   });

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -840,8 +840,13 @@ export function getCommandRoots(command: string): string[] {
 }
 
 export function stripShellWrapper(command: string): string {
+  // Tolerate wrapper flags between the shell name and -c / -Command so the
+  // inner command is always what the policy engine re-checks (#29202):
+  // short clusters (incl. combined -xc), long options, and -Name value
+  // pairs. Middle tokens must look flag-like so `bash script.sh -c x`
+  // (run a script file) never strips.
   const pattern =
-    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))\s+-c|cmd\.exe\s+\/c|powershell(?:\.exe)?\s+(?:-NoProfile\s+)?-Command|pwsh(?:\.exe)?\s+(?:-NoProfile\s+)?-Command)\s+/i;
+    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))(?:\s+-\S+)*\s+-(?:[A-Za-z]*c)|cmd\.exe(?:\s+\/\S+)*\s+\/c|powershell(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"']+))?)*\s+-Command|pwsh(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"']+))?)*\s+-Command)\s+/i;
   const match = command.match(pattern);
   if (match) {
     let newCommand = command.substring(match[0].length).trim();

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -844,9 +844,11 @@ export function stripShellWrapper(command: string): string {
   // inner command is always what the policy engine re-checks (#29202):
   // short clusters (incl. combined -xc), long options, and -Name value
   // pairs. Middle tokens must look flag-like so `bash script.sh -c x`
-  // (run a script file) never strips.
+  // (run a script file) never strips. Unquoted flag values must not start
+  // with `-` or flag names double as values and the group backtracks
+  // catastrophically (ReDoS, review on #29203).
   const pattern =
-    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))(?:\s+-\S+)*\s+-(?:[A-Za-z]*c)|cmd\.exe(?:\s+\/\S+)*\s+\/c|powershell(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"']+))?)*\s+-Command|pwsh(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"']+))?)*\s+-Command)\s+/i;
+    /^\s*(?:(?:(?:\S+\/)?(?:sh|bash|zsh))(?:\s+-\S+)*\s+-(?:[A-Za-z]*c)|cmd\.exe(?:\s+\/\S+)*\s+\/c|powershell(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"'-][^\s"']*))?)*\s+-Command|pwsh(?:\.exe)?(?:\s+-[A-Za-z]+(?:\s+(?:"[^"]*"|'[^']*'|[^\s"'-][^\s"']*))?)*\s+-Command)\s+/i;
   const match = command.match(pattern);
   if (match) {
     let newCommand = command.substring(match[0].length).trim();


### PR DESCRIPTION
## Summary

`stripShellWrapper` only recognized bare `bash -c` / `powershell [-NoProfile] -Command`, so any extra wrapper flag left the input unchanged — and the policy engine only re-checks the inner command when stripping changed something. The wrapper regex now tolerates short clusters (including combined `-xc`), long options, and `-Name value` pairs, while still requiring flag-like middles so `bash script.sh -c x` never strips.

## How to test

1. Call `stripShellWrapper('bash -x -c "rm -rf /"')` and the powershell `-ExecutionPolicy Bypass` form.
2. Observe the inner command now. Before the fix, both came back unchanged and escaped policy re-check.
3. Run `vitest run src/utils/shell-utils.test.ts` in `packages/core`. All pass, including the 3 new `#29202` tests (2 red without the fix, green with it).

## Related issues

Fixes #29202