### PR TITLE
fix(core): pass resumed session data through config init to avoid orphan session file

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -805,7 +805,7 @@ export async function main() {
       return;
     }
 
-    await config.initialize();
+    await config.initialize(resumedSessionData);
     startupProfiler.flush(config);
 
     // If not a TTY, read from stdin

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -480,7 +480,7 @@ export const AppContainer = (props: AppContainerProps) => {
       // Note: the program will not work if this fails so let errors be
       // handled by the global catch.
       if (!config.isInitialized()) {
-        await config.initialize();
+        await config.initialize(resumedSessionData);
       }
       setConfigInitialized(true);
       startupProfiler.flush(config);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,6 +11,7 @@ import { inspect } from 'node:util';
 import process from 'node:process';
 import { z } from 'zod';
 import type { ConversationRecord } from '../services/chatRecordingService.js';
+import type { ResumedSessionData } from '../services/chatRecordingTypes.js';
 import type {
   AgentHistoryProviderConfig,
   ContextManagementConfig,
@@ -1438,17 +1439,19 @@ export class Config implements McpContext, AgentLoopContext {
    * Dedups initialization requests using a shared promise that is only resolved
    * once.
    */
-  async initialize(): Promise<void> {
+  async initialize(resumedSessionData?: ResumedSessionData): Promise<void> {
     if (this.initPromise) {
       return this.initPromise;
     }
 
-    this.initPromise = this._initialize();
+    this.initPromise = this._initialize(resumedSessionData);
 
     return this.initPromise;
   }
 
-  private async _initialize(): Promise<void> {
+  private async _initialize(
+    resumedSessionData?: ResumedSessionData,
+  ): Promise<void> {
     await this.storage.initialize();
     ragLogger.initialize(this.storage.getProjectTempLogsDir());
 
@@ -1560,7 +1563,7 @@ export class Config implements McpContext, AgentLoopContext {
     this.memoryContextManager = new MemoryContextManager(this);
     await this.memoryContextManager.refresh();
 
-    await this._geminiClient.initialize();
+    await this._geminiClient.initialize(resumedSessionData);
     this.initialized = true;
   }
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -351,6 +351,34 @@ describe('Gemini Client (client.ts)', () => {
     });
   });
 
+  describe('initialize', () => {
+    it('passes resumed session data to startChat so recording reopens the existing file', async () => {
+      const resumedSessionData = {
+        conversation: {
+          sessionId: 'resumed-session-id',
+          projectHash: 'test-project-hash',
+          startTime: '2024-01-01T10:00:00.000Z',
+          lastUpdated: '2024-01-01T10:05:00.000Z',
+          messages: [],
+        },
+        filePath: '/test/temp/chats/session-2024-01-01T10-00-resumed-.jsonl',
+      } as unknown as Parameters<typeof client.initialize>[0];
+
+      const startChatSpy = vi.spyOn(client, 'startChat').mockResolvedValue({
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      } as unknown as GeminiChat);
+
+      await client.initialize(resumedSessionData);
+
+      // Without the resumed data the recording service treats this as a
+      // brand new conversation and opens a second file under the same
+      // eight-character id suffix, which startup retention cleanup later
+      // expands back over the real conversation.
+      expect(startChatSpy).toHaveBeenCalledWith(undefined, resumedSessionData);
+    });
+  });
+
   describe('resumeChat', () => {
     it('should update telemetry token count when a chat is resumed', async () => {
       const history: Content[] = [

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -260,8 +260,18 @@ export class GeminiClient {
     }
   }
 
-  async initialize() {
-    this.chat = await this.startChat();
+  /**
+   * When the process was started to resume a session, `resumedSessionData`
+   * must be passed here even though the history is only replayed later by
+   * `resumeChat`. Without it the recording service treats this as a brand
+   * new conversation and opens a second file for a session that already has
+   * one: both files carry the same eight-character id suffix, because the
+   * resumed session id is reused for the process. Startup retention cleanup
+   * then expands that suffix back to every matching file and takes the real
+   * conversation down with the empty one.
+   */
+  async initialize(resumedSessionData?: ResumedSessionData) {
+    this.chat = await this.startChat(undefined, resumedSessionData);
     this.updateTelemetryTokenCount();
   }
 


### PR DESCRIPTION
## The bug

`gemini --resume <uuid>` reuses the resumed session's id for the process
(`resolveSessionId` returns `sessionData.sessionId`). But `config.initialize()`
starts the Gemini client with **no** resumed session data:

```ts
await this._geminiClient.initialize();
```

`GeminiClient.initialize()` → `GeminiChat.initialize(undefined)` then takes the
"create new session" branch in `ChatRecordingService`, opening a **second**
JSONL file:

```
session-<UTC minute>-<session id[0:8]>.jsonl
```

Because the process id is the resumed session's real id, this orphan file
carries the *same* eight-character suffix as the real conversation file, and
holds nothing but an initial metadata line — the recorder never uses it, since
`useSessionResume`'s `resumeChat()` call (which does receive the resumed data
and correctly reopens the real file) only runs later, in a React effect.

That empty orphan is never cleaned up on its own exit path, either — cleanup
only runs against `config.getGeminiClient().getChatRecordingService()`, which
after `resumeChat()` completes points at the *real* file, not the orphan.
The orphan is what a later startup's session-retention sweep finds:
`hasResumableContent` is false for it, so it is treated as corrupted, and
cleanup derives the short id from its filename and expands the deletion to
*every* file ending in that same `-<shortId>.jsonl` — including the real
conversation. That's exactly what's reported in #29198: after resuming a
session and exiting without interacting, trying to resume the same session
again later shows it gone from `--list-sessions` and `--resume <uuid>` fails.

## The fix

Thread `resumedSessionData` through the one call site that was dropping it:

```
config.initialize(resumedSessionData)
  -> GeminiClient.initialize(resumedSessionData)
    -> startChat(undefined, resumedSessionData)
      -> GeminiChat.initialize(resumedSessionData)
        -> ChatRecordingService reopens the existing file instead of creating a new one
```

- `packages/core/src/config/config.ts`: `initialize()`/`_initialize()` accept
  and forward `resumedSessionData` to `this._geminiClient.initialize(...)`.
- `packages/core/src/core/client.ts`: `GeminiClient.initialize()` accepts
  `resumedSessionData` and passes it to `startChat()`.
- `packages/cli/src/gemini.tsx` and `packages/cli/src/ui/AppContainer.tsx`:
  the two call sites of `config.initialize()` (non-interactive and interactive
  paths) now pass the `resumedSessionData` they already have in scope.

History is untouched by this change — `startChat(undefined, resumedSessionData)`
still passes no `extraHistory`, so the in-memory chat history continues to be
built exclusively by the later `resumeChat()` call in `useSessionResume`. This
change only fixes which file chat recording targets from the start.

## Test plan

Added a regression test in `packages/core/src/core/client.test.ts` asserting
that `GeminiClient.initialize(resumedSessionData)` forwards the data to
`startChat`. Verified it fails without the fix:

```
$ git checkout HEAD~1 -- packages/core/src/core/client.ts
$ npm test --workspace @google/gemini-cli-core -- src/core/client.test.ts -t initialize
 FAIL  src/core/client.test.ts > Gemini Client (client.ts) > initialize > passes resumed session data to startChat so recording reopens the existing file
 AssertionError: expected "startChat" to be called with arguments: [ undefined, …(1) ]
 Received: [[]]  (called with no resumedSessionData)
$ git checkout HEAD -- packages/core/src/core/client.ts
```

With the fix, the full targeted suites pass:

```
$ npm test --workspace @google/gemini-cli-core -- src/core/client.test.ts src/config/config.test.ts src/services/chatRecordingService.test.ts src/core/geminiChat.test.ts
 Test Files  4 passed (4)
      Tests  480 passed | 1 skipped (481)

$ npm test --workspace @google/gemini-cli -- src/ui/AppContainer.test.tsx
 Test Files  1 passed (1)
      Tests  112 passed (112)
```

`src/gemini.test.tsx` has 9 pre-existing failures (`FatalUntrustedWorkspaceError:
Gemini CLI is not running in a trusted directory`) that reproduce identically
on unmodified `main` in this sandbox — unrelated to this change (headless/CI
trusted-folder detection in the test environment).

`npx eslint` and `npx prettier --check` are clean on all changed files, and
`npm run typecheck` passes across all workspaces.

Fixes #29198.

---

_This PR was prepared with AI assistance (an autonomous coding agent
investigated the issue, traced the root cause, wrote the fix, and verified it
with the tests above). A human reviewed the change before submission._
