### PR TITLE
fix(cli): avoid duplicate history and telemetry after confirmation

### DIFF
--- a/docs/cli/session-management.md
+++ b/docs/cli/session-management.md
@@ -91,6 +91,10 @@ For named branch points inside a session, use chat checkpoints:
 /resume resume decision-point
 ```
 
+If a checkpoint with the same tag exists, Gemini CLI asks you to confirm before
+overwriting it. Confirming the save keeps a single command entry in your chat
+history. Canceling preserves the existing checkpoint.
+
 Compatibility aliases:
 
 - `/chat ...` works for the same commands.

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx
@@ -17,10 +17,12 @@ import { FileCommandLoader } from '../../services/FileCommandLoader.js';
 import { McpPromptLoader } from '../../services/McpPromptLoader.js';
 import {
   SlashCommandStatus,
+  ToolConfirmationOutcome,
   MCPDiscoveryState,
   makeFakeConfig,
   coreEvents,
   type GeminiClient,
+  type ToolExecuteConfirmationDetails,
 } from '@google/gemini-cli-core';
 
 const {
@@ -1041,6 +1043,106 @@ describe('useSlashCommandProcessor', () => {
       expect(abortSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe.each(['confirm_action', 'confirm_shell_commands'] as const)(
+    '%s continuations',
+    (confirmationType) => {
+      it.each(['success', 'failure', 'cancel'] as const)(
+        'records one history entry and one terminal event on %s',
+        async (outcome) => {
+          const action = vi
+            .fn<NonNullable<SlashCommand['action']>>()
+            .mockResolvedValueOnce(
+              confirmationType === 'confirm_action'
+                ? {
+                    type: 'confirm_action',
+                    prompt: 'Overwrite the checkpoint?',
+                    originalInvocation: { raw: '/test' },
+                  }
+                : {
+                    type: 'confirm_shell_commands',
+                    commandsToConfirm: ['echo test'],
+                    originalInvocation: { raw: '/test' },
+                  },
+            );
+          if (outcome === 'failure') {
+            action.mockRejectedValue(new Error('Command failed'));
+          } else {
+            action.mockResolvedValue({
+              type: 'message',
+              messageType: 'info',
+              content: 'Command completed',
+            });
+          }
+
+          const result = await setupProcessorHook({
+            builtinCommands: [createTestCommand({ action })],
+          });
+          let commandPromise!: ReturnType<
+            typeof result.current.handleSlashCommand
+          >;
+          await act(async () => {
+            commandPromise = result.current.handleSlashCommand('/test');
+          });
+
+          expect(action).toHaveBeenCalledTimes(1);
+          expect(logSlashCommand).not.toHaveBeenCalled();
+
+          // An unrelated update must not expose a duplicate command after
+          // confirmation, even when consecutive-history deduplication cannot help.
+          result.current.commandContext.ui.addItem({
+            type: MessageType.INFO,
+            text: 'Background update',
+          });
+
+          await act(async () => {
+            if (confirmationType === 'confirm_action') {
+              expect(result.current.confirmationRequest).not.toBeNull();
+              result.current.confirmationRequest!.onConfirm(
+                outcome !== 'cancel',
+              );
+            } else {
+              const pendingItem = result.current.pendingHistoryItems[0];
+              if (pendingItem?.type !== 'tool_group') {
+                throw new Error('Expected a pending shell confirmation');
+              }
+              // Client-initiated shell confirmations retain their callback.
+              const confirmation = pendingItem.tools[0]
+                .confirmationDetails as ToolExecuteConfirmationDetails;
+              expect(confirmation).toBeDefined();
+              await confirmation.onConfirm(
+                outcome === 'cancel'
+                  ? ToolConfirmationOutcome.Cancel
+                  : ToolConfirmationOutcome.ProceedOnce,
+              );
+            }
+            await commandPromise;
+          });
+
+          expect(action).toHaveBeenCalledTimes(outcome === 'cancel' ? 1 : 2);
+          expect(
+            mockAddItem.mock.calls.filter(
+              ([item]) => item.type === MessageType.USER,
+            ),
+          ).toEqual([
+            [{ type: MessageType.USER, text: '/test' }, expect.any(Number)],
+          ]);
+          expect(logSlashCommand).toHaveBeenCalledExactlyOnceWith(
+            mockConfig,
+            expect.objectContaining({
+              command: 'test',
+              status:
+                outcome === 'failure'
+                  ? SlashCommandStatus.ERROR
+                  : SlashCommandStatus.SUCCESS,
+            }),
+          );
+          expect(result.current.confirmationRequest).toBeNull();
+          expect(result.current.pendingHistoryItems).toEqual([]);
+        },
+      );
+    },
+  );
 
   describe('Slash Command Logging', () => {
     const mockCommandAction = vi.fn().mockResolvedValue({ type: 'handled' });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -411,6 +411,7 @@ export const useSlashCommandProcessor = (
       }
 
       let hasError = false;
+      let commandReinvoked = false;
 
       const subcommand =
         resolvedCommandPath.length > 1
@@ -641,6 +642,7 @@ export const useSlashCommandProcessor = (
                     );
                   }
 
+                  commandReinvoked = true;
                   return await handleSlashCommand(
                     result.originalInvocation.raw,
                     // Pass the approved commands as a one-time grant for this execution.
@@ -673,10 +675,12 @@ export const useSlashCommandProcessor = (
                     return { type: 'handled' };
                   }
 
+                  commandReinvoked = true;
                   return await handleSlashCommand(
                     result.originalInvocation.raw,
                     undefined,
                     true,
+                    false, // Do not add to history again
                   );
                 }
                 case 'custom_dialog': {
@@ -727,7 +731,13 @@ export const useSlashCommandProcessor = (
         );
         return { type: 'handled' };
       } finally {
-        if (config && resolvedCommandPath[0] && !hasError) {
+        // A confirmed command's resumed invocation records its final outcome.
+        if (
+          config &&
+          resolvedCommandPath[0] &&
+          !hasError &&
+          !commandReinvoked
+        ) {
           const event = makeSlashCommandEvent({
             command: resolvedCommandPath[0],
             subcommand,


### PR DESCRIPTION
## Summary

Fixes duplicate slash-command history and telemetry when an action is confirmed. For example, confirming an overwrite with `/resume save <tag>` now keeps one command entry, even if another message arrived while the confirmation was open.

## Details

- Suppress the repeated history insertion when resuming `confirm_action`.
- Let the resumed invocation record the final telemetry outcome for both action and shell confirmations. This removes duplicate success events and prevents a failed continuation from also being reported as successful by its caller.
- Preserve cancellation behavior and add six regression cases covering success, failure, and cancellation across both confirmation paths.
- Document checkpoint overwrite confirmation in the session guide.

Draft for maintainer consideration: #29032 does not yet have the `help wanted` designation. Could a maintainer confirm whether this focused fix is suitable for community contribution?

## Related Issues

Fixes #29032.

## How to Validate

- `npm exec -w @google/gemini-cli -- vitest run src/ui/hooks/slashCommandProcessor.test.tsx --coverage.enabled=false`
  - 44 tests passed. Against the unchanged implementation, the new cases produced four failures (action history duplication and shell telemetry duplication/misclassification); both cancellation cases passed.
- `npx --no-install eslint packages/cli/src/ui/hooks/slashCommandProcessor.ts packages/cli/src/ui/hooks/slashCommandProcessor.test.tsx`
  - Passed.
- `npm run preflight` on macOS arm64 / Node.js 20.19.5:
  - All workspace builds, formatting, ESLint, actionlint, shellcheck, yamllint, and type checks passed.
  - Workspace tests: 15,218 passed, 20 failed, 64 skipped. The changed suite passed all 44 tests.
  - All 20 failures reproduce on unchanged upstream `24cab6830a`:
    - Nine failures in `src/gemini.test.tsx` require the test environment used by `.github/workflows/ci.yml`. Rerunning startup and configuration tests with `GEMINI_CLI_TRUST_WORKSPACE=true` passed 264 tests (two skipped).
    - Eleven failures in `src/config/extensionRegistryClient.test.ts` occur because this host resolves `geminicli.com` to a reserved address, which the existing private-IP check rejects. No registry or network-safety code was changed.
  - Preflight therefore did **not** exit successfully on this host.
- `npm run test:scripts` and `npm run test:sea-launch`
  - Run separately because the workspace-test failures stopped the final chained stages; 201 and 17 tests passed, respectively.

The regressions exercise an unrelated history update during confirmation, then assert a single command entry, one final telemetry event, and cleared confirmation state. They require no model request.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any): none
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
