### PR TITLE
fix(core): make tool file writes atomic and serialize same-path writes

### DIFF
--- a/packages/core/src/services/fileSystemService.atomic.test.ts
+++ b/packages/core/src/services/fileSystemService.atomic.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { StandardFileSystemService } from './fileSystemService.js';
+
+/**
+ * These tests exercise the real filesystem on purpose: the behaviour under
+ * test is what a concurrent observer can see on disk while a write is in
+ * flight, which a mocked `fs` cannot express.
+ */
+describe('StandardFileSystemService atomicity', () => {
+  let dir: string;
+  let service: StandardFileSystemService;
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'gemini-atomic-write-'));
+    service = new StandardFileSystemService();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true });
+  });
+
+  it('never exposes a partially written file to a concurrent observer', async () => {
+    // Large enough that the underlying write is split into several chunks;
+    // old and new are the same length so any other size is a partial state.
+    const SIZE = 16 * 1024 * 1024;
+    const filePath = path.join(dir, 'large.txt');
+    await fsp.writeFile(filePath, 'o'.repeat(SIZE), 'utf-8');
+
+    // The write runs on the libuv threadpool, so a *synchronous* loop on the
+    // main thread is what actually catches the destination mid-write. An
+    // async reader tends to be scheduled only before or after it.
+    const sizes = new Set<number>();
+    let settled = false;
+    const write = service
+      .writeTextFile(filePath, 'n'.repeat(SIZE))
+      .finally(() => {
+        settled = true;
+      });
+
+    let spins = 0;
+    while (!settled && spins < 2_000_000) {
+      try {
+        sizes.add(fs.statSync(filePath).size);
+      } catch {
+        // The destination may briefly not exist while being replaced.
+        sizes.add(-1);
+      }
+      spins++;
+      if (spins % 200 === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    }
+    await write;
+
+    // Guard against a vacuous pass where the observer never ran.
+    expect(sizes.size).toBeGreaterThan(0);
+
+    const partialStates = [...sizes].filter((size) => size !== SIZE);
+    expect(partialStates).toEqual([]);
+  });
+
+  it('writes the requested content', async () => {
+    const filePath = path.join(dir, 'content.txt');
+
+    await service.writeTextFile(filePath, 'hello');
+
+    await expect(fsp.readFile(filePath, 'utf-8')).resolves.toBe('hello');
+  });
+
+  it('preserves the permissions of an existing file', async () => {
+    const filePath = path.join(dir, 'secret.txt');
+    await fsp.writeFile(filePath, 'before', { mode: 0o600 });
+    await fsp.chmod(filePath, 0o600);
+
+    await service.writeTextFile(filePath, 'after');
+
+    const stats = await fsp.stat(filePath);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  it('leaves no temporary files behind on success', async () => {
+    const filePath = path.join(dir, 'clean.txt');
+
+    await service.writeTextFile(filePath, 'done');
+
+    await expect(fsp.readdir(dir)).resolves.toEqual(['clean.txt']);
+  });
+});

--- a/packages/core/src/services/fileSystemService.test.ts
+++ b/packages/core/src/services/fileSystemService.test.ts
@@ -51,12 +51,50 @@ describe('StandardFileSystemService', () => {
 
       await fileSystem.writeTextFile('/test/file.txt', 'Hello, World!');
 
-      const [tmpPath, content, encoding] = vi.mocked(fs.writeFile).mock
-        .calls[0] as [string, string, string];
+      const [tmpPath, content, options] = vi.mocked(fs.writeFile).mock
+        .calls[0] as [string, string, { encoding: string }];
       expect(content).toBe('Hello, World!');
-      expect(encoding).toBe('utf-8');
+      expect(options.encoding).toBe('utf-8');
       expect(tmpPath).toMatch(/^\/test\/file\.txt\..*\.tmp$/);
       expect(fs.rename).toHaveBeenCalledWith(tmpPath, '/test/file.txt');
+    });
+
+    it('should create the temp file with the destination permissions', async () => {
+      vi.mocked(fs.writeFile).mockResolvedValue();
+      vi.mocked(fs.rename).mockResolvedValue();
+      vi.mocked(fs.chmod).mockResolvedValue();
+      vi.mocked(fs.stat).mockResolvedValue({
+        mode: 0o600,
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+
+      await fileSystem.writeTextFile('/test/secret.txt', 'Hello, World!');
+
+      // Creating the temp file already restricted means the content is never
+      // briefly readable through a wider default mode.
+      const [, , options] = vi.mocked(fs.writeFile).mock.calls[0];
+      expect(options).toEqual({ encoding: 'utf-8', mode: 0o600 });
+    });
+
+    it('should still write the file when chmod is not permitted', async () => {
+      vi.mocked(fs.writeFile).mockResolvedValue();
+      vi.mocked(fs.rename).mockResolvedValue();
+      vi.mocked(fs.rm).mockResolvedValue();
+      vi.mocked(fs.stat).mockResolvedValue({
+        mode: 0o600,
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+      // FAT32/exFAT, some NFS/CIFS mounts and restricted sandboxes reject chmod.
+      vi.mocked(fs.chmod).mockRejectedValue(
+        Object.assign(new Error('operation not supported'), {
+          code: 'ENOTSUP',
+        }),
+      );
+
+      await expect(
+        fileSystem.writeTextFile('/test/file.txt', 'Hello, World!'),
+      ).resolves.toBeUndefined();
+
+      expect(fs.rename).toHaveBeenCalled();
+      expect(fs.rm).not.toHaveBeenCalled();
     });
 
     it('should remove the temp file when the write fails', async () => {

--- a/packages/core/src/services/fileSystemService.test.ts
+++ b/packages/core/src/services/fileSystemService.test.ts
@@ -44,16 +44,32 @@ describe('StandardFileSystemService', () => {
   });
 
   describe('writeTextFile', () => {
-    it('should write file content using fs', async () => {
+    it('should write to a sibling temp file and rename it into place', async () => {
       vi.mocked(fs.writeFile).mockResolvedValue();
+      vi.mocked(fs.rename).mockResolvedValue();
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
 
       await fileSystem.writeTextFile('/test/file.txt', 'Hello, World!');
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        '/test/file.txt',
-        'Hello, World!',
-        'utf-8',
-      );
+      const [tmpPath, content, encoding] = vi.mocked(fs.writeFile).mock
+        .calls[0] as [string, string, string];
+      expect(content).toBe('Hello, World!');
+      expect(encoding).toBe('utf-8');
+      expect(tmpPath).toMatch(/^\/test\/file\.txt\..*\.tmp$/);
+      expect(fs.rename).toHaveBeenCalledWith(tmpPath, '/test/file.txt');
+    });
+
+    it('should remove the temp file when the write fails', async () => {
+      vi.mocked(fs.writeFile).mockRejectedValue(new Error('ENOSPC'));
+      vi.mocked(fs.rm).mockResolvedValue();
+
+      await expect(
+        fileSystem.writeTextFile('/test/file.txt', 'Hello, World!'),
+      ).rejects.toThrow('ENOSPC');
+
+      expect(fs.rename).not.toHaveBeenCalled();
+      const [removed] = vi.mocked(fs.rm).mock.calls[0] as [string];
+      expect(removed).toMatch(/^\/test\/file\.txt\..*\.tmp$/);
     });
   });
 });

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -54,15 +54,30 @@ export class StandardFileSystemService implements FileSystemService {
     // concurrent writers do not clobber each other's temp file.
     const tmpPath = `${filePath}.${randomUUID()}.tmp`;
 
-    try {
-      await fs.writeFile(tmpPath, content, 'utf-8');
+    // A fresh temp file does not inherit the destination's permissions, so
+    // without this, replacing a 0600 file would silently widen it to the
+    // default mode.
+    const existingMode = await this.getFileMode(filePath);
 
-      // A fresh temp file does not inherit the destination's permissions, so
-      // copy them over before the rename. Without this, replacing a 0600 file
-      // would silently widen it to the default mode.
-      const existingMode = await this.getFileMode(filePath);
+    try {
+      // Create the temp file already carrying the destination's mode, so the
+      // content is never briefly readable through a wider default mode. The
+      // mode is masked by umask, so this can only be more restrictive.
+      await fs.writeFile(tmpPath, content, {
+        encoding: 'utf-8',
+        ...(existingMode !== undefined ? { mode: existingMode } : {}),
+      });
+
       if (existingMode !== undefined) {
-        await fs.chmod(tmpPath, existingMode);
+        try {
+          // Correct any narrowing that umask applied above. Best effort: some
+          // filesystems (FAT32, exFAT, a few NFS/CIFS mounts) and restricted
+          // sandboxes reject chmod with EPERM/ENOTSUP, and permissions must
+          // not be the reason a write fails.
+          await fs.chmod(tmpPath, existingMode);
+        } catch {
+          // Keep whatever mode the temp file was created with.
+        }
       }
 
       await this.renameWithRetry(tmpPath, filePath);

--- a/packages/core/src/services/fileSystemService.ts
+++ b/packages/core/src/services/fileSystemService.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
+import { isNodeError } from '../utils/errors.js';
 
 /**
  * Interface for file system operations that may be delegated to different implementations
@@ -27,6 +29,9 @@ export interface FileSystemService {
   writeTextFile(filePath: string, content: string): Promise<void>;
 }
 
+/** Rename retries, for transient Windows lock errors. */
+const RENAME_MAX_RETRIES = 5;
+
 /**
  * Standard file system implementation
  */
@@ -35,7 +40,66 @@ export class StandardFileSystemService implements FileSystemService {
     return fs.readFile(filePath, 'utf-8');
   }
 
+  /**
+   * Writes `content` to `filePath` atomically.
+   *
+   * A plain `fs.writeFile` truncates the destination and then streams the
+   * content in chunks, so anything reading the file concurrently can observe
+   * a truncated prefix. Writing to a sibling temp file and renaming it into
+   * place means an observer sees either the old file or the new one.
+   */
   async writeTextFile(filePath: string, content: string): Promise<void> {
-    await fs.writeFile(filePath, content, 'utf-8');
+    // The temp file must share a directory with the destination so that the
+    // rename stays within one filesystem, and must be uniquely named so that
+    // concurrent writers do not clobber each other's temp file.
+    const tmpPath = `${filePath}.${randomUUID()}.tmp`;
+
+    try {
+      await fs.writeFile(tmpPath, content, 'utf-8');
+
+      // A fresh temp file does not inherit the destination's permissions, so
+      // copy them over before the rename. Without this, replacing a 0600 file
+      // would silently widen it to the default mode.
+      const existingMode = await this.getFileMode(filePath);
+      if (existingMode !== undefined) {
+        await fs.chmod(tmpPath, existingMode);
+      }
+
+      await this.renameWithRetry(tmpPath, filePath);
+    } catch (error) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {
+        // Best effort: the original error is the one worth reporting.
+      });
+      throw error;
+    }
+  }
+
+  private async getFileMode(filePath: string): Promise<number | undefined> {
+    try {
+      const stats = await fs.stat(filePath);
+      return stats.mode & 0o777;
+    } catch {
+      // New file, or a destination we cannot stat; keep the default mode.
+      return undefined;
+    }
+  }
+
+  private async renameWithRetry(from: string, to: string): Promise<void> {
+    for (let attempt = 0; attempt < RENAME_MAX_RETRIES; attempt++) {
+      try {
+        await fs.rename(from, to);
+        return;
+      } catch (error: unknown) {
+        // Windows can transiently refuse a rename while another process has
+        // the destination open (antivirus, editors, watchers).
+        const code = isNodeError(error) ? error.code : '';
+        const isRetryable = code === 'EBUSY' || code === 'EPERM';
+        if (!isRetryable || attempt === RENAME_MAX_RETRIES - 1) {
+          throw error;
+        }
+        const delayMs = Math.pow(2, attempt) * 50;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
   }
 }

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -490,5 +490,37 @@ describe('GitService', () => {
       expect(hoistedMockRaw).toHaveBeenCalledWith('rev-parse', 'HEAD');
       expect(commitHash).toBe('current-head-hash');
     });
+
+    it('does not interleave staging and committing across concurrent snapshots', async () => {
+      const events: string[] = [];
+      hoistedMockAdd.mockImplementation(async () => {
+        events.push('add:start');
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        events.push('add:end');
+      });
+      hoistedMockStatus.mockResolvedValue({ isClean: () => false });
+      hoistedMockCommit.mockImplementation(async (message: string) => {
+        events.push(`commit:${message}`);
+        return { commit: `hash-${message}` };
+      });
+
+      const service = new GitService(projectRoot, storage);
+      await Promise.all([
+        service.createFileSnapshot('A'),
+        service.createFileSnapshot('B'),
+      ]);
+
+      // `add('.')` stages the whole working tree, so a second snapshot that
+      // stages while the first has not committed yet folds the first
+      // snapshot's files into its own commit.
+      expect(events).toEqual([
+        'add:start',
+        'add:end',
+        'commit:A',
+        'add:start',
+        'add:end',
+        'commit:B',
+      ]);
+    });
   });
 });

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { isNodeError } from '../utils/errors.js';
+import { withPathLock } from '../utils/pathMutex.js';
 import { spawnAsync } from '../utils/shell-utils.js';
 import {
   simpleGit,
@@ -194,23 +195,28 @@ export class GitService {
   }
 
   async createFileSnapshot(message: string): Promise<string> {
-    try {
-      const repo = this.shadowGitRepository;
-      await repo.add('.');
-      const status = await repo.status();
-      if (status.isClean()) {
-        // If no changes are staged, return the current HEAD commit hash
-        return await this.getCurrentCommitHash();
+    // `add('.')` stages the entire working tree, so two snapshots running at
+    // once fold each other's files into whichever commit lands first. Serialize
+    // stage -> status -> commit per shadow repository.
+    return withPathLock(`git-snapshot:${this.projectRoot}`, async () => {
+      try {
+        const repo = this.shadowGitRepository;
+        await repo.add('.');
+        const status = await repo.status();
+        if (status.isClean()) {
+          // If no changes are staged, return the current HEAD commit hash
+          return await this.getCurrentCommitHash();
+        }
+        const commitResult = await repo.commit(message, {
+          '--no-verify': null,
+        });
+        return commitResult.commit;
+      } catch (error) {
+        throw new Error(
+          `Failed to create checkpoint snapshot: ${error instanceof Error ? error.message : 'Unknown error'}. Checkpointing may not be working properly.`,
+        );
       }
-      const commitResult = await repo.commit(message, {
-        '--no-verify': null,
-      });
-      return commitResult.commit;
-    } catch (error) {
-      throw new Error(
-        `Failed to create checkpoint snapshot: ${error instanceof Error ? error.message : 'Unknown error'}. Checkpointing may not be working properly.`,
-      );
-    }
+    });
   }
 
   async restoreProjectFromSnapshot(commitHash: string): Promise<void> {

--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -1496,4 +1496,39 @@ function doIt() {
       fs.rmSync(plansDir, { recursive: true, force: true });
     });
   });
+
+  describe('concurrent edits to the same file', () => {
+    it('applies both edits rather than losing one', async () => {
+      const filePath = path.join(rootDir, 'shared.txt');
+      fs.writeFileSync(filePath, 'alpha\nbeta\n', 'utf8');
+
+      const first = tool.build({
+        file_path: filePath,
+        instruction: 'Uppercase alpha',
+        old_string: 'alpha',
+        new_string: 'ALPHA',
+      });
+      const second = tool.build({
+        file_path: filePath,
+        instruction: 'Uppercase beta',
+        old_string: 'beta',
+        new_string: 'BETA',
+      });
+
+      const signal = new AbortController().signal;
+      const results = await Promise.all([
+        first.execute({ abortSignal: signal }),
+        second.execute({ abortSignal: signal }),
+      ]);
+
+      for (const result of results) {
+        expect(result.error).toBeUndefined();
+      }
+
+      // Both tool calls reported success, so neither edit may be missing.
+      const finalContent = fs.readFileSync(filePath, 'utf8');
+      expect(finalContent).toContain('ALPHA');
+      expect(finalContent).toContain('BETA');
+    });
+  });
 });

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -34,6 +34,7 @@ import {
   resolveToRealPath,
 } from '../utils/paths.js';
 import { isNodeError } from '../utils/errors.js';
+import { withPathLock } from '../utils/pathMutex.js';
 import { correctPath } from '../utils/pathCorrector.js';
 import type { Config } from '../config/config.js';
 import { CoreToolCallStatus } from '../scheduler/types.js';
@@ -911,6 +912,21 @@ class EditToolInvocation
       };
     }
 
