### PR TITLE
fix(cli): prevent terminal flickering caused by stdout contention and cursor focus

### DIFF
--- a/packages/cli/src/ui/components/CliSpinner.tsx
+++ b/packages/cli/src/ui/components/CliSpinner.tsx
@@ -5,15 +5,19 @@
  */
 
 import Spinner from 'ink-spinner';
-import { type ComponentProps, useEffect } from 'react';
+import { type ComponentProps, useEffect, useState } from 'react';
 import { debugState } from '../debug.js';
 import { useSettings } from '../contexts/SettingsContext.js';
+import { appEvents, AppEvent } from '../../utils/events.js';
+import { Text } from 'ink';
+import cliSpinners from 'cli-spinners';
 
 export type SpinnerProps = ComponentProps<typeof Spinner>;
 
 export const CliSpinner = (props: SpinnerProps) => {
   const settings = useSettings();
   const shouldShow = settings.merged.ui?.showSpinner !== false;
+  const [isTyping, setIsTyping] = useState(false);
 
   useEffect(() => {
     if (shouldShow) {
@@ -25,8 +29,32 @@ export const CliSpinner = (props: SpinnerProps) => {
     return undefined;
   }, [shouldShow]);
 
+  useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined = undefined;
+    const handleTyping = () => {
+      setIsTyping(true);
+      if (timeout) clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        setIsTyping(false);
+      }, 150); // Pause animation for 150ms after last keystroke
+    };
+
+    appEvents.on(AppEvent.UserTyping, handleTyping);
+    return () => {
+      appEvents.off(AppEvent.UserTyping, handleTyping);
+      if (timeout) clearTimeout(timeout);
+    };
+  }, []);
+
   if (!shouldShow) {
     return null;
+  }
+
+  if (isTyping) {
+    // Show static frame when typing to avoid tearing
+    const spinner = cliSpinners[props.type || 'dots'];
+    const staticFrame = spinner?.frames?.[0] || '⠋';
+    return <Text>{staticFrame}</Text>;
   }
 
   return <Spinner {...props} />;

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -684,6 +684,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleInput = useCallback(
     (key: Key) => {
+      appEvents.emit(AppEvent.UserTyping);
+
       if (handleVoiceInput(key)) return true;
 
       // Determine if this keypress is a history navigation command
@@ -1657,15 +1659,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         cursorVisualColAbsolute === cpLen(lineText) &&
         currentLineGhost;
       return (
-        <Box height={1}>
-          <Text
-            terminalCursorFocus={showCursor && isOnCursorLine}
-            terminalCursorPosition={cpIndexToOffset(
-              lineText,
-              cursorVisualColAbsolute,
-            )}
-          >
-            {renderedLine}
+       <Box height={1}>
+         <Text>
+           {renderedLine}
             {showCursorBeforeGhost && (showCursor ? chalk.inverse(' ') : ' ')}
             {currentLineGhost && (
               <Text color={theme.text.secondary}>{currentLineGhost}</Text>
@@ -1848,10 +1844,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             {buffer.text.length === 0 ? (
               effectivePlaceholder ? (
                 showCursor ? (
-                  <Text
-                    terminalCursorFocus={showCursor}
-                    terminalCursorPosition={0}
-                  >
+                  <Text>
                     {chalk.inverse(effectivePlaceholder.slice(0, 1))}
                     <Text color={theme.text.secondary}>
                       {effectivePlaceholder.slice(1)}

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -24,6 +24,7 @@ export enum AppEvent {
   TerminalBackground = 'terminal-background',
   TransientMessage = 'transient-message',
   ScrollToBottom = 'scroll-to-bottom',
+  UserTyping = 'user-typing',
 }
 
 export interface AppEvents {
@@ -34,6 +35,7 @@ export interface AppEvents {
   [AppEvent.TerminalBackground]: [string];
   [AppEvent.TransientMessage]: [TransientMessagePayload];
   [AppEvent.ScrollToBottom]: never[];
+  [AppEvent.UserTyping]: never[];
 }
 
 export const appEvents = new EventEmitter<AppEvents>();


### PR DESCRIPTION
## The Issue
Typing in the prompt while a background command is executing (or just typing fast) causes aggressive flickering and tearing in the terminal.

Closes #29295

## Root Cause Analysis
This flickering stems from two concurrent rendering bottlenecks in the `ink` reconciler cycle:
1. **Stdout Contention:** `CliSpinner` aggressively triggers state updates to animate its frames. Concurrently, `InputPrompt` listens to keystrokes and triggers complex re-renders (syntax highlighting, ghost text calculations). Because terminal emulators lack double-buffering, `ink`'s ANSI line-clearing followed by heavy redraws from both components simultaneously causes visible tearing.
2. **Native Cursor vs Block Cursor:** `InputPrompt` simulates a cursor using `chalk.inverse()`, while also passing `terminalCursorFocus` to the internal `@jrichman/ink` fork. This forces the native terminal cursor to constantly toggle visibility (`\x1B[?25l` and `\x1B[?25h`) and recalculate ANSI positions on every single keystroke, severely exacerbating the visual tearing.

## The Solution
*   **Spinner Debouncing:** Introduced a new `AppEvent.UserTyping` event. `CliSpinner` now listens to this event and debounces its animation (pausing on a static frame for 150ms) during active typing, freeing up the `stdout` buffer for smooth input rendering.
*   **Disabled Redundant Native Cursor Focus:** Disabled `terminalCursorFocus` in `InputPrompt`. The CLI already implements a robust simulated block cursor via `chalk.inverse`, making the native cursor reconciliation overhead redundant and harmful to performance.

## Testing
Tested locally by building the bundle and running concurrent CLI operations. The typing experience is now completely smooth without any tearing or animation stutter.