### PR TITLE
fix(agent): prevent session context poisoning on interrupted turns

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -27,6 +27,7 @@ import {
   THINKING_ONLY_NUDGE_MESSAGE,
   NO_RESPONSE_TEXT_NUDGE_MESSAGE,
   applyRetryNudge,
+  INTERRUPTED_RESPONSE_PLACEHOLDER,
 } from './geminiChat.js';
 import {
   type CompletedToolCall,
@@ -3831,6 +3832,50 @@ describe('GeminiChat', () => {
       expect(modelTurn.content.parts![0].thoughtSignature).toBe(
         'existing-sig-on-call',
       );
+    });
+  });
+
+  describe('interruption handling in getHistoryTurns', () => {
+    it('should replace INTERRUPTED_RESPONSE_PLACEHOLDER with a benign continuing message in curated history to prevent poisoning while preventing turn fusion', () => {
+      vi.mocked(mockConfig.isContextManagementEnabled).mockReturnValue(false);
+      vi.mocked(mockConfig.getModel).mockReturnValue('gemini-2.5-pro');
+
+      chat.setHistory([
+        { role: 'user', parts: [{ text: 'search for files' }] },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'glob', args: {} } }],
+        },
+        {
+          role: 'user',
+          parts: [{ functionResponse: { name: 'glob', response: { files: [] } } }],
+        },
+        {
+          role: 'model',
+          parts: [{ text: INTERRUPTED_RESPONSE_PLACEHOLDER }],
+        },
+        { role: 'user', parts: [{ text: 'continue search' }] },
+      ]);
+
+      const turns = chat.getHistoryTurns(true);
+
+      // The interrupted response turn should be mapped to "Continuing.".
+      // The turns should NOT be coalesced, and their roles must alternate perfectly.
+      expect(turns).toHaveLength(5);
+      expect(turns[0].content.role).toBe('user');
+      expect(turns[0].content.parts![0].text).toBe('search for files');
+
+      expect(turns[1].content.role).toBe('model');
+      expect(turns[1].content.parts![0].functionCall?.name).toBe('glob');
+
+      expect(turns[2].content.role).toBe('user');
+      expect(turns[2].content.parts![0].functionResponse?.name).toBe('glob');
+
+      expect(turns[3].content.role).toBe('model');
+      expect(turns[3].content.parts![0].text).toBe('Continuing.');
+
+      expect(turns[4].content.role).toBe('user');
+      expect(turns[4].content.parts![0].text).toBe('continue search');
     });
   });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -227,8 +227,28 @@ function extractCuratedHistory(
       const modelOutput: HistoryTurn[] = [];
       let isValid = true;
       while (i < length && comprehensiveHistory[i].content.role === 'model') {
-        modelOutput.push(comprehensiveHistory[i]);
-        if (isValid && !isValidContent(comprehensiveHistory[i].content)) {
+        let turn = comprehensiveHistory[i];
+        if (
+          turn.content.parts?.some(
+            (part) => part.text === INTERRUPTED_RESPONSE_PLACEHOLDER,
+          )
+        ) {
+          const newParts = turn.content.parts.map((part) => {
+            if (part.text === INTERRUPTED_RESPONSE_PLACEHOLDER) {
+              return { ...part, text: 'Continuing.' };
+            }
+            return part;
+          });
+          turn = {
+            ...turn,
+            content: {
+              ...turn.content,
+              parts: newParts,
+            },
+          };
+        }
+        modelOutput.push(turn);
+        if (isValid && !isValidContent(turn.content)) {
           isValid = false;
         }
         i++;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -230,11 +230,11 @@ function extractCuratedHistory(
         let turn = comprehensiveHistory[i];
         if (
           turn.content.parts?.some(
-            (part) => part.text === INTERRUPTED_RESPONSE_PLACEHOLDER,
+            (part) => part?.text === INTERRUPTED_RESPONSE_PLACEHOLDER,
           )
         ) {
           const newParts = turn.content.parts.map((part) => {
-            if (part.text === INTERRUPTED_RESPONSE_PLACEHOLDER) {
+            if (part?.text === INTERRUPTED_RESPONSE_PLACEHOLDER) {
               return { ...part, text: 'Continuing.' };
             }
             return part;


### PR DESCRIPTION
## Summary
This PR resolves a critical issue where interrupting an agentic stream (via SIGINT, timeout, or aborted tool executions) poisons the active chat session history and breaks subsequent prompt execution.

## Details
- **The Issue**: When an active model generation or tool execution is interrupted, `closeUnansweredToolResponseTurn()` appends `[The previous response was interrupted before it completed.]` (defined as `INTERRUPTED_RESPONSE_PLACEHOLDER`) to the history to close the dangling turn and prevent adjacent user turns from coalescing (which would otherwise fuse user chat input into previous tool responses, violating API turn invariants). However, sending this synthetic placeholder to the model in subsequent prompts causes severe context poisoning—the model treats it as a few-shot completion pattern and parrots it back, breaking the agentic loop.
- **The Solution**: In `packages/core/src/core/geminiChat.ts`'s `extractCuratedHistory` (which compiles the history payload sent to the Gemini API), any model turns containing `INTERRUPTED_RESPONSE_PLACEHOLDER` are intercepted and mapped to a benign model turn `"Continuing."`.
  - **For the User**: The UI still records and displays the clear warning notification: `✦ [The previous response was interrupted before it completed.]`.
  - **For the Model**: The model only sees a natural `"Continuing."` transition. If it mimics this phrase in its next response, it is perfectly harmless and does not disrupt the loop.

## Related Issues
Closes #29264

## How to Validate
1. Run a tool-calling prompt (e.g. `search the codebase for all API handlers`).
2. Trigger an interruption (SIGINT/Ctrl+C or abort). The CLI outputs the warning nicely.
3. Submit a subsequent prompt (e.g. `list files`). The agent now executes and completes normally instead of outputting `✦ [The previous response was interrupted before it completed.]`.
4. Run vitest: `npm test -w @google/gemini-cli-core -- src/core/geminiChat.test.ts`. All tests (including the new suite covering mapped interruption placeholders) pass with 100% success.

## Pre-Merge Checklist
- [x] Added/updated tests (if needed)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run