### PR TITLE
fix(core): preserve explicit versioned Flash model IDs

### DIFF
--- a/packages/core/src/config/models.test.ts
+++ b/packages/core/src/config/models.test.ts
@@ -754,7 +754,7 @@ describe('getAutoModelDescription', () => {
 });
 
 describe('resolveModel Gemini 3.5 Flash GA', () => {
-  it('should resolve all but preview flash models to DEFAULT_GEMINI_FLASH_MODEL when useGemini3_5Flash is true (legacy)', () => {
+  it('should resolve known non-preview flash models to DEFAULT_GEMINI_FLASH_MODEL when useGemini3_5Flash is true (legacy)', () => {
     expect(
       resolveModel(
         GEMINI_MODEL_ALIAS_FLASH,
@@ -787,7 +787,21 @@ describe('resolveModel Gemini 3.5 Flash GA', () => {
     ).toBe(PREVIEW_GEMINI_FLASH_MODEL);
   });
 
-  it('should resolve all but preview flash models to gemini-3.5-flash when useGemini3_5Flash is true (dynamic)', () => {
+  it.each([
+    'gemini-3.6-flash',
+    'gemini-3.7-flash',
+    'gemini-3.8-flash',
+    'gemini-9.9-flash',
+  ])(
+    'should preserve the explicit versioned model %s when useGemini3_5Flash is true (legacy)',
+    (model) => {
+      expect(resolveModel(model, false, false, true, undefined, true)).toBe(
+        model,
+      );
+    },
+  );
+
+  it('should resolve known non-preview flash models to gemini-3.5-flash when useGemini3_5Flash is true (dynamic)', () => {
     const mockDynamicConfig = {
       getExperimentalDynamicModelConfiguration: () => true,
       modelConfigService,

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -229,7 +229,7 @@ export function resolveModel(
 
   if (
     useGemini3_5Flash &&
-    isFlashModel(resolved) &&
+    isPromotableFlashModel(resolved) &&
     normalizedModel !== PREVIEW_GEMINI_FLASH_MODEL
   ) {
     return DEFAULT_GEMINI_FLASH_MODEL;
@@ -259,14 +259,15 @@ export function resolveModel(
   return resolved;
 }
 
-function isFlashModel(model: string): boolean {
+function isPromotableFlashModel(model: string): boolean {
+  // Keep explicit versioned model IDs intact so callers can pin newer or older
+  // Flash models. Rollout remapping only applies to known aliases/backend IDs.
   return (
     model === DEFAULT_GEMINI_FLASH_MODEL ||
     model === PREVIEW_GEMINI_FLASH_MODEL ||
     model === DEFAULT_GEMINI_3_5_FLASH_MODEL ||
     model === SECONDARY_GEMINI_3_5_FLASH_MODEL ||
-    model === 'flash' ||
-    model.endsWith('flash')
+    model === GEMINI_MODEL_ALIAS_FLASH
   );
 }
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2305,6 +2305,39 @@ describe('GeminiChat', () => {
       );
     });
 
+    it('should send an explicit versioned Flash model unchanged when Gemini 3.5 Flash GA is enabled', async () => {
+      vi.mocked(mockConfig.hasGemini35FlashGAAccess).mockReturnValue(true);
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: { parts: [{ text: 'response' }], role: 'model' },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })(),
+      );
+
+      const stream = await chat.sendMessageStream(
+        { model: 'gemini-3.8-flash' },
+        'hello',
+        'prompt-id-explicit-flash',
+        new AbortController().signal,
+        LlmRole.MAIN,
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3.8-flash' }),
+        'prompt-id-explicit-flash',
+        LlmRole.MAIN,
+      );
+    });
+
     it('should use thinkingLevel and remove thinkingBudget for gemini-3 models', async () => {
       const response = (async function* () {
         yield {


### PR DESCRIPTION
## Summary

Preserve explicit versioned Flash model IDs instead of silently remapping them to the Gemini 3.5 Flash rollout default. This keeps `--model` pinning accurate and lets the API return an honest error for invalid model IDs.

## Details

- Limit Gemini 3.5 Flash rollout remapping to known aliases and backend model IDs.
- Pass explicit versioned Flash IDs, such as `gemini-3.8-flash`, through unchanged.
- Add regression coverage at both model resolution and the final `GeminiChat` request boundary.

## Related Issues

Fixes #28859

## How to Validate

1. Run the focused core tests:

   ```bash
   npm exec --workspace @google/gemini-cli-core -- vitest run src/config/models.test.ts src/core/geminiChat.test.ts src/core/modelMappingContentGenerator.test.ts --coverage.enabled=false
   ```

   Expected: 3 test files and 217 tests pass. The tests verify that known Flash aliases still resolve to the rollout default while explicit versioned IDs reach the request unchanged.

2. Run the core type check:

   ```bash
   npm run typecheck --workspace @google/gemini-cli-core
   ```

   Expected: the type check passes without errors.

The full core suite was also attempted, but unrelated tests cannot complete in a restricted macOS workspace because they require nested Seatbelt sandboxing, filesystem watchers, listening sockets, or writes under `~/.gemini`.

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed; existing documentation already specifies that `--model` takes precedence)
- [x] Added/updated tests (if needed)
- [x] Noted breaking changes (if any; none)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
