### PR TITLE
fix(config): prevent rewriting explicitly pinned flash models

### DIFF
--- a/packages/core/src/config/defaultModelConfigs.ts
+++ b/packages/core/src/config/defaultModelConfigs.ts
@@ -492,12 +492,6 @@ export const DEFAULT_MODEL_CONFIGS: ModelConfigServiceConfig = {
         },
       ],
     },
-    'gemini-2.5-flash': {
-      default: 'gemini-2.5-flash',
-      contexts: [
-        { condition: { useGemini3_5Flash: true }, target: 'gemini-3.5-flash' },
-      ],
-    },
     'gemini-3-pro-preview': {
       default: 'gemini-3-pro-preview',
       contexts: [

--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   resolveModel,
   resolveClassifierModel,
@@ -19,6 +19,7 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_3_5_FLASH_MODEL,
   DEFAULT_GEMINI_FLASH_LITE_MODEL,
+  setFlashModels,
   supportsMultimodalFunctionResponse,
   GEMINI_MODEL_ALIAS_PRO,
   GEMINI_MODEL_ALIAS_FLASH,
@@ -787,7 +788,20 @@ describe('resolveModel Gemini 3.5 Flash GA', () => {
     ).toBe(PREVIEW_GEMINI_FLASH_MODEL);
   });
 
-  it('should resolve all but preview flash models to gemini-3.5-flash when useGemini3_5Flash is true (dynamic)', () => {
+  describe('explicit gemini-2.5-flash', () => {
+    afterEach(() => {
+      setFlashModels('gemini-3-flash-preview', 'gemini-2.5-flash');
+    });
+
+    it('should not rewrite explicitly requested gemini-2.5-flash to gemini-3.5-flash', () => {
+      setFlashModels('gemini-3.5-flash', 'gemini-3.5-flash');
+      expect(
+        resolveModel('gemini-2.5-flash', false, false, true, undefined, true),
+      ).toBe('gemini-2.5-flash');
+    });
+  });
+
+  it('should resolve flash alias to gemini-3.5-flash but leave concrete models untouched (dynamic)', () => {
     const mockDynamicConfig = {
       getExperimentalDynamicModelConfiguration: () => true,
       modelConfigService,
@@ -805,14 +819,14 @@ describe('resolveModel Gemini 3.5 Flash GA', () => {
     ).toBe('gemini-3.5-flash');
     expect(
       resolveModel(
-        DEFAULT_GEMINI_FLASH_MODEL,
+        'gemini-2.5-flash',
         false,
         false,
         true,
         mockDynamicConfig,
         true,
       ),
-    ).toBe('gemini-3.5-flash');
+    ).toBe('gemini-2.5-flash');
     expect(
       resolveModel(
         PREVIEW_GEMINI_FLASH_MODEL,

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -265,8 +265,7 @@ function isFlashModel(model: string): boolean {
     model === PREVIEW_GEMINI_FLASH_MODEL ||
     model === DEFAULT_GEMINI_3_5_FLASH_MODEL ||
     model === SECONDARY_GEMINI_3_5_FLASH_MODEL ||
-    model === 'flash' ||
-    model.endsWith('flash')
+    model === 'flash'
   );
 }
 


### PR DESCRIPTION
## Summary

When invoking Gemini CLI with `--model gemini-2.5-flash`, the model resolution logic silently rewrote the request to `gemini-3.5-flash` on backends where Gemini 3.5 Flash GA access is enabled (such as Vertex AI). For environments without access to `gemini-3.5-flash`, this resulted in a `ModelNotFoundError`.

This PR fixes model resolution so that explicitly pinned model IDs (like `gemini-2.5-flash`) are preserved and passed through untouched, while ensuring generic aliases (like `'flash'`) continue to resolve to `gemini-3.5-flash` as expected.

## Details

- **Legacy Model Resolution (`packages/core/src/config/models.ts`)**:
  - Removed `model.endsWith('flash')` from `isFlashModel()`. This catch-all condition was matching concrete model IDs such as `gemini-2.5-flash` and incorrectly treating them as generic flash aliases eligible for auto-upgrade.
- **Dynamic Model Config (`packages/core/src/config/defaultModelConfigs.ts`)**:
  - Removed the `'gemini-2.5-flash'` entry from `modelIdResolutions`. In dynamic model configuration, concrete model IDs without explicit resolution rules automatically fall back to the requested model name.
- **Regression Tests (`packages/core/src/config/models.test.ts`)**:
  - Added unit tests to ensure `gemini-2.5-flash` is not rewritten under both legacy and dynamic routing, while verifying that the generic `'flash'` alias continues to resolve to `gemini-3.5-flash`.

## Related Issues

Fixes #29213

## How to Validate

1. Verify resolution logic directly:
```bash
npx tsx -e "
import { resolveModel, setFlashModels } from './packages/core/src/config/models.ts';
setFlashModels('gemini-3.5-flash', 'gemini-3.5-flash');
console.log('Concrete model:', resolveModel('gemini-2.5-flash', false, false, true, undefined, true));
console.log('Flash alias:', resolveModel('flash', false, false, true, undefined, true));
"
```
Expected output:
- `Concrete model: gemini-2.5-flash`
- `Flash alias: gemini-3.5-flash`

2. Run targeted tests:
```bash
npm test -w @google/gemini-cli-core -- src/config/models.test.ts
```

3. Run typecheck and linter:
```bash
npm run typecheck --workspace @google/gemini-cli-core
npm run lint --workspace @google/gemini-cli-core
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
