### PR TITLE
fix(cli): validate system configuration path ownership and access con…

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -21,6 +21,7 @@ import {
   AuthType,
   type AdminControlsSettings,
   createCache,
+  isPathSecureSync,
 } from '@google/gemini-cli-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/builtin/light/default-light.js';
@@ -118,8 +119,13 @@ export function getSystemDefaultsPath(): string {
   if (process.env['GEMINI_CLI_SYSTEM_DEFAULTS_PATH']) {
     return process.env['GEMINI_CLI_SYSTEM_DEFAULTS_PATH'];
   }
-  return path.join(
-    path.dirname(getSystemSettingsPath()),
+  const systemSettingsPath = getSystemSettingsPath();
+  const pathHelper =
+    platform() === 'win32' || systemSettingsPath.includes('\\')
+      ? path.win32
+      : path;
+  return pathHelper.join(
+    pathHelper.dirname(systemSettingsPath),
     'system-defaults.json',
   );
 }
@@ -844,8 +850,34 @@ function _doLoadSettings(workspaceDir: string): LoadedSettings {
     return { settings: {}, rawSettings: {} };
   };
 
-  const systemResult = load(systemSettingsPath);
-  const systemDefaultsResult = load(systemDefaultsPath);
+  const validateSystemPath = (filePath: string, scopeName: string): boolean => {
+    if (!fs.existsSync(filePath)) {
+      return true;
+    }
+    const check = isPathSecureSync(filePath);
+    if (!check.secure) {
+      const reason = check.reason || 'insecure path permissions';
+      const message = `Skipping ${scopeName} configuration file ${filePath} due to insecure permissions: ${reason}`;
+      settingsErrors.push({
+        message,
+        path: filePath,
+        severity: 'warning',
+      });
+      coreEvents.emitFeedback('warning', message);
+      return false;
+    }
+    return true;
+  };
+
+  const systemResult = validateSystemPath(systemSettingsPath, 'system')
+    ? load(systemSettingsPath)
+    : { settings: {}, rawSettings: {} };
+  const systemDefaultsResult = validateSystemPath(
+    systemDefaultsPath,
+    'system default',
+  )
+    ? load(systemDefaultsPath)
+    : { settings: {}, rawSettings: {} };
   const userResult = load(USER_SETTINGS_PATH);
 
   let workspaceResult: {

--- a/packages/cli/src/config/system_defaults_security.test.ts
+++ b/packages/cli/src/config/system_defaults_security.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+vi.mock('os', async (importOriginal) => {
+  const actualOs = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actualOs,
+    platform: vi.fn(() => 'linux'),
+  };
+});
+
+vi.mock('fs', async (importOriginal) => {
+  const actualFs = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actualFs,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+vi.mock('@google/gemini-cli-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@google/gemini-cli-core')>();
+  return {
+    ...actual,
+    isPathSecureSync: vi.fn(actual.isPathSecureSync),
+  };
+});
+
+import * as core from '@google/gemini-cli-core';
+import {
+  loadSettings,
+  getSystemSettingsPath,
+  getSystemDefaultsPath,
+  resetSettingsCacheForTesting,
+} from './settings.js';
+
+describe('System configuration security validation', () => {
+  const mockSystemDefaultsPath = path.resolve(
+    '/mock/system/system-defaults.json',
+  );
+  const mockSystemSettingsPath = path.resolve('/mock/system/settings.json');
+  let feedbackSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetSettingsCacheForTesting();
+    core.clearSecurityCheckCacheForTesting();
+
+    vi.stubEnv('GEMINI_CLI_SYSTEM_DEFAULTS_PATH', mockSystemDefaultsPath);
+    vi.stubEnv('GEMINI_CLI_SYSTEM_SETTINGS_PATH', mockSystemSettingsPath);
+
+    (fs.existsSync as unknown as Mock).mockReturnValue(false);
+    (fs.readFileSync as unknown as Mock).mockReturnValue('{}');
+    (os.platform as unknown as Mock).mockReturnValue('linux');
+    (core.isPathSecureSync as unknown as Mock).mockReturnValue({
+      secure: true,
+    });
+
+    feedbackSpy = vi.spyOn(core.coreEvents, 'emitFeedback');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    core.clearSecurityCheckCacheForTesting();
+  });
+
+  it('skips system-defaults.json when path security check fails', () => {
+    (fs.existsSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemDefaultsPath) return true;
+      return false;
+    });
+
+    (fs.readFileSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemDefaultsPath) {
+        return JSON.stringify({
+          general: { enableAutoUpdate: false },
+        });
+      }
+      return '{}';
+    });
+
+    (core.isPathSecureSync as unknown as Mock).mockImplementation(
+      (targetPath: string) => {
+        if (targetPath === mockSystemDefaultsPath) {
+          return {
+            secure: false,
+            reason: 'Path owner is not an administrator',
+          };
+        }
+        return { secure: true };
+      },
+    );
+
+    const loadedSettings = loadSettings('/mock/workspace');
+
+    expect(loadedSettings.systemDefaults.settings).toEqual({});
+    expect(loadedSettings.merged.general?.enableAutoUpdate).toBe(true);
+
+    expect(feedbackSpy).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining(
+        `Skipping system default configuration file ${mockSystemDefaultsPath} due to insecure permissions`,
+      ),
+    );
+
+    const securityError = loadedSettings.errors.find(
+      (err) => err.path === mockSystemDefaultsPath,
+    );
+    expect(securityError).toBeDefined();
+    expect(securityError?.severity).toBe('warning');
+  });
+
+  it('skips system settings.json when path security check fails', () => {
+    (fs.existsSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemSettingsPath) return true;
+      return false;
+    });
+
+    (fs.readFileSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemSettingsPath) {
+        return JSON.stringify({
+          general: { enableAutoUpdate: false },
+        });
+      }
+      return '{}';
+    });
+
+    (core.isPathSecureSync as unknown as Mock).mockImplementation(
+      (targetPath: string) => {
+        if (targetPath === mockSystemSettingsPath) {
+          return {
+            secure: false,
+            reason: 'User groups have write permissions',
+          };
+        }
+        return { secure: true };
+      },
+    );
+
+    const loadedSettings = loadSettings('/mock/workspace');
+
+    expect(loadedSettings.system.settings).toEqual({});
+    expect(loadedSettings.merged.general?.enableAutoUpdate).toBe(true);
+
+    expect(feedbackSpy).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining(
+        `Skipping system configuration file ${mockSystemSettingsPath} due to insecure permissions`,
+      ),
+    );
+
+    const securityError = loadedSettings.errors.find(
+      (err) => err.path === mockSystemSettingsPath,
+    );
+    expect(securityError).toBeDefined();
+    expect(securityError?.severity).toBe('warning');
+  });
+
+  it('loads system defaults successfully when path is secure', () => {
+    (fs.existsSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemDefaultsPath) return true;
+      return false;
+    });
+
+    (fs.readFileSync as unknown as Mock).mockImplementation((p: string) => {
+      if (p === mockSystemDefaultsPath) {
+        return JSON.stringify({
+          general: { enableAutoUpdate: false },
+        });
+      }
+      return '{}';
+    });
+
+    (core.isPathSecureSync as unknown as Mock).mockReturnValue({
+      secure: true,
+    });
+
+    const loadedSettings = loadSettings('/mock/workspace');
+
+    expect(
+      loadedSettings.systemDefaults.settings.general?.enableAutoUpdate,
+    ).toBe(false);
+    expect(loadedSettings.merged.general?.enableAutoUpdate).toBe(false);
+    expect(feedbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles non-existent system configuration files gracefully', () => {
+    (fs.existsSync as unknown as Mock).mockReturnValue(false);
+
+    const loadedSettings = loadSettings('/mock/workspace');
+
+    expect(loadedSettings.systemDefaults.settings).toEqual({});
+    expect(loadedSettings.system.settings).toEqual({});
+    expect(core.isPathSecureSync).not.toHaveBeenCalled();
+    expect(feedbackSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves Windows system defaults path correctly on win32 platform', () => {
+    vi.unstubAllEnvs();
+    (os.platform as unknown as Mock).mockReturnValue('win32');
+
+    const expectedPath = 'C:\\ProgramData\\gemini-cli\\system-defaults.json';
+    expect(getSystemDefaultsPath()).toBe(expectedPath);
+    expect(getSystemSettingsPath()).toBe(
+      'C:\\ProgramData\\gemini-cli\\settings.json',
+    );
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,7 @@ export * from './utils/constants.js';
 export * from './utils/sessionUtils.js';
 export * from './utils/cache.js';
 export * from './utils/markdownUtils.js';
+export * from './utils/security.js';
 
 // Export services
 export * from './services/fileDiscoveryService.js';

--- a/packages/core/src/utils/security.test.ts
+++ b/packages/core/src/utils/security.test.ts
@@ -3,23 +3,39 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { isDirectorySecure } from './security.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isDirectorySecure,
+  isDirectorySecureSync,
+  isPathSecure,
+  isPathSecureSync,
+  clearSecurityCheckCacheForTesting,
+} from './security.js';
 import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 import { constants, type Stats } from 'node:fs';
 import * as os from 'node:os';
 import { spawnAsync } from './shell-utils.js';
+import { spawnSync } from 'node:child_process';
 
 vi.mock('node:fs/promises');
 vi.mock('node:fs');
 vi.mock('node:os');
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
 vi.mock('./shell-utils.js', () => ({
   spawnAsync: vi.fn(),
 }));
 
 describe('isDirectorySecure', () => {
+  beforeEach(() => {
+    clearSecurityCheckCacheForTesting();
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    clearSecurityCheckCacheForTesting();
   });
 
   it('returns secure=true on Windows if ACL check passes', async () => {
@@ -184,6 +200,220 @@ describe('isDirectorySecure', () => {
 
     const result = await isDirectorySecure('/some/path');
 
+    expect(result.secure).toBe(true);
+  });
+});
+
+describe('isDirectorySecureSync', () => {
+  beforeEach(() => {
+    clearSecurityCheckCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearSecurityCheckCacheForTesting();
+  });
+
+  it('returns secure=false if path is not a directory', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+      uid: 0,
+      mode: 0o755,
+    } as unknown as Stats);
+
+    const result = isDirectorySecureSync('/some/file');
+    expect(result.secure).toBe(false);
+    expect(result.reason).toBe('Not a directory');
+  });
+
+  it('returns secure=true if directory is owned by root and secure on POSIX', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => true,
+      uid: 0,
+      mode: 0o755,
+    } as unknown as Stats);
+
+    const result = isDirectorySecureSync('/etc/gemini-cli');
+    expect(result.secure).toBe(true);
+  });
+});
+
+describe('isPathSecureSync', () => {
+  beforeEach(() => {
+    clearSecurityCheckCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearSecurityCheckCacheForTesting();
+  });
+
+  it('returns secure=true if file does not exist (ENOENT)', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    const error = new Error('ENOENT');
+    Object.assign(error, { code: 'ENOENT' });
+    vi.mocked(fsSync.statSync).mockImplementation(() => {
+      throw error;
+    });
+
+    const result = isPathSecureSync('/non/existent/path.json');
+    expect(result.secure).toBe(true);
+  });
+
+  it('returns secure=false on Windows if path has untrusted owner', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: 'InsecureOwner: COMPUTER\\Attacker\n',
+      stderr: '',
+      status: 0,
+      pid: 1,
+      output: [],
+      signal: null,
+    });
+
+    const result = isPathSecureSync(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
+  });
+
+  it('returns secure=false on Windows if user groups have write permissions', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: 'BUILTIN\\Users\n',
+      stderr: '',
+      status: 0,
+      pid: 1,
+      output: [],
+      signal: null,
+    });
+
+    const result = isPathSecureSync(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('BUILTIN\\Users');
+  });
+
+  it('validates parent directory for files on POSIX and fails if parent is insecure', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
+
+    vi.mocked(fsSync.existsSync).mockReturnValue(true);
+    vi.mocked(fsSync.statSync).mockImplementation((target) => {
+      if (target === '/etc/gemini-cli/system-defaults.json') {
+        return {
+          isDirectory: () => false,
+          uid: 0,
+          mode: 0o644,
+        } as unknown as Stats;
+      }
+      // Parent directory owned by non-root
+      return {
+        isDirectory: () => true,
+        uid: 1000,
+        mode: 0o755,
+      } as unknown as Stats;
+    });
+
+    const result = isPathSecureSync('/etc/gemini-cli/system-defaults.json');
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('not owned by root (uid 0)');
+  });
+
+  it('returns secure=true on POSIX if both file and parent directory are secure', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
+
+    vi.mocked(fsSync.existsSync).mockReturnValue(true);
+    vi.mocked(fsSync.statSync).mockImplementation((target) => {
+      if (target === '/etc/gemini-cli/system-defaults.json') {
+        return {
+          isDirectory: () => false,
+          uid: 0,
+          mode: 0o644,
+        } as unknown as Stats;
+      }
+      return {
+        isDirectory: () => true,
+        uid: 0,
+        mode: 0o755,
+      } as unknown as Stats;
+    });
+
+    const result = isPathSecureSync('/etc/gemini-cli/system-defaults.json');
+    expect(result.secure).toBe(true);
+  });
+});
+
+describe('isPathSecure', () => {
+  beforeEach(() => {
+    clearSecurityCheckCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearSecurityCheckCacheForTesting();
+  });
+
+  it('returns secure=true if file does not exist (ENOENT)', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    const error = new Error('ENOENT');
+    Object.assign(error, { code: 'ENOENT' });
+    vi.mocked(fs.stat).mockRejectedValue(error);
+
+    const result = await isPathSecure('/non/existent/path.json');
+    expect(result.secure).toBe(true);
+  });
+
+  it('returns secure=false on Windows if path has untrusted owner', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fs.stat).mockResolvedValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnAsync).mockResolvedValue({
+      stdout: 'InsecureOwner: COMPUTER\\Attacker\n',
+      stderr: '',
+    });
+
+    const result = await isPathSecure(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
+  });
+
+  it('returns secure=true on POSIX if both file and parent directory are secure', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
+
+    vi.mocked(fsSync.existsSync).mockReturnValue(true);
+    vi.mocked(fs.stat).mockImplementation(async (target) => {
+      if (target === '/etc/gemini-cli/system-defaults.json') {
+        return {
+          isDirectory: () => false,
+          uid: 0,
+          mode: 0o644,
+        } as unknown as Stats;
+      }
+      return {
+        isDirectory: () => true,
+        uid: 0,
+        mode: 0o755,
+      } as unknown as Stats;
+    });
+
+    const result = await isPathSecure('/etc/gemini-cli/system-defaults.json');
     expect(result.secure).toBe(true);
   });
 });

