### PR TITLE
fix(core): skip non-numeric background PID lines

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -366,6 +366,39 @@ describe('ShellTool', () => {
       expect(fs.existsSync(extractedTmpFile)).toBe(false);
     });
 
+    it('should skip non-numeric background PID lines', async () => {
+      const debugErrorSpy = vi
+        .spyOn(debugLogger, 'error')
+        .mockImplementation(() => undefined);
+      try {
+        const invocation = shellTool.build({ command: 'my-command &' });
+        const promise = invocation.execute({ abortSignal: mockAbortSignal });
+
+        fs.writeFileSync(
+          extractedTmpFile,
+          [
+            '54321',
+            '54322',
+            'stray shell warning',
+            'sysmond service not found',
+          ].join(os.EOL),
+        );
+
+        resolveShellExecution({ pid: 54321 });
+
+        const result = await promise;
+
+        expect(debugErrorSpy).toHaveBeenCalledWith(
+          'background pid output: stray shell warning',
+        );
+        expect(result.llmContent).toContain('Background PIDs: 54322');
+        expect(result.llmContent).not.toContain('NaN');
+        expect(fs.existsSync(extractedTmpFile)).toBe(false);
+      } finally {
+        debugErrorSpy.mockRestore();
+      }
+    });
+
     it('should disable PTY execution when interactive shell is unavailable', async () => {
       (mockConfig.getEnableInteractiveShell as Mock).mockReturnValue(true);
       (mockConfig.isInteractiveShellEnabled as Mock).mockReturnValue(false);

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -757,6 +757,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
                 continue;
               }
               debugLogger.error(`background pid output: ${line}`);
+              continue;
             }
             const pid = Number(line);
             if (pid !== result.pid) {


### PR DESCRIPTION
## Summary

- skip unrecognized non-numeric background PID lines after logging them
- keep valid background PIDs in tool output while preventing `NaN` from reaching `llmContent`
- add regression coverage for mixed valid PID, stray warning, and known sysmond message lines

Fixes #29042

## Testing

```bash
npm test -w @google/gemini-cli-core -- src/tools/shell.test.ts
git diff --check
```
