### PR TITLE
docs: fix stale JSDoc parameter names

### DIFF
--- a/packages/core/src/agents/a2a-client-manager.ts
+++ b/packages/core/src/agents/a2a-client-manager.ts
@@ -80,7 +80,7 @@ export class A2AClientManager {
   /**
    * Loads an agent by fetching its AgentCard and caches the client.
    * @param name The name to assign to the agent.
-   * @param agentCardUrl The full URL to the agent's card.
+   * @param options Load options, including the resolved agent card URL.
    * @param authHandler Optional authentication handler to use for this agent.
    * @returns The loaded AgentCard.
    */

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -70,8 +70,7 @@ export class WorkspaceContext {
   /**
    * Adds a directory to the workspace.
    * @param directory The directory path to add (can be relative or absolute)
-   * @param basePath Optional base path for resolving relative paths (defaults to cwd)
-   * @throws Error if the directory cannot be added
+   *    * @throws Error if the directory cannot be added
    */
   addDirectory(directory: string): void {
     const result = this.addDirectories([directory]);


### PR DESCRIPTION
Two JSDoc blocks documented parameters that no longer exist:

1. `packages/core/src/utils/workspaceContext.ts` `addDirectory`: documented `basePath`, removed when path resolution moved into `addDirectories`
2. `packages/core/src/agents/a2a-client-manager.ts` `loadAgent`: documented `agentCardUrl`; the URL now rides inside the `AgentCardLoadOptions` object

Docstrings only — no code change.