--- a/packages/core/src/utils/security.test.ts
+++ b/packages/core/src/utils/security.test.ts
@@ -52,6 +52,7 @@ describe('isDirectorySecure', () => {
       expect.arrayContaining(['-Command', expect.stringContaining('Get-Acl')]),
       expect.objectContaining({
         env: expect.objectContaining({ GEMINI_TARGET_PATH: 'C:\\Some\\Path' }),
+        timeout: 5000,
       }),
     );
   });
@@ -284,7 +285,9 @@ describe('isPathSecureSync', () => {
       'C:\\ProgramData\\gemini-cli\\system-defaults.json',
     );
     expect(result.secure).toBe(false);
-    expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
+    expect(result.reason).toBe(
+      "File 'C:\\ProgramData\\gemini-cli\\system-defaults.json' is insecure. Owner is untrusted: COMPUTER\\Attacker. Only SYSTEM and Administrators may own system configuration paths.",
+    );
     expect(spawnSync).toHaveBeenCalledWith(
       'powershell',
       expect.anything(),
@@ -293,6 +296,7 @@ describe('isPathSecureSync', () => {
           GEMINI_TARGET_PATH:
             'C:\\ProgramData\\gemini-cli\\system-defaults.json',
         }),
+        timeout: 5000,
       }),
     );
   });
