### PR TITLE
fix(core): close sibling-prefix bypass in get_internal_docs path guard

### DIFF
--- a/packages/core/src/tools/get-internal-docs.test.ts
+++ b/packages/core/src/tools/get-internal-docs.test.ts
@@ -87,6 +87,88 @@ describe('GetInternalDocsTool (Integration)', () => {
     }
   });
 
+  it('should prevent access through a symlink that points outside the docs directory', async () => {
+    // The link itself sits inside docsRoot, so a lexical resolve still reports
+    // an internal path. Only resolving the link exposes the real target.
+    const docsRoot = path.resolve(__dirname, '../../../../docs');
+    const outsideDir = `${docsRoot}-symlink-probe`;
+    const secretFile = path.join(outsideDir, 'secret.md');
+    const linkPath = path.join(docsRoot, 'symlink-escape-probe.md');
+    const secret = 'SENSITIVE-SYMLINK-CONTENT';
+
+    await fs.rm(linkPath, { force: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(secretFile, secret, 'utf8');
+    await fs.symlink(secretFile, linkPath);
+
+    try {
+      const invocation = tool.build({ path: 'symlink-escape-probe.md' });
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+      expect(result.error?.message).toContain('Access denied');
+      expect(String(result.llmContent)).not.toContain(secret);
+    } finally {
+      await fs.rm(linkPath, { force: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should prevent access through a symlinked directory that points outside the docs directory', async () => {
+    // Same escape, but the link is an intermediate path segment rather than
+    // the final one, so the whole chain has to be resolved.
+    const docsRoot = path.resolve(__dirname, '../../../../docs');
+    const outsideDir = `${docsRoot}-symlink-dir-probe`;
+    const linkPath = path.join(docsRoot, 'symlink-dir-probe');
+    const secret = 'SENSITIVE-SYMLINK-DIR-CONTENT';
+
+    await fs.rm(linkPath, { force: true, recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(outsideDir, 'secret.md'), secret, 'utf8');
+    await fs.symlink(
+      outsideDir,
+      linkPath,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    try {
+      const invocation = tool.build({ path: 'symlink-dir-probe/secret.md' });
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+      expect(result.error?.message).toContain('Access denied');
+      expect(String(result.llmContent)).not.toContain(secret);
+    } finally {
+      await fs.rm(linkPath, { force: true, recursive: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should still allow a symlink that stays inside the docs directory', async () => {
+    // Resolving symlinks must not turn every legitimate link into a denial.
+    const docsRoot = path.resolve(__dirname, '../../../../docs');
+    const targetPath = path.join(docsRoot, 'symlink-target-probe.md');
+    const linkPath = path.join(docsRoot, 'symlink-internal-probe.md');
+    const content = 'INTERNAL-SYMLINK-CONTENT';
+
+    await fs.rm(linkPath, { force: true });
+    await fs.writeFile(targetPath, content, 'utf8');
+    await fs.symlink(targetPath, linkPath);
+
+    try {
+      const invocation = tool.build({ path: 'symlink-internal-probe.md' });
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toBe(content);
+    } finally {
+      await fs.rm(linkPath, { force: true });
+      await fs.rm(targetPath, { force: true });
+    }
+  });
+
   it('should handle non-existent files', async () => {
     const invocation = tool.build({ path: 'this-file-does-not-exist.md' });
     const result = await invocation.execute({ abortSignal });

--- a/packages/core/src/tools/get-internal-docs.test.ts
+++ b/packages/core/src/tools/get-internal-docs.test.ts
@@ -62,6 +62,31 @@ describe('GetInternalDocsTool (Integration)', () => {
     expect(result.error?.message).toContain('Access denied');
   });
 
+  it('should prevent access to a sibling directory that shares the docs prefix', async () => {
+    // getDocsRoot() resolves to the repository's real docs/ directory, so the
+    // probe has to be a real sibling of it.
+    const docsRoot = path.resolve(__dirname, '../../../../docs');
+    const siblingDir = `${docsRoot}-traversal-probe`;
+    const secret = 'SENSITIVE-PROBE-CONTENT';
+
+    await fs.mkdir(siblingDir, { recursive: true });
+    await fs.writeFile(path.join(siblingDir, 'secret.md'), secret, 'utf8');
+
+    try {
+      const invocation = tool.build({
+        path: `../${path.basename(siblingDir)}/secret.md`,
+      });
+      const result = await invocation.execute({ abortSignal });
+
+      expect(result.error).toBeDefined();
+      expect(result.error?.type).toBe(ToolErrorType.EXECUTION_FAILED);
+      expect(result.error?.message).toContain('Access denied');
+      expect(String(result.llmContent)).not.toContain(secret);
+    } finally {
+      await fs.rm(siblingDir, { recursive: true, force: true });
+    }
+  });
+
   it('should handle non-existent files', async () => {
     const invocation = tool.build({ path: 'this-file-does-not-exist.md' });
     const result = await invocation.execute({ abortSignal });

--- a/packages/core/src/tools/get-internal-docs.ts
+++ b/packages/core/src/tools/get-internal-docs.ts
@@ -22,6 +22,7 @@ import { glob } from 'glob';
 import { ToolErrorType } from './tool-error.js';
 import { GET_INTERNAL_DOCS_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
+import { isSubpath } from '../utils/paths.js';
 
 /**
  * Parameters for the GetInternalDocs tool.
@@ -120,9 +121,12 @@ class GetInternalDocsInvocation extends BaseToolInvocation<
       }
 
       // Read a specific file
-      // Security: Prevent path traversal by resolving and verifying it stays within docsRoot
+      // Security: Prevent path traversal by resolving and verifying it stays
+      // within docsRoot. A plain startsWith() check is not enough: it also
+      // accepts any sibling directory that shares the prefix, so a docsRoot of
+      // `<repo>/docs` would let `../docs-private/secret.md` through.
       const resolvedPath = path.resolve(docsRoot, this.params.path);
-      if (!resolvedPath.startsWith(docsRoot)) {
+      if (!isSubpath(docsRoot, resolvedPath)) {
         throw new Error(
           'Access denied: Requested path is outside the documentation directory.',
         );

--- a/packages/core/src/tools/get-internal-docs.ts
+++ b/packages/core/src/tools/get-internal-docs.ts
@@ -22,7 +22,7 @@ import { glob } from 'glob';
 import { ToolErrorType } from './tool-error.js';
 import { GET_INTERNAL_DOCS_DEFINITION } from './definitions/coreTools.js';
 import { resolveToolDeclaration } from './definitions/resolver.js';
-import { isSubpath } from '../utils/paths.js';
+import { isSubpath, resolveToRealPath } from '../utils/paths.js';
 
 /**
  * Parameters for the GetInternalDocs tool.
@@ -122,11 +122,24 @@ class GetInternalDocsInvocation extends BaseToolInvocation<
 
       // Read a specific file
       // Security: Prevent path traversal by resolving and verifying it stays
-      // within docsRoot. A plain startsWith() check is not enough: it also
-      // accepts any sibling directory that shares the prefix, so a docsRoot of
-      // `<repo>/docs` would let `../docs-private/secret.md` through.
-      const resolvedPath = path.resolve(docsRoot, this.params.path);
-      if (!isSubpath(docsRoot, resolvedPath)) {
+      // within docsRoot. Two separate escapes have to be closed here.
+      //
+      // A plain startsWith() check accepts any sibling directory that shares
+      // the prefix, so a docsRoot of `<repo>/docs` would let
+      // `../docs-private/secret.md` through. isSubpath() compares path
+      // segments instead of characters.
+      //
+      // Lexical resolution alone still follows a symlink planted inside the
+      // docs tree: the resolved path stays under docsRoot while the file it
+      // opens does not. Both sides are resolved to their real paths so the
+      // check sees the file that is actually read, and docsRoot is resolved
+      // too so a repository reached through a symlinked parent is not denied
+      // by mistake.
+      const realDocsRoot = resolveToRealPath(docsRoot);
+      const resolvedPath = resolveToRealPath(
+        path.resolve(realDocsRoot, this.params.path),
+      );
+      if (!isSubpath(realDocsRoot, resolvedPath)) {
         throw new Error(
           'Access denied: Requested path is outside the documentation directory.',
         );


### PR DESCRIPTION
## Summary

The path traversal guard in the `get_internal_docs` tool uses a string prefix
comparison, which has no path-component boundary. It therefore accepts any
sibling directory whose name begins with the docs directory name, and the tool
reads that file and returns its contents to the model.

`packages/core/src/tools/get-internal-docs.ts`:

```ts
// Security: Prevent path traversal by resolving and verifying it stays within docsRoot
const resolvedPath = path.resolve(docsRoot, this.params.path);
if (!resolvedPath.startsWith(docsRoot)) {
  throw new Error('Access denied: Requested path is outside the documentation directory.');
}
```

With a `docsRoot` of `<repo>/docs`, a request for `../docs-private/secret.md`
resolves to `<repo>/docs-private/secret.md`. That still starts with
`<repo>/docs`, so the guard passes.

## Details

The fix swaps the prefix comparison for `isSubpath()` from
`packages/core/src/utils/paths.ts`, which the repository already uses for
exactly this purpose in `services/sandboxedFileSystemService.ts`. It compares
using `path.relative()` instead of a string prefix, so the component boundary
is respected, and it also handles the case-insensitive comparison needed on
Windows and macOS, which a raw `startsWith` does not.

### Why the existing test did not catch it

The current traversal test requests `../package.json`. That resolves to
`<repo>/package.json`, which does not share the `<repo>/docs` prefix, so it was
already blocked. The sibling-prefix case was simply never exercised.

The new test creates a real sibling of the docs directory containing a marker
file, asserts the request is denied with `Access denied`, and asserts the marker
content is absent from `llmContent`. It cleans the directory up in a `finally`
block. I confirmed it fails on `main` before the fix, with the tool returning no
error at all.

### Scope and severity

Deliberately narrow. This tool is read-only and its reachable surface is limited
to paths that share the docs directory prefix, so this is hardening rather than a
broad disclosure path. I kept the change to the one incorrect comparison rather
than reworking the tool.

Worth noting for a follow-up, not addressed here: the guard resolves with
`path.resolve` and does not resolve symlinks, so a symlink inside the docs tree
pointing outside it would still be followed. `isSubpath` alone does not fix that;
it needs `resolveToRealPath` as well, which is a slightly larger behavioural
change and felt like a separate decision.

## Related Issues

No existing issue. Found while investigating #29078. Happy to open one first if
you would prefer the discussion to start there.

## How to Validate

On `main`, the new test fails because the guard lets the sibling path through:

```bash
# packages/core
npx vitest run src/tools/get-internal-docs.test.ts
# FAIL ... should prevent access to a sibling directory that shares the docs prefix
#   AssertionError: expected undefined to be defined   <- no error was raised
```

With this change:

```bash
# packages/core
npx vitest run src/tools/get-internal-docs.test.ts
# 5 passed
```

Full gate:

```bash
npm run preflight
# exit 0
```

Note for reviewers running preflight locally: if your checkout is not a trusted
workspace, 9 tests in `packages/cli/src/gemini.test.tsx` fail with
`FatalUntrustedWorkspaceError` regardless of any change. Set
`GEMINI_CLI_TRUST_WORKSPACE=true` and they pass.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — not needed, no
      user-facing surface change
- [x] Added/updated tests (if needed) — one regression test, confirmed failing
      before the fix
- [x] Noted breaking changes (if any) — none. Legitimate paths inside the docs
      directory behave identically
- [ ] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker

Validated on macOS with `npm run`. `isSubpath` has its own platform handling and
existing test coverage, so the Windows and Linux risk here is low, but I could
not exercise those hosts myself.
