### PR TITLE
fix(core): choose collision-free env expansion keys

### DIFF
--- a/packages/core/src/utils/envExpansion.test.ts
+++ b/packages/core/src/utils/envExpansion.test.ts
@@ -73,6 +73,24 @@ describe('expandEnvVars', () => {
     ])('should handle %s', (_, input, env, expected) => {
       expect(expandEnvVars(input, env)).toBe(expected);
     });
+
+    it('should preserve an environment value that collides with the temporary key', () => {
+      expect(
+        expandEnvVars('Hello $USER from $__GCLI_EXPAND_TARGET__', {
+          ...defaultEnv,
+          __GCLI_EXPAND_TARGET__: 'the Citadel',
+        }),
+      ).toBe('Hello morty from the Citadel');
+    });
+
+    it('should avoid collisions with fallback temporary keys', () => {
+      expect(
+        expandEnvVars('${__GCLI_EXPAND_TARGET__}:${__GCLI_EXPAND_TARGET___}', {
+          __GCLI_EXPAND_TARGET__: 'first',
+          __GCLI_EXPAND_TARGET___: 'second',
+        }),
+      ).toBe('first:second');
+    });
   });
 
   describe('Windows behavior', () => {

--- a/packages/core/src/utils/envExpansion.ts
+++ b/packages/core/src/utils/envExpansion.ts
@@ -36,7 +36,7 @@ export function expandEnvVars(
   // dotenv-expand is designed to process an object of key-value pairs (like a .env file).
   // To expand a single string, we wrap it in an object with a temporary key.
   let dummyKey = '__GCLI_EXPAND_TARGET__';
-  while (Object.hasOwn(env, dummyKey)) {
+  while (Object.hasOwn(env, dummyKey) || processedStr.includes(dummyKey)) {
     dummyKey += '_';
   }
 

--- a/packages/core/src/utils/envExpansion.ts
+++ b/packages/core/src/utils/envExpansion.ts
@@ -35,7 +35,10 @@ export function expandEnvVars(
   // 2. Use dotenv-expand for POSIX/Bash syntax ($VAR, ${VAR}).
   // dotenv-expand is designed to process an object of key-value pairs (like a .env file).
   // To expand a single string, we wrap it in an object with a temporary key.
-  const dummyKey = '__GCLI_EXPAND_TARGET__';
+  let dummyKey = '__GCLI_EXPAND_TARGET__';
+  while (Object.hasOwn(env, dummyKey)) {
+    dummyKey += '_';
+  }
 
   // Filter out undefined values to satisfy the Record<string, string> requirement safely
   const processEnv: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Prevent `expandEnvVars()` from using a temporary key that collides with the caller-provided environment.

The helper now chooses a temporary key absent from the environment. This prevents the environment from overriding the input string while preserving every caller-provided value for expansion.

## Details

- Start with the existing `__GCLI_EXPAND_TARGET__` temporary key.
- Append `_` until the key is absent from the caller's environment.
- Add regression coverage for the original key and fallback-key collisions.
- Preserve expansion of environment values whose names collide with temporary-key candidates.

PR #29277 addresses the same collision by removing the matching caller-provided entry from the environment copy. This alternative keeps that value available for expansion and instead selects an unused internal key.

## Related Issues

Fixes #29270

## How to Validate

```bash
npm test -w @google/gemini-cli-core -- src/utils/envExpansion.test.ts
npx eslint packages/core/src/utils/envExpansion.ts packages/core/src/utils/envExpansion.test.ts
npm run typecheck --workspace @google/gemini-cli-core
npx -y -p node@20.19.0 -c 'npm test -w @google/gemini-cli-core'
```

Results:

- Focused suite: 17 passed.
- Full core suite on Node 20.19: 7,991 passed and 53 skipped.
- ESLint and core type checking passed.

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] MacOS
    - [x] npm run
    - [ ] npx
    - [ ] Docker
    - [ ] Podman
    - [ ] Seatbelt
  - [ ] Windows
    - [ ] npm run
    - [ ] npx
    - [ ] Docker
  - [ ] Linux
    - [ ] npm run
    - [ ] npx
    - [ ] Docker