### PR TITLE
fix(cli): prevent ghost text wrapping infinite loop at narrow widths

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -5394,6 +5394,41 @@ describe('InputPrompt', () => {
     });
   });
 
+  describe('ghost text wrapping', () => {
+    it('does not freeze when ghost text contains wide chars and inputWidth is narrow', async () => {
+      // Regression for #19985: when inputWidth is smaller than a wide
+      // character's rendered width, the hard-split loop must still advance.
+      // buffer.text must be non-empty so getGhostTextLines does not early-return.
+      props.inputWidth = 1;
+      props.suggestionsWidth = 1;
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        promptCompletion: {
+          text: 'a' + '好'.repeat(10),
+          accept: vi.fn(),
+          clear: vi.fn(),
+          isLoading: false,
+          isActive: true,
+          markSelected: vi.fn(),
+        },
+      });
+      mockBuffer.text = 'a';
+      mockBuffer.lines = ['a'];
+      mockBuffer.cursor = [0, 1];
+
+      const { lastFrame, unmount } = await renderWithProviders(
+        <TestInputPrompt {...props} />,
+        { uiState: {} },
+      );
+
+      // Without the guard this hang pegs CPU and the wait times out.
+      await waitFor(() => {
+        expect(lastFrame()).toBeDefined();
+      });
+      unmount();
+    });
+  });
+
   describe('terminal buffer rendering', () => {
     it('does not clip the last char of a visual line whose width equals inputWidth', async () => {
       const fullLine = '1234567890'; // 10 chars, exactly props.inputWidth

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1515,6 +1515,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 partWidth += charWidth;
                 splitIndex = i + 1;
               }
+              // When inputWidth is narrower than a single codepoint, nothing
+              // fits and splitIndex stays 0, causing an infinite loop. Force-
+              // advance by one codepoint so the loop always terminates.
+              if (splitIndex === 0 && wordCP.length > 0) {
+                part = wordCP[0];
+                splitIndex = 1;
+              }
               additionalLines.push(part);
               wordToProcess = cpSlice(wordToProcess, splitIndex);
             }


### PR DESCRIPTION
Fixes #19985

### Description
In `packages/cli/src/ui/components/InputPrompt.tsx`, `getGhostTextLines` attempts to wrap words using a while loop:
```typescript
while (stringWidth(wordToProcess) > inputWidth) {
  let part = '';
  const wordCP = toCodePoints(wordToProcess);
  let partWidth = 0;
  let splitIndex = 0;
  for (let i = 0; i < wordCP.length; i++) {
    const char = wordCP[i];
    const charWidth = stringWidth(char);
    if (partWidth + charWidth > inputWidth) {
      break;
    }
    part += char;
    partWidth += charWidth;
    splitIndex = i + 1;
  }
  additionalLines.push(part);
  wordToProcess = cpSlice(wordToProcess, splitIndex);
}
```

When `inputWidth` is narrower than a single character's rendered width (such as wide CJK or emoji characters with width 2 in narrow terminals where `inputWidth <= 1`), `splitIndex` stays `0`. Because `wordToProcess = cpSlice(wordToProcess, splitIndex)` fails to shrink, the loop spins indefinitely at 100% CPU and freezes the terminal prompt.

### Solution
Added a safeguard after the character width loop:
```typescript
if (splitIndex === 0 && wordCP.length > 0) {
  part = wordCP[0];
  splitIndex = 1;
}
```
This guarantees that `wordToProcess` shrinks by at least one code point per iteration, ensuring the hard-split loop always terminates.

### Testing
- Added regression test in `packages/cli/src/ui/components/InputPrompt.test.tsx` under `describe('ghost text wrapping')` verifying that rendering with narrow `inputWidth = 1` and wide character ghost text completes without hanging.
- All 200 unit tests in `InputPrompt.test.tsx` pass cleanly.
- `npm run typecheck --workspace @google/gemini-cli` passed with 0 errors.
- `eslint` passed with 0 warnings.