### PR TITLE
fix(checkpoint): validate history is an array in loadCheckpoint (#29194)

### DIFF
--- a/packages/core/src/core/logger.test.ts
+++ b/packages/core/src/core/logger.test.ts
@@ -567,6 +567,26 @@ describe('Logger', () => {
       );
     });
 
+    it('should return an empty history if checkpoint JSON has non-array history', async () => {
+      const tag = 'corrupt-history-tag';
+      const encodedTag = 'corrupt-history-tag';
+      const taggedFilePath = path.join(
+        TEST_GEMINI_DIR,
+        `checkpoint-${encodedTag}.json`,
+      );
+      await fs.writeFile(taggedFilePath, JSON.stringify({ history: null }));
+      const consoleWarnSpy = vi
+        .spyOn(debugLogger, 'warn')
+        .mockImplementation(() => {});
+      const loadedCheckpoint = await logger.loadCheckpoint(tag);
+      expect(loadedCheckpoint).toEqual({ history: [] });
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'has an unknown format. Returning empty checkpoint.',
+        ),
+      );
+    });
+
     it('should return an empty history if logger is not initialized', async () => {
       const uninitializedLogger = new Logger(
         testSessionId,

--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -365,7 +365,7 @@ export class Logger {
       if (
         typeof parsedContent === 'object' &&
         parsedContent !== null &&
-        'history' in parsedContent
+        Array.isArray(parsedContent.history)
       ) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         return parsedContent as Checkpoint;


### PR DESCRIPTION
### Summary
Fixes #29194

When loading a checkpoint JSON file with valid JSON syntax but a non-array `history` property (e.g., `{"history": null}` or `{"history": 123}` caused by partial file writes or corruption), `loadCheckpoint()` returned the object as valid. Subsequent operations on `/resume` accessing `checkpoint.history.length` threw an unhandled `TypeError`.

This PR updates `loadCheckpoint()` in `packages/core/src/core/logger.ts` to explicitly verify `Array.isArray(parsedContent.history)` before returning the parsed object. If `history` is not an array, it logs a warning and degrades gracefully to an empty checkpoint (`{ history: [] }`).

### Changes
- Updated type guard in `loadCheckpoint()` from `'history' in parsedContent` to `Array.isArray(parsedContent.history)`.
- Added unit test in `packages/core/src/core/logger.test.ts` to verify non-array `history` shapes degrade gracefully.

### Testing
- Ran test suite: `npm run test --workspace @google/gemini-cli-core -- src/core/logger.test.ts`
- Result: **40/40 tests passed cleanly.**