### PR TITLE
fix(cli): isolate settings directory in sandbox containers

### DIFF
--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -836,6 +836,61 @@ describe('sandbox', () => {
       );
     });
 
+    it('should mount an isolated settings directory rather than exposing host credentials', async () => {
+      const config: SandboxConfig = createMockSandboxConfig({
+        command: 'docker',
+        image: 'gemini-cli-sandbox',
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      interface MockProcessWithStdout extends EventEmitter {
+        stdout: EventEmitter;
+      }
+      const mockImageCheckProcess = new EventEmitter() as MockProcessWithStdout;
+      mockImageCheckProcess.stdout = new EventEmitter();
+      vi.mocked(spawn).mockImplementationOnce(() => {
+        setTimeout(() => {
+          mockImageCheckProcess.stdout.emit('data', Buffer.from('image-id'));
+          mockImageCheckProcess.emit('close', 0);
+        }, 1);
+        return mockImageCheckProcess as unknown as ReturnType<typeof spawn>;
+      });
+
+      const mockSpawnProcess = new EventEmitter() as unknown as ReturnType<
+        typeof spawn
+      >;
+      mockSpawnProcess.on = vi.fn().mockImplementation((event, cb) => {
+        if (event === 'close') {
+          setTimeout(() => cb(0), 10);
+        }
+        return mockSpawnProcess;
+      });
+      vi.mocked(spawn).mockImplementationOnce(() => mockSpawnProcess);
+
+      await start_sandbox(config);
+
+      // Verify that docker run does NOT mount the raw host settings directory directly
+      expect(spawn).toHaveBeenNthCalledWith(
+        2,
+        'docker',
+        expect.not.arrayContaining(['/home/user/.gemini:/home/node/.gemini']),
+        expect.any(Object),
+      );
+
+      // Verify that docker run mounts the isolated settings directory
+      expect(spawn).toHaveBeenNthCalledWith(
+        2,
+        'docker',
+        expect.arrayContaining([
+          '--volume',
+          expect.stringMatching(
+            /gemini-sandbox-settings.*:[\\/]home[\\/]node[\\/]\.gemini/,
+          ),
+        ]),
+        expect.any(Object),
+      );
+    });
+
     it('should handle allowedPaths in Docker', async () => {
       const config: SandboxConfig = createMockSandboxConfig({
         command: 'docker',

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -38,6 +38,7 @@ import {
   SANDBOX_NETWORK_NAME,
   SANDBOX_PROXY_NAME,
   BUILTIN_SEATBELT_PROFILES,
+  prepareIsolatedSettingsDir,
 } from './sandboxUtils.js';
 import { BUILTIN_SEATBELT_PROFILE_CONTENTS } from './sandboxBuiltinProfiles.js';
 
@@ -59,8 +60,20 @@ export async function start_sandbox(
   let stopProxy: (() => void) | undefined = undefined;
   let tempProfileFile: string | null = null;
   let sandboxTmpDir: string | null = null;
+  let isolatedSettingsDir: string | null = null;
 
   const cleanup = () => {
+    if (isolatedSettingsDir) {
+      const dirToDelete = isolatedSettingsDir;
+      isolatedSettingsDir = null;
+      try {
+        if (fs.existsSync(dirToDelete)) {
+          fs.rmSync(dirToDelete, { recursive: true, force: true });
+        }
+      } catch {
+        // ignore
+      }
+    }
     if (sandboxTmpDir) {
       const dirToDelete = sandboxTmpDir;
       sandboxTmpDir = null;
@@ -72,6 +85,7 @@ export async function start_sandbox(
         // ignore
       }
     }
+
     if (tempProfileFile) {
       const fileToDelete = tempProfileFile;
       tempProfileFile = null;
@@ -453,14 +467,13 @@ export async function start_sandbox(
       fs.mkdirSync(userSettingsDirOnHost, { recursive: true });
     }
 
-    args.push(
-      '--volume',
-      `${userSettingsDirOnHost}:${userSettingsDirInSandbox}`,
-    );
+    isolatedSettingsDir = prepareIsolatedSettingsDir(userSettingsDirOnHost);
+
+    args.push('--volume', `${isolatedSettingsDir}:${userSettingsDirInSandbox}`);
     if (userSettingsDirInSandbox !== getContainerPath(userSettingsDirOnHost)) {
       args.push(
         '--volume',
-        `${userSettingsDirOnHost}:${getContainerPath(userSettingsDirOnHost)}`,
+        `${isolatedSettingsDir}:${getContainerPath(userSettingsDirOnHost)}`,
       );
     }
 

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -337,6 +337,16 @@ describe('sandboxUtils', () => {
       ).toBe(false);
     });
 
+    it('should not false-positive on nested bin or tmp directories inside commands or skills', () => {
+      const rootDir = '/home/user/.gemini';
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/commands/bin', rootDir),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/skills/tmp', rootDir),
+      ).toBe(false);
+    });
+
     it('should not filter out the root directory itself', () => {
       const rootDir = '/home/user/.gemini';
       expect(isCredentialOrSensitivePath(rootDir, rootDir)).toBe(false);

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -324,6 +324,19 @@ describe('sandboxUtils', () => {
       );
     });
 
+    it('should not false-positive on user scripts containing credential in filename', () => {
+      expect(
+        isCredentialOrSensitivePath(
+          '/home/user/.gemini/commands/setup-credentials.sh',
+        ),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath(
+          '/home/user/.gemini/skills/credential-helper.js',
+        ),
+      ).toBe(false);
+    });
+
     it('should not filter out the root directory itself', () => {
       const rootDir = '/home/user/.gemini';
       expect(isCredentialOrSensitivePath(rootDir, rootDir)).toBe(false);

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -14,6 +14,9 @@ import {
   ports,
   entrypoint,
   shouldUseCurrentUserInSandbox,
+  isCredentialOrSensitivePath,
+  prepareIsolatedSettingsDir,
+  SENSITIVE_SETTINGS_FILENAMES,
 } from './sandboxUtils.js';
 
 vi.mock('node:os');
@@ -33,6 +36,7 @@ describe('sandboxUtils', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv };
+    vi.mocked(os.tmpdir).mockReturnValue('/tmp');
     // Clean up these env vars that might affect tests
     delete process.env['NODE_ENV'];
     delete process.env['DEBUG'];
@@ -236,6 +240,131 @@ describe('sandboxUtils', () => {
       delete process.env['SANDBOX_SET_UID_GID'];
       vi.mocked(os.platform).mockReturnValue('darwin');
       expect(await shouldUseCurrentUserInSandbox()).toBe(false);
+    });
+  });
+
+  describe('isCredentialOrSensitivePath', () => {
+    it('should include known credential filenames in SENSITIVE_SETTINGS_FILENAMES', () => {
+      expect(SENSITIVE_SETTINGS_FILENAMES.has('oauth_creds.json')).toBe(true);
+      expect(SENSITIVE_SETTINGS_FILENAMES.has('google_accounts.json')).toBe(
+        true,
+      );
+      expect(SENSITIVE_SETTINGS_FILENAMES.has('gemini-credentials.json')).toBe(
+        true,
+      );
+      expect(SENSITIVE_SETTINGS_FILENAMES.has('mcp-oauth-tokens.json')).toBe(
+        true,
+      );
+      expect(SENSITIVE_SETTINGS_FILENAMES.has('a2a-oauth-tokens.json')).toBe(
+        true,
+      );
+    });
+
+    it('should identify known credential and auth filenames as sensitive', () => {
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/oauth_creds.json'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/google_accounts.json'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath(
+          '/home/user/.gemini/gemini-credentials.json',
+        ),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/mcp-oauth-tokens.json'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/a2a-oauth-tokens.json'),
+      ).toBe(true);
+    });
+
+    it('should identify tokens, credentials, and sensitive directories', () => {
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/custom-tokens.json'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/api.credentials'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/user_creds.json'),
+      ).toBe(true);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/history')).toBe(
+        true,
+      );
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/tmp')).toBe(true);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/bin')).toBe(true);
+    });
+
+    it('should allow non-sensitive configuration files and directories', () => {
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/settings.json'),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/keybindings.json'),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/trustedFolders.json'),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/policy_integrity.json'),
+      ).toBe(false);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/commands')).toBe(
+        false,
+      );
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/skills')).toBe(
+        false,
+      );
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/policies')).toBe(
+        false,
+      );
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/agents')).toBe(
+        false,
+      );
+    });
+
+    it('should not filter out the root directory itself', () => {
+      const rootDir = '/home/user/.gemini';
+      expect(isCredentialOrSensitivePath(rootDir, rootDir)).toBe(false);
+    });
+  });
+
+  describe('prepareIsolatedSettingsDir', () => {
+    it('should create an isolated directory and copy files with credential filter', () => {
+      const fakeHostSettingsDir = '/home/user/.gemini';
+      const fakeIsolatedDir = '/tmp/gemini-sandbox-settings-xyz';
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.mkdtempSync).mockReturnValue(fakeIsolatedDir);
+
+      const result = prepareIsolatedSettingsDir(fakeHostSettingsDir);
+
+      expect(fs.mkdtempSync).toHaveBeenCalledWith(
+        expect.stringContaining('gemini-sandbox-settings-'),
+      );
+      expect(fs.cpSync).toHaveBeenCalledWith(
+        fakeHostSettingsDir,
+        fakeIsolatedDir,
+        expect.objectContaining({
+          recursive: true,
+          filter: expect.any(Function),
+        }),
+      );
+      expect(result).toBe(fakeIsolatedDir);
+    });
+
+    it('should return isolated directory even if source settings directory does not exist', () => {
+      const fakeHostSettingsDir = '/home/user/.gemini';
+      const fakeIsolatedDir = '/tmp/gemini-sandbox-settings-xyz';
+
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdtempSync).mockReturnValue(fakeIsolatedDir);
+
+      const result = prepareIsolatedSettingsDir(fakeHostSettingsDir);
+
+      expect(result).toBe(fakeIsolatedDir);
+      expect(fs.cpSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -290,6 +290,18 @@ describe('sandboxUtils', () => {
       expect(
         isCredentialOrSensitivePath('/home/user/.gemini/user_creds.json'),
       ).toBe(true);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/.env')).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/private.key'),
+      ).toBe(true);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/cert.pem')).toBe(
+        true,
+      );
+      expect(
+        isCredentialOrSensitivePath(
+          '/home/user/.gemini/service-account-key.json',
+        ),
+      ).toBe(true);
       expect(isCredentialOrSensitivePath('/home/user/.gemini/history')).toBe(
         true,
       );

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -284,11 +284,20 @@ describe('sandboxUtils', () => {
       expect(
         isCredentialOrSensitivePath('/home/user/.gemini/custom-tokens.json'),
       ).toBe(true);
+      expect(isCredentialOrSensitivePath('/home/user/.gemini/token.json')).toBe(
+        true,
+      );
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/github-token'),
+      ).toBe(true);
       expect(
         isCredentialOrSensitivePath('/home/user/.gemini/api.credentials'),
       ).toBe(true);
       expect(
         isCredentialOrSensitivePath('/home/user/.gemini/user_creds.json'),
+      ).toBe(true);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/user_cred.json'),
       ).toBe(true);
       expect(isCredentialOrSensitivePath('/home/user/.gemini/.env')).toBe(true);
       expect(
@@ -378,6 +387,7 @@ describe('sandboxUtils', () => {
       expect(fs.mkdtempSync).toHaveBeenCalledWith(
         expect.stringContaining('gemini-sandbox-settings-'),
       );
+      expect(fs.chmodSync).toHaveBeenCalledWith(fakeIsolatedDir, 0o700);
       expect(fs.cpSync).toHaveBeenCalledWith(
         fakeHostSettingsDir,
         fakeIsolatedDir,
@@ -398,6 +408,7 @@ describe('sandboxUtils', () => {
 
       const result = prepareIsolatedSettingsDir(fakeHostSettingsDir);
 
+      expect(fs.chmodSync).toHaveBeenCalledWith(fakeIsolatedDir, 0o700);
       expect(result).toBe(fakeIsolatedDir);
       expect(fs.cpSync).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/utils/sandboxUtils.test.ts
+++ b/packages/cli/src/utils/sandboxUtils.test.ts
@@ -358,6 +358,18 @@ describe('sandboxUtils', () => {
       ).toBe(false);
     });
 
+    it('should not false-positive on words sharing sensitive substrings without separators', () => {
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/monkey.json'),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/sacred.json'),
+      ).toBe(false);
+      expect(
+        isCredentialOrSensitivePath('/home/user/.gemini/commands/tokenized.js'),
+      ).toBe(false);
+    });
+
     it('should not false-positive on nested bin or tmp directories inside commands or skills', () => {
       const rootDir = '/home/user/.gemini';
       expect(

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -56,9 +56,10 @@ export function isCredentialOrSensitivePath(
   }
   if (
     base.endsWith('.credentials') ||
-    base.includes('tokens.json') ||
-    base.includes('creds.json') ||
-    base.includes('credential')
+    base.endsWith('credentials') ||
+    base.endsWith('credentials.json') ||
+    base.endsWith('tokens.json') ||
+    base.endsWith('creds.json')
   ) {
     return true;
   }

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -62,7 +62,13 @@ export function isCredentialOrSensitivePath(
     base.endsWith('credentials') ||
     base.endsWith('credentials.json') ||
     base.endsWith('tokens.json') ||
-    base.endsWith('creds.json')
+    base.endsWith('creds.json') ||
+    base === '.env' ||
+    base.endsWith('.env') ||
+    base.endsWith('.key') ||
+    base.endsWith('.pem') ||
+    base.endsWith('.p12') ||
+    base.endsWith('key.json')
   ) {
     return true;
   }

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -6,6 +6,7 @@
 
 import os from 'node:os';
 import fs from 'node:fs';
+import path from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { quote } from 'shell-quote';
 import { debugLogger, GEMINI_DIR } from '@google/gemini-cli-core';
@@ -23,6 +24,75 @@ export const BUILTIN_SEATBELT_PROFILES = [
   'strict-open',
   'strict-proxied',
 ];
+
+/**
+ * Known sensitive or credential file names that must not be mounted into the sandbox container.
+ */
+export const SENSITIVE_SETTINGS_FILENAMES = new Set([
+  'oauth_creds.json',
+  'google_accounts.json',
+  'gemini-credentials.json',
+  'mcp-oauth-tokens.json',
+  'a2a-oauth-tokens.json',
+]);
+
+/**
+ * Returns true if the given file or directory path corresponds to credentials or sensitive data
+ * that must not be mounted into the untrusted sandbox container.
+ */
+export function isCredentialOrSensitivePath(
+  targetPath: string,
+  rootDir?: string,
+): boolean {
+  if (rootDir && path.resolve(targetPath) === path.resolve(rootDir)) {
+    return false;
+  }
+  const base = path.basename(targetPath).toLowerCase();
+  if (SENSITIVE_SETTINGS_FILENAMES.has(base)) {
+    return true;
+  }
+  if (base === 'history' || base === 'tmp' || base === 'bin') {
+    return true;
+  }
+  if (
+    base.endsWith('.credentials') ||
+    base.includes('tokens.json') ||
+    base.includes('creds.json') ||
+    base.includes('credential')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Creates an isolated settings directory in a temporary location, populated with non-sensitive
+ * configuration files from the user settings directory while excluding credential and auth files.
+ */
+export function prepareIsolatedSettingsDir(
+  userSettingsDirOnHost: string,
+): string {
+  const baseTmpDir = os.tmpdir() || '/tmp';
+  const isolatedDir = fs.mkdtempSync(
+    path.join(baseTmpDir, 'gemini-sandbox-settings-'),
+  );
+
+  if (fs.existsSync(userSettingsDirOnHost)) {
+    try {
+      fs.cpSync(userSettingsDirOnHost, isolatedDir, {
+        recursive: true,
+        filter: (source) =>
+          !isCredentialOrSensitivePath(source, userSettingsDirOnHost),
+      });
+    } catch (err) {
+      debugLogger.warn(
+        `Failed to copy user settings to sandbox directory: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return isolatedDir;
+}
 
 export function getContainerPath(hostPath: string): string {
   if (os.platform() !== 'win32') {

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -51,7 +51,10 @@ export function isCredentialOrSensitivePath(
   if (SENSITIVE_SETTINGS_FILENAMES.has(base)) {
     return true;
   }
-  if (base === 'history' || base === 'tmp' || base === 'bin') {
+  const isRootChild = rootDir
+    ? path.dirname(path.resolve(targetPath)) === path.resolve(rootDir)
+    : true;
+  if (isRootChild && (base === 'history' || base === 'tmp' || base === 'bin')) {
     return true;
   }
   if (

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -62,7 +62,10 @@ export function isCredentialOrSensitivePath(
     base.endsWith('credentials') ||
     base.endsWith('credentials.json') ||
     base.endsWith('tokens.json') ||
+    base.endsWith('token.json') ||
+    base.endsWith('token') ||
     base.endsWith('creds.json') ||
+    base.endsWith('cred.json') ||
     base === '.env' ||
     base.endsWith('.env') ||
     base.endsWith('.key') ||
@@ -86,6 +89,7 @@ export function prepareIsolatedSettingsDir(
   const isolatedDir = fs.mkdtempSync(
     path.join(baseTmpDir, 'gemini-sandbox-settings-'),
   );
+  fs.chmodSync(isolatedDir, 0o700);
 
   if (fs.existsSync(userSettingsDirOnHost)) {
     try {

--- a/packages/cli/src/utils/sandboxUtils.ts
+++ b/packages/cli/src/utils/sandboxUtils.ts
@@ -57,21 +57,29 @@ export function isCredentialOrSensitivePath(
   if (isRootChild && (base === 'history' || base === 'tmp' || base === 'bin')) {
     return true;
   }
+  const hasSensitiveSuffix = (s: string) => {
+    if (base === s) return true;
+    if (base.endsWith(s)) {
+      const charBefore = base.charAt(base.length - s.length - 1);
+      return charBefore === '-' || charBefore === '_' || charBefore === '.';
+    }
+    return false;
+  };
+
   if (
     base.endsWith('.credentials') ||
-    base.endsWith('credentials') ||
-    base.endsWith('credentials.json') ||
-    base.endsWith('tokens.json') ||
-    base.endsWith('token.json') ||
-    base.endsWith('token') ||
-    base.endsWith('creds.json') ||
-    base.endsWith('cred.json') ||
-    base === '.env' ||
+    hasSensitiveSuffix('credentials') ||
+    hasSensitiveSuffix('credentials.json') ||
+    hasSensitiveSuffix('tokens.json') ||
+    hasSensitiveSuffix('token.json') ||
+    hasSensitiveSuffix('token') ||
+    hasSensitiveSuffix('creds.json') ||
+    hasSensitiveSuffix('cred.json') ||
     base.endsWith('.env') ||
     base.endsWith('.key') ||
     base.endsWith('.pem') ||
     base.endsWith('.p12') ||
-    base.endsWith('key.json')
+    hasSensitiveSuffix('key.json')
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

When running Gemini CLI inside a container sandbox (Docker/Podman), the user configuration directory was previously mounted directly from the host's `~/.gemini` folder. This could inadvertently expose sensitive local credentials (such as OAuth tokens, account credentials, and authentication stores) within the container's execution boundary.

This change isolates the mounted settings directory by creating a session-scoped temporary directory on the host that includes only non-sensitive configuration (e.g., `settings.json`, custom commands, skills, policies, keybindings, and trusted folders) while strictly omitting credential stores. The temporary settings directory is automatically cleaned up upon container process completion.

## Details

1. **Selective Settings Copy & Credential Omission**:
   - Introduced `prepareIsolatedSettingsDir` and `isCredentialOrSensitivePath` in `packages/cli/src/utils/sandboxUtils.ts`.
   - Explicitly redacts known credential and token stores (`oauth_creds.json`, `google_accounts.json`, `gemini-credentials.json`, `mcp-oauth-tokens.json`, `a2a-oauth-tokens.json`, and wildcard credential/token patterns).
   - Omits session history and cache stores (`history/`, `tmp/`, `bin/`).
   - Copies user configuration files and directories (`settings.json`, `commands/`, `skills/`, `policies/`, `keybindings.json`, `trustedFolders.json`).

2. **Container Volume Isolation**:
   - Updated `packages/cli/src/utils/sandbox.ts` to mount the isolated directory into `/home/node/.gemini` (and the containerized host settings mirror) instead of mounting the host's raw `.gemini` directory.
   - Retained all existing functional volume mounts (workspace `workdir`, temp directory, `~/.config/gcloud`, and `GOOGLE_APPLICATION_CREDENTIALS` for Vertex AI ADC workflows).

3. **Lifecycle Cleanup**:
   - Registered `isolatedSettingsDir` for automatic cleanup via `fs.rmSync` in the `cleanup()` handler executed on process exit, `SIGINT`, and `SIGTERM`.

4. **Testing**:
   - Added unit test in `packages/cli/src/utils/sandbox.test.ts` verifying that `start_sandbox` mounts the isolated directory and does not mount raw host `.gemini` folders.
   - Added unit test suite in `packages/cli/src/utils/sandboxUtils.test.ts` testing credential identification and isolation logic.

## Related Issues

## How to Validate

1. Run the sandbox unit tests:
   ```bash
   npm test -w @google/gemini-cli -- src/utils/sandbox.test.ts
   npm test -w @google/gemini-cli -- src/utils/sandboxUtils.test.ts
   ```
   **Expected result**: All tests pass, verifying that the container receives an isolated settings directory without credential files.

## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [ ] Updated relevant documentation and README (if needed)
- [ x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ x] Linux
    - [ x] npm run
    - [ ] npx
    - [ x] Docker
