### PR TITLE
fix(core): prevent env var collision with expandEnvVars sentinel key

### DIFF
--- a/packages/core/src/utils/envExpansion.test.ts
+++ b/packages/core/src/utils/envExpansion.test.ts
@@ -114,4 +114,50 @@ describe('expandEnvVars', () => {
       expect(expandEnvVars(input, env)).toBe(expected);
     });
   });
+
+  describe('internal sentinel key collision', () => {
+    beforeEach(() => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not let a caller-provided __GCLI_EXPAND_TARGET__ entry override the input', () => {
+      expect(
+        expandEnvVars('Hello $USER', {
+          USER: 'morty',
+          __GCLI_EXPAND_TARGET__: 'unexpected override',
+        }),
+      ).toBe('Hello morty');
+    });
+
+    it('ignores the sentinel key even when it is the only entry in env', () => {
+      expect(
+        expandEnvVars('literal text, no vars', {
+          __GCLI_EXPAND_TARGET__: 'unexpected override',
+        }),
+      ).toBe('literal text, no vars');
+    });
+
+    it('still expands other variables when the sentinel key is also present', () => {
+      expect(
+        expandEnvVars('$USER says ${GREETING}', {
+          USER: 'morty',
+          GREETING: 'hi',
+          __GCLI_EXPAND_TARGET__: 'unexpected override',
+        }),
+      ).toBe('morty says hi');
+    });
+
+    it('still expands a variable whose name merely resembles the sentinel', () => {
+      expect(
+        expandEnvVars('token: $__GCLI_EXPAND_TARGET', {
+          __GCLI_EXPAND_TARGET: 'real-value',
+          __GCLI_EXPAND_TARGET__: 'unexpected override',
+        }),
+      ).toBe('token: real-value');
+    });
+  });
 });

--- a/packages/core/src/utils/envExpansion.ts
+++ b/packages/core/src/utils/envExpansion.ts
@@ -37,10 +37,13 @@ export function expandEnvVars(
   // To expand a single string, we wrap it in an object with a temporary key.
   const dummyKey = '__GCLI_EXPAND_TARGET__';
 
-  // Filter out undefined values to satisfy the Record<string, string> requirement safely
+  // Filter out undefined values to satisfy the Record<string, string> requirement safely.
+  // Also drop the internal dummyKey if the caller's env happens to define it: dotenv-expand
+  // gives processEnv priority over parsed, so leaving it in would let a caller-controlled
+  // environment variable silently replace the string we are trying to expand.
   const processEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) {
+    if (value !== undefined && key !== dummyKey) {
       processEnv[key] = value;
     }
   }


### PR DESCRIPTION
## Summary

`expandEnvVars()` in `packages/core/src/utils/envExpansion.ts` returned the value of a caller-provided `__GCLI_EXPAND_TARGET__` environment entry instead of expanding its input, whenever the environment passed in happened to contain that exact key. Reproduced with the reporter's case:

```ts
expandEnvVars('Hello $USER', {
  USER: 'morty',
  __GCLI_EXPAND_TARGET__: 'unexpected override',
});
```

Actual return value before the fix: `unexpected override`. Expected: `Hello morty`.

## Details

The helper wraps its input string in an object under a fixed internal key, `__GCLI_EXPAND_TARGET__` (line 38), then calls `dotenv-expand` with that object as `parsed` and the caller's own environment as `processEnv` (lines 48-51):

```ts
const result: DotenvExpandOutput = expand({
  parsed: { [dummyKey]: processedStr },
  processEnv,
});
```

`dotenv-expand` gives `processEnv` priority over `parsed` for a shared key. Since `processEnv` here is a direct copy of the caller-supplied environment (lines 41-46), any environment record that happened to define `__GCLI_EXPAND_TARGET__` clobbered the wrapped input before expansion ever ran. This affects MCP configuration, since MCP transport headers and server environment values are expanded through this helper (`packages/core/src/tools/mcp-client.ts:1001` and `:2373`).

I considered three fixes:

- Generate the sentinel key randomly per call (e.g. a UUID) instead of a fixed string. This shrinks the collision window but does not eliminate it, and trades a deterministic guarantee for one that is merely astronomically unlikely, while making the function's behavior harder to reason about and test.
- Avoid the `dotenv-expand` wrapping trick entirely and reimplement POSIX expansion by hand. Much larger diff, throws away the library's parsing behavior the surrounding tests already depend on, and is not warranted by a one-key collision bug.
- Strip the sentinel key out of the `processEnv` copy before calling `expand()`. This is what I went with: it is a one-line addition to a loop that already filters `processEnv` (it drops `undefined` values there for type safety), it guarantees the internal key can never be shadowed by caller input regardless of what the caller passes, and it needs no change to the function's public signature or behavior for any legitimate input.

The fix:

```ts
for (const [key, value] of Object.entries(env)) {
  if (value !== undefined && key !== dummyKey) {
    processEnv[key] = value;
  }
}
```

## Related Issues

Fixes #29270

## How to Validate

Reproduce on unfixed code (RED), commit before the fix, `packages/core/src/utils/envExpansion.ts` at the version referenced in the issue:

```
$ npm test -w @google/gemini-cli-core -- src/utils/envExpansion.test.ts
```

```
× expandEnvVars > internal sentinel key collision > does not let a caller-provided __GCLI_EXPAND_TARGET__ entry override the input
  → expected 'unexpected override' to be 'Hello morty'
× expandEnvVars > internal sentinel key collision > ignores the sentinel key even when it is the only entry in env
  → expected 'unexpected override' to be 'literal text, no vars'
× expandEnvVars > internal sentinel key collision > still expands other variables when the sentinel key is also present
  → expected 'unexpected override' to be 'morty says hi'
× expandEnvVars > internal sentinel key collision > still expands a variable whose name merely resembles the sentinel
  → expected 'unexpected override' to be 'token: real-value'

Test Files  1 failed (1)
     Tests  4 failed | 15 passed (19)
```

After the fix (GREEN):

```
$ npm test -w @google/gemini-cli-core -- src/utils/envExpansion.test.ts
 ✓ src/utils/envExpansion.test.ts (19 tests) 3ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
```

I also ran the full core package suite (`npm test -w @google/gemini-cli-core`): 7971 passed, 53 skipped. One unrelated file, `src/utils/pathReader.test.ts`, fails both with and without this change, on this Node v26.8.2 install, with `TypeError: Cannot read properties of undefined (reading 'read')` inside `mock-fs`'s `patchReadFileContext` (a `mock-fs` / current Node internals incompatibility, unrelated to this diff).

Also ran, both clean on the changed files and on the `core` package:

```
$ npx eslint packages/core/src/utils/envExpansion.ts packages/core/src/utils/envExpansion.test.ts
$ npm run typecheck --workspace @google/gemini-cli-core
```

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [ ] Validated on required platforms/methods:
  - [ ] MacOS
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
