### PR TITLE
fix(cli): keep surrogate pairs intact at ExpandableText truncation boundaries

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1017,13 +1017,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             return true;
           }
           if (keyMatchers[Command.COLLAPSE_SUGGESTION](key)) {
-            if (suggestions[activeSuggestionIndex].value.length >= MAX_WIDTH) {
+            if (cpLen(suggestions[activeSuggestionIndex].value) > MAX_WIDTH) {
               setExpandedSuggestionIndex(-1);
               return true;
             }
           }
           if (keyMatchers[Command.EXPAND_SUGGESTION](key)) {
-            if (suggestions[activeSuggestionIndex].value.length >= MAX_WIDTH) {
+            if (cpLen(suggestions[activeSuggestionIndex].value) > MAX_WIDTH) {
               setExpandedSuggestionIndex(activeSuggestionIndex);
               return true;
             }

--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -160,4 +160,51 @@ describe('SuggestionsDisplay', () => {
     expect(frame).toContain('-- auto --');
     expect(frame).toContain('-- checkpoints --');
   });
+
+  it('does not show the expand hint when the value fits when measured in code points', async () => {
+    const { lastFrame } = await render(
+      <SuggestionsDisplay
+        suggestions={[
+          {
+            label: 'emoji',
+            value: '😀'.repeat(100),
+          },
+        ]}
+        activeIndex={0}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput=""
+        mode="reverse"
+      />,
+    );
+
+    // cpLen is 100 (<= MAX_WIDTH) so the label renders in full and must not
+    // offer expansion, even though its UTF-16 length (200) exceeds MAX_WIDTH.
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('→');
+    expect(frame).not.toContain('←');
+  });
+
+  it('shows the expand hint when the value is long in code points', async () => {
+    const { lastFrame } = await render(
+      <SuggestionsDisplay
+        suggestions={[
+          {
+            label: 'emoji',
+            value: '😀'.repeat(200),
+          },
+        ]}
+        activeIndex={0}
+        isLoading={false}
+        width={80}
+        scrollOffset={0}
+        userInput=""
+        mode="reverse"
+      />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('→');
+  });
 });

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -9,7 +9,7 @@ import { theme } from '../semantic-colors.js';
 import { ExpandableText, MAX_WIDTH } from './shared/ExpandableText.js';
 import { CommandKind } from '../commands/types.js';
 import { Colors } from '../colors.js';
-import { sanitizeForDisplay } from '../utils/textUtils.js';
+import { sanitizeForDisplay, cpLen } from '../utils/textUtils.js';
 
 export interface Suggestion {
   label: string;
@@ -88,7 +88,7 @@ export function SuggestionsDisplay({
         const isActive = originalIndex === activeIndex;
         const isExpanded = originalIndex === expandedIndex;
         const textColor = isActive ? theme.ui.focus : theme.text.secondary;
-        const isLong = suggestion.value.length >= MAX_WIDTH;
+        const isLong = cpLen(suggestion.value) > MAX_WIDTH;
         const previousSectionTitle =
           suggestions[originalIndex - 1]?.sectionTitle;
         const shouldRenderSectionHeader =

--- a/packages/cli/src/ui/components/shared/ExpandableText.test.tsx
+++ b/packages/cli/src/ui/components/shared/ExpandableText.test.tsx
@@ -11,6 +11,8 @@ import { ExpandableText, MAX_WIDTH } from './ExpandableText.js';
 describe('ExpandableText', () => {
   const color = 'white';
   const flat = (s: string | undefined) => (s ?? '').replace(/\n/g, '');
+  const containsLoneSurrogate = (s: string) =>
+    /[\uD800-\uDFFF]/.test(s.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ''));
 
   it('renders plain label when no match (short label)', async () => {
     const renderResult = await render(
@@ -152,6 +154,84 @@ describe('ExpandableText', () => {
     const f = flat(out);
     expect(f.endsWith('...')).toBe(true);
     expect(f.length).toBe(customWidth + 3);
+    await expect(renderResult).toMatchSvgSnapshot();
+    unmount();
+  });
+
+  it('keeps an emoji intact when the truncation boundary splits a surrogate pair', async () => {
+    const renderResult = await render(
+      <ExpandableText
+        label="aaaa😀tail"
+        userInput=""
+        textColor={color}
+        isExpanded={false}
+        maxWidth={5}
+      />,
+    );
+    const { lastFrame, unmount } = renderResult;
+    const f = flat(lastFrame());
+    // The cut lands between the surrogates of the emoji, so truncation must
+    // stop before the pair and keep the whole emoji.
+    expect(f).toBe('aaaa😀...');
+    expect(containsLoneSurrogate(f)).toBe(false);
+    await expect(renderResult).toMatchSvgSnapshot();
+    unmount();
+  });
+
+  it('keeps an emoji intact when maxLines truncation hits the boundary', async () => {
+    const renderResult = await render(
+      <ExpandableText
+        label="aaaa😀tail"
+        userInput=""
+        textColor={color}
+        isExpanded={false}
+        maxWidth={5}
+        maxLines={3}
+      />,
+    );
+    const { lastFrame, unmount } = renderResult;
+    const f = flat(lastFrame());
+    expect(f).toBe('aaaa😀...');
+    expect(containsLoneSurrogate(f)).toBe(false);
+    await expect(renderResult).toMatchSvgSnapshot();
+    unmount();
+  });
+
+  it('does not truncate a label that fits when measured in code points', async () => {
+    const renderResult = await render(
+      <ExpandableText
+        label="😀😀😀"
+        userInput=""
+        textColor={color}
+        isExpanded={false}
+        maxWidth={3}
+      />,
+    );
+    const { lastFrame, unmount } = renderResult;
+    const f = flat(lastFrame());
+    expect(f).toBe('😀😀😀');
+    expect(containsLoneSurrogate(f)).toBe(false);
+    await expect(renderResult).toMatchSvgSnapshot();
+    unmount();
+  });
+
+  it('does not split surrogate pairs at match-window edges', async () => {
+    const renderResult = await render(
+      <ExpandableText
+        label="aaaa😀😀git😀😀tail"
+        userInput="git"
+        matchedIndex={8}
+        textColor={color}
+        isExpanded={false}
+        maxWidth={12}
+      />,
+    );
+    const { lastFrame, unmount } = renderResult;
+    const f = flat(lastFrame());
+    expect(f.includes('git')).toBe(true);
+    expect(containsLoneSurrogate(f)).toBe(false);
+    // The emojis adjacent to the window survive instead of being dropped.
+    expect(f).toBe('...😀git😀😀...');
     await expect(renderResult).toMatchSvgSnapshot();
     unmount();
   });

--- a/packages/cli/src/ui/components/shared/ExpandableText.tsx
+++ b/packages/cli/src/ui/components/shared/ExpandableText.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Text } from 'ink';
 import { theme } from '../../semantic-colors.js';
+import { cpLen, cpSlice, toCodePoints } from '../../utils/textUtils.js';
 
 export const MAX_WIDTH = 150;
 
@@ -19,6 +20,24 @@ export interface ExpandableTextProps {
   maxWidth?: number;
   maxLines?: number;
 }
+
+/**
+ * Converts a UTF-16 code-unit index (e.g. one produced by String.indexOf)
+ * into a code-point index, stepping back so the boundary never falls inside
+ * a surrogate pair.
+ */
+const toCodePointIndex = (str: string, utf16Index: number): number => {
+  const index =
+    utf16Index > 0 &&
+    utf16Index < str.length &&
+    str.charCodeAt(utf16Index - 1) >= 0xd800 &&
+    str.charCodeAt(utf16Index - 1) <= 0xdbff &&
+    str.charCodeAt(utf16Index) >= 0xdc00 &&
+    str.charCodeAt(utf16Index) <= 0xdfff
+      ? utf16Index - 1
+      : utf16Index;
+  return toCodePoints(str.slice(0, index)).length;
+};
 
 const _ExpandableText: React.FC<ExpandableTextProps> = ({
   label,
@@ -46,15 +65,15 @@ const _ExpandableText: React.FC<ExpandableTextProps> = ({
         let truncated = lines.slice(0, maxLines).join('\n');
         const hasMoreLines = lines.length > maxLines;
 
-        // 2. Truncate by characters (visual approximation) to prevent massive wrapping
-        if (truncated.length > maxWidth) {
-          truncated = truncated.slice(0, maxWidth) + '...';
+        // 2. Truncate by code points so a surrogate pair is never split
+        if (cpLen(truncated) > maxWidth) {
+          truncated = cpSlice(truncated, 0, maxWidth) + '...';
         } else if (hasMoreLines) {
           truncated += '...';
         }
         display = truncated;
-      } else if (label.length > maxWidth) {
-        display = label.slice(0, maxWidth) + '...';
+      } else if (cpLen(label) > maxWidth) {
+        display = cpSlice(label, 0, maxWidth) + '...';
       }
     }
 
@@ -65,52 +84,61 @@ const _ExpandableText: React.FC<ExpandableTextProps> = ({
     );
   }
 
-  const matchLength = userInput.length;
+  // All indexes below are code-point based so truncation never lands inside
+  // a surrogate pair (matchedIndex itself is a UTF-16 index from indexOf).
+  const totalCp = cpLen(label);
+  const matchStartCp = toCodePointIndex(label, matchedIndex);
+  const matchLengthCp = cpLen(userInput);
   let before = '';
   let match = '';
   let after = '';
 
   // Case 1: Show the full string if it's expanded or already fits
-  if (isExpanded || label.length <= maxWidth) {
-    before = label.slice(0, matchedIndex);
-    match = label.slice(matchedIndex, matchedIndex + matchLength);
-    after = label.slice(matchedIndex + matchLength);
+  if (isExpanded || totalCp <= maxWidth) {
+    before = cpSlice(label, 0, matchStartCp);
+    match = cpSlice(label, matchStartCp, matchStartCp + matchLengthCp);
+    after = cpSlice(label, matchStartCp + matchLengthCp);
   }
   // Case 2: The match itself is too long, so we only show a truncated portion of the match
-  else if (matchLength >= maxWidth) {
-    match = label.slice(matchedIndex, matchedIndex + maxWidth - 1) + '...';
+  else if (matchLengthCp >= maxWidth) {
+    match = cpSlice(label, matchStartCp, matchStartCp + maxWidth - 1) + '...';
   }
   // Case 3: Truncate the string to create a window around the match
   else {
-    const contextSpace = maxWidth - matchLength;
+    const contextSpace = maxWidth - matchLengthCp;
     const beforeSpace = Math.floor(contextSpace / 2);
     const afterSpace = Math.ceil(contextSpace / 2);
 
-    let start = matchedIndex - beforeSpace;
-    let end = matchedIndex + matchLength + afterSpace;
+    let start = matchStartCp - beforeSpace;
+    let end = matchStartCp + matchLengthCp + afterSpace;
 
     if (start < 0) {
       end += -start; // Slide window right
       start = 0;
     }
-    if (end > label.length) {
-      start -= end - label.length; // Slide window left
-      end = label.length;
+    if (end > totalCp) {
+      start -= end - totalCp; // Slide window left
+      end = totalCp;
     }
     start = Math.max(0, start);
 
-    const finalMatchIndex = matchedIndex - start;
-    const slicedLabel = label.slice(start, end);
+    const finalMatchIndex = matchStartCp - start;
+    const slicedLabel = cpSlice(label, start, end);
 
-    before = slicedLabel.slice(0, finalMatchIndex);
-    match = slicedLabel.slice(finalMatchIndex, finalMatchIndex + matchLength);
-    after = slicedLabel.slice(finalMatchIndex + matchLength);
+    before = cpSlice(slicedLabel, 0, finalMatchIndex);
+    match = cpSlice(
+      slicedLabel,
+      finalMatchIndex,
+      finalMatchIndex + matchLengthCp,
+    );
+    after = cpSlice(slicedLabel, finalMatchIndex + matchLengthCp);
 
     if (start > 0) {
-      before = before.length >= 3 ? '...' + before.slice(3) : '...';
+      before = cpLen(before) >= 3 ? '...' + cpSlice(before, 3) : '...';
     }
-    if (end < label.length) {
-      after = after.length >= 3 ? after.slice(0, -3) + '...' : '...';
+    if (end < totalCp) {
+      after =
+        cpLen(after) >= 3 ? cpSlice(after, 0, cpLen(after) - 3) + '...' : '...';
     }
   }
 

--- a/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-does-not-split-surrogate-pairs-at-match-window-edges.snap.svg
+++ b/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-does-not-split-surrogate-pairs-at-match-window-edges.snap.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="37" viewBox="0 0 920 37">
+  <style>
+    text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
+  </style>
+  <rect width="920" height="37" fill="#000000" />
+  <g transform="translate(10, 10)">
+    <text x="0" y="2" fill="#e5e5e5" textLength="36" lengthAdjust="spacingAndGlyphs">...😀</text>
+    <rect x="36" y="0" width="27" height="17" fill="#e5e5e5" />
+    <text x="36" y="2" fill="#000000" textLength="27" lengthAdjust="spacingAndGlyphs">git</text>
+    <text x="63" y="2" fill="#e5e5e5" textLength="45" lengthAdjust="spacingAndGlyphs">😀😀...</text>
+  </g>
+</svg>

--- a/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-does-not-truncate-a-label-that-fits-when-measured-in-code-points.snap.svg
+++ b/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-does-not-truncate-a-label-that-fits-when-measured-in-code-points.snap.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="37" viewBox="0 0 920 37">
+  <style>
+    text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
+  </style>
+  <rect width="920" height="37" fill="#000000" />
+  <g transform="translate(10, 10)">
+    <text x="0" y="2" fill="#e5e5e5" textLength="27" lengthAdjust="spacingAndGlyphs">😀😀😀</text>
+  </g>
+</svg>

--- a/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-keeps-an-emoji-intact-when-maxLines-truncation-hits-the-boundary.snap.svg
+++ b/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-keeps-an-emoji-intact-when-maxLines-truncation-hits-the-boundary.snap.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="37" viewBox="0 0 920 37">
+  <style>
+    text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
+  </style>
+  <rect width="920" height="37" fill="#000000" />
+  <g transform="translate(10, 10)">
+    <text x="0" y="2" fill="#e5e5e5" textLength="72" lengthAdjust="spacingAndGlyphs">aaaa😀...</text>
+  </g>
+</svg>

--- a/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-keeps-an-emoji-intact-when-the-truncation-boundary-splits-a-surrogate-pair.snap.svg
+++ b/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText-ExpandableText-keeps-an-emoji-intact-when-the-truncation-boundary-splits-a-surrogate-pair.snap.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="37" viewBox="0 0 920 37">
+  <style>
+    text { font-family: Consolas, "Courier New", monospace; font-size: 14px; dominant-baseline: text-before-edge; white-space: pre; }
+  </style>
+  <rect width="920" height="37" fill="#000000" />
+  <g transform="translate(10, 10)">
+    <text x="0" y="2" fill="#e5e5e5" textLength="72" lengthAdjust="spacingAndGlyphs">aaaa😀...</text>
+  </g>
+</svg>

--- a/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText.test.tsx.snap
+++ b/packages/cli/src/ui/components/shared/__snapshots__/ExpandableText.test.tsx.snap
@@ -5,7 +5,15 @@ exports[`ExpandableText > creates centered window around match when collapsed 1`
 components//and/then/some/more/components//and/..."
 `;
 
+exports[`ExpandableText > does not split surrogate pairs at match-window edges 1`] = `"...😀git😀😀..."`;
+
+exports[`ExpandableText > does not truncate a label that fits when measured in code points 1`] = `"😀😀😀"`;
+
 exports[`ExpandableText > highlights matched substring when expanded (text only visible) 1`] = `"run: git commit -m "feat: add search""`;
+
+exports[`ExpandableText > keeps an emoji intact when maxLines truncation hits the boundary 1`] = `"aaaa😀..."`;
+
+exports[`ExpandableText > keeps an emoji intact when the truncation boundary splits a surrogate pair 1`] = `"aaaa😀..."`;
 
 exports[`ExpandableText > renders plain label when no match (short label) 1`] = `"simple command"`;
 


### PR DESCRIPTION
## Summary

`ExpandableText` truncated labels using UTF-16 code-unit indexes. When the limit landed on the high surrogate of an emoji, Ink received an unpaired surrogate and silently dropped the character from the TUI — e.g. label `aaaa😀tail` with `maxWidth 5` rendered `aaaa...` instead of `aaaa😀...`. All truncation paths now measure and slice in code points, so a surrogate pair is never split and the complete emoji is retained before the `...` marker.

## Details

- `ExpandableText.tsx`: the no-match path, the `maxLines` path, and the match-window path (including before/after ellipsis trimming) now use the existing `cpLen`/`cpSlice` helpers from `ui/utils/textUtils.ts`. `matchedIndex` is a UTF-16 offset produced by `String.indexOf` at the call site, so a small local helper converts it to a code-point index, stepping back when the boundary falls inside a pair.
- Call-site gates: `SuggestionsDisplay` (`isLong`) and `InputPrompt` (expand/collapse key handlers) compared `value.length` against `MAX_WIDTH` in UTF-16 units and now use `cpLen`. The boundary also changes from `>=` to `>` so the expand affordance only appears when the label is actually truncated — a label of exactly `MAX_WIDTH` code points renders in full, so the old `>=` showed an arrow that expanded nothing.
- Pure-ASCII labels hit the fast path in `cpLen`/`cpSlice` and produce byte-identical output to before.
- Known limitation (pre-existing, unchanged): code-point count remains a visual-width approximation (emoji render as 2 columns), matching the component's original "visual approximation" semantics.
- Out of scope, filed separately: #29301 (`sanitizeForDisplay` has the same UTF-16 truncation issue on the description path) and #29302 (reverse-search highlight offset when lowercasing changes string length).

## Related Issues

Fixes #29296

## How to Validate

```sh
cd packages/cli
npx vitest run src/ui/components/shared/ExpandableText.test.tsx src/ui/components/SuggestionsDisplay.test.tsx src/ui/components/InputPrompt.test.tsx
```

Expected: 219/219 pass. New regression tests cover:

- the issue's repro: `aaaa😀tail`, `maxWidth 5` → `aaaa😀...` (was `aaaa...`)
- the `maxLines` truncation path hitting the same boundary
- a label that fits when measured in code points renders in full with no spurious `...` (e.g. 3 emoji with `maxWidth 3`)
- match-window edges: `...😀git😀😀...` — emojis adjacent to the window survive

Every new test also asserts the rendered frame contains no unpaired surrogate.

Edge cases: a 150-code-point label of emoji has UTF-16 length 300 — it previously got truncated (and could split a pair) and showed the expand arrow; it now renders in full with no arrow. An ASCII label of exactly 150 characters no longer shows the expand arrow (it was never actually truncated).

## Pre-Merge Checklist

- [ ] Updated relevant documentation and README (if needed) — not needed, internal rendering fix
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any) — none
- [ ] Validated on required platforms/methods: validated via the `packages/cli` vitest suite on macOS; no manual CLI runs on other platforms