### PR TITLE
fix(core): make isWithinRoot case-insensitive on Windows

### DIFF
--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -177,20 +177,6 @@ describe('fileUtils', () => {
     );
 
     describe.skipIf(process.platform !== 'win32')('on Windows', () => {
-      const mockPlatform = (platform: string) => {
-        vi.stubGlobal(
-          'process',
-          Object.create(process, {
-            platform: {
-              get: () => platform,
-            },
-          }),
-        );
-      };
-
-      beforeEach(() => mockPlatform('win32'));
-      afterEach(() => vi.unstubAllGlobals());
-
       it('treats drive-letter casing as equivalent', () => {
         expect(
           isWithinRoot('C:\\Users\\Test\\file.txt', 'c:\\Users\\Test'),

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -175,6 +175,40 @@ describe('fileUtils', () => {
         expect(isWithinRoot(testPath, root || defaultRoot)).toBe(expected);
       },
     );
+
+    describe.skipIf(process.platform !== 'win32')('on Windows', () => {
+      const mockPlatform = (platform: string) => {
+        vi.stubGlobal(
+          'process',
+          Object.create(process, {
+            platform: {
+              get: () => platform,
+            },
+          }),
+        );
+      };
+
+      beforeEach(() => mockPlatform('win32'));
+      afterEach(() => vi.unstubAllGlobals());
+
+      it('treats drive-letter casing as equivalent', () => {
+        expect(
+          isWithinRoot('C:\\Users\\Test\\file.txt', 'c:\\Users\\Test'),
+        ).toBe(true);
+      });
+
+      it('treats path-component casing as equivalent', () => {
+        expect(
+          isWithinRoot('c:\\users\\test\\file.txt', 'C:\\Users\\Test'),
+        ).toBe(true);
+      });
+
+      it('still rejects a different drive', () => {
+        expect(
+          isWithinRoot('D:\\Users\\Test\\file.txt', 'C:\\Users\\Test'),
+        ).toBe(false);
+      });
+    });
   });
 
   describe('getRealPath', () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -15,7 +15,7 @@ import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
 import { createRequire as createModuleRequire } from 'node:module';
 import { debugLogger } from './debugLogger.js';
-import { resolveToRealPath } from './paths.js';
+import { isSubpath, resolveToRealPath } from './paths.js';
 
 import {
   DEFAULT_MAX_LINES_TEXT_FILE,
@@ -302,34 +302,16 @@ export function isWithinRoot(
     path.resolve(rootDirectory),
   );
 
-  // Ensure the rootDirectory path ends with a separator for correct startsWith comparison,
-  // unless it's the root path itself (e.g., '/' or 'C:\').
-  const rootWithSeparator =
-    normalizedRootDirectory === path.sep ||
-    normalizedRootDirectory.endsWith(path.sep)
-      ? normalizedRootDirectory
-      : normalizedRootDirectory + path.sep;
-
-  if (
-    normalizedPathToCheck === normalizedRootDirectory ||
-    normalizedPathToCheck.startsWith(rootWithSeparator)
-  ) {
+  if (isSubpath(normalizedRootDirectory, normalizedPathToCheck)) {
     return true;
   }
 
   // Cross-platform check for macOS /private symlink aliases
   if (process.platform === 'darwin') {
     try {
-      const realPathToCheck = resolveToRealPath(normalizedPathToCheck);
-      const realRootDirectory = resolveToRealPath(normalizedRootDirectory);
-      const realRootWithSeparator =
-        realRootDirectory === path.sep || realRootDirectory.endsWith(path.sep)
-          ? realRootDirectory
-          : realRootDirectory + path.sep;
-
-      return (
-        realPathToCheck === realRootDirectory ||
-        realPathToCheck.startsWith(realRootWithSeparator)
+      return isSubpath(
+        resolveToRealPath(normalizedRootDirectory),
+        resolveToRealPath(normalizedPathToCheck),
       );
     } catch {
       return false;


### PR DESCRIPTION
## Summary

`isWithinRoot()` compared paths with case-sensitive `===` / `startsWith`. On Windows that rejects valid in-root paths when the drive letter or folder casing differs (`c:\...` vs `C:\...`), which breaks ACP/IDE FS routing and ignore-path normalization.

Reuse `isSubpath()`, which already does a case-insensitive check on Windows (and Darwin).

## Details

`isSubpath()` already uses `path.win32` and case-insensitive `relative()` on Windows. `isWithinRoot()` was a second containment helper that did not.

macOS `/private` alias handling is unchanged; it now also goes through `isSubpath()`.

## Related Issues

Fixes #29000

## How to Validate

1. On Windows, call `isWithinRoot('C:\\Users\\proj\\file.ts', 'c:\\Users\\proj')` — should be `true`.
2. `packages/core` tests: `isWithinRoot on Windows` (drive-letter casing, path-component casing, different drive).
3. Existing `isWithinRoot` cases still pass on POSIX.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [x] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker