### PR TITLE
fix(core): stop matching 401 as a substring in isAuthenticationError

### DIFF
--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -103,6 +103,24 @@ describe('isAuthenticationError', () => {
     expect(isAuthenticationError(new Error('401 Unauthorized'))).toBe(true);
     expect(isAuthenticationError(new Error('HTTP 401'))).toBe(true);
     expect(isAuthenticationError(new Error('Status code: 401'))).toBe(true);
+    expect(
+      isAuthenticationError(
+        new Error('Error POSTing to endpoint (HTTP 401): denied'),
+      ),
+    ).toBe(true);
+  });
+
+  it('should not match 401 as a substring of a larger number', () => {
+    expect(isAuthenticationError(new Error('listening on port 4012'))).toBe(
+      false,
+    );
+    expect(
+      isAuthenticationError(new Error('connection refused at 127.0.0.1:4015')),
+    ).toBe(false);
+    expect(isAuthenticationError(new Error('processed 24013 records'))).toBe(
+      false,
+    );
+    expect(isAuthenticationError(new Error('error at line 1401'))).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -298,8 +298,10 @@ export function isAuthenticationError(error: unknown): boolean {
 
   // Fallback: Check for MCP SDK's plain Error messages with HTTP 401
   // The SDK sometimes throws: new Error(`Error POSTing to endpoint (HTTP 401): ...`)
+  // Match 401 as a standalone status code, not as a substring of a larger
+  // number (e.g. a port like 4012 or an id), which produced false positives.
   const message = getErrorMessage(error);
-  if (message.includes('401')) {
+  if (/\b401\b/.test(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

`isAuthenticationError` fell back to `message.includes('401')`, which matches any error message containing `401` as a substring — a port number like `4012`, an id, or a line number — and misreports those as authentication errors. That can trigger a spurious re-auth / logout flow on errors that have nothing to do with auth.

## Details

The other branches of `isAuthenticationError` (numeric `code === 401`, `UnauthorizedError`) are precise; only the string fallback was too loose. This changes it to match `401` as a standalone number token (`\b401\b`) instead of a raw substring, so a larger number that merely contains `401` no longer matches, while real messages like `HTTP 401`, `401 Unauthorized`, `Status code: 401`, and the MCP SDK's `Error POSTing to endpoint (HTTP 401): ...` still resolve.

## Related Issues

Fixes #28203

## How to Validate

```bash
cd packages/core
npx vitest run src/utils/errors.test.ts
```

The `isAuthenticationError` suite adds cases that the old substring check failed:
- true (unchanged): `401 Unauthorized`, `HTTP 401`, `Status code: 401`, `Error POSTing to endpoint (HTTP 401): denied`
- false (previously true): `listening on port 4012`, `connection refused at 127.0.0.1:4015`, `processed 24013 records`, `error at line 1401`

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any) — none; behavior only narrows to genuine 401s
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run (vitest, all 30 tests in errors.test.ts pass; RED confirmed on the prior code)