@@ -330,7 +334,62 @@ describe('isPathSecureSync', () => {
       'C:\\ProgramData\\gemini-cli\\system-defaults.json',
     );
     expect(result.secure).toBe(false);
-    expect(result.reason).toContain('BUILTIN\\Users');
+    expect(result.reason).toBe(
+      "File 'C:\\ProgramData\\gemini-cli\\system-defaults.json' is insecure. The following user groups have write permissions: BUILTIN\\Users. To fix this, remove Write and Modify permissions for these groups from the file's ACLs.",
+    );
+  });
+
+  it('recursively validates parent directories on Windows and leverages cache', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: '',
+      stderr: '',
+      status: 0,
+      pid: 1,
+      output: [],
+      signal: null,
+    });
+
+    const result1 = isPathSecureSync(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result1.secure).toBe(true);
+
+    const initialSpawnCount = vi.mocked(spawnSync).mock.calls.length;
+
+    // Second file in the same directory: parent directory C:\ProgramData\gemini-cli and ancestors should be cached
+    const result2 = isPathSecureSync(
+      'C:\\ProgramData\\gemini-cli\\settings.json',
+    );
+    expect(result2.secure).toBe(true);
+
+    // Only 1 additional spawn for settings.json itself, none for the already cached parent hierarchy
+    expect(vi.mocked(spawnSync).mock.calls.length).toBe(initialSpawnCount + 1);
+  });
+
+  it('returns secure=false on Windows if spawnSync times out or fails', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: '',
+      stderr: 'The process timed out',
+      status: 1,
+      pid: 1,
+      output: [],
+      signal: null,
+      error: new Error('spawnSync powershell ETIMEDOUT'),
+    });
+
+    const result = isPathSecureSync(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('ETIMEDOUT');
   });
 
   it('validates parent directory for files on POSIX and fails if parent is insecure', () => {
@@ -416,7 +475,64 @@ describe('isPathSecure', () => {
       'C:\\ProgramData\\gemini-cli\\system-defaults.json',
     );
     expect(result.secure).toBe(false);
-    expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
+    expect(result.reason).toBe(
+      "File 'C:\\ProgramData\\gemini-cli\\system-defaults.json' is insecure. Owner is untrusted: COMPUTER\\Attacker. Only SYSTEM and Administrators may own system configuration paths.",
+    );
+    expect(spawnAsync).toHaveBeenCalledWith(
+      'powershell',
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GEMINI_TARGET_PATH:
+            'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+        }),
+        timeout: 5000,
+      }),
+    );
+  });
+
+  it('returns secure=false on Windows if localized non-English group has write permissions', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fs.stat).mockResolvedValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnAsync).mockResolvedValue({
+      stdout: 'VORDEFINIERT\\Benutzer\n',
+      stderr: '',
+    });
+
+    const result = await isPathSecure(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain('VORDEFINIERT\\Benutzer');
+  });
+
+  it('recursively validates parent directories on Windows and leverages cache in isPathSecure', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+    vi.mocked(fs.stat).mockResolvedValue({
+      isDirectory: () => false,
+    } as unknown as Stats);
+    vi.mocked(spawnAsync).mockResolvedValue({
+      stdout: '',
+      stderr: '',
+    });
+
+    const result1 = await isPathSecure(
+      'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+    );
+    expect(result1.secure).toBe(true);
+
+    const initialSpawnCount = vi.mocked(spawnAsync).mock.calls.length;
+
+    // Second file in the same directory: parent directory C:\ProgramData\gemini-cli and ancestors should be cached
+    const result2 = await isPathSecure(
+      'C:\\ProgramData\\gemini-cli\\settings.json',
+    );
+    expect(result2.secure).toBe(true);
+
+    // Only 1 additional spawn for settings.json itself, none for the already cached parent hierarchy
+    expect(vi.mocked(spawnAsync).mock.calls.length).toBe(initialSpawnCount + 1);
   });
 
   it('returns secure=false on POSIX in isPathSecure if parent directory is insecure', async () => {

--- a/packages/core/src/utils/security.test.ts
+++ b/packages/core/src/utils/security.test.ts
@@ -50,6 +50,9 @@ describe('isDirectorySecure', () => {
     expect(spawnAsync).toHaveBeenCalledWith(
       'powershell',
       expect.arrayContaining(['-Command', expect.stringContaining('Get-Acl')]),
+      expect.objectContaining({
+        env: expect.objectContaining({ GEMINI_TARGET_PATH: 'C:\\Some\\Path' }),
+      }),
     );
   });
 
@@ -282,6 +285,31 @@ describe('isPathSecureSync', () => {
     );
     expect(result.secure).toBe(false);
     expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
+    expect(spawnSync).toHaveBeenCalledWith(
+      'powershell',
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GEMINI_TARGET_PATH:
+            'C:\\ProgramData\\gemini-cli\\system-defaults.json',
+        }),
+      }),
+    );
+  });
+
+  it('returns secure=false with File prefix on POSIX when file is not owned by root', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    vi.mocked(fsSync.statSync).mockReturnValue({
+      isDirectory: () => false,
+      uid: 1000,
+      mode: 0o644,
+    } as unknown as Stats);
+
+    const result = isPathSecureSync('/etc/gemini-cli/system-defaults.json');
+    expect(result.secure).toBe(false);
+    expect(result.reason).toBe(
+      'File \'/etc/gemini-cli/system-defaults.json\' is not owned by root (uid 0). Current uid: 1000. To fix this, run: sudo chown root:root "/etc/gemini-cli/system-defaults.json"',
+    );
   });
 
   it('returns secure=false on Windows if user groups have write permissions', () => {
@@ -309,7 +337,6 @@ describe('isPathSecureSync', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
 
-    vi.mocked(fsSync.existsSync).mockReturnValue(true);
     vi.mocked(fsSync.statSync).mockImplementation((target) => {
       if (target === '/etc/gemini-cli/system-defaults.json') {
         return {
@@ -335,7 +362,6 @@ describe('isPathSecureSync', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
 
-    vi.mocked(fsSync.existsSync).mockReturnValue(true);
     vi.mocked(fsSync.statSync).mockImplementation((target) => {
       if (target === '/etc/gemini-cli/system-defaults.json') {
         return {
@@ -393,11 +419,36 @@ describe('isPathSecure', () => {
     expect(result.reason).toContain('Owner is untrusted: COMPUTER\\Attacker');
   });
 
+  it('returns secure=false on POSIX in isPathSecure if parent directory is insecure', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
+
+    vi.mocked(fs.stat).mockImplementation(async (target) => {
+      if (target === '/etc/gemini-cli/system-defaults.json') {
+        return {
+          isDirectory: () => false,
+          uid: 0,
+          mode: 0o644,
+        } as unknown as Stats;
+      }
+      return {
+        isDirectory: () => true,
+        uid: 1000,
+        mode: 0o755,
+      } as unknown as Stats;
+    });
+
+    const result = await isPathSecure('/etc/gemini-cli/system-defaults.json');
+    expect(result.secure).toBe(false);
+    expect(result.reason).toContain(
+      "Directory '/etc/gemini-cli' is not owned by root (uid 0)",
+    );
+  });
+
   it('returns secure=true on POSIX if both file and parent directory are secure', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     Object.assign(constants, { S_IWGRP: 0, S_IWOTH: 0 });
 
-    vi.mocked(fsSync.existsSync).mockReturnValue(true);
     vi.mocked(fs.stat).mockImplementation(async (target) => {
       if (target === '/etc/gemini-cli/system-defaults.json') {
         return {

--- a/packages/core/src/utils/security.ts
+++ b/packages/core/src/utils/security.ts
@@ -5,13 +5,285 @@
  */
 
 import * as fs from 'node:fs/promises';
-import { constants } from 'node:fs';
+import * as fsSync from 'node:fs';
+import { constants, type Stats } from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { spawnAsync } from './shell-utils.js';
+import { isNodeError, getErrorMessage } from './errors.js';
 
 export interface SecurityCheckResult {
   secure: boolean;
   reason?: string;
+}
+
+const securityCheckCache = new Map<
+  string,
+  { result: SecurityCheckResult; expiresAt: number }
+>();
+
+const CACHE_TTL_MS = 10_000;
+
+/**
+ * Clears the path security cache. Used exclusively for test isolation.
+ */
+export function clearSecurityCheckCacheForTesting(): void {
+  securityCheckCache.clear();
+}
+
+function buildPowerShellAclScript(targetPath: string): string {
+  const escapedPath = targetPath.replace(/'/g, "''");
+  return `
+    $path = '${escapedPath}';
+    $acl = Get-Acl -LiteralPath $path;
+
+    $trustedSids = @('S-1-5-32-544', 'S-1-5-18', 'S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464');
+    $trustedNames = @('administrators', 'builtin\\administrators', 'system', 'nt authority\\system', 'trustedinstaller', 'nt service\\trustedinstaller');
+
+    # Check owner
+    $ownerSid = '';
+    try { $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value } catch {};
+    $ownerName = $acl.Owner;
+    $ownerIsTrusted = ($ownerSid -and ($trustedSids -contains $ownerSid)) -or
+                      ($ownerName -and ($trustedNames -contains $ownerName.ToLower()));
+
+    if (-not $ownerIsTrusted -and ($ownerName -or $ownerSid)) {
+        Write-Output "InsecureOwner: $($ownerName)";
+        exit 0;
+    }
+
+    $rules = $acl.Access | Where-Object { 
+        $_.AccessControlType -eq 'Allow' -and 
+        (($_.FileSystemRights -match 'Write') -or ($_.FileSystemRights -match 'Modify') -or ($_.FileSystemRights -match 'FullControl')) 
+    };
+    $insecureIdentity = $rules | Where-Object { 
+        $_.IdentityReference.Value -match 'Users' -or $_.IdentityReference.Value -eq 'Everyone' 
+    } | Select-Object -ExpandProperty IdentityReference;
+
+    if (-not $insecureIdentity) {
+        $insecureIdentity = $rules | Where-Object {
+            $rSid = '';
+            try { $rSid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value } catch {};
+            $rName = $_.IdentityReference.Value;
+            -not (
+                ($rSid -and ($trustedSids -contains $rSid)) -or
+                ($rName -and ($trustedNames -contains $rName.ToLower())) -or
+                ($rSid -eq 'S-1-3-0') -or
+                ($rName -eq 'CREATOR OWNER')
+            )
+        } | Select-Object -ExpandProperty IdentityReference;
+    }
+
+    Write-Output ($insecureIdentity -join ', ');
+  `;
+}
+
+function evaluateWindowsSecurityOutput(
+  stdout: string,
+  targetPath: string,
+): SecurityCheckResult {
+  const output = stdout.trim();
+  if (!output) {
+    return { secure: true };
+  }
+  if (output.startsWith('InsecureOwner:')) {
+    const owner = output.replace('InsecureOwner:', '').trim();
+    return {
+      secure: false,
+      reason: `Path '${targetPath}' is insecure. Owner is untrusted: ${owner}. Only SYSTEM and Administrators may own system configuration paths.`,
+    };
+  }
+  return {
+    secure: false,
+    reason: `Directory '${targetPath}' is insecure. The following user groups have write permissions: ${output}. To fix this, remove Write and Modify permissions for these groups from the directory's ACLs.`,
+  };
+}
+
+function checkPosixStats(
+  targetPath: string,
+  stats: Stats,
+): SecurityCheckResult {
+  // Check ownership: must be root (uid 0)
+  if (stats.uid !== 0) {
+    return {
+      secure: false,
+      reason: `Directory '${targetPath}' is not owned by root (uid 0). Current uid: ${stats.uid}. To fix this, run: sudo chown root:root "${targetPath}"`,
+    };
+  }
+
+  // Check permissions: not writable by group (S_IWGRP) or others (S_IWOTH)
+  const mode = stats.mode;
+  if ((mode & (constants.S_IWGRP | constants.S_IWOTH)) !== 0) {
+    return {
+      secure: false,
+      reason: `Directory '${targetPath}' is writable by group or others (mode: ${mode.toString(
+        8,
+      )}). To fix this, run: sudo chmod g-w,o-w "${targetPath}"`,
+    };
+  }
+
+  return { secure: true };
+}
+
+function validateSinglePathSync(targetPath: string): SecurityCheckResult {
+  try {
+    const stats = fsSync.statSync(targetPath);
+
+    if (os.platform() === 'win32') {
+      try {
+        const script = buildPowerShellAclScript(targetPath);
+        const { stdout, error, status } = spawnSync(
+          'powershell',
+          ['-NoProfile', '-NonInteractive', '-Command', script],
+          { encoding: 'utf-8' },
+        );
+
+        if (error || (status !== null && status !== 0)) {
+          return {
+            secure: false,
+            reason: `A security check for the system policy directory '${targetPath}' failed and could not be completed. Please file a bug report. Original error: ${error?.message || `exit code ${status}`}`,
+          };
+        }
+
+        return evaluateWindowsSecurityOutput(stdout || '', targetPath);
+      } catch (error) {
+        return {
+          secure: false,
+          reason: `A security check for the system policy directory '${targetPath}' failed and could not be completed. Please file a bug report. Original error: ${getErrorMessage(error)}`,
+        };
+      }
+    }
+
+    return checkPosixStats(targetPath, stats);
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return { secure: true };
+    }
+    return {
+      secure: false,
+      reason: `Failed to access directory: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+async function validateSinglePathAsync(
+  targetPath: string,
+): Promise<SecurityCheckResult> {
+  try {
+    const stats = await fs.stat(targetPath);
+
+    if (os.platform() === 'win32') {
+      try {
+        const script = buildPowerShellAclScript(targetPath);
+        const { stdout } = await spawnAsync('powershell', [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          script,
+        ]);
+        return evaluateWindowsSecurityOutput(stdout, targetPath);
+      } catch (error) {
+        return {
+          secure: false,
+          reason: `A security check for the system policy directory '${targetPath}' failed and could not be completed. Please file a bug report. Original error: ${getErrorMessage(error)}`,
+        };
+      }
+    }
+
+    return checkPosixStats(targetPath, stats);
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return { secure: true };
+    }
+    return {
+      secure: false,
+      reason: `Failed to access directory: ${getErrorMessage(error)}`,
+    };
+  }
+}
+
+/**
+ * Synchronously verifies if a file or directory path is secure against unauthorized modification.
+ * If targetPath is a file, both the file and its parent directory are validated.
+ *
+ * @param targetPath The path to check.
+ * @returns A SecurityCheckResult.
+ */
+export function isPathSecureSync(targetPath: string): SecurityCheckResult {
+  const cached = securityCheckCache.get(targetPath);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.result;
+  }
+
+  const result = (() => {
+    const targetCheck = validateSinglePathSync(targetPath);
+    if (!targetCheck.secure) {
+      return targetCheck;
+    }
+
+    const pathHelper = os.platform() === 'win32' ? path.win32 : path;
+    const parentDir = pathHelper.dirname(targetPath);
+    if (parentDir && parentDir !== targetPath && fsSync.existsSync(parentDir)) {
+      const parentCheck = validateSinglePathSync(parentDir);
+      if (!parentCheck.secure) {
+        return parentCheck;
+      }
+    }
+
+    return { secure: true };
+  })();
+
+  securityCheckCache.set(targetPath, {
+    result,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return result;
+}
+
+/**
+ * Asynchronously verifies if a file or directory path is secure against unauthorized modification.
+ * If targetPath is a file, both the file and its parent directory are validated.
+ *
+ * @param targetPath The path to check.
+ * @returns A promise that resolves to a SecurityCheckResult.
+ */
+export async function isPathSecure(
+  targetPath: string,
+): Promise<SecurityCheckResult> {
+  const cached = securityCheckCache.get(targetPath);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.result;
+  }
+
+  const targetCheck = await validateSinglePathAsync(targetPath);
+  if (!targetCheck.secure) {
+    securityCheckCache.set(targetPath, {
+      result: targetCheck,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return targetCheck;
+  }
+
+  const pathHelper = os.platform() === 'win32' ? path.win32 : path;
+  const parentDir = pathHelper.dirname(targetPath);
+  if (parentDir && parentDir !== targetPath && fsSync.existsSync(parentDir)) {
+    const parentCheck = await validateSinglePathAsync(parentDir);
+    if (!parentCheck.secure) {
+      securityCheckCache.set(targetPath, {
+        result: parentCheck,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      });
+      return parentCheck;
+    }
+  }
+
+  const secureResult: SecurityCheckResult = { secure: true };
+  securityCheckCache.set(targetPath, {
+    result: secureResult,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return secureResult;
 }
 
 /**
@@ -29,79 +301,41 @@ export async function isDirectorySecure(
     if (!stats.isDirectory()) {
       return { secure: false, reason: 'Not a directory' };
     }
-
-    if (os.platform() === 'win32') {
-      try {
-        // Check ACLs using PowerShell to ensure standard users don't have write access
-        const escapedPath = dirPath.replace(/'/g, "''");
-        const script = `
-          $path = '${escapedPath}';
-          $acl = Get-Acl -LiteralPath $path;
-          $rules = $acl.Access | Where-Object { 
-              $_.AccessControlType -eq 'Allow' -and 
-              (($_.FileSystemRights -match 'Write') -or ($_.FileSystemRights -match 'Modify') -or ($_.FileSystemRights -match 'FullControl')) 
-          };
-          $insecureIdentity = $rules | Where-Object { 
-              $_.IdentityReference.Value -match 'Users' -or $_.IdentityReference.Value -eq 'Everyone' 
-          } | Select-Object -ExpandProperty IdentityReference;
-          Write-Output ($insecureIdentity -join ', ');
-        `;
-
-        const { stdout } = await spawnAsync('powershell', [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          script,
-        ]);
-
-        const insecureGroups = stdout.trim();
-        if (insecureGroups) {
-          return {
-            secure: false,
-            reason: `Directory '${dirPath}' is insecure. The following user groups have write permissions: ${insecureGroups}. To fix this, remove Write and Modify permissions for these groups from the directory's ACLs.`,
-          };
-        }
-
-        return { secure: true };
-      } catch (error) {
-        return {
-          secure: false,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-          reason: `A security check for the system policy directory '${dirPath}' failed and could not be completed. Please file a bug report. Original error: ${(error as Error).message}`,
-        };
-      }
-    }
-
-    // POSIX checks
-    // Check ownership: must be root (uid 0)
-    if (stats.uid !== 0) {
-      return {
-        secure: false,
-        reason: `Directory '${dirPath}' is not owned by root (uid 0). Current uid: ${stats.uid}. To fix this, run: sudo chown root:root "${dirPath}"`,
-      };
-    }
-
-    // Check permissions: not writable by group (S_IWGRP) or others (S_IWOTH)
-    const mode = stats.mode;
-    if ((mode & (constants.S_IWGRP | constants.S_IWOTH)) !== 0) {
-      return {
-        secure: false,
-        reason: `Directory '${dirPath}' is writable by group or others (mode: ${mode.toString(
-          8,
-        )}). To fix this, run: sudo chmod g-w,o-w "${dirPath}"`,
-      };
-    }
-
-    return { secure: true };
   } catch (error) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (isNodeError(error) && error.code === 'ENOENT') {
       return { secure: true };
     }
     return {
       secure: false,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      reason: `Failed to access directory: ${(error as Error).message}`,
+      reason: `Failed to access directory: ${getErrorMessage(error)}`,
     };
   }
+
+  return validateSinglePathAsync(dirPath);
+}
+
+/**
+ * Synchronously verifies if a directory is secure.
+ *
+ * @param dirPath The path to the directory to check.
+ * @returns A SecurityCheckResult.
+ */
+export function isDirectorySecureSync(dirPath: string): SecurityCheckResult {
+  try {
+    const stats = fsSync.statSync(dirPath);
+
+    if (!stats.isDirectory()) {
+      return { secure: false, reason: 'Not a directory' };
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return { secure: true };
+    }
+    return {
+      secure: false,
+      reason: `Failed to access directory: ${getErrorMessage(error)}`,
+    };
+  }
+
+  return validateSinglePathSync(dirPath);
 }

--- a/packages/core/src/utils/security.ts
+++ b/packages/core/src/utils/security.ts
@@ -12,18 +12,17 @@ import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { spawnAsync } from './shell-utils.js';
 import { isNodeError, getErrorMessage } from './errors.js';
+import { createCache } from './cache.js';
 
 export interface SecurityCheckResult {
   secure: boolean;
   reason?: string;
 }
 
-const securityCheckCache = new Map<
-  string,
-  { result: SecurityCheckResult; expiresAt: number }
->();
-
-const CACHE_TTL_MS = 10_000;
+const securityCheckCache = createCache<string, SecurityCheckResult>({
+  storage: 'map',
+  defaultTtl: 10_000,
+});
 
 /**
  * Clears the path security cache. Used exclusively for test isolation.
@@ -32,10 +31,9 @@ export function clearSecurityCheckCacheForTesting(): void {
   securityCheckCache.clear();
 }
 
-function buildPowerShellAclScript(targetPath: string): string {
-  const escapedPath = targetPath.replace(/'/g, "''");
+function buildPowerShellAclScript(): string {
   return `
-    $path = '${escapedPath}';
+    $path = $env:GEMINI_TARGET_PATH;
     $acl = Get-Acl -LiteralPath $path;
 
     $trustedSids = @('S-1-5-32-544', 'S-1-5-18', 'S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464');
@@ -104,11 +102,12 @@ function checkPosixStats(
   targetPath: string,
   stats: Stats,
 ): SecurityCheckResult {
+  const pathType = stats.isDirectory() ? 'Directory' : 'File';
   // Check ownership: must be root (uid 0)
   if (stats.uid !== 0) {
     return {
       secure: false,
-      reason: `Directory '${targetPath}' is not owned by root (uid 0). Current uid: ${stats.uid}. To fix this, run: sudo chown root:root "${targetPath}"`,
+      reason: `${pathType} '${targetPath}' is not owned by root (uid 0). Current uid: ${stats.uid}. To fix this, run: sudo chown root:root "${targetPath}"`,
     };
   }
 
@@ -117,7 +116,7 @@ function checkPosixStats(
   if ((mode & (constants.S_IWGRP | constants.S_IWOTH)) !== 0) {
     return {
       secure: false,
-      reason: `Directory '${targetPath}' is writable by group or others (mode: ${mode.toString(
+      reason: `${pathType} '${targetPath}' is writable by group or others (mode: ${mode.toString(
         8,
       )}). To fix this, run: sudo chmod g-w,o-w "${targetPath}"`,
     };
@@ -132,11 +131,14 @@ function validateSinglePathSync(targetPath: string): SecurityCheckResult {
 
     if (os.platform() === 'win32') {
       try {
-        const script = buildPowerShellAclScript(targetPath);
+        const script = buildPowerShellAclScript();
         const { stdout, error, status } = spawnSync(
           'powershell',
           ['-NoProfile', '-NonInteractive', '-Command', script],
-          { encoding: 'utf-8' },
+          {
+            encoding: 'utf-8',
+            env: { ...process.env, GEMINI_TARGET_PATH: targetPath },
+          },
         );
 
         if (error || (status !== null && status !== 0)) {
@@ -175,13 +177,14 @@ async function validateSinglePathAsync(
 
     if (os.platform() === 'win32') {
       try {
-        const script = buildPowerShellAclScript(targetPath);
-        const { stdout } = await spawnAsync('powershell', [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          script,
-        ]);
+        const script = buildPowerShellAclScript();
+        const { stdout } = await spawnAsync(
+          'powershell',
+          ['-NoProfile', '-NonInteractive', '-Command', script],
+          {
+            env: { ...process.env, GEMINI_TARGET_PATH: targetPath },
+          },
+        );
         return evaluateWindowsSecurityOutput(stdout, targetPath);
       } catch (error) {
         return {
@@ -212,8 +215,8 @@ async function validateSinglePathAsync(
  */
 export function isPathSecureSync(targetPath: string): SecurityCheckResult {
   const cached = securityCheckCache.get(targetPath);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.result;
+  if (cached) {
+    return cached;
   }
 
   const result = (() => {
@@ -224,7 +227,7 @@ export function isPathSecureSync(targetPath: string): SecurityCheckResult {
 
     const pathHelper = os.platform() === 'win32' ? path.win32 : path;
     const parentDir = pathHelper.dirname(targetPath);
-    if (parentDir && parentDir !== targetPath && fsSync.existsSync(parentDir)) {
+    if (parentDir && parentDir !== targetPath) {
       const parentCheck = validateSinglePathSync(parentDir);
       if (!parentCheck.secure) {
         return parentCheck;
@@ -234,10 +237,7 @@ export function isPathSecureSync(targetPath: string): SecurityCheckResult {
     return { secure: true };
   })();
 
-  securityCheckCache.set(targetPath, {
-    result,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
+  securityCheckCache.set(targetPath, result);
   return result;
 }
 
@@ -252,37 +252,28 @@ export async function isPathSecure(
   targetPath: string,
 ): Promise<SecurityCheckResult> {
   const cached = securityCheckCache.get(targetPath);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.result;
+  if (cached) {
+    return cached;
   }
 
   const targetCheck = await validateSinglePathAsync(targetPath);
   if (!targetCheck.secure) {
-    securityCheckCache.set(targetPath, {
-      result: targetCheck,
-      expiresAt: Date.now() + CACHE_TTL_MS,
-    });
+    securityCheckCache.set(targetPath, targetCheck);
     return targetCheck;
   }
 
   const pathHelper = os.platform() === 'win32' ? path.win32 : path;
   const parentDir = pathHelper.dirname(targetPath);
-  if (parentDir && parentDir !== targetPath && fsSync.existsSync(parentDir)) {
+  if (parentDir && parentDir !== targetPath) {
     const parentCheck = await validateSinglePathAsync(parentDir);
     if (!parentCheck.secure) {
-      securityCheckCache.set(targetPath, {
-        result: parentCheck,
-        expiresAt: Date.now() + CACHE_TTL_MS,
-      });
+      securityCheckCache.set(targetPath, parentCheck);
       return parentCheck;
     }
   }
 
   const secureResult: SecurityCheckResult = { secure: true };
-  securityCheckCache.set(targetPath, {
-    result: secureResult,
-    expiresAt: Date.now() + CACHE_TTL_MS,
-  });
+  securityCheckCache.set(targetPath, secureResult);
   return secureResult;
 }
 

--- a/packages/core/src/utils/security.ts
+++ b/packages/core/src/utils/security.ts
@@ -33,7 +33,13 @@ export function clearSecurityCheckCacheForTesting(): void {
 
 function buildPowerShellAclScript(): string {
   return `
+    $ErrorActionPreference = 'Stop';
     $path = $env:GEMINI_TARGET_PATH;
+    if (-not $path) {
+        Write-Error "GEMINI_TARGET_PATH environment variable is not set";
+        exit 1;
+    }
+
     $acl = Get-Acl -LiteralPath $path;
 
     $trustedSids = @('S-1-5-32-544', 'S-1-5-18', 'S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464');
@@ -47,7 +53,8 @@ function buildPowerShellAclScript(): string {
                       ($ownerName -and ($trustedNames -contains $ownerName.ToLower()));
 
     if (-not $ownerIsTrusted -and ($ownerName -or $ownerSid)) {
-        Write-Output "InsecureOwner: $($ownerName)";
+        $ownerDisplay = if ($ownerName) { $ownerName } else { $ownerSid };
+        Write-Output "InsecureOwner: $ownerDisplay";
         exit 0;
     }
 
@@ -55,23 +62,17 @@ function buildPowerShellAclScript(): string {
         $_.AccessControlType -eq 'Allow' -and 
         (($_.FileSystemRights -match 'Write') -or ($_.FileSystemRights -match 'Modify') -or ($_.FileSystemRights -match 'FullControl')) 
     };
-    $insecureIdentity = $rules | Where-Object { 
-        $_.IdentityReference.Value -match 'Users' -or $_.IdentityReference.Value -eq 'Everyone' 
-    } | Select-Object -ExpandProperty IdentityReference;
-
-    if (-not $insecureIdentity) {
-        $insecureIdentity = $rules | Where-Object {
-            $rSid = '';
-            try { $rSid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value } catch {};
-            $rName = $_.IdentityReference.Value;
-            -not (
-                ($rSid -and ($trustedSids -contains $rSid)) -or
-                ($rName -and ($trustedNames -contains $rName.ToLower())) -or
-                ($rSid -eq 'S-1-3-0') -or
-                ($rName -eq 'CREATOR OWNER')
-            )
-        } | Select-Object -ExpandProperty IdentityReference;
-    }
+    $insecureIdentity = $rules | Where-Object {
+        $rSid = '';
+        try { $rSid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value } catch {};
+        $rName = $_.IdentityReference.Value;
+        -not (
+            ($rSid -and ($trustedSids -contains $rSid)) -or
+            ($rName -and ($trustedNames -contains $rName.ToLower())) -or
+            ($rSid -eq 'S-1-3-0') -or
+            ($rName -eq 'CREATOR OWNER')
+        )
+    } | Select-Object -ExpandProperty IdentityReference -Unique;
 
     Write-Output ($insecureIdentity -join ', ');
   `;
@@ -80,6 +81,7 @@ function buildPowerShellAclScript(): string {
 function evaluateWindowsSecurityOutput(
   stdout: string,
   targetPath: string,
+  pathType: 'Directory' | 'File' = 'Directory',
 ): SecurityCheckResult {
   const output = stdout.trim();
   if (!output) {
@@ -89,12 +91,12 @@ function evaluateWindowsSecurityOutput(
     const owner = output.replace('InsecureOwner:', '').trim();
     return {
       secure: false,
-      reason: `Path '${targetPath}' is insecure. Owner is untrusted: ${owner}. Only SYSTEM and Administrators may own system configuration paths.`,
+      reason: `${pathType} '${targetPath}' is insecure. Owner is untrusted: ${owner}. Only SYSTEM and Administrators may own system configuration paths.`,
     };
   }
   return {
     secure: false,
-    reason: `Directory '${targetPath}' is insecure. The following user groups have write permissions: ${output}. To fix this, remove Write and Modify permissions for these groups from the directory's ACLs.`,
+    reason: `${pathType} '${targetPath}' is insecure. The following user groups have write permissions: ${output}. To fix this, remove Write and Modify permissions for these groups from the ${pathType.toLowerCase()}'s ACLs.`,
   };
 }
 
@@ -128,27 +130,35 @@ function checkPosixStats(
 function validateSinglePathSync(targetPath: string): SecurityCheckResult {
   try {
     const stats = fsSync.statSync(targetPath);
+    const pathType = stats.isDirectory() ? 'Directory' : 'File';
 
     if (os.platform() === 'win32') {
       try {
         const script = buildPowerShellAclScript();
-        const { stdout, error, status } = spawnSync(
+        const { stdout, error, status, stderr } = spawnSync(
           'powershell',
           ['-NoProfile', '-NonInteractive', '-Command', script],
           {
             encoding: 'utf-8',
             env: { ...process.env, GEMINI_TARGET_PATH: targetPath },
+            timeout: 5000,
           },
         );
 
         if (error || (status !== null && status !== 0)) {
+          const detail =
+            error?.message || (stderr ? stderr.trim() : `exit code ${status}`);
           return {
             secure: false,
-            reason: `A security check for the system policy directory '${targetPath}' failed and could not be completed. Please file a bug report. Original error: ${error?.message || `exit code ${status}`}`,
+            reason: `A security check for the system policy directory '${targetPath}' failed and could not be completed. Please file a bug report. Original error: ${detail}`,
           };
         }
 
-        return evaluateWindowsSecurityOutput(stdout || '', targetPath);
+        return evaluateWindowsSecurityOutput(
+          stdout || '',
+          targetPath,
+          pathType,
+        );
       } catch (error) {
         return {
           secure: false,
@@ -164,7 +174,7 @@ function validateSinglePathSync(targetPath: string): SecurityCheckResult {
     }
     return {
       secure: false,
-      reason: `Failed to access directory: ${getErrorMessage(error)}`,
+      reason: `Failed to access path: ${getErrorMessage(error)}`,
     };
   }
 }
@@ -174,6 +184,7 @@ async function validateSinglePathAsync(
 ): Promise<SecurityCheckResult> {
   try {
     const stats = await fs.stat(targetPath);
+    const pathType = stats.isDirectory() ? 'Directory' : 'File';
 
     if (os.platform() === 'win32') {
       try {
@@ -183,9 +194,10 @@ async function validateSinglePathAsync(
           ['-NoProfile', '-NonInteractive', '-Command', script],
           {
             env: { ...process.env, GEMINI_TARGET_PATH: targetPath },
+            timeout: 5000,
           },
         );
-        return evaluateWindowsSecurityOutput(stdout, targetPath);
+        return evaluateWindowsSecurityOutput(stdout, targetPath, pathType);
       } catch (error) {
         return {
           secure: false,
@@ -201,7 +213,7 @@ async function validateSinglePathAsync(
     }
     return {
       secure: false,
-      reason: `Failed to access directory: ${getErrorMessage(error)}`,
+      reason: `Failed to access path: ${getErrorMessage(error)}`,
     };
   }
 }
@@ -228,7 +240,7 @@ export function isPathSecureSync(targetPath: string): SecurityCheckResult {
     const pathHelper = os.platform() === 'win32' ? path.win32 : path;
     const parentDir = pathHelper.dirname(targetPath);
     if (parentDir && parentDir !== targetPath) {
-      const parentCheck = validateSinglePathSync(parentDir);
+      const parentCheck = isPathSecureSync(parentDir);
       if (!parentCheck.secure) {
         return parentCheck;
       }
@@ -265,7 +277,7 @@ export async function isPathSecure(
   const pathHelper = os.platform() === 'win32' ? path.win32 : path;
   const parentDir = pathHelper.dirname(targetPath);
   if (parentDir && parentDir !== targetPath) {
-    const parentCheck = await validateSinglePathAsync(parentDir);
+    const parentCheck = await isPathSecure(parentDir);
     if (!parentCheck.secure) {
       securityCheckCache.set(targetPath, parentCheck);
       return parentCheck;


### PR DESCRIPTION
…trols

Enforce filesystem ownership and access control checks before loading system configuration files (system-defaults.json and settings.json).

On Windows, verify that the configuration file and containing directory are owned by privileged accounts (Administrators, SYSTEM, or TrustedInstaller) and that standard user groups do not possess write or modify permissions. On POSIX platforms, verify root ownership (uid 0) and restrictive permissions (g-w, o-w).

If access control checks fail, system configuration files are skipped and reported via feedback warnings without crashing the CLI.

## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ ] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
