### PR TITLE
fix(cli): submit MCP prompt text without JSON encoding

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -222,7 +222,26 @@ describe('McpPromptLoader', () => {
       });
       expect(result).toEqual({
         type: 'submit_prompt',
-        content: JSON.stringify('Hello, world!'),
+        content: 'Hello, world!',
+      });
+    });
+
+    it('should preserve quotes and newlines in prompt response text', async () => {
+      const promptText = 'He said "hello".\nNext line';
+      mockPrompt.invoke.mockResolvedValueOnce({
+        messages: [{ content: { type: 'text', text: promptText } }],
+      });
+
+      const loader = new McpPromptLoader(mockConfigWithPrompts);
+      const commands = await loader.loadCommands(new AbortController().signal);
+      const result = await commands[0].action!(
+        {} as CommandContext,
+        'test-name 123 tiger',
+      );
+
+      expect(result).toEqual({
+        type: 'submit_prompt',
+        content: promptText,
       });
     });
 

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -139,7 +139,7 @@ export class McpPromptLoader implements ICommandLoader {
 
               return {
                 type: 'submit_prompt',
-                content: JSON.stringify(maybeContent.text),
+                content: maybeContent.text,
               };
             } catch (error) {
               return {


### PR DESCRIPTION
## Summary

- Submit MCP prompt response text directly instead of JSON-encoding it.
- Preserve embedded quotes and newlines exactly as returned by the MCP server.
- Replace the prior encoded-output expectation and add a focused regression test.

## Details

`McpPromptLoader` wrapped every successful text response in `JSON.stringify()`. That added literal outer quotes and escaped characters before the value reached `submit_prompt`, so MCP-generated prompts were altered before entering the conversation. The loader now passes `maybeContent.text` through unchanged.

## Related Issues

Fixes #29204

## How to Validate

1. Configure an MCP prompt that returns `He said "hello".` followed by a newline and `Next line`; invoke its slash command and verify the submitted prompt contains the exact original text without outer JSON quotes or escaped newline characters.
2. Run `npm test --workspace @google/gemini-cli -- src/services/McpPromptLoader.test.ts` (32 passing).
3. Run `GEMINI_CLI_TRUST_WORKSPACE=true npm test --workspace @google/gemini-cli` (464 test files, 7,023 passing, 4 skipped).
4. Run `npm run typecheck --workspace @google/gemini-cli`.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [x] Linux
    - [x] npm run
    - [ ] npx
    - [ ] Docker