### PR TITLE
Fix: list_background_processes prints (Exit Code: null) for signal-killed processes

### DIFF
--- a/packages/core/src/tools/shellBackgroundTools.test.ts
+++ b/packages/core/src/tools/shellBackgroundTools.test.ts
@@ -102,6 +102,117 @@ describe('Background Tools', () => {
     );
   });
 
+  it('list_background_processes should omit exit-code clause when exitCode is null', async () => {
+    const pid = 98990;
+    const history = new Map();
+    history.set(pid, {
+      command: 'killed command',
+      status: 'exited',
+      exitCode: null,
+      startTime: Date.now(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ShellExecutionService as any).backgroundProcessHistory.set(
+      'default',
+      history,
+    );
+
+    const invocation = listTool.build({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+    const result = await invocation.execute({
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(result.llmContent).toContain(
+      `- [PID ${pid}] EXITED: \`killed command\``,
+    );
+    expect(result.llmContent).not.toContain('(Exit Code:');
+  });
+
+  it('list_background_processes should omit exit-code clause when exitCode is undefined', async () => {
+    const pid = 98991;
+    const history = new Map();
+    history.set(pid, {
+      command: 'unknown exit command',
+      status: 'exited',
+      startTime: Date.now(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ShellExecutionService as any).backgroundProcessHistory.set(
+      'default',
+      history,
+    );
+
+    const invocation = listTool.build({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+    const result = await invocation.execute({
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(result.llmContent).toContain(
+      `- [PID ${pid}] EXITED: \`unknown exit command\``,
+    );
+    expect(result.llmContent).not.toContain('(Exit Code:');
+  });
+
+  it('list_background_processes should show exit code 0', async () => {
+    const pid = 98992;
+    const history = new Map();
+    history.set(pid, {
+      command: 'success command',
+      status: 'exited',
+      exitCode: 0,
+      startTime: Date.now(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ShellExecutionService as any).backgroundProcessHistory.set(
+      'default',
+      history,
+    );
+
+    const invocation = listTool.build({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+    const result = await invocation.execute({
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(result.llmContent).toContain(
+      `- [PID ${pid}] EXITED: \`success command\` (Exit Code: 0)`,
+    );
+  });
+
+  it('list_background_processes should show signal without exit-code when exitCode is null', async () => {
+    const pid = 98993;
+    const history = new Map();
+    history.set(pid, {
+      command: 'signaled command',
+      status: 'exited',
+      exitCode: null,
+      signal: 15,
+      startTime: Date.now(),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (ShellExecutionService as any).backgroundProcessHistory.set(
+      'default',
+      history,
+    );
+
+    const invocation = listTool.build({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (invocation as any).context = { config: { getSessionId: () => 'default' } };
+    const result = await invocation.execute({
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(result.llmContent).toContain(
+      `- [PID ${pid}] EXITED: \`signaled command\` (Signal: 15)`,
+    );
+    expect(result.llmContent).not.toContain('(Exit Code:');
+  });
+
   it('read_background_output should return error if log file does not exist', async () => {
     const pid = 12345 + Math.floor(Math.random() * 1000);
     const history = new Map();

--- a/packages/core/src/tools/shellBackgroundTools.ts
+++ b/packages/core/src/tools/shellBackgroundTools.ts
@@ -56,7 +56,7 @@ class ListBackgroundProcessesInvocation extends BaseToolInvocation<
     const lines = processes.map(
       (p) =>
         `- [PID ${p.pid}] ${p.status.toUpperCase()}: \`${p.command}\`${
-          p.exitCode !== undefined ? ` (Exit Code: ${p.exitCode})` : ''
+          typeof p.exitCode === 'number' ? ` (Exit Code: ${p.exitCode})` : ''
         }${p.signal ? ` (Signal: ${p.signal})` : ''}`,
     );
 


### PR DESCRIPTION
## Summary

<!-- Concisely describe what this PR changes and why. Focus on impact and
urgency. -->

- Stop printing `(Exit Code: null)` from `list_background_processes` when a background process has no numeric exit code (signal kill / `exitCode: null`).
- Guard the clause with `typeof p.exitCode === 'number'` in `shellBackgroundTools.ts`.
- Add unit tests for `null`, undefined, `0`, and signal-only listings in `src/tools/shellBackgroundTools.test.ts`.

## Details

<!-- Add any extra context and design decisions. Keep it brief but complete. -->
No design decisions were made for this change.

## Related Issues

<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
only related to an issue or is a partial fix, simply reference the issue number
without a keyword (Related to #123). -->
Fixes #29167 

## How to Validate

<!-- List exact steps for reviewers to validate the change. Include commands,
expected results, and edge cases. -->
Run `npx vitest run src/tools/shellBackgroundTools.test.ts`.
## Pre-Merge Checklist

<!-- Check all that apply before requesting review or merging. -->

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [x] npm run
    - [x] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