+    // Serialize the whole read-modify-write against other writers of this
+    // path. Two edits scheduled in parallel (common with sub-agents) would
+    // otherwise both read the original content, and whichever wrote second
+    // would silently discard the other's edit while still reporting success.
+    return withPathLock(this.resolvedPath, () => this.applyEdit(signal));
+  }
+
+  /**
+   * Computes and applies the edit.
+   *
+   * Must be called while holding the path lock for `this.resolvedPath`, so
+   * that the read in `calculateEdit` and the subsequent write cannot be
+   * interleaved with another writer of the same file.
+   */
+  private async applyEdit(signal: AbortSignal): Promise<ToolResult> {
     let editData: CalculatedEdit;
     try {
       editData = await this.calculateEdit(this.params, signal);

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -944,6 +944,36 @@ describe('WriteFileTool', () => {
     });
   });
 
+  describe('concurrent writes to the same file', () => {
+    it('does not report two creations of the same new file', async () => {
+      const abortSignal = new AbortController().signal;
+      const filePath = path.join(rootDir, 'concurrent_new_file.txt');
+      mockEnsureCorrectFileContent.mockImplementation(
+        async (content: string) => content,
+      );
+
+      const first = tool.build({ file_path: filePath, content: 'first' });
+      const second = tool.build({ file_path: filePath, content: 'second' });
+
+      const results = await Promise.all([
+        first.execute({ abortSignal }),
+        second.execute({ abortSignal }),
+      ]);
+
+      // Whichever call lands second must observe the file the other created,
+      // otherwise both report a creation and the second one's diff claims the
+      // file was empty beforehand.
+      const created = results.filter((r) =>
+        /Successfully created and wrote to new file/.test(String(r.llmContent)),
+      );
+      const overwrote = results.filter((r) =>
+        /Successfully overwrote file/.test(String(r.llmContent)),
+      );
+      expect(created).toHaveLength(1);
+      expect(overwrote).toHaveLength(1);
+    });
+  });
+
   describe('workspace boundary validation', () => {
     it('should validate paths are within workspace root', () => {
       const params = {

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -62,6 +62,7 @@ import {
   resolveModel,
 } from '../config/models.js';
 import { discoverJitContext, appendJitContext } from './jit-context.js';
+import { withPathLock } from '../utils/pathMutex.js';
 
 /**
  * Parameters for the WriteFile tool
@@ -379,6 +380,18 @@ class WriteFileToolInvocation extends BaseToolInvocation<
       };
     }
 
+    // Serialize against other writers of this path, so that the existence
+    // check and content read that produce the diff cannot be interleaved with
+    // another write to the same file.
+    return withPathLock(this.resolvedPath, () => this.applyWrite(abortSignal));
+  }
+
+  /**
+   * Writes the file.
+   *
+   * Must be called while holding the path lock for `this.resolvedPath`.
+   */
+  private async applyWrite(abortSignal: AbortSignal): Promise<ToolResult> {
     const { content, ai_proposed_content, modified_by_user } = this.params;
     const correctedContentResult = await getCorrectedFileContent(
       this.config,

--- a/packages/core/src/utils/pathMutex.test.ts
+++ b/packages/core/src/utils/pathMutex.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pendingPathLockCount, withPathLock } from './pathMutex.js';
+
+describe('withPathLock', () => {
+  it('serializes callbacks that target the same key', async () => {
+    const events: string[] = [];
+
+    const first = withPathLock('/tmp/same.txt', async () => {
+      events.push('first:enter');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events.push('first:exit');
+    });
+
+    const second = withPathLock('/tmp/same.txt', async () => {
+      events.push('second:enter');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      events.push('second:exit');
+    });
+
+    await Promise.all([first, second]);
+
+    expect(events).toEqual([
+      'first:enter',
+      'first:exit',
+      'second:enter',
+      'second:exit',
+    ]);
+  });
+
+  it('runs callbacks for different keys concurrently', async () => {
+    let bothEntered = false;
+    let aEntered = false;
+    let bEntered = false;
+
+    const a = withPathLock('/tmp/a.txt', async () => {
+      aEntered = true;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (bEntered) bothEntered = true;
+    });
+
+    const b = withPathLock('/tmp/b.txt', async () => {
+      bEntered = true;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (aEntered) bothEntered = true;
+    });
+
+    await Promise.all([a, b]);
+
+    expect(bothEntered).toBe(true);
+  });
+
+  it('returns the value produced by the callback', async () => {
+    await expect(withPathLock('/tmp/value.txt', async () => 42)).resolves.toBe(
+      42,
+    );
+  });
+
+  it('releases the lock when a callback rejects', async () => {
+    await expect(
+      withPathLock('/tmp/throws.txt', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    await expect(
+      withPathLock('/tmp/throws.txt', async () => 'recovered'),
+    ).resolves.toBe('recovered');
+  });
+
+  it('does not retain lock state for keys that are no longer in use', async () => {
+    await withPathLock('/tmp/transient.txt', async () => undefined);
+    expect(pendingPathLockCount()).toBe(0);
+  });
+});

--- a/packages/core/src/utils/pathMutex.ts
+++ b/packages/core/src/utils/pathMutex.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * In-process, per-path mutex used to serialize read-modify-write sequences
+ * against the same file.
+ *
+ * Parallel tool execution (notably sub-agents) can schedule two writes to the
+ * same path concurrently. Without serialization the two sequences interleave
+ * and one update is silently lost.
+ *
+ * Scope: this coordinates callers inside a single process only. It does not
+ * guard against a second Gemini CLI process, an editor, or any other program
+ * writing the same file; that would require an on-disk lock.
+ *
+ * Callers are expected to pass an already-resolved absolute path so that two
+ * spellings of the same file map to the same lock.
+ */
+const chains = new Map<string, Promise<unknown>>();
+
+/**
+ * Runs `fn` with exclusive access to `key`, relative to other `withPathLock`
+ * callers using the same key.
+ *
+ * @param key - The resolved path (or other identifier) to lock.
+ * @param fn - The critical section.
+ * @returns Whatever `fn` resolves to.
+ */
+export async function withPathLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  // The stored chain is deliberately non-rejecting (see below), so waiting for
+  // our turn cannot fail just because the previous lock holder threw.
+  const previous = chains.get(key) ?? Promise.resolve();
+  const run = previous.then(fn);
+
+  // Store a settled-either-way view of our run, so a throwing critical section
+  // neither blocks the next waiter nor raises an unhandled rejection.
+  const chained = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  chains.set(key, chained);
+
+  try {
+    return await run;
+  } finally {
+    // Drop the entry once we are the last waiter, so the map does not grow
+    // without bound across a long session.
+    if (chains.get(key) === chained) {
+      chains.delete(key);
+    }
+  }
+}
+
+/**
+ * Number of paths currently holding lock state. Exposed for tests.
+ */
+export function pendingPathLockCount(): number {
+  return chains.size;
+}


### PR DESCRIPTION
## Summary

Parallel tool execution lets two file operations target the same path at once.
Today that silently loses edits: two concurrent `replace` calls on one file both
read the original content, and whichever writes second discards the other's edit
while **both tool calls report success to the model**. Neither the user nor the
agent can tell it happened.

This makes tool writes atomic and serializes the read-modify-write per path, and
covers the other three races in #29078. Every one was reproduced on `main` first,
with a regression test added for each.

## Details

Four distinct problems, and what each fix does.

**1. Writes were not atomic.** `fs.writeFile` opens with `O_TRUNC` and then
streams the content back in 512KB chunks, so a concurrent reader sees a
truncated prefix. A 64MB write exposed 129 distinct partial sizes
(`0, 524288, 1048576, ...`).

`StandardFileSystemService.writeTextFile` now writes to a uniquely named sibling
temp file and renames it into place, so an observer sees either the old file or
the new one. Two details worth flagging for review:

- It copies the destination's mode onto the temp file before the rename.
  A fresh temp file does not inherit permissions, so without this, replacing a
  `0600` file would silently widen it.
- The rename retries on `EBUSY`/`EPERM`, which Windows raises transiently while
  another process holds the destination open. This mirrors the existing
  backoff in `config/projectRegistry.ts`.

**2. Lost update in `replace`.** `EditTool.execute` reads via `calculateEdit`
and writes later in the same method, with `await` points in between, so two
invocations interleave as read, read, write, write. Editing `alpha` and `beta`
in one file concurrently left `alpha\nBETA\n`.

Fixed with a new in-process per-path async mutex (`utils/pathMutex.ts`). The
body of `execute` moved into `applyEdit`, which runs inside the lock, so the
second edit reads the first one's result and both land. The key is the
already realpath-resolved target, so two spellings of one file share a lock.

**3. `write_file` existence check raced.** Two concurrent calls to the same new
path both reported "Successfully created and wrote to new file", so the second
one's diff claimed the file was empty beforehand. Same fix, `applyWrite` inside
the path lock.

**4. Checkpoint snapshots interleaved.** `GitService.createFileSnapshot` runs
`add('.')`, `status()`, `commit()`. Concurrent calls interleaved as
`add, add, commit, commit`, and because `add('.')` stages the whole worktree,
one snapshot folded the other's files into its commit. Now serialized per
shadow repository.

### Deliberately out of scope

Happy to extend this PR or open follow-ups, whichever you prefer:

- **The lock is in-process only.** It does not coordinate with a second Gemini
  CLI process or an external editor writing the same file. That needs an on-disk
  lock (`proper-lockfile` or an `O_EXCL` lockfile), which felt like a separate
  decision.
- **`SandboxedFileSystemService` is unchanged.** It writes through a `__write`
  sandbox command, so sandboxed writes are still not atomic. Fixing it means
  changing the sandbox helper, not just this service.

No user-facing command, flag, or output changes, so no `/docs` update. No
breaking changes: `FileSystemService` keeps its existing two-method interface.

## Related Issues

Fixes #29078

## How to Validate

Reproduce the headline bug on `main` (before this change):

```bash
# packages/core
npx vitest run src/tools/edit.test.ts -t "concurrent edits"
# FAIL: expected 'alpha\nBETA\n' to contain 'ALPHA'
```

Then with this branch, all four regression tests pass:

```bash
# packages/core
npx vitest run \
  src/utils/pathMutex.test.ts \
  src/services/fileSystemService.test.ts \
  src/services/fileSystemService.atomic.test.ts \
  src/services/gitService.test.ts \
  src/tools/edit.test.ts \
  src/tools/write-file.test.ts
# 155 passed
```

The atomicity test is worth a look, because the obvious version of it does not
work. An async reader polling during the write is only ever scheduled before or
after it, since the write runs on the libuv threadpool. It needs a synchronous
`statSync` loop on the main thread to actually catch the destination mid-write.
`src/services/fileSystemService.atomic.test.ts` does that, and guards against a
vacuous pass by asserting the observer ran at least once.

Full gate:

```bash
npm run preflight
```

Note for reviewers running this locally: if your checkout is not a trusted
workspace, 9 tests in `packages/cli/src/gemini.test.tsx` fail with
`FatalUntrustedWorkspaceError` regardless of this change. Set
`GEMINI_CLI_TRUST_WORKSPACE=true` and they pass. I confirmed those same 9 fail
on a pristine stashed tree.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — not needed, no
      user-facing surface change
- [x] Added/updated tests (if needed) — one regression test per defect, each
      watched failing first
- [x] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Validated on macOS with `npm run` only. I do not have Windows, Linux, Docker,
Podman or Seatbelt available here. The Windows-relevant part of this change is
the `EBUSY`/`EPERM` rename retry, which I could not exercise on a real Windows
host, so it deserves a careful look or a CI run on Windows before merge.

## Why this is a draft

#29078 does not carry the `help wanted` label, and CONTRIBUTING asks
contributors to discuss the issue and wait for maintainer feedback first. I had
the fix working while investigating, so I am opening this as a draft rather than
sitting on it. Happy to close it, split it up, or take it in a different
direction if a maintainer would rather shape the approach first.
